### PR TITLE
Implement application components

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -3,4 +3,31 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export interface Component {}
+import {Constructor, Provider} from '@loopback/context';
+import {Application} from '.';
+
+// tslint:disable:no-any
+
+export interface Component {
+  controllers?: Constructor<any>[];
+  providers?: {
+    [key: string]: Constructor<Provider<any>>;
+  };
+}
+
+export function mountComponent(
+  app: Application,
+  component: Component,
+) {
+  if (component.controllers) {
+    for (const controllerCtor of component.controllers) {
+      app.controller(controllerCtor);
+    }
+  }
+
+  if (component.providers) {
+    for (const providerKey in component.providers) {
+      app.bind(providerKey).toProvider(component.providers[providerKey]);
+    }
+  }
+}

--- a/packages/core/test/acceptance/bootstrapping/application.feature.md
+++ b/packages/core/test/acceptance/bootstrapping/application.feature.md
@@ -23,6 +23,5 @@ const app = new Application({
 });
 
 // get metadata about the registered components
-console.log(app.find('component.*')); // [Bindings] should match the 4 components registered above
 console.log(app.find('sequence.*')); // [Bindings] should match the 1 sequence registered above
 ```


### PR DESCRIPTION
A component can be registered with an application either at construction time via AppOptions, or by calling `app.component()` later.

This first version allows components to contribute controllers and arbitrary provider bindings.

cc @bajtos @raymondfeng @ritch @superkhau
