### PR TITLE
add basic Jenkinsfile to run CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+#! groovy
+
+def withNode(ver) {
+  return {
+    node('nvm') {
+      checkout scm
+      sh("""#!/bin/bash
+        export NVM_DIR=/home/jenkins/.nvm
+        . ~/.nvm/nvm.sh
+        nvm install ${ver}
+        npm install
+        npm run bootstrap
+        npm test
+      """)
+    }
+  }
+}
+
+def builds = [
+  node4: withNode(4),
+  node6: withNode(6),
+  node7: withNode(7),
+  failFast: false,
+]
+
+parallel builds


### PR DESCRIPTION
Here's a quick'n'dirty `Jenkinsfile` that will run this repo's tests on node v4, v6, and v7 in parallel. It's not very ideal since the parallel runs get their console output munged together in weird ways depending on how you view the build log, but it gets things going.

@bajtos I think this does what you want to at least MVP level.