### PR TITLE
Upgrade tslint to ^5.1 + enable no-unnecessary-callback-wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "request-promise": "^4.1.1",
     "ts-node": "^2.0.0",
     "tsconfig-paths": "^2.1.0",
-    "tslint": "^4.4.2",
+    "tslint": "^5.1.0",
     "typescript": "^2.1.5"
   },
   "dependencies": {

--- a/packages/loopback/index.ts
+++ b/packages/loopback/index.ts
@@ -10,15 +10,15 @@ export {
 } from './lib/server';
 
 export {
-  Application
+  Application,
 } from './lib/application';
 
 export {
   api,
-} from './lib/router/metadata'
+} from './lib/router/metadata';
 
 export * from '@loopback/openapi-spec';
 
 export {
-  inject
+  inject,
 } from '@loopback/context';

--- a/packages/testlab/src/testlab.ts
+++ b/packages/testlab/src/testlab.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /// <reference path="./should-as-function.d.ts" />
 
 import shouldAsFunction = require('should/as-function');

--- a/tslint.json
+++ b/tslint.json
@@ -20,8 +20,6 @@
     "no-shadowed-variable": true,
     "no-string-throw": true,
     "no-unused-expression": true,
-    "no-unused-new": true,
-    "no-use-before-declare": true,
     "no-var-keyword": true,
     "triple-equals": [
       true,

--- a/tslint.json
+++ b/tslint.json
@@ -45,6 +45,7 @@
     "comment-format": [true, "check-space"],
     "file-header": [true, "Copyright IBM"],
     "no-consecutive-blank-lines": [true, 2],
+    "no-unnecessary-callback-wrapper": true,
     "one-variable-per-declaration": [true, "ignore-for-loop"],
     "prefer-method-signature": true,
     "quotemark": [true, "single", "avoid-escape"],


### PR DESCRIPTION
- Upgrade tslint to ^5.1
- Enable `no-unnecessary-callback-wrapper`: reject `foo(x => fn(x))`, prefer `foo(fn)` instead.
- Disable `no-use-before-declare`, it was meant for `var` (which is not allowed by our config) and reports false positives in our code base (e.g. `UserController` is using `UserResponse` before it was declared).

cc @bajtos @raymondfeng @ritch @superkhau
