### PR TITLE
Add per-request child context

### DIFF
--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -60,7 +60,7 @@ export function resolveInjectedArguments(fn: Function, ctx: Context): BoundValue
     }
 
     const binding = ctx.getBinding(bindingKey);
-    const valueOrPromise = binding.getValue();
+    const valueOrPromise = binding.getValue(ctx);
     if (isPromise(valueOrPromise)) {
       if (!asyncResolvers) asyncResolvers = [];
       asyncResolvers.push(valueOrPromise.then((v: BoundValue) => args[ix] = v));

--- a/packages/context/test/acceptance/child-context.ts
+++ b/packages/context/test/acceptance/child-context.ts
@@ -1,0 +1,48 @@
+
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Context} from '../..';
+
+describe('Context bindings - contexts inheritance', () => {
+  let parentCtx: Context;
+  let childCtx: Context;
+
+  beforeEach('given a parent and a child context', createParentAndChildContext);
+
+  it('child inherits values bound in parent', () => {
+    parentCtx.bind('foo').to('bar');
+    expect(childCtx.getSync('foo')).to.equal('bar');
+  });
+
+  it('child changes are not propagated to parent', () => {
+    childCtx.bind('foo').to('bar');
+    expect(() => parentCtx.getSync('foo')).to.throw(/not bound/);
+  });
+
+  it('includes parent bindings when searching via find()', () => {
+    parentCtx.bind('foo').to('parent:foo');
+    parentCtx.bind('bar').to('parent:bar');
+    childCtx.bind('foo').to('child:foo');
+
+    const found = childCtx.find().map(b => b.getValue(childCtx));
+    expect(found).to.deepEqual(['child:foo', 'parent:bar']);
+  });
+
+  it('includes parent bindings when searching via findByTag()', () => {
+    parentCtx.bind('foo').to('parent:foo').tag('a-tag');
+    parentCtx.bind('bar').to('parent:bar').tag('a-tag');
+    childCtx.bind('foo').to('child:foo').tag('a-tag');
+
+    const found = childCtx.findByTag('a-tag').map(b => b.getValue(childCtx));
+    expect(found).to.deepEqual(['child:foo', 'parent:bar']);
+  });
+
+  function createParentAndChildContext() {
+    parentCtx = new Context();
+    childCtx = new Context(parentCtx);
+  }
+});

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -77,7 +77,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     }
     const b = ctx.bind(INFO_CONTROLLER).toClass(InfoController);
 
-    const valueOrPromise = b.getValue();
+    const valueOrPromise = b.getValue(ctx);
     expect(valueOrPromise).to.not.be.Promise();
     expect(valueOrPromise as InfoController).to.have.property('appName', 'CodeHub');
   });

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -9,6 +9,7 @@ import {Binding, Context} from '../..';
 const key = 'foo';
 
 describe('Binding', () => {
+  let ctx: Context;
   let binding: Binding;
   beforeEach(givenBinding);
 
@@ -33,12 +34,12 @@ describe('Binding', () => {
   describe('to(value)', () => {
     it('returns the value synchronously', () => {
       binding.to('value');
-      expect(binding.getValue()).to.equal('value');
+      expect(binding.getValue(ctx)).to.equal('value');
     });
   });
 
   function givenBinding() {
-    const ctx = new Context();
-    binding = new Binding(ctx, key);
+    ctx = new Context();
+    binding = new Binding(key);
   }
 });

--- a/packages/loopback/index.ts
+++ b/packages/loopback/index.ts
@@ -22,3 +22,8 @@ export * from '@loopback/openapi-spec';
 export {
   inject,
 } from '@loopback/context';
+
+export {
+  ServerRequest,
+  ServerResponse,
+} from 'http';

--- a/packages/loopback/lib/application.ts
+++ b/packages/loopback/lib/application.ts
@@ -20,8 +20,9 @@ export class Application extends Context {
       }
 
       const ctorFactory = (req: http.ServerRequest, res: http.ServerResponse) => {
-        // TODO(bajtos) Create a new nested/child per-request Context
-        const requestContext = this;
+        const requestContext = new Context(this);
+        requestContext.bind('http.request').to(req);
+        requestContext.bind('http.response').to(res);
         return requestContext.get(b.key);
       };
       const apiSpec = getApiSpec(ctor);

--- a/packages/loopback/lib/server.ts
+++ b/packages/loopback/lib/server.ts
@@ -44,7 +44,7 @@ export class Server extends Context {
     const apps = this.find('applications.*');
     for (const appBinding of apps) {
       debug('Registering app controllers for %j', appBinding.key);
-      const app = await appBinding.getValue() as Application;
+      const app = await Promise.resolve(appBinding.getValue(this)) as Application;
       app.mountControllers(router);
     }
 

--- a/packages/loopback/test/support/client.ts
+++ b/packages/loopback/test/support/client.ts
@@ -15,11 +15,20 @@ export class Client {
   }
 
   public async get(path : string) : Promise<Client.Result> {
+    return this.request('get', path);
+  }
+
+  public async put(path: string): Promise<Client.Result> {
+    return this.request('put', path);
+  }
+
+  public async request(verb: string, path: string): Promise<Client.Result> {
     await this._ensureAppIsListening();
 
     const url = 'http://localhost:' + this.app.config.port + path;
     const options = {
       uri: url,
+      method: verb,
       resolveWithFullResponse: true,
     };
 


### PR DESCRIPTION
Create a new child context for each request handled by the app. Add the following two bindings to this new context:

 - `http.request`
 - `http.response`

This is a pre-requisite for #186 which I am implementing as part of the time allocated in https://github.com/strongloop-internal/scrum-asteroid/issues/117.

cc @bajtos @raymondfeng @ritch @superkhau
