### PR TITLE
Extract shared settings to tsconfig.common.json

### DIFF
--- a/packages/example-codehub/src/controllers/HealthController.ts
+++ b/packages/example-codehub/src/controllers/HealthController.ts
@@ -17,6 +17,6 @@ export class HealthController {
   }
 }
 
-interface HealthResponse {
+export interface HealthResponse {
   uptime : number;
 }

--- a/packages/loopback/lib/router/SwaggerRouter.ts
+++ b/packages/loopback/lib/router/SwaggerRouter.ts
@@ -23,8 +23,8 @@ type OperationRetval = any;
 
 const parseJsonBody: (req: Request) => Promise<MaybeBody> = Promise.promisify(jsonBody);
 
-type HandlerCallback = (err?: Error | string) => void;
-type RequestHandler = (req: Request, res: Response, cb?: HandlerCallback) => void;
+export type HandlerCallback = (err?: Error | string) => void;
+export type RequestHandler = (req: Request, res: Response, cb?: HandlerCallback) => void;
 
 
 export type ControllerFactory = (request: Request, response: Response) => Object;

--- a/packages/openapi-spec/src/OpenApiSpec-v2.ts
+++ b/packages/openapi-spec/src/OpenApiSpec-v2.ts
@@ -10,7 +10,7 @@
 // NOTE(bajtos) Custom extensions can use arbitrary type as the value,
 // e.g. a string, an object or an array
 // tslint:disable-next-line:no-any
-type ExtensionValue = any;
+export type ExtensionValue = any;
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object
 export interface OpenApiSpec {
@@ -69,7 +69,7 @@ export interface ParameterObject {
 }
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterIn
-type ParameterLocation = 'query'| 'header'| 'path'| 'formData' | 'body';
+export type ParameterLocation = 'query'| 'header'| 'path'| 'formData' | 'body';
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#referenceObject
 export interface ReferenceObject {

--- a/packages/testlab/tsconfig.json
+++ b/packages/testlab/tsconfig.json
@@ -1,18 +1,7 @@
 {
+  "extends": "../../tsconfig.common.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "*": ["*"]
-    },
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": ["es6", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "outDir": "./lib",
-    "strictNullChecks": true,
-    "target": "es5",
-    "declaration": true
+    "outDir": "./lib"
   },
   "include": [
     "src"

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+
+    "lib": ["es2017", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es6",
+    "declaration": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "./tsconfig.common.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
       "*": ["packages/*"]
-    },
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": ["es2017", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "target": "es6"
+    }
   },
   "include": [
     "packages/**/*"


### PR DESCRIPTION
- Extract shared `tsc` settings to tsconfig.common.json
- Enable repository-wide export of declaration `.d.ts` files together with `.js` files created by `tsc` (compiler option `declaration: true`).
- Add missing exports to types/aliases that are transitively required to be public (this has been discovered by enabling `declaration: true`)

cc @bajtos @raymondfeng @ritch @superkhau
