### PR TITLE
Drop support for Node.js 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "url": "https://github.com/strongloop/loopback-next.git"
   },
   "version": "4.0.0-alpha.1",
+  "engines": {
+    "node": ">=6"
+  },
   "license": "MIT",
   "devDependencies": {
     "@types/mocha": "^2.2.38",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,11 @@
     },
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es2017", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "strictNullChecks": true,
-    "target": "es5"
+    "target": "es6"
   },
   "include": [
     "packages/**/*"


### PR DESCRIPTION
 - modify engines field in the top-level package.json (we will have to edit engines in all sub-packages eventually too)
 - change `tsc` transpilation target to `es6`
 - (unrelated): upgrade `lib` from `es6` to `es2017`

My reasoning why it's ok to stop supporting Node.js 4: the release line is in maintenance mode and will go out of support in April 2018. Since LB.next will be used on new projects, I think it's reasonable to ask LB.next users to use a recent supported Node.js version for their new work.

cc @bajtos @raymondfeng @ritch @superkhau
