### PR TITLE
Fix build

### DIFF
--- a/packages/example-codehub/package.json
+++ b/packages/example-codehub/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "http-errors": "^1.6.1",
-    "loopback": "^4.0.0-alpha.1"
+    "@loopback/loopback": "^4.0.0-alpha.1"
   },
   "devDependencies": {
     "@loopback/testlab": "^4.0.0-alpha.1",


### PR DESCRIPTION
Fix example-codehub's package.json to depend on the new name `@loopback/loopback` instead of `loopback`.

See 8546154

cc @bajtos @raymondfeng @ritch @superkhau
