### PR TITLE
Use HttpErrors in parser and SwaggerRouter

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -8,11 +8,12 @@ import {
   PathParameterValues,
   OperationArgs,
   ParsedRequest,
-  HttpError,
-  createHttpError,
 } from './router/SwaggerRouter';
+import {HttpErrors} from './';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
 import {promisify} from './promisify';
+
+type HttpError = HttpErrors.HttpError;
 
 type jsonBodyFn = (req: Request, cb: (err?: Error, body?: {}) => void) => void;
 const jsonBody: jsonBodyFn = require('body/json');
@@ -35,7 +36,8 @@ function loadRequestBodyIfNeeded(operationSpec: OperationObject, request: Reques
 
   const contentType = request.headers['content-type'];
   if (contentType && !/json/.test(contentType)) {
-    const err = createHttpError(415, `Content-type ${contentType} is not supported.`);
+    const err = new HttpErrors.UnsupportedMediaType(
+      `Content-type ${contentType} is not supported.`);
     return Promise.reject(err);
   }
 
@@ -85,7 +87,8 @@ function buildOperationArguments(operationSpec: OperationObject, request: Parsed
         args.push(body);
         break;
       default:
-        throw createHttpError(501, 'Parameters with "in: ' + spec.in + '" are not supported yet.');
+        throw new HttpErrors.NotImplemented(
+          'Parameters with "in: ' + spec.in + '" are not supported yet.');
     }
   }
   return args;

--- a/packages/core/src/router/SwaggerRouter.ts
+++ b/packages/core/src/router/SwaggerRouter.ts
@@ -11,7 +11,11 @@ import {RoutingTable, ResolvedRoute} from './routing-table';
 import * as assert from 'assert';
 import * as url from 'url';
 import * as pathToRegexp from 'path-to-regexp';
+import {HttpErrors} from '../..';
+
 const debug = require('debug')('loopback:SwaggerRouter');
+
+type HttpError = HttpErrors.HttpError;
 
 // tslint:disable:no-any
 export type OperationArgs = any[];
@@ -133,18 +137,6 @@ export interface ParsedRequest extends Request {
   pathname: string;
   method: string;
 }
-
-export interface HttpError extends Error {
-  statusCode?: number;
-  status?: number;
-}
-
-export function createHttpError(statusCode: number, message: string) {
-  const err = new Error(message) as HttpError;
-  err.statusCode = statusCode;
-  return err;
-}
-
 export function parseRequestUrl(request: Request): ParsedRequest {
   // TODO(bajtos) The following parsing can be skipped when the router
   // is mounted on an express app


### PR DESCRIPTION
Drop our custom implementation in favour of http-errors package.

cc @bajtos @raymondfeng @ritch @superkhau
