### PR TITLE
Ignore generated lib/lib6 in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,8 @@
     "**/.hg": true,
     "**/CVS": true,
     "**/.DS_Store": true,
+    "packages/*/lib": true,
+    "packages/*/lib6": true,
     "coverage": true,
     ".nyc_output": true
   },


### PR DESCRIPTION
Hide the output of `tsc` from the file/project explorer in VS Code.

cc @bajtos @raymondfeng @ritch @superkhau
