### PR TITLE
Add support for mixed sync/async bindings

### DIFF
--- a/packages/authentication/test/acceptance/authentication/feature.md
+++ b/packages/authentication/test/acceptance/authentication/feature.md
@@ -58,10 +58,10 @@ const USERS = {
 };
 
 // my get user function
-app.bind('authentication.user').to(() => {
+app.bind('authentication.user').to(async () => {
   const ctx = this;
-  const username = ctx.get('authentication.credentials.username');
-  const password = ctx.get('authentication.credentials.password');
+  const username = await ctx.get('authentication.credentials.username');
+  const password = await ctx.get('authentication.credentials.password');
   const user = USERS[username];
   if (!user) return null;
   if (!verifyPassword(user.password, password)) return null;

--- a/packages/context/index.ts
+++ b/packages/context/index.ts
@@ -4,5 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export {Binding, BoundValue} from './src/binding';
-export {Context, Constructor} from './src/context';
+export {Context} from './src/context';
+export {Constructor} from './src/resolver';
 export {inject} from './src/inject';
+export const isPromise = require('is-promise');

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -16,6 +16,8 @@
   },
   "devDependencies": {
     "@loopback/testlab": "^4.0.0-alpha.1",
+    "@types/bluebird": "^3.5.2",
+    "bluebird": "^3.5.0",
     "mocha": "^3.2.0"
   },
   "keywords": [

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -3,15 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, Constructor} from './context';
+import {Context} from './context';
+import {Constructor, createClassInstance} from './resolver';
 
 // tslint:disable-next-line:no-any
 export type BoundValue = any;
 
+// FIXME(bajtos) The binding class should be parameterized by the value type stored
 export class Binding {
-  // FIXME(bajtos) The binding class should be parameterized by the value type stored
-  public value: BoundValue;
-  public getValue: () => BoundValue = () => { throw new Error(`No value was configured for binding ${this._key}.`); };
   private _tagName: string;
 
   // For bindings bound via toClass, this property contains the constructor function
@@ -20,6 +19,30 @@ export class Binding {
   constructor(private readonly _context: Context, private readonly _key: string, public isLocked: boolean = false) {}
   get key() { return this._key; }
   get tagName() { return this._tagName; }
+
+  /**
+   * This is an internal function optimized for performance.
+   * Users should use `@inject(key)` or `ctx.get(key)` instead.
+   *
+   * Get the value bound to this key. Depending on `isSync`, this function returns either:
+   *  - the bound value
+   *  - a promise of the bound value
+   *
+   * Consumers wishing to consume sync values directly should use `isPromise`
+   * to check the type of the returned value to decide how to handle it.
+   *
+   * ```
+   * const result = binding.getValue();
+   * if (isPromise(result)) {
+   *   result.then(doSomething)
+   * } else {
+   *   doSomething(result);
+   * }
+   * ```
+   */
+  getValue(): BoundValue | Promise<BoundValue> {
+    return Promise.reject(new Error(`No value was configured for binding ${this._key}.`));
+  }
 
   lock() {
     this.isLocked = true;
@@ -30,18 +53,54 @@ export class Binding {
     return this;
   }
 
+  /**
+   * Bind the key to a constant value.
+   *
+   * @param value The bound value.
+   *
+   * @example
+   *
+   * ```ts
+   * ctx.bind('appName').to('CodeHub');
+   * ```
+   */
   to(value: BoundValue): this {
     this.getValue = () => value;
     return this;
   }
 
-  toDynamicValue(factoryFn: () => BoundValue): this {
+  /**
+   * Bind the key to a computed (dynamic) value.
+   *
+   * @param factoryFn The factory function creating the value.
+   *   Both sync and async functions are supported.
+   *
+   * @example
+   *
+   * ```ts
+   * // synchronous
+   * ctx.bind('now').toDynamicValue(() => Date.now());
+   *
+   * // asynchronous
+   * ctx.bind('something').toDynamicValue(
+   *  async () => Promise.delay(10).then(doSomething)
+   * );
+   * ```
+   */
+  toDynamicValue(factoryFn: () => BoundValue | Promise<BoundValue>): this {
     this.getValue = factoryFn;
     return this;
   }
 
+  /**
+   * Bind the key to an instance of the given class.
+   *
+   * @param ctor The class constructor to call. Any constructor
+   *   arguments must be annotated with `@inject` so that
+   *   we can resolve them from the context.
+   */
   toClass<T>(ctor: Constructor<T>): this {
-    this.getValue = () => this._context.createClassInstance(ctor);
+    this.getValue = () => createClassInstance(ctor, this._context);
     this.valueConstructor = ctor;
     return this;
   }

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from './context';
-import {Constructor, createClassInstance} from './resolver';
+import {Constructor, instantiateClass} from './resolver';
 
 // tslint:disable-next-line:no-any
 export type BoundValue = any;
@@ -100,7 +100,7 @@ export class Binding {
    *   we can resolve them from the context.
    */
   toClass<T>(ctor: Constructor<T>): this {
-    this.getValue = () => createClassInstance(ctor, this._context);
+    this.getValue = () => instantiateClass(ctor, this._context);
     this.valueConstructor = ctor;
     return this;
   }

--- a/packages/context/src/isPromise.ts
+++ b/packages/context/src/isPromise.ts
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  if (!value)
+    return false;
+  if (typeof value !== 'object' && typeof value !== 'function')
+    return false;
+  return typeof (value as Promise<T>).then === 'function';
+}

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -21,7 +21,7 @@ export type Constructor<T> = new(...args: any[]) => T;
  * @param ctor The class constructor to call.
  * @param ctx The context containing values for `@inject` resolution
  */
-export function createClassInstance<T>(ctor: Constructor<T>, ctx: Context): T | Promise<T> {
+export function instantiateClass<T>(ctor: Constructor<T>, ctx: Context): T | Promise<T> {
   const argsOrPromise = resolveInjectedArguments(ctor, ctx);
   if (isPromise(argsOrPromise)) {
     return argsOrPromise.then(args => new ctor(...args));

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import { Context } from './context';
+import { Binding, BoundValue } from './binding';
+import { isPromise } from './isPromise';
+import { describeInjectedArguments } from './inject';
+
+// tslint:disable-next-line:no-any
+export type Constructor<T> = new(...args: any[]) => T;
+
+/**
+ * Create an instance of a class which constructor has arguments
+ * decorated with `@inject`.
+ *
+ * The function returns a class when all dependencies were
+ * resolved synchronously, or a Promise otherwise.
+ *
+ * @param ctor The class constructor to call.
+ * @param ctx The context containing values for `@inject` resolution
+ */
+export function createClassInstance<T>(ctor: Constructor<T>, ctx: Context): T | Promise<T> {
+  const argsOrPromise = resolveInjectedArguments(ctor, ctx);
+  if (isPromise(argsOrPromise)) {
+    return argsOrPromise.then(args => new ctor(...args));
+  } else {
+    return new ctor(...argsOrPromise);
+  }
+}
+
+/**
+ * Given a function with arguments decorated with `@inject`,
+ * return the list of arguments resolved using the values
+ * bound in `ctx`.
+
+ * The function returns an argument array when all dependencies were
+ * resolved synchronously, or a Promise otherwise.
+ *
+ * @param fn The function for which the arguments should be resolved.
+ * @param ctx The context containing values for `@inject` resolution
+ */
+export function resolveInjectedArguments(fn: Function, ctx: Context): BoundValue[] | Promise<BoundValue[]> {
+  // NOTE: the array may be sparse, i.e.
+  //   Object.keys(injectedArgs).length !== injectedArgs.length
+  // Example value:
+  //   [ , 'key1', , 'key2']
+  const injectedArgs = describeInjectedArguments(fn);
+
+  const args: BoundValue[] = new Array(fn.length);
+  let asyncResolvers: Promise<void>[] | undefined = undefined;
+
+  for (let ix = 0; ix < fn.length; ix++) {
+    const bindingKey = injectedArgs[ix];
+    if (!bindingKey) {
+      throw new Error(
+        `Cannot resolve injected arguments for function ${fn.name}: ` +
+        `The argument ${ix + 1} was not decorated for dependency injection.`);
+    }
+
+    const binding = ctx.getBinding(bindingKey);
+    const valueOrPromise = binding.getValue();
+    if (isPromise(valueOrPromise)) {
+      if (!asyncResolvers) asyncResolvers = [];
+      asyncResolvers.push(valueOrPromise.then((v: BoundValue) => args[ix] = v));
+    } else {
+      args[ix] = valueOrPromise as BoundValue;
+    }
+  }
+
+  if (asyncResolvers) {
+    return Promise.all(asyncResolvers).then(() => args);
+  } else {
+    return args;
+  }
+}

--- a/packages/context/test/acceptance/_feature.md
+++ b/packages/context/test/acceptance/_feature.md
@@ -26,8 +26,8 @@ child.get('foo'); // => 'bar'
 let ctx = new Context();
 ctx.bind(':name').to('hello world')
 
-ctx.get('foo'); // => hello world
-ctx.get('bat'); // => hello world
+await ctx.get('foo'); // => hello world
+await ctx.get('bat'); // => hello world
 ```
 
 ## Scenario: Simple Dynamic Paramaterized Binding
@@ -47,8 +47,8 @@ ctx.bind(':name').to((name) => {
   return data[name];
 });
 
-ctx.get('foo'); // => bar
-ctx.get('bat'); // => baz
+await ctx.get('foo'); // => bar
+await ctx.get('bat'); // => baz
 ```
 
 ## Scenario: Namespaced Paramaterized Binding
@@ -61,6 +61,6 @@ ctx.get('bat'); // => baz
 let ctx = new Context();
 ctx.bind('foo.:name').to('hello world');
 
-ctx.get('foo.bar'); // => hello world
-ctx.get('foo.bat'); // => hello world
+await ctx.get('foo.bar'); // => hello world
+await ctx.get('foo.bat'); // => hello world
 ```

--- a/packages/context/test/acceptance/class-level-bindings.feature.md
+++ b/packages/context/test/acceptance/class-level-bindings.feature.md
@@ -28,6 +28,6 @@
  }
  ctx.bind('controllers.info').toClass(InfoController);
 
- const instance = ctx.get('controllers.info');
+ const instance = await ctx.get('controllers.info');
  instance.appName; // => CodeHub
  ```

--- a/packages/context/test/acceptance/creating-and-resolving-bindings.feature.md
+++ b/packages/context/test/acceptance/creating-and-resolving-bindings.feature.md
@@ -22,7 +22,7 @@ ctx.bind('foo').to('bar');
 ctx.contains('foo'); // true
 
 // ensure bound to value `bar` is returned
-const val = ctx.get('foo'); // val => bar
+const val = await ctx.get('foo'); // val => bar
 ```
 
 ## Scenario: Dynamic Bindings
@@ -44,7 +44,7 @@ ctx.bind('data').toDynamicValue(() => {
   return data.shift();
 });
 
-ctx.get('data'); // => a
-ctx.get('data'); // => b
-ctx.get('data'); // => c
+await ctx.get('data'); // => a
+await ctx.get('data'); // => b
+await ctx.get('data'); // => c
 ```

--- a/packages/context/test/acceptance/unlocking-bindings.feature.md
+++ b/packages/context/test/acceptance/unlocking-bindings.feature.md
@@ -30,5 +30,5 @@ binding.unlock();
 ctx.bind('foo').to('baz');
 
 // new value is baz
-console.log(ctx.get('foo')); // => baz
+console.log(await ctx.get('foo')); // => baz
 ```

--- a/packages/context/test/acceptance/unlocking-bindings.ts
+++ b/packages/context/test/acceptance/unlocking-bindings.ts
@@ -35,8 +35,8 @@ describe(`Context bindings - Unlocking bindings`, () => {
           expect(operation).to.not.throw();
         });
 
-        it('binds the duplicate key to the new value', () => {
-          const result = ctx.get('foo');
+        it('binds the duplicate key to the new value', async () => {
+          const result = await ctx.get('foo');
           expect(result).to.equal('baz');
         });
       });

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -30,6 +30,13 @@ describe('Binding', () => {
     });
   });
 
+  describe('to(value)', () => {
+    it('returns the value synchronously', () => {
+      binding.to('value');
+      expect(binding.getValue()).to.equal('value');
+    });
+  });
+
   function givenBinding() {
     const ctx = new Context();
     binding = new Binding(ctx, key);

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -41,6 +41,31 @@ describe('Context', () => {
     });
   });
 
+  describe('getBinding', () => {
+    it('returns the binding object registered under the given key', () => {
+      const expected = ctx.bind('foo');
+      const actual = ctx.getBinding('foo');
+      expect(actual).to.equal(expected);
+    });
+
+    it('reports an error when binding was not found', () => {
+      expect(() => ctx.getBinding('unknown-key')).to.throw(/unknown-key/);
+    });
+  });
+
+  describe('getSync', () => {
+    it('returns the value immediately when the binding is sync', () => {
+      ctx.bind('foo').to('bar');
+      const result = ctx.getSync('foo');
+      expect(result).to.equal('bar');
+    });
+
+    it('throws a helpful error when the binding is async', () => {
+      ctx.bind('foo').toDynamicValue(() => Promise.resolve('bar'));
+      expect(() => ctx.getSync('foo')).to.throw(/foo.*async/);
+   });
+  });
+
   function createContext() {
     ctx = new Context();
   }

--- a/packages/context/test/unit/isPromise.test.ts
+++ b/packages/context/test/unit/isPromise.test.ts
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as bluebird from 'bluebird';
+import {expect} from '@loopback/testlab';
+import {isPromise} from '../..';
+
+describe('isPromise', () => {
+  it('returns false for undefined', () => {
+    expect(isPromise(undefined)).to.be.false();
+  });
+
+  it('returns false for a string value', () => {
+    expect(isPromise('string-value')).to.be.false();
+  });
+
+  it('returns false for a plain object', () => {
+    expect(isPromise({foo: 'bar'})).to.be.false();
+  });
+
+  it('returns false for an array', () => {
+    expect(isPromise([1, 2, 3])).to.be.false();
+  });
+
+  it('returns false for a Date', () => {
+    expect(isPromise(new Date())).to.be.false();
+  });
+
+  it('returns true for a native Promise', () => {
+    expect(isPromise(Promise.resolve())).to.be.true();
+  });
+
+  it('returns true for a Bluebird Promise', () => {
+    expect(isPromise(bluebird.resolve())).to.be.true();
+  });
+
+  it('returns false when .then() is not a function', () => {
+    expect(isPromise({ then: 'later' })).to.be.false();
+  });
+});

--- a/packages/example-codehub/src/CodeHubApplication.ts
+++ b/packages/example-codehub/src/CodeHubApplication.ts
@@ -27,14 +27,15 @@ export class CodeHubApplication extends Application {
 
   async start() {
     this._startTime = new Date();
-    const server = new Server({port: this.get('servers.http.port')});
+    const httpPort = await this.get('servers.http.port');
+    const server = new Server({port: httpPort});
     this.bind('servers.http.server').to(server);
     server.bind('applications.code-hub').to(this);
     return server.start();
   }
 
-  info() {
-    const server = this.get('servers.http.server') as Server;
+  async info() {
+    const server = await this.get('servers.http.server') as Server;
     const port = server.config.port;
 
     return {

--- a/packages/example-codehub/test/support/util.ts
+++ b/packages/example-codehub/test/support/util.ts
@@ -6,8 +6,8 @@
 import {supertest} from 'testlab';
 import {CodeHubApplication} from 'example-codehub/src/CodeHubApplication';
 
-export function createClientForApp(app: CodeHubApplication) {
-  const url = app.info().url;
+export async function createClientForApp(app: CodeHubApplication) {
+  const url = (await app.info()).url;
   return supertest(url);
 }
 
@@ -20,6 +20,6 @@ export function createApp() {
 export async function createAppAndClient() {
   const app = createApp();
   await app.start();
-  const client = createClientForApp(app);
+  const client = await createClientForApp(app);
   return {app, client};
 }

--- a/packages/loopback/lib/router/SwaggerRouter.ts
+++ b/packages/loopback/lib/router/SwaggerRouter.ts
@@ -183,19 +183,20 @@ class Endpoint {
       pathParams[key.name] = match[matchIndex];
     }
 
-    const controller = this._controllerFactory(request, response);
     const operationName = this._spec['x-operation-name'];
-
-    loadRequestBodyIfNeeded(this._spec, request)
-      .then(body => buildOperationArguments(this._spec, request, pathParams, body))
-      .then(
-        args => {
-          this._invoke(controller, operationName, args, response, next);
-        },
-        err => {
-          debug('Cannot parse arguments of operation %s: %s', operationName, err.stack || err);
-          next(err);
-        });
+    Promise.resolve(this._controllerFactory(request, response))
+      .then(controller => {
+        loadRequestBodyIfNeeded(this._spec, request)
+          .then(body => buildOperationArguments(this._spec, request, pathParams, body))
+          .then(
+            args => {
+              this._invoke(controller, operationName, args, response, next);
+            },
+            err => {
+              debug('Cannot parse arguments of operation %s: %s', operationName, err.stack || err);
+              next(err);
+            });
+      });
   }
 
   private _invoke(controller: Object, operationName: string, args: OperationArgs, response: Response, next: HandlerCallback) {

--- a/packages/loopback/lib/server.ts
+++ b/packages/loopback/lib/server.ts
@@ -40,11 +40,13 @@ export class Server extends Context {
     // after the app started. The idea is to rebuild the SwaggerRouter
     // instance whenever a controller was added/deleted.
     const router = new SwaggerRouter();
-    this.find('applications.*').forEach(appBinding => {
+
+    const apps = this.find('applications.*');
+    for (const appBinding of apps) {
       debug('Registering app controllers for %j', appBinding.key);
-      const app = appBinding.getValue() as Application;
+      const app = await appBinding.getValue() as Application;
       app.mountControllers(router);
-    });
+    }
 
     const server = http.createServer(router.handler);
 

--- a/packages/loopback/test/acceptance/routing/feature.md
+++ b/packages/loopback/test/acceptance/routing/feature.md
@@ -102,7 +102,7 @@ app.bind('currentMethod').toDynamicValue(() => {
 });
 
 
-server.on('request', async (req, res) {
+server.on('request', async (req, res) => {
   let ctx = new Context();
   ctx.bind('url').to(req.url);
   ctx.bind('req.body').toPromise((reject, resolve) => {
@@ -110,15 +110,15 @@ server.on('request', async (req, res) {
   });
   ctx.bind('req').to(req);
 
-  let controller = ctx.get('currentController');
+  let controller = await ctx.get('currentController');
 
   // allow apps to create / customize bindings
   controller.bind();
 
   ctx.bind('result')
-    .toPromise((reject, resolve, ctx) => {
-      let method = ctx.get('currentMethod');
-      let methodArgs = ctx.get('currentArgs');
+    .toPromise(async (reject, resolve, ctx) => {
+      let method = await ctx.get('currentMethod');
+      let methodArgs = await ctx.get('currentArgs');
       return method.invoke(args);
     })
     .memoize()


### PR DESCRIPTION
This is required to allow injection of asynchronously-computed values into Controller constructors.

- Allow dynamic bindings to be created using an async function returning
a promise.

 - Modify `ctx.get` to always return a promise, regardless of whether
the binding is sync or async.

 - Modify dependency injection code to detect sync vs. async dependencies and optimise the code building the dependencies to prefer sync flow if allowed by dependencies.

 - Add new API `ctx.getAsync` that returns the bound value synchronously and throws if the factory function was async.

 - Add new API `ctx.getBinding` to look up the `Binding` object by a key

 - Add new API `isPromise` that can be used by consumers of `ctx.getBinding().getValue()` to detect whether the value was resolved sync or async.

As we discussed elsewhere, most code should use `@inject` to resolve dependencies, therefore it should not be affected by sync/async nuances.

When getting values from the context directly, people should default to asynchronous `ctx.get(key)`, because it's difficult to tell in advance which bindings may eventually become asynchronous due to 3rd party extensions.

```ts
const name = await ctx.get('application.name');
```

Having wrote that, the internal API for accessing either sync value or async Promise is public and available for advanced users.

```ts
const binding = ctx.getBinding('application.name');
const valueOrPromise = binding.getValue();
if (isPromise(valueOrPromise)) {
  valueOrPromise.then(doSomething);
} else {
  doSomething(valueOrPromise);
}
```

---

This is a pre-requisite for #186 and #188 which I am implementing as part of the time allocated in strongloop-internal/scrum-asteroid#117.

cc @bajtos @raymondfeng @ritch @superkhau
