### PR TITLE
Fix ts-node version to 3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nyc": "^11.0.1",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
-    "ts-node": "^3.0.4",
+    "ts-node": "3.0.4",
     "tslint": "^5.4.2",
     "typescript": "^2.1.5"
   },


### PR DESCRIPTION
The new version 3.0.5 seems to contain a regression that causes
our builds to fail when running under `nyc`.

cc @bajtos @raymondfeng @ritch @superkhau
