### PR TITLE
Inject constructor args

### DIFF
--- a/packages/context/index.ts
+++ b/packages/context/index.ts
@@ -4,5 +4,5 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export {Binding} from './src/binding';
-export {Context} from './src/context';
+export {Context, Constructor} from './src/context';
 export {inject} from './src/inject';

--- a/packages/context/index.ts
+++ b/packages/context/index.ts
@@ -5,3 +5,4 @@
 
 export {Binding} from './src/binding';
 export {Context} from './src/context';
+export {inject} from './src/inject';

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -3,6 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Context, Constructor} from './context';
+
 // tslint:disable-next-line:no-any
 export type BoundValue = any;
 
@@ -12,7 +14,7 @@ export class Binding {
   public getValue: () => BoundValue = () => { throw new Error(`No value was configured for binding ${this._key}.`); };
   private _tagName: string;
 
-  constructor(private readonly _key: string, public isLocked: boolean = false) {}
+  constructor(private readonly _context: Context, private readonly _key: string, public isLocked: boolean = false) {}
   get key() { return this._key; }
   get tagName() { return this._tagName; }
 
@@ -32,6 +34,11 @@ export class Binding {
 
   toDynamicValue(factoryFn: () => BoundValue): this {
     this.getValue = factoryFn;
+    return this;
+  }
+
+  toClass<T>(ctor: Constructor<T>): this {
+    this.getValue = () => this._context.createClassInstance(ctor);
     return this;
   }
 

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 // tslint:disable-next-line:no-any
-type BoundValue = any;
+export type BoundValue = any;
 
 export class Binding {
   // FIXME(bajtos) The binding class should be parameterized by the value type stored

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -14,6 +14,9 @@ export class Binding {
   public getValue: () => BoundValue = () => { throw new Error(`No value was configured for binding ${this._key}.`); };
   private _tagName: string;
 
+  // For bindings bound via toClass, this property contains the constructor function
+  public valueConstructor: Constructor<BoundValue>;
+
   constructor(private readonly _context: Context, private readonly _key: string, public isLocked: boolean = false) {}
   get key() { return this._key; }
   get tagName() { return this._tagName; }
@@ -39,6 +42,7 @@ export class Binding {
 
   toClass<T>(ctor: Constructor<T>): this {
     this.getValue = () => this._context.createClassInstance(ctor);
+    this.valueConstructor = ctor;
     return this;
   }
 

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -36,11 +36,20 @@ export class Context {
 
   private _resolveInjectedArguments(fn: Function): BoundValue[] {
     const args: BoundValue[] = [];
+    // NOTE: the array may be sparse, i.e.
+    //   Object.keys(injectedArgs).length !== injectedArgs.length
+    // Example value:
+    //   [ , 'key1', , 'key2']
     const injectedArgs = describeInjectedArguments(fn);
-    // TODO(bajtos) Verify that all fn arguments were decorated with @inject
-    // i.e. compare fn.length vs. injectedArgs.length
-    for (const bindingKey of injectedArgs) {
-      // TODO(bajtos) Handle the case where key is undefined
+
+    for (let ix = 0; ix < fn.length; ix++) {
+      const bindingKey = injectedArgs[ix];
+      if (!bindingKey) {
+        throw new Error(
+          `Cannot resolve injected arguments for function ${fn.name}: ` +
+          `The argument ${ix+1} was not decorated for dependency injection.`);
+      }
+
       args.push(this.get(bindingKey));
     }
     return args;

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -39,6 +39,6 @@ export function inject(bindingKey: string) {
   };
 }
 
-export function describeInjectedArguments(target: Function) {
-  return Reflect.getOwnMetadata(REFLECTION_KEY, target);
+export function describeInjectedArguments(target: Function): string[] {
+  return Reflect.getOwnMetadata(REFLECTION_KEY, target) || [];
 }

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as assert from 'assert';
+import 'reflect-metadata';
+
+const REFLECTION_KEY = 'loopback.inject';
+
+/**
+ * A decorator to annotate method arguments for automatic injection
+ * by LoopBack IoC container.
+ *
+ * Usage - Typescript:
+ *
+ * ```ts
+ * class InfoController {
+ *   constructor(@inject('application.name') public appName: string) {
+ *   }
+ *   // ...
+ * }
+ * ```
+ *
+ * Usage - JavaScript:
+ *
+ *  - TODO(bajtos)
+ *
+ * @param bindingKey What binding to use in order to resolve the value
+ * of the annotated argument.
+ */
+export function inject(bindingKey: string) {
+  return function markArgumentAsInjected(target: Object, propertyKey: string | symbol, parameterIndex: number) {
+    assert(parameterIndex != undefined, '@inject decorator can be used on function arguments only!');
+
+    const injectedArgs: string[] = Reflect.getOwnMetadata(REFLECTION_KEY, target, propertyKey) || [];
+    injectedArgs[parameterIndex] = bindingKey;
+    Reflect.defineMetadata(REFLECTION_KEY, injectedArgs, target, propertyKey);
+  };
+}
+
+export function describeInjectedArguments(target: Function) {
+  return Reflect.getOwnMetadata(REFLECTION_KEY, target);
+}

--- a/packages/context/test/acceptance/class-level-bindings.feature.md
+++ b/packages/context/test/acceptance/class-level-bindings.feature.md
@@ -1,0 +1,33 @@
+# Feature: Context bindings - injecting dependencies of classes
+
+- In order to manage my dependencies
+- As a developer
+- I want to setup bindings for my classes
+- So that class dependencies are injected by the IoC framework
+
+## Scenario: Inject constructor arguments
+
+ - Given a context
+ - Given class `InfoController` with a constructor
+    accepting a single argument `appName: string`
+ - Given `InfoController` ctor argument is decorated
+     with `@inject('application.name')`
+ - Given a static binding named `application.name` with value `CodeHub`
+ - Given a class binding named `controllers.info` bound to class `InfoController`
+ - When I resolve the binding for `controllers.info`
+ - Then I get a new instance of `InfoController`
+ - And the instance was created with `appName` set to `CodeHub`
+
+ ```ts
+ const cxt = new Context();
+ ctx.bind('application.name').to('CodeHub');
+
+ class InfoController {
+   constructor(@inject('application.name') public appName: string) {
+   }
+ }
+ ctx.bindClass('controllers.info', InfoController);
+
+ const instance = ctx.get('controllers.info');
+ instance.appName; // => CodeHub
+ ```

--- a/packages/context/test/acceptance/class-level-bindings.feature.md
+++ b/packages/context/test/acceptance/class-level-bindings.feature.md
@@ -19,7 +19,7 @@
  - And the instance was created with `appName` set to `CodeHub`
 
  ```ts
- const cxt = new Context();
+ const ctx = new Context();
  ctx.bind('application.name').to('CodeHub');
 
  class InfoController {

--- a/packages/context/test/acceptance/class-level-bindings.feature.md
+++ b/packages/context/test/acceptance/class-level-bindings.feature.md
@@ -26,7 +26,7 @@
    constructor(@inject('application.name') public appName: string) {
    }
  }
- ctx.bindClass('controllers.info', InfoController);
+ ctx.bind('controllers.info').toClass(InfoController);
 
  const instance = ctx.get('controllers.info');
  instance.appName; // => CodeHub

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -17,7 +17,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       constructor(@inject('application.name') public appName: string) {
       }
     }
-    ctx.bindClass('controllers.info', InfoController);
+    ctx.bind('controllers.info').toClass(InfoController);
 
     const instance = ctx.get('controllers.info');
     expect(instance).to.have.property('appName', 'CodeHub');

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -1,0 +1,29 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from 'testlab';
+import {Context, inject} from '../..';
+
+describe('Context bindings - Injecting dependencies of classes', () => {
+  let ctx: Context;
+  before('given a context', createContext);
+
+  it('injects constructor args', () => {
+    ctx.bind('application.name').to('CodeHub');
+
+    class InfoController {
+      constructor(@inject('application.name') public appName: string) {
+      }
+    }
+    ctx.bindClass('controllers.info', InfoController);
+
+    const instance = ctx.get('controllers.info');
+    expect(instance).to.have.property('appName', 'CodeHub');
+  });
+
+  function createContext() {
+    ctx = new Context();
+  }
+});

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -6,6 +6,8 @@
 import {expect} from 'testlab';
 import {Context, inject} from '../..';
 
+const INFO_CONTROLLER = 'controllers.info';
+
 describe('Context bindings - Injecting dependencies of classes', () => {
   let ctx: Context;
   before('given a context', createContext);
@@ -17,10 +19,36 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       constructor(@inject('application.name') public appName: string) {
       }
     }
-    ctx.bind('controllers.info').toClass(InfoController);
+    ctx.bind(INFO_CONTROLLER).toClass(InfoController);
 
-    const instance = ctx.get('controllers.info');
+    const instance = ctx.get(INFO_CONTROLLER);
     expect(instance).to.have.property('appName', 'CodeHub');
+  });
+
+  it('throws helpful error when no ctor args are decorated', () => {
+    class InfoController {
+      constructor(appName: string) {
+      }
+    }
+    ctx.bind(INFO_CONTROLLER).toClass(InfoController);
+
+    expect.throws(
+      () => ctx.get(INFO_CONTROLLER),
+      /resolve.*InfoController.*argument 1/);
+  });
+
+  it('throws helpful error when some ctor args are not decorated', () => {
+    ctx.bind('application.name').to('CodeHub');
+
+    class InfoController {
+      constructor(argNotInjected: string, @inject('application.name') appName: string) {
+      }
+    }
+    ctx.bind(INFO_CONTROLLER).toClass(InfoController);
+
+    expect.throws(
+      () => ctx.get(INFO_CONTROLLER),
+      /resolve.*InfoController.*argument 1/);
   });
 
   function createContext() {

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -4,12 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from 'testlab';
-import {Binding} from '../..';
+import {Binding, Context} from '../..';
 
 const key = 'foo';
-const binding = new Binding(key);
 
 describe('Binding', () => {
+  let binding: Binding;
+  beforeEach(givenBinding);
+
   describe('constructor', () => {
     it('sets the given key', () => {
       const result = binding.key;
@@ -27,4 +29,9 @@ describe('Binding', () => {
       expect(binding.isLocked).to.be.true();
     });
   });
+
+  function givenBinding() {
+    const ctx = new Context();
+    binding = new Binding(ctx, key);
+  }
 });

--- a/packages/context/test/unit/inject.test.ts
+++ b/packages/context/test/unit/inject.test.ts
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from 'testlab';
+import {inject, describeInjectedArguments} from '../../src/inject';
+
+describe('function argument injection', () => {
+  it('can decorate class constructor arguments', () => {
+    class TestClass {
+      constructor(@inject('foo') foo: string) {
+      }
+    }
+    // the test passes when TypeScript Compiler is happy
+  });
+
+  it('can retrieve information about injected constructor arguments', () => {
+    class TestClass {
+      constructor(@inject('foo') foo: string) {
+      }
+    }
+
+    const meta = describeInjectedArguments(TestClass);
+    expect(meta).to.deepEqual(['foo']);
+  });
+});

--- a/packages/context/test/unit/inject.test.ts
+++ b/packages/context/test/unit/inject.test.ts
@@ -24,4 +24,14 @@ describe('function argument injection', () => {
     const meta = describeInjectedArguments(TestClass);
     expect(meta).to.deepEqual(['foo']);
   });
+
+  it('returns an empty array when no ctor arguments are decorated', () => {
+    class TestClass {
+      constructor(foo: string) {
+      }
+    }
+
+    const meta = describeInjectedArguments(TestClass);
+    expect(meta).to.deepEqual([]);
+  });
 });

--- a/packages/example-codehub/src/CodeHubApplication.ts
+++ b/packages/example-codehub/src/CodeHubApplication.ts
@@ -16,6 +16,8 @@ export class CodeHubApplication extends Application {
 
     app.bind('userId').to(42);
 
+    app.bind('app.info').toDynamicValue(() => this.info());
+
     app.bind('servers.http.enabled').to(true);
     app.bind('servers.http.port').to(3000);
     app.bind('servers.https.enabled').to(true);

--- a/packages/loopback/index.ts
+++ b/packages/loopback/index.ts
@@ -19,8 +19,6 @@ export {
 
 export * from '@loopback/openapi-spec';
 
-export function inject(name: string) {
-  return function(target, propoertyNAme, index) {
-    // TODO(bajtos, superkhau)
-  };
-}
+export {
+  inject
+} from '@loopback/context';


### PR DESCRIPTION
 - Add a new Binding method `toClass(ctor)` to define a value that should be resolved by calling the constructor with arguments resolved using `@inject` annotation
 - Integrate this new API with Application and Controller concept

Connect to #142 
Requires #175 to be resolved first.

cc @bajtos @raymondfeng @ritch @superkhau