### PR TITLE
lint: simplify tslint config and invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check --exclude \"examples/**/*\" --exclude \"**/node_modules/**\" --exclude \"**/*.d.ts\" \"**/*.ts\"",
+    "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check",
     "lint:fix": "npm run lint -- --fix",
     "clean": "lerna run clean",
     "build": "lerna run build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.common.json",
   "include": [
-    "packages/**/*"
+    "packages"
   ],
   "exclude": [
-    "node_modules/**/*",
-    "packages/*/node_modules/**/*",
+    "node_modules/**",
+    "packages/*/node_modules/**",
     "**/*.d.ts"
   ]
 }


### PR DESCRIPTION
It is redundant to specify the included and excluded paths in the config
as well as on the commandline. Also trim glob patterns to remove
redundant trailing wildcards.

cc @bajtos @raymondfeng @ritch @superkhau @deepakrkris 