### PR TITLE
Add build & clean tasks for VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -331,6 +331,28 @@
           }
         }
       ]
+    },
+
+    // build
+    {
+      "taskName": "Compile TypeScript sources",
+      "isBuildCommand": true,
+      "isShellCommand": true,
+      "command": "npm",
+      "args": [
+        "run",
+        "build"
+      ],
+      "problemMatcher": "$tsc"
+    },
+    {
+      "taskName": "Clean all generated files",
+      "isShellCommand": true,
+      "command": "npm",
+      "args": [
+        "run",
+        "clean"
+      ]
     }
   ]
 }

--- a/bin/compile-package.js
+++ b/bin/compile-package.js
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/*
+========
+
+Usage:
+  node ../../bin/compile-package <target>
+
+Where <target> is either es2017 or es2015.
+
+Under the hood, we change the current directory to loopback-next root
+and call tsc with project configuration from the original package's
+tsconfig.build.json. This way tsc error messages contain a path
+that's relative to loopback-next project root.
+
+TODO(bajtos) Detect whether "npm run build" was triggered by lerna
+or manually. When triggered manually from the package directory,
+then we should not change the directory.
+
+========
+*/
+
+'use strict';
+
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+const rootDir = path.resolve(__dirname, '..');
+const packageDir = path.relative(rootDir, process.cwd());
+
+const compilerOpts = process.argv.slice(2);
+const target = compilerOpts.shift();
+
+let outDir;
+switch (target) {
+  case 'es2017':
+    outDir = 'lib';
+    break;
+  case 'es2015':
+    outDir = 'lib6'
+    break;
+  default:
+    console.error('Unknown build target %s. Supported values: es2015, es2017');
+    process.exit(1);
+}
+
+process.chdir(rootDir);
+
+const args = [
+  require.resolve('typescript/lib/tsc'), // see typescript/bin/tsc
+  '-p',
+  // It's important to keep this path relative to rootDir
+  path.join(packageDir, 'tsconfig.build.json'),
+  '--target',
+  target,
+  '--outDir',
+  path.join(packageDir, outDir),
+  ...compilerOpts
+];
+
+console.log('loopback-next$ tsc', args.slice(1).join(' '));
+
+spawn(
+  process.execPath, // Typically '/usr/local/bin/node'
+  args,
+  {
+    stdio: 'inherit'
+  })
+  .on('close', (number, signal) => process.exitCode = number);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "bootstrap": "lerna bootstrap",
     "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check --exclude \"examples/**/*\" --exclude \"**/node_modules/**\" --exclude \"**/*.d.ts\" \"**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
+    "clean": "lerna run clean",
+    "build": "lerna run build",
     "test": "nyc mocha --opts test/mocha.opts \"packages/*/test/**/*.ts\"",
     "posttest": "npm run lint",
     "coverage": "nyc report --reporter=text-lcov | coveralls"

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",
-    "build:lib": "tsc -p tsconfig.build.json --target es2017 --outDir lib",
-    "build:lib6": "tsc -p tsconfig.build.json --target es2015 --outDir lib6",
+    "build:lib": "node ../../bin/compile-package es2017",
+    "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -f loopback-authentication*.tgz && rm -rf lib* && rm -rf package",
     "integration": "mocha --opts ../../test/mocha.opts 'test/integration/**/*.ts'",
     "prepublish": "npm run build",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",
-    "build:lib": "tsc -p tsconfig.build.json --target es2017 --outDir lib",
-    "build:lib6": "tsc -p tsconfig.build.json --target es2015 --outDir lib6",
+    "build:lib": "node ../../bin/compile-package es2017",
+    "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -f loopback-context*.tgz && rm -rf lib* && rm -rf package",
     "prepublish": "npm run build",
     "pretest": "npm run build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",
-    "build:lib": "tsc -p tsconfig.build.json --target es2017 --outDir lib ",
-    "build:lib6": "tsc -p tsconfig.build.json --target es2015 --outDir lib6",
+    "build:lib": "node ../../bin/compile-package es2017",
+    "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -f loopback-core*.tgz && rm -rf lib* && rm -rf package",
     "prepublish": "npm run build",
     "pretest": "npm run build",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -4,8 +4,8 @@
   "description": "Make it easy to create OpenAPI (Swagger) specification documents in your tests using the builder pattern.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
-    "build:lib": "tsc -p tsconfig.build.json --target es2017 --outDir lib",
-    "build:lib6": "tsc -p tsconfig.build.json --target es2015 --outDir lib6",
+    "build:lib": "node ../../bin/compile-package es2017",
+    "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -f loopback-openapi-spec*.tgz && rm -rf lib* && rm -rf package",
     "prepublish": "npm run build",
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -4,8 +4,8 @@
   "description": "TypeScript type definitions for OpenAPI Spec/Swagger documents.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
-    "build:lib": "tsc -p tsconfig.build.json --target es2017 --outDir lib",
-    "build:lib6": "tsc -p tsconfig.build.json --target es2015 --outDir lib6",
+    "build:lib": "node ../../bin/compile-package es2017",
+    "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -f loopback-openapi-spec*.tgz && rm -rf lib* && rm -rf package",
     "prepublish": "npm run build",
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -4,8 +4,8 @@
   "description": "A collection of test utilities we use to write LoopBack tests.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
-    "build:lib": "tsc -p tsconfig.build.json --target es2017 --outDir lib",
-    "build:lib6": "tsc -p tsconfig.build.json --target es2015 --outDir lib6",
+    "build:lib": "node ../../bin/compile-package es2017",
+    "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -f loopback-testlab*.tgz && rm -rf lib* && rm -rf package",
     "prepublish": "npm run build",
     "pretest": "npm run build",


### PR DESCRIPTION
Create "bin/compile-package" helper for running tsc compiler
from each package directory in a way that reports errors
with paths relative to loopback-next project root.
This makes it possible to feed compilation errors into VS Code
"Problems" window.

Rework all packages "build" scripts to use this new helper.

Add two new top-level npm scripts:

 - npm run build
 - npm run clean

Add two new VS Code tasks:

 - "Compile TypeScript sources" with "isBuildCommand": true,
   to integrate with the built-in "build" task (shift+command+b)
 - "Clean all generated files" to remove generated files

cc @bajtos @raymondfeng @ritch @superkhau
