### PR TITLE
Remove unused tsconfig options

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "ts-node": "^2.0.0",
-    "tsconfig-paths": "^2.1.0",
     "tslint": "^5.1.0",
     "typescript": "^2.1.5"
   },
@@ -27,7 +26,7 @@
     "bootstrap": "lerna bootstrap",
     "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check --exclude \"examples/**/*\" --exclude \"**/node_modules/**\" --exclude \"**/*.d.ts\" \"**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
-    "test": "mocha --opts test/mocha.opts.root \"packages/*/test/**/*.ts\"",
+    "test": "mocha --opts test/mocha.opts \"packages/*/test/**/*.ts\"",
     "posttest": "npm run lint"
   }
 }

--- a/packages/example-codehub/test/acceptance/health.test.ts
+++ b/packages/example-codehub/test/acceptance/health.test.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import { CodeHubApplication } from 'example-codehub/src/CodeHubApplication';
-import {expect, supertest as request} from 'testlab';
-import * as util from 'example-codehub/test/support/util';
+import { CodeHubApplication } from '../../src/CodeHubApplication';
+import {expect, supertest as request} from '@loopback/testlab';
+import * as util from '../support/util';
 
 describe('health', () => {
   let app: CodeHubApplication;

--- a/packages/example-codehub/test/acceptance/user.test.ts
+++ b/packages/example-codehub/test/acceptance/user.test.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import { CodeHubApplication } from 'example-codehub/src/CodeHubApplication';
-import {expect, supertest as request} from 'testlab';
-import * as util from 'example-codehub/test/support/util';
+import { CodeHubApplication } from '../../src/CodeHubApplication';
+import {expect, supertest as request} from '@loopback/testlab';
+import * as util from '../support/util';
 
 describe('users', () => {
   let app: CodeHubApplication;

--- a/packages/example-codehub/test/integration/smoke.ts
+++ b/packages/example-codehub/test/integration/smoke.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from 'testlab';
+import {expect} from '@loopback/testlab';
 
 describe('codehub integration smoke test', () => {
   it('passes', () => {

--- a/packages/example-codehub/test/support/util.ts
+++ b/packages/example-codehub/test/support/util.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {supertest} from 'testlab';
+import {supertest} from '@loopback/testlab';
 import {CodeHubApplication} from '../../src/CodeHubApplication';
 
 export async function createClientForApp(app: CodeHubApplication) {

--- a/packages/example-codehub/test/unit/smoke.ts
+++ b/packages/example-codehub/test/unit/smoke.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from 'testlab';
+import {expect} from '@loopback/testlab';
 
 describe('codehub unit smoke test', () => {
   it('passes', () => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
---compilers ts:ts-node/register,ts:tsconfig-paths/register
+--compilers ts:ts-node/register
 --recursive

--- a/test/mocha.opts.root
+++ b/test/mocha.opts.root
@@ -1,2 +1,0 @@
---compilers ts:ts-node/register,ts:tsconfig-paths/register
---recursive

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "./tsconfig.common.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "*": ["packages/*"]
-    }
-  },
   "include": [
     "packages/**/*"
   ],


### PR DESCRIPTION
Remove the following compiler options:
 - baseUrl
 - paths

In the past, these options allowed us to write `import from 'core'` instead of `import from '@loopback/core'`. The former works only inside our monorepo and breaks after we compile and publish our code to npmjs.org, therefore we shouldn't be using it anyways.

cc @bajtos @raymondfeng @ritch @superkhau
