### PR TITLE
Fix tests imports to reference lib, not src + fix code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,16 +38,15 @@
   },
   "nyc": {
     "include": [
-      "packages/*/src/**/*.ts"
+      "packages/example-codehub/src/**",
+      "packages/*/lib*/*"
     ],
     "exclude": [
       "packages/core/*/promisify.*"
     ],
     "extension": [
+      ".js",
       ".ts"
-    ],
-    "require": [
-      "ts-node/register"
     ],
     "reporter": [
       "html",

--- a/packages/authentication/test/unit/authenticate.test.ts
+++ b/packages/authentication/test/unit/authenticate.test.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {authenticate, getAuthenticateMetadata, AuthenticationMetadata} from '../../src/decorator';
+import {authenticate, getAuthenticateMetadata, AuthenticationMetadata} from '../..';
 
 describe('Authentication', () => {
   describe('Class AuthenticationMetadata type', () => {

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -8,3 +8,7 @@ export {Context} from './context';
 export {Constructor} from './resolver';
 export {inject} from './inject';
 export const isPromise = require('is-promise');
+
+// internals for testing
+export {instantiateClass} from './resolver';
+export {describeInjectedArguments, describeInjectedProperties} from './inject';

--- a/packages/context/test/acceptance/child-context.ts
+++ b/packages/context/test/acceptance/child-context.ts
@@ -5,7 +5,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context} from '../../src';
+import {Context} from '../..';
 
 describe('Context bindings - contexts inheritance', () => {
   let parentCtx: Context;

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, inject, isPromise} from '../../src';
+import {Context, inject, isPromise} from '../..';
 
 const INFO_CONTROLLER = 'controllers.info';
 

--- a/packages/context/test/acceptance/creating-and-resolving-bindings.ts
+++ b/packages/context/test/acceptance/creating-and-resolving-bindings.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, isPromise} from '../../src';
+import {Context, isPromise} from '../..';
 
 describe('Context bindings - Creating and resolving bindings', () => {
   let ctx: Context;

--- a/packages/context/test/acceptance/finding-bindings.ts
+++ b/packages/context/test/acceptance/finding-bindings.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, BoundValue} from '../../src';
+import {Context, BoundValue} from '../..';
 
 describe('Context bindings - Finding bindings', () => {
   let ctx: Context;

--- a/packages/context/test/acceptance/locking-bindings.ts
+++ b/packages/context/test/acceptance/locking-bindings.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, Binding} from '../../src';
+import {Context, Binding} from '../..';
 
 describe('Context bindings - Locking bindings', () => {
   describe('Binding with a duplicate key', () => {

--- a/packages/context/test/acceptance/tagged-bindings.ts
+++ b/packages/context/test/acceptance/tagged-bindings.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, Binding} from '../../src';
+import {Context, Binding} from '../..';
 
 describe('Context bindings - Tagged bindings', () => {
   let ctx: Context;

--- a/packages/context/test/acceptance/unlocking-bindings.ts
+++ b/packages/context/test/acceptance/unlocking-bindings.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, Binding} from '../../src';
+import {Context, Binding} from '../..';
 
 describe(`Context bindings - Unlocking bindings`, () => {
   describe('Unlocking a locked binding', () => {

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Binding, Context} from '../../src';
+import {Binding, Context} from '../..';
 
 const key = 'foo';
 

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, Binding} from '../../src';
+import {Context, Binding} from '../..';
 
 describe('Context', () => {
   let ctx: Context;

--- a/packages/context/test/unit/inject.test.ts
+++ b/packages/context/test/unit/inject.test.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {inject, describeInjectedArguments, describeInjectedProperties} from '../../src/inject';
+import {inject, describeInjectedArguments, describeInjectedProperties} from '../..';
 
 describe('function argument injection', () => {
   it('can decorate class constructor arguments', () => {

--- a/packages/context/test/unit/isPromise.test.ts
+++ b/packages/context/test/unit/isPromise.test.ts
@@ -5,7 +5,7 @@
 
 import * as bluebird from 'bluebird';
 import {expect} from '@loopback/testlab';
-import {isPromise} from '../../src';
+import {isPromise} from '../..';
 
 describe('isPromise', () => {
   it('returns false for undefined', () => {

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -4,9 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context} from '../../src/context';
-import {inject} from '../../src/inject';
-import {instantiateClass} from '../../src/resolver';
+import {Context, inject, instantiateClass} from '../..';
 
 describe('constructor injection', () => {
   let ctx: Context;

--- a/packages/core/test/acceptance/bootstrapping/application.acceptance.ts
+++ b/packages/core/test/acceptance/bootstrapping/application.acceptance.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Application, Sequence} from '../../../src';
+import {Application, Sequence} from '../../..';
 
 describe('Bootstrapping - Application', () => {
   context('with user-defined configurations', () => {

--- a/packages/core/test/acceptance/bootstrapping/server.ts
+++ b/packages/core/test/acceptance/bootstrapping/server.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Server, Application} from '../../../src';
+import {Server, Application} from '../../..';
 
 describe('Bootstrapping - Single server', () => {
   describe('Single application', () => {

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -7,7 +7,7 @@ import {
   Application, Server, api,
   OpenApiSpec, ParameterObject, OperationObject,
   ServerRequest, ServerResponse,
-} from '../../../src';
+} from '../../..';
 import {expect, Client, createClientForServer} from '@loopback/testlab';
 import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';

--- a/packages/core/test/unit/application/application.controller.test.ts
+++ b/packages/core/test/unit/application/application.controller.test.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Application} from '../../../src/application';
+import {Application} from '../../..';
 
 describe('Application.controller()', () => {
   it('binds the controller to "controllers.*" namespace', () => {


### PR DESCRIPTION
~~Initially, I thought this may be the reason for wrong code coverage numbers we are observing. Unfortunately it was not, but I think it's still an change that should be made.~~

Fix tests imports to reference lib, not src. With that change in place, we can gather code-coverage data for transpiled .js files in lib/lib6 only. This fixes the problem where code coverage numbers were not including all passes.

Configure an exception for example-codehub which is not tranpiled nor published to npmjs.org.

cc @bajtos @raymondfeng @ritch @superkhau
