### PR TITLE
Fix problem matchers for the test task in VS Code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -105,6 +105,7 @@
         "test",
         "-s"
       ],
+      "problemMatcher": ["$tsc", "$tslint5"],
       "isTestCommand": true
     },
     // running example-codehub tests

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "coverage": "open coverage/index.html",
     "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check",
     "lint:fix": "npm run lint -- --fix",
-    "clean": "lerna run clean",
-    "build": "lerna run build",
+    "clean": "lerna run --loglevel=silent clean",
+    "build": "lerna run --loglevel=silent build",
     "pretest": "npm run build",
     "test": "nyc mocha --opts test/mocha.opts \"packages/*/test/**/*.ts\"",
     "posttest": "npm run lint"


### PR DESCRIPTION
Since "npm test" runs both TS Compiler and tslint now, the output can contain compilation and linting errors.

This commit is configuring problem matchers for the "run all tests" task to correctly pick up errors reported by tsc and tslint and list them in "problems" window.

Note: the tslint5 problem matcher is contributed by the VSCode extension vscode-tslint (maintained by Microsoft).

cc @bajtos @raymondfeng @ritch @superkhau

With this patch in place, we can use the single command "run tests" command (Cmd+Shift+T IIRC)  for a full build+test+lint run, with compiler/linter errors neatly listed in the Problems window.