### PR TITLE
Support synchronous resolution of Provider binding

### DIFF
--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -5,7 +5,7 @@
 
 export {Binding, BoundValue} from './binding';
 export {Context} from './context';
-export {Constructor, resolveValueOrPromise} from './resolver';
+export {Constructor} from './resolver';
 export {inject} from './inject';
 export {NamespacedReflect} from './reflect';
 export {Provider} from './provider';

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -132,17 +132,3 @@ export function resolveInjectedProperties(fn: Function, ctx: Context): KV | Prom
     return properties;
   }
 }
-
-/**
- * resolve a ValueOrPromise<T> to T
- */
-export async function resolveValueOrPromise<T>(instanceOrPromise: ValueOrPromise<T>): Promise<T> {
-  if (isPromise(instanceOrPromise)) {
-    const providerPromise = instanceOrPromise as Promise<T>;
-    const instance: T = await providerPromise;
-    return instance;
-  } else {
-    const instance: T = instanceOrPromise as T;
-    return instance;
-  }
-}

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -52,6 +52,13 @@ describe('Binding', () => {
       const value: String = ctx.getSync('provider_key');
       expect(value).to.equal('hello world');
     });
+
+    it('support asynchronous dependencies of provider class', async () => {
+      ctx.bind('msg').toDynamicValue(() => Promise.resolve('hello'));
+      ctx.bind('provider_key').toProvider(MyProvider);
+      const value: String = await ctx.get('provider_key');
+      expect(value).to.equal('hello world');
+    });
   });
 
   function givenBinding() {

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -38,38 +38,18 @@ describe('Binding', () => {
     });
   });
 
-  describe('getProviderInstance(ctx)', () => {
-    it('returns error when no provider is attached', async () => {
-      let err;
-      try {
-        await binding.getProviderInstance<String>(ctx);
-      } catch (exception) {
-        err = exception;
-        expect(exception.message).to.equal('No provider is attached to binding foo.');
-      }
-      expect(err).to.not.to.be.undefined();
-    });
-  });
-
   describe('toProvider(provider)', () => {
-    it('attaches a provider class to the binding', async () => {
-      ctx.bind('msg').to('hello');
-      binding.toProvider(MyProvider);
-      const providerInstance: Provider<String> = await binding.getProviderInstance<String>(ctx);
-      expect(providerInstance).to.be.instanceOf(MyProvider);
-    });
-
-    it('provider instance is injected with constructor arguments', async () => {
-      ctx.bind('msg').to('hello');
-      binding.toProvider(MyProvider);
-      const providerInstance: Provider<String> = await binding.getProviderInstance<String>(ctx);
-      expect(providerInstance.value()).to.equal('hello world');
-    });
-
     it('binding returns the expected value', async () => {
       ctx.bind('msg').to('hello');
       ctx.bind('provider_key').toProvider(MyProvider);
       const value: String = await ctx.get('provider_key');
+      expect(value).to.equal('hello world');
+    });
+
+    it('can resolve provided value synchronously', () => {
+      ctx.bind('msg').to('hello');
+      ctx.bind('provider_key').toProvider(MyProvider);
+      const value: String = ctx.getSync('provider_key');
       expect(value).to.equal('hello world');
     });
   });

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, inject, instantiateClass, resolveValueOrPromise} from '../..';
+import {Context, inject, instantiateClass} from '../..';
 
 describe('constructor injection', () => {
   let ctx: Context;
@@ -167,17 +167,5 @@ describe('sync constructor & async property injection', () => {
     const t = await instantiateClass(TestClass, ctx);
     expect(t.foo).to.eql('FOO');
     expect(t.bar).to.eql('BAR');
-  });
-});
-
-describe('resolveValueOrPromise()', () => {
-  it('resolves both a promise and a value', async () => {
-    const value: String = 'hello';
-    const promise = new Promise<String>((resolve) => {
-      resolve(value);
-    });
-    const result1 = await resolveValueOrPromise<String>(promise);
-    const result2 = await resolveValueOrPromise<String>(value);
-    expect(result1).to.be.equal(result2);
   });
 });


### PR DESCRIPTION
A follow-up for #343:

Modify `getValue()` function to correctly support the case where both the provider instance and the provided value can be obtained synchronously.

Simplify related code by removing stuff no longer needed.

cc @bajtos @raymondfeng @ritch @superkhau

