### PR TITLE
Decompose writer

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,3 +27,5 @@ export {HttpErrors};
 export {parseOperationArgs} from './parser';
 export {ParsedRequest, parseRequestUrl} from './router/swagger-router';
 export {RoutingTable, ResolvedRoute} from './router/routing-table';
+export {OperationRetval} from './invoke';
+export {writeResultToResponse} from './writer';

--- a/packages/core/src/writer.ts
+++ b/packages/core/src/writer.ts
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ServerResponse as Response} from 'http';
+import {OperationRetval} from './invoke';
+
+export function writeResultToResponse(
+  response: Response, // not needed and responsibility should be in the sequence.send
+  result: OperationRetval, // result returned back from invoking controller method
+): void {
+  if (result) {
+    if (typeof result === 'object') {
+      // TODO(ritch) remove this, should be configurable
+      response.setHeader('Content-Type', 'application/json');
+      // TODO(bajtos) handle errors - JSON.stringify can throw
+      result = JSON.stringify(result);
+    } else if (typeof result === 'string') {
+      response.setHeader('Content-Type', 'text/plain');
+    }
+    response.write(result);
+  }
+  response.end();
+}

--- a/packages/core/test/unit/writer.test.ts
+++ b/packages/core/test/unit/writer.test.ts
@@ -1,0 +1,51 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  ServerResponse,
+  OperationRetval,
+  writeResultToResponse,
+} from '../..';
+
+import {
+  expect,
+  ShotRequest,
+  ShotResponse,
+  ShotObservedResponse,
+} from '@loopback/testlab';
+
+describe('writer', () => {
+  let response: ServerResponse;
+  let observedResponse: Promise<ShotObservedResponse>;
+
+  beforeEach(setupResponseMock);
+
+  it('writes string result to response as text', async () => {
+    writeResultToResponse(response, 'Joe');
+    const result = await observedResponse;
+
+    // content-type should be 'application/json' since it's set into the response in writer.writeResultToResponse()
+    expect(result.headers['content-type']).to.eql('text/plain');
+    expect(result.payload).to.equal('Joe');
+  });
+
+  it('writes object result to response as JSON', async () => {
+    writeResultToResponse(response, {name: 'Joe'});
+    const result = await observedResponse;
+
+    expect(result.headers['content-type']).to.eql('application/json');
+    expect(result.payload).to.equal('{"name":"Joe"}');
+  });
+
+  function setupResponseMock() {
+    const req = new ShotRequest({url: '/'});
+    observedResponse = new Promise(resolve => {
+      response = new ShotResponse(req, resolve);
+    });
+
+    // content-type should be undefined since it's not set in the response yet.
+    expect(response.getHeader('content-type')).to.eql(undefined);
+  }
+});

--- a/packages/testlab/src/shot.ts
+++ b/packages/testlab/src/shot.ts
@@ -15,7 +15,7 @@ import {
   ResponseObject,
   inject} from 'shot';
 
-export {inject, ShotRequestOptions, ResponseObject};
+export {inject, ShotRequestOptions};
 
 // tslint:disable-next-line:variable-name
 export const ShotRequest: ShotRequestCtor = require('shot/lib/request');
@@ -31,3 +31,4 @@ export type ShotCallback = (response: ResponseObject) => void;
 export type ShotResponseCtor =
   new(request: ServerRequest, onEnd: ShotCallback) => ServerResponse;
 
+export type ShotObservedResponse = ResponseObject;


### PR DESCRIPTION
- This PR decomposes writer into it's own method. This method marshals/writes return result from operation invocation into HTTP response.
- invoker.ts calls writer(..) 

@bajtos @raymondfeng PTAL 

With this PR, we have fairly good decomposition of Swagger Router. We have now  Router(SwaggerRouter), Parser, invoke(invoker), writer separated out. However the current invocation path is still tightly coupled. HTTP Req -> http server --> Swagger Router --> Application.ts --> Swagger Router --> parser --> Swagger Router -> invoker --> End User Operation(MyController) --> writer --> send back HTTP response to HTTP server. As we can see in this case, the argument which are passed into parser, invoker, writer are still coupled with Router itself. For e.g parser() needs Endpoint to be passed in, invoker() needs controller, response, next to be passed in etc. From this invocation pattern, how we can support below invocation pattern for the framework developer? 

As you can see in below invocation pattern, it assumes that whatever parser, invoker, writer needs as arguments is somehow magically available.
```
class MyRequestHandler {
construction(private @inject('router': Runnable ..) {}
   async run(
        await this.router.run();
        await this.parser.run();
        await this.invoker.run();
        await this.writer.run();
  }
}
```

I had a follow up discussion with @raymondfeng for above item as our next work - I have documented all the details for next work in here https://github.com/strongloop-internal/scrum-asteroid/issues/190 @bajtos Feel free to start some of this.. If you start something, let me know at the end of your day. I will continue from that point onwards.

