### PR TITLE
Provider classes to bind a value source to the context

### DIFF
--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -7,6 +7,8 @@ export {Binding, BoundValue} from './binding';
 export {Context} from './context';
 export {Constructor} from './resolver';
 export {inject} from './inject';
+export {BindingProvider, ValueProvider, FunctionProvider, ConstructorProvider} from './provider';
+
 export const isPromise = require('is-promise');
 
 // internals for testing

--- a/packages/context/src/provider.ts
+++ b/packages/context/src/provider.ts
@@ -1,0 +1,119 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Context} from './context';
+import {BoundValue, ValueOrPromise} from './binding';
+import {Constructor, instantiateClass} from './resolver';
+
+/**
+ * Provider of a value
+ */
+export interface Provider<T> {
+  value(ctx?: Context): ValueOrPromise<T>;
+}
+
+/**
+ * BindingProvider provisions injecting a value into the binding asynchronously
+ * @example:
+ * ```ts
+ * ctx.bind('provider_key').toProvider(MyProvider);
+ * ```
+ */
+export abstract class BindingProvider<T> implements Provider<T> {
+  /**
+   * binding source which provides the value
+   */
+  abstract source(): T;
+  /**
+   * target value to return
+   * @param ctx - context object
+   */
+  abstract value(ctx: Context): ValueOrPromise<BoundValue>;
+}
+
+/**
+ * ValueProvider to provide the source of a value
+ * @example:
+ * ```ts
+ * export class MyProvider extends ValueProvider {
+ *   constructor(@inject('value') param){}
+ *   source<string>(): string {
+ *     return computed_value;
+ *   }
+ * }
+ * ```
+ */
+export abstract class ValueProvider implements BindingProvider<ValueOrPromise<BoundValue>> {
+  /**
+   * return a value
+   */
+  abstract source(): ValueOrPromise<BoundValue>;
+  value(ctx: Context): ValueOrPromise<BoundValue> {
+    return this.source();
+  }
+}
+
+/**
+ * FunctionProvider to provide the function source of a value
+ * @example:
+ * ```ts
+ * export class MyProvider extends FunctionProvider {
+ *   constructor(@inject('value') param){}
+ *   source<() => string>(): () => string {
+ *     if (param)
+ *        return function1
+ *     else
+ *        return function2;
+ *   }
+ * }
+ * ```
+ */
+export abstract class FunctionProvider implements BindingProvider<(ctx: Context) => ValueOrPromise<BoundValue>> {
+  /**
+   * return a function to get dynamic value
+   */
+  abstract source(): (ctx: Context) => ValueOrPromise<BoundValue>;
+
+  value(ctx: Context): ValueOrPromise<BoundValue> {
+    return this.executeFunction(ctx);
+  }
+  /**
+   * get dynamic value from a factory function
+   */
+  async executeFunction(ctx: Context): Promise<BoundValue> {
+    const factoryFn = this.source();
+    return factoryFn(ctx);
+  }
+}
+
+/**
+ * ConstructorProvider to provide the constructor source of an object instance
+ * @example:
+ * ```ts
+ * export class MyProvider extends ConstructorProvider {
+ *   constructor(@inject('value') param){}
+ *   source<T>(): Constructor<T> {
+ *     return class1;
+ *   }
+ * }
+ * ```
+ */
+export abstract class ConstructorProvider<T> implements BindingProvider<Constructor<T>> {
+  /**
+   * return a constructor
+   */
+  abstract source(): Constructor<T>;
+
+  value(ctx: Context): ValueOrPromise<BoundValue> {
+    return this.getInstanceFromConstructor(ctx);
+  }
+  /**
+   * get an instance from a constructor
+   */
+  getInstanceFromConstructor<T>(ctx: Context): ValueOrPromise<BoundValue> {
+    const ctor = this.source();
+    return instantiateClass(ctor, ctx);
+  }
+}

--- a/packages/context/test/unit/fixtures/mock-binding-providers.ts
+++ b/packages/context/test/unit/fixtures/mock-binding-providers.ts
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ValueProvider, FunctionProvider, ConstructorProvider, Constructor, inject} from '../../../src';
+
+export class MockValueProvider extends ValueProvider {
+  constructor(@inject('msg') private _msg: string) {
+    super();
+  }
+
+  source(): string {
+    return this._msg + ' world';
+  }
+}
+
+export class MockFunctionProvider extends FunctionProvider {
+  constructor(@inject('now') private now: Date, @inject('prefix') private prefix: string) {
+    super();
+  }
+
+  source(): () => string {
+    return () => {
+      return this.prefix + ' ' + this.now;
+    };
+  }
+}
+
+export class MockLoopbackController {
+  constructor(@inject('param') private param: string) {}
+  action(): string {
+    return this.param;
+  }
+}
+
+export class MockConstructorProvider extends ConstructorProvider<MockLoopbackController> {
+  constructor(@inject('arg1') private arg1: string) {
+    super();
+  }
+
+  source(): Constructor<MockLoopbackController> {
+    return MockLoopbackController;
+  }
+}

--- a/packages/context/test/unit/provider.ts
+++ b/packages/context/test/unit/provider.ts
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {BindingProvider, Context} from '../../src';
+
+describe('BindingProvider', () => {
+  let provider: BindingProvider<String>;
+
+  beforeEach(givenProvider);
+
+  describe('source()', () => {
+    it('returns the source of the binding', () => {
+      expect(provider.source()).to.equal('hello');
+    });
+  });
+
+  describe('value()', () => {
+    it('returns the value of the binding', () => {
+      const ctx: Context = new Context();
+      expect(provider.value(ctx)).to.equal('hello world');
+    });
+  });
+
+  function givenProvider() {
+    provider = new MyProvider('hello');
+  }
+});
+
+class MyProvider extends BindingProvider<string> {
+  constructor(private _msg: string) {
+    super();
+  }
+  source(): string {
+    return this._msg;
+  }
+  value(ctx: Context): string {
+    return this.source() + ' world';
+  }
+}


### PR DESCRIPTION
* Create a BindingProvider interface

* Create abstract classes for ValueProvider or FunctionProvider or ConstructorProvider

* Add Binding.toProvider() to bind a ValueProvider or FunctionProvider or ConstructorProvider

* return provider.value() asynchronously thru Binding.getValue()

https://github.com/strongloop/loopback-next/issues/319

cc @bajtos @raymondfeng @ritch @superkhau
