### PR TITLE
Clean up types in binding.ts

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -3,13 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+// tslint:disable-next-line:no-any
+type BoundValue = any;
+
 export class Binding {
   // FIXME(bajtos) The binding class should be parameterized by the value type stored
-  // tslint:disable:no-any
-  public value: any;
-  public getValue: () => any = () => { throw new Error(`No value was configured for binding {this._key}.`); };
+  public value: BoundValue;
+  public getValue: () => BoundValue = () => { throw new Error(`No value was configured for binding ${this._key}.`); };
   private _tagName: string;
-  // tslint:enable:no-any
 
   constructor(private readonly _key: string, public isLocked: boolean = false) {}
   get key() { return this._key; }
@@ -24,14 +25,12 @@ export class Binding {
     return this;
   }
 
-  // tslint:disable-next-line:no-any
-  to(value: any): this {
+  to(value: BoundValue): this {
     this.getValue = () => value;
     return this;
   }
 
-  // tslint:disable-next-line:no-any
-  toDynamicValue(factoryFn: () => any): this {
+  toDynamicValue(factoryFn: () => BoundValue): this {
     this.getValue = factoryFn;
     return this;
   }


### PR DESCRIPTION
Alias "any" as "BoundValue" so that we can keep the tslint exception allowing "any" type in a single place.

This commit was extracted from #176 to get it landed sooner.

Connect to #142

cc @bajtos @raymondfeng @ritch @superkhau
