### PR TITLE
Remove promise-function-async

### DIFF
--- a/tslint.full.json
+++ b/tslint.full.json
@@ -9,7 +9,6 @@
   "rules": {
     // These rules find errors related to TypeScript features.
 
-    "promise-function-async": true,
 
     // These rules catch common errors in JS programming or otherwise
     // confusing constructs that are prone to producing bugs.


### PR DESCRIPTION
I enabled promise-function-async to catch the kind of errors
where a function returning a promise is not annotated with type
information and therefore the compiler cannot verify the correctness
of what the function is actually returning.

With noImplicitAny enabled, we have a better tool to detect such errors.

I also want to avoid the following downside of promise-function-async (see https://github.com/palantir/tslint/issues/2637):
it forces async functions even in places where an async function is
clearly a wrong thing to do, e.g.

```ts
const bar = () => Promise.resolve(1);
```

cc @bajtos @raymondfeng @ritch @superkhau
