### PR TITLE
Disable all email notifications from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_script:
 
 after_success:
   - npm run coverage
+
+notifications:
+  email: false


### PR DESCRIPTION
I never read the email notifications from Travis CI because I am always checking build results in the browser (on GitHub's pull request view), I find these notifications as spam.

What's the opinion of other contributors? Do you find the email notifications useful? Please approve this pull request if you are happy to disable them, reject if you prefer to keep these notifications enabled.

(If we decide to keep the notifications around, then I can workaround this by creating an email filtering rule to delete all Travis emails at arrival. I.e. not a big deal to me.)

cc @strongloop/loopback-next