### PR TITLE
Added nyc for test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ lerna-debug.log
 node_modules
 npm-debug.log
 .DS_Store
+coverage
+.nyc_output

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,19 @@
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.tabSize": 2,
   "editor.trimAutoWhitespace": true,
+
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "coverage": true,
+    ".nyc_output": true
+  },
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
+
   "tslint.ignoreDefinitionFiles": true,
   // Temporarily disable linting & compilation of examples,
   // because they are depending on features/APIs that are

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/request-promise": "^4.1.33",
     "lerna": "^2.0.0-rc.4",
     "mocha": "^3.2.0",
+    "nyc": "^10.3.2",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
     "ts-node": "^2.0.0",
@@ -27,6 +28,22 @@
     "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check --exclude \"examples/**/*\" --exclude \"**/node_modules/**\" --exclude \"**/*.d.ts\" \"**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
     "test": "mocha --opts test/mocha.opts \"packages/*/test/**/*.ts\"",
-    "posttest": "npm run lint"
+    "posttest": "npm run lint",
+    "coverage": "nyc npm test"
+  },
+  "nyc": {
+    "include": [
+      "packages/*/src/**/*.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "html",
+      "lcov"
+    ]
   }
 }


### PR DESCRIPTION
cc @bajtos @raymondfeng @ritch @superkhau

This is an attempt to try and get the ball rolling on - https://github.com/strongloop/loopback-next/issues/131 I have used nyc before in our repos, Its a good tool for getting coverage for typescript. It will also play well with coveralls from what I can see here https://github.com/nickmerwin/node-coveralls there is a section on nyc.

Here is a screenshot of the current test coverage. Am still not 100% sure how lerna works or am i grabbing the correct coverage metrics so please provide feedback

![coverage](https://cloud.githubusercontent.com/assets/11195158/25763771/97eb513e-31dc-11e7-8b03-4e26a1872f86.png)

![2017-05-05 21_52_30-code coverage report for core_src_application ts](https://cloud.githubusercontent.com/assets/11195158/25763893/37b9786c-31dd-11e7-9fa5-149cbf332e57.png)

The command to use is 

```
npm run coverage
```

This will generate a folder called _test_results/coverage_ which I have ignored in the .gitignore file.

In our organization to ensure the code coverage does not go down we enforce a certain threshold which will fail the build if it goes below that threshold, It would be good to do something similar here, nyc can actually do this if configured correctly, https://github.com/istanbuljs/nyc see section on "Checking Coverage"

Anyways please let me know your thoughts or concerns or if there is a better way of doing this that I do not know about, Am always looking for better ways to do things. 