### PR TITLE
Fix http header typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/mocha": "^2.2.39",
-    "@types/node": "^7.0.28",
+    "@types/node": "^7.0.31",
     "@types/request": "^0.0.43",
     "@types/request-promise": "^4.1.33",
     "coveralls": "^2.13.1",


### PR DESCRIPTION
With `@types/node 7.0.31`, the header value is now string | string[]

@deepakrkris 