### PR TITLE
Enable TypeScript's "strictNullCheck" compiler opt

### DIFF
--- a/packages/loopback/lib/context/index.ts
+++ b/packages/loopback/lib/context/index.ts
@@ -13,10 +13,12 @@ export class Context {
 
   bind(key: string): Binding {
     const keyExists = this.registry.has(key);
-    const bindingIsLocked = this.registry.get(key) && this.registry.get(key).isLocked;
-
-    if (keyExists && bindingIsLocked)
-      throw new Error(`Cannot rebind key "${key}", associated binding is locked`);
+    if (keyExists) {
+      const existingBinding = this.registry.get(key);
+      const bindingIsLocked = existingBinding && existingBinding.isLocked;
+      if (bindingIsLocked)
+        throw new Error(`Cannot rebind key "${key}", associated binding is locked`);
+    }
 
     const binding = new Binding(key);
     this.registry.set(key, binding);
@@ -28,7 +30,7 @@ export class Context {
   }
 
   find(pattern: string): Binding[] {
-    let bindings = [];
+    let bindings: Binding[] = [];
     if (pattern) {
       // TODO(@superkhau): swap with production grade glob to regex lib
       const glob = new RegExp('^' + pattern.split('*').join('.*') + '$');
@@ -45,7 +47,7 @@ export class Context {
   }
 
   findByTag(pattern: string): Binding[] {
-    const bindings = [];
+    const bindings: Binding[] = [];
     // TODO(@superkhau): swap with production grade glob to regex lib
     const glob = new RegExp('^' + pattern.split('*').join('.*') + '$');
     this.registry.forEach(binding => {

--- a/packages/loopback/lib/router/SwaggerRouter.ts
+++ b/packages/loopback/lib/router/SwaggerRouter.ts
@@ -78,9 +78,11 @@ export class SwaggerRouter {
   private _handleRequest(request: Request, response: Response, next: HandlerCallback): void {
     // TODO(bajtos) The following parsing can be skipped when the router
     // is mounted on an express app
-    const parsedUrl = url.parse(request.url, true);
+    // "as string" is a workaround for buggy .d.ts definition
+    const parsedUrl = url.parse(request.url as string, true);
     const parsedRequest = request as ParsedRequest;
-    parsedRequest.path = parsedUrl.pathname;
+    // "as string" is a workaround for buggy .d.ts definition
+    parsedRequest.path = parsedUrl.pathname as string;
     parsedRequest.query = parsedUrl.query;
 
     debug('Handle request "%s %s"', request.method, parsedRequest.path);
@@ -140,7 +142,8 @@ class Endpoint {
 
   public handle(request: ParsedRequest, response: Response, next: HandlerCallback) {
     debug('trying endpoint', this);
-    if (this._verb !== request.method.toLocaleLowerCase()) {
+    // "as string" is a workaround for buggy .d.ts definition
+    if (this._verb !== (request.method as string).toLowerCase()) {
       debug(' -> next (verb mismatch)');
       next();
       return;
@@ -191,7 +194,7 @@ class Endpoint {
 
 function buildOperationArguments(operationSpec: OperationObject, request: ParsedRequest,
     pathParams: {[key: string]: any}): any[] {
-  const args = [];
+  const args: String[] = [];
   for (const paramSpec of operationSpec.parameters || []) {
     if ('$ref' in paramSpec) {
       // TODO(bajtos) implement $ref parameters

--- a/packages/loopback/lib/server.ts
+++ b/packages/loopback/lib/server.ts
@@ -24,12 +24,11 @@ export enum ServerState {
 }
 
 export class Server extends Context {
+  public config: ServerConfig;
   // get runtime to enforce AppConfig as AppConfig
-  constructor(public config?: ServerConfig) {
+  constructor(config?: ServerConfig) {
     super();
-    if (config === undefined) {
-      this.config = {port: 3000};
-    }
+    this.config = config || {port: 3000};
   }
 
   public state: ServerState = ServerState.cold;

--- a/packages/loopback/test/support/client.ts
+++ b/packages/loopback/test/support/client.ts
@@ -25,7 +25,8 @@ export class Client {
 
     const response = await this._request(options);
     return {
-      status: response.statusCode,
+      // "as number" is a workaround for buggy .d.ts definition
+      status: response.statusCode as number,
       body: response.body,
     };
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": ["es6", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "strictNullChecks": true,
     "target": "es5"
   },
   "include": [


### PR DESCRIPTION
Enable strict null check to allow the compiler to tell us at compile-time about places where we may be accessing a possibly undefined value.

Further reading: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#null--and-undefined-aware-types and https://ariya.io/2016/10/typescript-2-and-strict-null-checking


cc @bajtos @raymondfeng @ritch @superkhau
