### PR TITLE
Implement parser/unmarshaller

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,9 @@
   "devDependencies": {
     "@loopback/openapi-spec-builder": "^4.0.0-alpha.2",
     "@loopback/testlab": "^4.0.0-alpha.3",
+    "@types/shot": "^3.4.0",
     "mocha": "^3.2.0",
+    "shot": "^3.4.0",
     "typescript": "^2.3.2"
   },
   "files": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,7 @@ export * from '@loopback/openapi-spec';
 
 // external dependencies
 export {ServerRequest, ServerResponse} from 'http';
+
+// internals used by unit-tests
+export {parseOperationArgs} from './parser';
+export {ParsedRequest, parseRequestUrl} from './router/SwaggerRouter';

--- a/packages/core/src/promisify.ts
+++ b/packages/core/src/promisify.ts
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+// TODO(bajtos) Move this file to a standalone module, or find an existing
+// npm module that we could use instead. Just make sure the existing
+// module is using native utils.promisify() when available.
+
+// tslint:disable:no-any
+
+import * as util from 'util';
+
+const nativePromisify = (util as any).promisify;
+
+export function promisify<T>(func: (callback: (err: any, result: T) => void) => void): () => Promise<T>;
+export function promisify<T, A1>(func: (arg1: A1, callback: (err: any, result: T) => void) => void): (arg1: A1) => Promise<T>;
+export function promisify<T, A1, A2>(func: (arg1: A1, arg2: A2, callback: (err: any, result: T) => void) => void): (arg1: A1, arg2: A2) => Promise<T>;
+
+export function promisify<T>(func: (...args: any[]) => void): (...args: any[]) => Promise<T> {
+  if (nativePromisify)
+    return nativePromisify(func);
+
+  // The simplest implementation of Promisify
+  return (...args) => {
+    return new Promise((resolve, reject) => {
+      try {
+        func(...args, (err?: any, result?: any) => {
+          if (err) reject(err);
+          else resolve(result);
+        });
+      } catch (err) {
+        reject(err);
+      }
+    });
+  };
+}

--- a/packages/core/test/integration/router/SwaggerRouter.integration.ts
+++ b/packages/core/test/integration/router/SwaggerRouter.integration.ts
@@ -351,6 +351,26 @@ context('with an operation echoing a string parameter from query', () => {
     });
   });
 
+  context('error handling', () => {
+    it('handles errors throws by controller constructor', () => {
+      const spec = givenOpenApiSpec()
+        .withOperationReturningString('get', '/hello', 'greet')
+        .build();
+
+      class ThrowingController {
+        constructor() {
+          throw new Error('Thrown from constructor.');
+        }
+      }
+
+      givenControllerClass(ThrowingController, spec);
+
+      logErrorsExcept(500);
+      return client.get('/hello')
+        .expect(500);
+    });
+  });
+
   let router: SwaggerRouter;
   function givenRouter() {
     router = new SwaggerRouter();
@@ -358,7 +378,7 @@ context('with an operation echoing a string parameter from query', () => {
 
   // tslint:disable-next-line:no-any
   function givenControllerClass(ctor: new (...args: any[]) => Object, spec: OpenApiSpec) {
-    router.controller((req, res) => new ctor(), spec);
+    router.controller((req, res) => Promise.resolve().then(() => new ctor()), spec);
   }
 
   function logErrorsExcept(ignoreStatusCode: number) {

--- a/packages/core/test/unit/parser.test.ts
+++ b/packages/core/test/unit/parser.test.ts
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  parseOperationArgs,
+  ServerRequest,
+  ParsedRequest,
+  parseRequestUrl,
+} from '../..';
+import {expect} from '@loopback/testlab';
+import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
+
+import {RequestOptions as ShotRequestOptions} from 'shot';
+type ShotRequestCtor = new(options: ShotRequestOptions) => ServerRequest;
+// tslint:disable-next-line:variable-name
+const ShotRequest: ShotRequestCtor = require('shot/lib/request');
+
+describe('operationArgsParser', () => {
+  it('parses path parameters', async () => {
+    const spec = givenOperationWithParameters([{
+      name: 'id',
+      type: 'number',
+      in: 'path',
+    }]);
+    const req = givenRequest();
+
+    const args = await parseOperationArgs(req, spec, {id: 1});
+
+    expect(args).to.eql([1]);
+  });
+
+  it('parsed body parameter', async () => {
+    const spec = givenOperationWithParameters([{
+      name: 'data',
+      type: 'object',
+      in: 'body',
+    }]);
+
+    const req = givenRequest({
+      url: '/',
+      payload: {key: 'value'},
+    });
+
+    const args = await parseOperationArgs(req, spec, {});
+
+    expect(args).to.eql([{key: 'value'}]);
+  });
+
+  function givenOperationWithParameters(params?: ParameterObject[]) {
+    return <OperationObject> {
+      'x-operation-name': 'testOp',
+      parameters: params,
+      responses: {},
+    };
+  }
+
+  function givenRequest(options?: ShotRequestOptions): ParsedRequest {
+    return parseRequestUrl(new ShotRequest(options || {url: '/'}));
+  }
+});


### PR DESCRIPTION
- New parser/unmarshaller function (yet to delete the same logic/functions from SwaggerRouter)
- This code assumes router is already created which has mounted controllers and created endpoints prior to calling parser() method. (We still need to create the router() function with just this logic.. In master branch code, everything is glued together in SwaggerRouter and Application.ts).
- See comments at the beginning of the method in the file.
- Parser method only unmarshalls the request and returns back the method arguments for the given endpoint.

@bajtos @raymondfeng  Feel free to provide initial feedback. 
