### PR TITLE
Ignore coverage of platform-dependent promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "include": [
       "packages/*/src/**/*.ts"
     ],
+    "exclude": [
+      "packages/core/*/promisify.*"
+    ],
     "extension": [
       ".ts"
     ],


### PR DESCRIPTION
When running on Node.js 8, most of the code in promisify is ignored because we use native `util.promisify`. Therefore I see little value in measuring code coverage of this source file and I am proposing to exclude it from code coverage.

cc @bajtos @raymondfeng @ritch @superkhau
