### PR TITLE
Track latest ts-node releases again

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nyc": "^11.0.1",
     "request": "^2.79.0",
     "request-promise": "^4.1.1",
-    "ts-node": "3.0.4",
+    "ts-node": "^3.0.6",
     "tslint": "^5.4.3",
     "typescript": "^2.2.1"
   },


### PR DESCRIPTION
The version 3.0.6 has fixed the regression from 3.0.5, see https://github.com/TypeStrong/ts-node/issues/344

cc @bajtos @raymondfeng @ritch @superkhau
