### PR TITLE
server: call server.address after listening event

### DIFF
--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -61,12 +61,11 @@ describe('Routing', () => {
     }
     givenControllerInApp(app, EchoController);
 
-    return (
-      whenIMakeRequestTo(app)
-        .get('/echo?msg=hello%20world')
-        // Then I get the result `hello world` from the `Method`
-        .expect('hello world')
-    );
+    return whenIMakeRequestTo(app).then(client => {
+      return client.get('/echo?msg=hello%20world')
+      // Then I get the result `hello world` from the `Method`
+      .expect('hello world');
+    });
   });
 
   it('injects controller constructor arguments', () => {
@@ -94,7 +93,10 @@ describe('Routing', () => {
     }
     givenControllerInApp(app, InfoController);
 
-    return whenIMakeRequestTo(app).get('/name').expect('TestApp');
+    return whenIMakeRequestTo(app).then(client => {
+      return client.get('/name')
+      .expect('TestApp');
+    });
   });
 
   it('creates a new child context for each request', async () => {
@@ -127,10 +129,16 @@ describe('Routing', () => {
     // Rebind "flag" to "modified". Since we are modifying
     // the per-request child context, the change should
     // be discarded after the request is done.
-    await whenIMakeRequestTo(app).put('/flag');
+    await whenIMakeRequestTo(app).then(client => {
+      return client.put('/flag');
     // Get the value "flag" is bound to.
     // This should return the original value.
-    await whenIMakeRequestTo(app).get('/flag').expect('original');
+
+    });
+    await whenIMakeRequestTo(app).then(client => {
+      return client.get('/flag')
+      .expect('original');
+    });
   });
 
   it('binds request and response objects', () => {
@@ -154,7 +162,10 @@ describe('Routing', () => {
     }
     givenControllerInApp(app, StatusController);
 
-    return whenIMakeRequestTo(app).get('/status').expect(202, 'GET');
+    return whenIMakeRequestTo(app).then(client => {
+      return client.get('/status')
+      .expect(202, 'GET');
+    });
   });
 
   it('binds controller constructor object and operation', () => {
@@ -182,9 +193,13 @@ describe('Routing', () => {
     }
     givenControllerInApp(app, GetCurrentController);
 
-    return whenIMakeRequestTo(app).get('/name').expect({
-      ctor: 'GetCurrentController',
-      operation: 'getControllerName',
+    return whenIMakeRequestTo(app).then(client => {
+      return client.get('/name')
+      .expect({
+        ctor: 'GetCurrentController',
+        operation: 'getControllerName',
+      });
+
     });
   });
 
@@ -201,8 +216,9 @@ describe('Routing', () => {
     app.controller(controller);
   }
 
-  function whenIMakeRequestTo(app: Application): Client {
+  function whenIMakeRequestTo(app: Application): Promise<Client> {
     const server = new Server(app, {port: 0});
-    return createClientForServer(server);
+    const result = createClientForServer(server);
+    return result;
   }
 });

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -32,7 +32,10 @@ describe('Sequence - ', () => {
   beforeEach(givenAppWithController);
 
   it('default sequence', () => {
-    return whenIMakeRequestTo().get('/name').expect('SequenceApp');
+    return whenIMakeRequestTo(app).then(client => {
+      return client.get('/name')
+        .expect('SequenceApp');
+    });
   });
 
   it('user defined sequence', () => {
@@ -59,7 +62,10 @@ describe('Sequence - ', () => {
     // bind user defined sequence
     app.bind('sequence').toClass(MySequence);
 
-    return whenIMakeRequestTo().get('/name').expect('MySequence SequenceApp');
+    return whenIMakeRequestTo(app).then(client => {
+      return client.get('/name')
+        .expect('MySequence SequenceApp');
+    });
   });
 
   function givenAppWithController() {
@@ -97,8 +103,8 @@ describe('Sequence - ', () => {
     app.controller(controller);
   }
 
-  function whenIMakeRequestTo(): Client {
-    const server = new Server(app, {port: 0});
+  function whenIMakeRequestTo(application: Application): Promise<Client> {
+    const server = new Server(application, {port: 0});
     return createClientForServer(server);
   }
 });

--- a/packages/testlab/src/client.ts
+++ b/packages/testlab/src/client.ts
@@ -31,8 +31,8 @@ export interface Server {
   start(): Promise<void>;
 }
 
-export function createClientForServer(server: Server): Client {
-  const dontWaitForListening = server.start();
+export async function createClientForServer(server: Server): Promise<Client> {
+  await server.start();
   const url = `http://127.0.0.1:${server.config.port}`;
   // TODO(bajtos) Find a way how to stop the server after all tests are done
   return supertest(url);


### PR DESCRIPTION
As per the Node.js API docs (https://nodejs.org/api/http.html)
the `server.address` function should only be called *after*
the "listening" event is triggered.

cc @bajtos @raymondfeng @ritch @superkhau
