### PR TITLE
Unify isPromise implementation

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -17,7 +17,6 @@
   "author": "IBM",
   "license": "MIT",
   "dependencies": {
-    "is-promise": "^2.1.0",
     "reflect-metadata": "^0.1.10"
   },
   "devDependencies": {

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -9,7 +9,7 @@ export {Constructor, resolveValueOrPromise} from './resolver';
 export {inject} from './inject';
 export {NamespacedReflect} from './reflect';
 export {Provider} from './provider';
-export const isPromise = require('is-promise');
+export {isPromise} from './isPromise';
 
 // internals for testing
 export {instantiateClass} from './resolver';

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -5,6 +5,7 @@
 
 export const jugglerModule = require('loopback-datasource-juggler');
 
+import {isPromise} from '@loopback/context';
 import {MixinBuilder} from './mixin';
 import {Class, ObjectType, Options, Any} from './common-types';
 
@@ -35,12 +36,8 @@ import {Entity} from './model';
 import {Filter, Where} from './query';
 import {EntityCrudRepository} from './repository';
 
-function isPromise<T>(p: Any): p is Promise<T> {
-  return p !== null && typeof p === 'object' && typeof p.then === 'function';
-}
-
 function ensurePromise<T>(p: juggler.PromiseOrVoid<T>): Promise<T> {
-  if (isPromise(p)) {
+  if (p && isPromise(p)) {
     return p;
   } else {
     return Promise.reject(new Error('The value should be a Promise: ' + p));


### PR DESCRIPTION
Use the version provided by `@loopback/context` in all places.

cc @bajtos @raymondfeng @ritch @superkhau
