### PR TITLE
Disable fast TS compilation in tests

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
---compilers ts:tsconfig-paths/register
+--compilers ts:ts-node/register,ts:tsconfig-paths/register
 --recursive
---require ../../test/ts-node

--- a/test/mocha.opts.root
+++ b/test/mocha.opts.root
@@ -1,3 +1,2 @@
---compilers ts:tsconfig-paths/register
+--compilers ts:ts-node/register,ts:tsconfig-paths/register
 --recursive
---require test/ts-node

--- a/test/ts-node.js
+++ b/test/ts-node.js
@@ -1,1 +1,0 @@
-require('ts-node').register({fast: true});


### PR DESCRIPTION
The fast mode disables type checking and therefore is prone to ignoring
type problems.

We should be running to our code in the same way as it will be run in
production, with full type checking enabled.

@raymondfeng @ritch @superkhau
