### PR TITLE
Cleanup import in sequence.acceptance.ts

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,10 @@ export {HttpErrors};
 export {
   ParsedRequest,
   OperationRetval,
+  FindRoute,
+  InvokeMethod,
+  LogError,
+  OperationArgs,
 } from './internal-types';
 export {parseOperationArgs} from './parser';
 export {parseRequestUrl} from './router/routing-table';

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -6,9 +6,10 @@
 import {
   Application, Server, api,
   OpenApiSpec, ParameterObject,
-  ServerRequest, ServerResponse, parseOperationArgs, writeResultToResponse,
-} from '../../../index';
-import {ParsedRequest, OperationArgs, FindRoute, InvokeMethod} from '../../../src/internal-types';
+  ServerRequest, ServerResponse, parseOperationArgs,
+  writeResultToResponse, ParsedRequest, OperationArgs,
+  FindRoute, InvokeMethod,
+} from '../../..';
 import {expect, Client, createClientForServer} from '@loopback/testlab';
 import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';


### PR DESCRIPTION
This is to help code coverage and also those types should be in index.ts as well since they are used in user defined sequence. @raymondfeng PTAL As talked before, I opened a new PR with same changes as previous PR https://github.com/strongloop/loopback-next/pull/347
