### PR TITLE
Move OpenApiSpec to a standalone npm package

### DIFF
--- a/packages/loopback/index.ts
+++ b/packages/loopback/index.ts
@@ -17,7 +17,7 @@ export {
   api,
 } from './lib/router/metadata'
 
-export * from './lib/router/OpenApiSpec';
+export * from '@loopback/openapi-spec';
 
 export function inject(name: string) {
   return function(target, propoertyNAme, index) {

--- a/packages/loopback/lib/router/SwaggerRouter.ts
+++ b/packages/loopback/lib/router/SwaggerRouter.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {ServerRequest as Request, ServerResponse as Response} from 'http';
-import {OpenApiSpec, OperationObject, ParameterObject} from './OpenApiSpec';
+import {OpenApiSpec, OperationObject, ParameterObject} from '@loopback/openapi-spec';
 import * as assert from 'assert';
 import * as jsonBody from 'body/json';
 import * as url from 'url';

--- a/packages/loopback/lib/router/metadata.ts
+++ b/packages/loopback/lib/router/metadata.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import 'reflect-metadata';
 
-import {OpenApiSpec} from './OpenApiSpec';
+import {OpenApiSpec} from '@loopback/openapi-spec';
 
 /**
  * Decorate the given Controller constructor with metadata describing

--- a/packages/loopback/package.json
+++ b/packages/loopback/package.json
@@ -15,6 +15,7 @@
     "@loopback/ioc": "^4.0.0-alpha.1",
     "@loopback/juggler": "^4.0.0-alpha.1",
     "@loopback/remoting": "^4.0.0-alpha.1",
+    "@loopback/openapi-spec": "^4.0.0-alpha.1",
     "body": "^5.1.0",
     "debug": "^2.6.0",
     "path-to-regexp": "^1.7.0"

--- a/packages/loopback/test/integration/router/SwaggerRouter.integration.ts
+++ b/packages/loopback/test/integration/router/SwaggerRouter.integration.ts
@@ -10,7 +10,7 @@ import { FullRequestResponse } from './../../support/FullRequestResponse';
 import * as bluebird from 'bluebird';
 import {expect} from 'testlab';
 import {listen} from '../../support/util';
-import {OpenApiSpec, ParameterObject} from '../../../lib/router/OpenApiSpec';
+import {OpenApiSpec, ParameterObject} from '@loopback/openapi-spec';
 import {givenOpenApiSpec} from '../../support/OpenApiSpecBuilder';
 
 describe('SwaggerRouter', () => {

--- a/packages/loopback/test/support/OpenApiSpecBuilder.ts
+++ b/packages/loopback/test/support/OpenApiSpecBuilder.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {OpenApiSpec, OperationObject} from './../../lib/router/OpenApiSpec';
+import {OpenApiSpec, OperationObject} from '@loopback/openapi-spec';
 
 export function givenOpenApiSpec(basePath?: string) {
   return new OpenApiSpecBuilder(basePath);

--- a/packages/openapi-spec/LICENSE
+++ b/packages/openapi-spec/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) IBM Corp. 2013,2017. All Rights Reserved.
+Node module: @loopback/openapi-spec
+This project is licensed under the MIT License, full text below.
+
+--------
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/openapi-spec/README.md
+++ b/packages/openapi-spec/README.md
@@ -1,0 +1,42 @@
+# @loopback/openapi-spec
+
+TypeScript type definitions for OpenAPI Spec/Swagger documents.
+
+## Overview
+
+TypeScript definitions describing the schema of OpenAPI/Swagger documents,
+including LoopBack-specific extensions.
+
+## Installation
+
+```
+$ npm install --save @loopback/openapi-spec
+```
+
+## Basic use
+
+Use `OpenApiSpec` type in your function accepting a Swagger/OpenAPI document:
+
+```ts
+import {OpenApiSpec} from '@loopback/openapi-spec';
+
+export function validateSpec(spec: OpenApiSpec) {
+  // ...
+}
+```
+
+IDEs like Visual Studio Code will offer auto-completion for spec properties
+when constructing a spec argument value.
+
+## Related resources
+
+See https://www.openapis.org/ and [version 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md)
+of OpenAPI Specification.
+
+## Contributions
+
+IBM/StrongLoop is an active supporter of open source and welcomes contributions to our projects as well as those of the Node.js community in general. For more information on how to contribute please refer to the [Contribution Guide](https://loopback.io/doc/en/contrib/index.html).
+
+## License
+
+MIT

--- a/packages/openapi-spec/index.ts
+++ b/packages/openapi-spec/index.ts
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/openapi-spec
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './src/OpenApiSpec-v2';

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@loopback/openapi-spec",
+  "version": "4.0.0-alpha.1",
+  "description": "TypeScript type definitions for OpenAPI Spec/Swagger documents.",
+  "author": "IBM",
+  "license": "MIT",
+  "keywords": [
+    "Swagger",
+    "OpenAPI Spec",
+    "TypeScript",
+    "Typings"
+  ]
+}

--- a/packages/openapi-spec/src/OpenApiSpec-v2.ts
+++ b/packages/openapi-spec/src/OpenApiSpec-v2.ts
@@ -1,19 +1,16 @@
 // Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: loopback
+// Node module: @loopback/openapi-spec
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
 /*
  * OpenApiSpec - A typescript representation of OpenApi/Swagger Spec 2.0
- *
- * TODO(bajtos) I think this code should be released as a standalone npm package,
- * possibly contributed either to definitely-typed or to OpenAPI project.
  */
 
 // NOTE(bajtos) Custom extensions can use arbitrary type as the value,
 // e.g. a string, an object or an array
 // tslint:disable-next-line:no-any
-export type ExtensionValue = any;
+type ExtensionValue = any;
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object
 export interface OpenApiSpec {


### PR DESCRIPTION
Connect to #135

Next steps (I'll create a follow-up issues): 
 - add basic tests to verify that example Swagger documents can be compiled against this type definition
 - support the upcoming 3.0 flavour of OpenAPI Spec

cc @bajtos @raymondfeng @ritch @superkhau
