### PR TITLE
Add "app.controller()" sugar API

### DIFF
--- a/packages/example-codehub/src/server.ts
+++ b/packages/example-codehub/src/server.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
   const app = new Application();
   const server = new Server();
 
-  app.bind('controllers.users').to(UserController);
+  app.controller(UserController);
   app.bind('userId').to(42);
 
   // FIXME

--- a/packages/loopback/lib/application.ts
+++ b/packages/loopback/lib/application.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Binding} from './context/binding';
 import {Context} from './context';
 import * as http from 'http';
 import SwaggerRouter from './router/SwaggerRouter';
@@ -22,5 +23,23 @@ export class Application extends Context {
       const apiSpec = getApiSpec(ctor);
       router.controller(ctorFactory, apiSpec);
     });
+  }
+
+  /**
+   * Register a controller class with this application.
+   *
+   * @param controllerCtor {Function} The controller class (constructor function).
+   * @return {Binding} The newly created binding, you can use the reference to further
+   * modify the binding, e.g. lock the value to prevent further modifications.
+   *
+   * ```ts
+   * @spec(apiSpec)
+   * class MyController {
+   * }
+   * app.controller(MyController).lock();
+   * ```
+   */
+  public controller(controllerCtor: new(...args: any[]) => Object): Binding {
+    return this.bind('controllers.' + controllerCtor.name).to(controllerCtor);
   }
 }

--- a/packages/loopback/test/acceptance/routing/feature.md
+++ b/packages/loopback/test/acceptance/routing/feature.md
@@ -46,7 +46,7 @@ class MyController {
   }
 }
 
-app.bind('controllers.myController').to(MyController);
+app.controller(MyController);
 server.bind('applications.myApp').to(app);
 
 await server.start();

--- a/packages/loopback/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/loopback/test/acceptance/routing/routing.acceptance.ts
@@ -64,8 +64,8 @@ describe('Routing', () => {
     return new Application();
   }
 
-  function givenControllerInApp(app: Application, controller: Function) {
-    app.bind('controllers.' + controller.name).to(controller);
+  function givenControllerInApp(app: Application, controller: new(...args: any[]) => any) {
+    app.controller(controller);
   }
 
   function whenIMakeRequestTo(app: Application): Client {

--- a/packages/loopback/test/unit/application/application.controller.test.ts
+++ b/packages/loopback/test/unit/application/application.controller.test.ts
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from 'testlab';
+import {Application} from './../../../lib/application';
+
+describe('Application.controller()', () => {
+  it('binds the controller to "controllers.*" namespace', () => {
+    const app = new Application();
+
+    class TestController {
+    }
+
+    app.controller(TestController);
+
+    const boundControllers = app.find('controllers.*').map(b => b.key);
+    expect(boundControllers).to.contain('controllers.TestController');
+  });
+});


### PR DESCRIPTION
I have several objections against the current API `app.bind('controllers.foo').to(FooController)`:
 - it's too low level
 - there is no auto-completion hinting users how to register a controller
 - it's easy to make a typo in the binding key, e.g. `controller.foo`, which creates a difficult-to-debug situation
 - if we decided to use a different look-up mechanism for controllers, for example tags, then it would require changes everywhere

In this pull request, I am proposing a new API for registering controllers:

Usage:

```diff
-  app.bind('controllers.users').to(UserController);
+  app.controller(UserController);
```

Implementation:

```ts
class Application {
  // ...
  public controller(controllerCtor: new(...args: any[]) => Object): Binding {
    return this.bind('controllers.' + controllerCtor.name).to(controllerCtor);
  }
}
```

I have updated all acceptance files, code-hub example and all tests to use this new API.

@raymondfeng @ritch @superkhau thoughts?
