### PR TITLE
Move logError() to an app-level binding

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -59,6 +59,8 @@ export class Application extends Context {
 
     this.handleHttp = (req: ServerRequest, res: ServerResponse) =>
       this._handleHttpRequest(req, res);
+
+    this.bind('logError').to(this._logError.bind(this));
   }
 
   protected _handleHttpRequest(request: ServerRequest, response: ServerResponse) {
@@ -99,6 +101,11 @@ export class Application extends Context {
    */
   public controller<T>(controllerCtor: Constructor<T>): Binding {
     return this.bind('controllers.' + controllerCtor.name).toClass(controllerCtor);
+  }
+
+  protected _logError(err: Error, statusCode: number, req: ServerRequest): void {
+    console.error('Unhandled error in %s %s: %s %s',
+      req.method, req.url, statusCode, err.stack || err);
   }
 }
 

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -35,11 +35,12 @@ export class HttpHandler {
     this._bindFindRoute(requestContext);
     this._bindInvokeMethod(requestContext);
 
+    // TODO(bajtos) instantiate the Sequence via ctx.get()
     const findRoute = await requestContext.get('findRoute');
     const invokeMethod = await requestContext.get('invokeMethod');
+    const logError = await requestContext.get('logError');
+    const sequence = new Sequence(findRoute, invokeMethod, logError);
 
-    // TODO(bajtos) instantiate the Sequence via ctx.get()
-    const sequence = new Sequence(findRoute, invokeMethod, this.logError.bind(this));
     return sequence.run(parsedRequest, response);
   }
 
@@ -78,10 +79,5 @@ export class HttpHandler {
         return result;
       };
     });
-  }
-
-  logError(err: Error, statusCode: number, req: ServerRequest): void {
-    console.error('Unhandled error in %s %s: %s %s',
-      req.method, req.url, statusCode, err.stack || err);
   }
 }

--- a/packages/core/test/unit/application/application.test.ts
+++ b/packages/core/test/unit/application/application.test.ts
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, ShotRequest} from '@loopback/testlab';
+import {Application, ServerRequest} from '../../..';
+
+describe('Application', () => {
+  describe('"logError" binding', () => {
+    it('provides a default', async () => {
+      const app = new Application();
+      const logError = await app.get('logError');
+      expect(logError.length).to.equal(3); // (err, statusCode, request)
+    });
+
+    it('can be customized by overriding Application._logError() method', async () => {
+      let lastLog: string = 'logError() was not called';
+
+      class MyApp extends Application {
+        protected _logError(err: Error, statusCode: number, request: ServerRequest) {
+          lastLog = `${request.url} ${statusCode} ${err.message}`;
+        }
+      }
+
+      const app = new MyApp();
+      const logError = await app.get('logError');
+      logError(new Error('test-error'), 400, new ShotRequest({url: '/'}));
+
+      expect(lastLog).to.equal('/ 400 test-error');
+    });
+  });
+});
+


### PR DESCRIPTION
Refactor the code and move logError implementation from a hard-coded HttpHandler method into a customizable Application-level method and binding.

Connect to #308

cc @bajtos @raymondfeng @ritch @superkhau
