### PR TITLE
Improve debugging experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,9 @@
       "args": [
         "--opts",
         "${workspaceRoot}/test/mocha.opts",
-        "packages/*/test/**/*.ts"
+        "packages/*/test/**/*.ts",
+        "-t",
+        "0"
       ]
     },
     {

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -10,6 +10,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es6",
+    "sourceMap": true,
     "declaration": true
   }
 }


### PR DESCRIPTION
 - Enable source maps to allow debuggers to map transpiled .js files
   back to original .ts files

 - Disable timeout when running Mocha tests in the debugger. Otherwise
   tests fail on timeout when the debugging session is longer than
   the 2 seconds (which is almost always).

cc @bajtos @raymondfeng @ritch @superkhau
