### PR TITLE
Use "test/integration" instead of "test/int"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Run unit tests for one package:
 lerna run unit --scope loopback
 ```
 
-Replace `unit` with `int` or `e2e` for integration/end-to-end tests accordingly.
+Replace `unit` with `integration` or `e2e` for integration/end-to-end tests accordingly.


### PR DESCRIPTION
Because "int" can stand for "international" and "internal" too.

cc @ritch @superkhau 