### PR TITLE
Lint variable names again

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -56,7 +56,7 @@
       "method": "never",
       "constructor": "never"
     }],
-    "variable-name": [false, "ban-keywords", "check-format"],
+    "variable-name": [true, "allow-leading-underscore", "ban-keywords", "check-format"],
     "whitespace": [
       true,
       "check-branch",


### PR DESCRIPTION
Lint variable names again, enable "allow-leading-underscore".

See #48

@raymondfeng @ritch @superkhau
