### PR TITLE
Fix problem matching for the Build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -338,9 +338,10 @@
       "taskName": "Compile TypeScript sources",
       "isBuildCommand": true,
       "isShellCommand": true,
-      "command": "npm",
+      "command": "lerna",
       "args": [
         "run",
+        "--loglevel=silent",
         "build"
       ],
       "problemMatcher": "$tsc"


### PR DESCRIPTION
Suppress lerna output which was duplicating compiler errors. The duplicates were prefixed with "lerna ERR! execute" prefix, which confused the built-in "$tsc" matcher and problems with non-existent paths were reported as a result.

This is a follow-up for #300.

cc @bajtos @raymondfeng @ritch @superkhau
