### PR TITLE
Improve context bindings

### DIFF
--- a/packages/context/test/acceptance/locking-bindings.ts
+++ b/packages/context/test/acceptance/locking-bindings.ts
@@ -40,7 +40,7 @@ describe('Context bindings - Locking bindings', () => {
           const operation = () => ctx.bind('foo');
           expect(operation).to.throw(
             new RegExp(
-              `Cannot rebind key "${key}", associated binding is locked`,
+              `Cannot rebind key "${key}" to a locked binding`,
             ),
           );
         });

--- a/packages/context/test/acceptance/tagged-bindings.feature.md
+++ b/packages/context/test/acceptance/tagged-bindings.feature.md
@@ -19,5 +19,5 @@ let ctx = new Context();
 // create a tagged binding
 let binding = ctx.bind('foo').to('bar').tag('qux');
 
-console.log(binding.tagName) // => qux
+console.log(binding.tags) // => Set { 'qux' }
 ```

--- a/packages/context/test/acceptance/tagged-bindings.ts
+++ b/packages/context/test/acceptance/tagged-bindings.ts
@@ -12,16 +12,29 @@ describe('Context bindings - Tagged bindings', () => {
   before('given a context', createContext);
   before(createBinding);
 
-  describe('Single tag', () => {
+  describe('tag', () => {
     context('when the binding is tagged', () => {
       before(tagBinding);
 
       it('has a tag name', () => {
-        expect(binding.tagName).to.equal('qux');
+        expect(binding.tags.has('qux')).to.be.true();
       });
 
       function tagBinding() {
         binding.tag('qux');
+      }
+    });
+
+    context('when the binding is tagged with multiple names', () => {
+      before(tagBinding);
+
+      it('has tags', () => {
+        expect(binding.tags.has('x')).to.be.true();
+        expect(binding.tags.has('y')).to.be.true();
+      });
+
+      function tagBinding() {
+        binding.tag(['x', 'y']);
       }
     });
   });

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -31,6 +31,22 @@ describe('Binding', () => {
     });
   });
 
+  describe('tag', () => {
+    it('tags the binding', () => {
+      binding.tag('t1');
+      expect(binding.tags.has('t1')).to.be.true();
+      binding.tag('t2');
+      expect(binding.tags.has('t1')).to.be.true();
+      expect(binding.tags.has('t2')).to.be.true();
+    });
+
+    it('tags the binding with an array', () => {
+      binding.tag(['t1', 't2']);
+      expect(binding.tags.has('t1')).to.be.true();
+      expect(binding.tags.has('t2')).to.be.true();
+    });
+  });
+
   describe('to(value)', () => {
     it('returns the value synchronously', () => {
       binding.to('value');

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -8,24 +8,27 @@ import {Context, Binding} from '../..';
 
 describe('Context', () => {
   let ctx: Context;
-  before('given a context', createContext);
+  beforeEach('given a context', createContext);
 
   describe('bind', () => {
-    let binding: Binding;
-    before('create a binding', createBinding);
 
     it('adds a binding into the registry', () => {
+      ctx.bind('foo');
       const result = ctx.contains('foo');
       expect(result).to.be.true();
     });
 
     it('returns a binding', () => {
+      const binding = ctx.bind('foo');
       expect(binding).to.be.instanceOf(Binding);
     });
 
-    function createBinding() {
-      binding = ctx.bind('foo');
-    }
+    it('rejects a key containing property separator', () => {
+      const key = 'a' + Binding.PROPERTY_SEPARATOR + 'b';
+      expect(() =>
+        ctx.bind(key)).to.throw(/Binding key .* cannot contain/);
+    });
+
   });
 
   describe('contains', () => {
@@ -38,6 +41,41 @@ describe('Context', () => {
     it('returns false when the key is not in the registry', () => {
       const result = ctx.contains('bar');
       expect(result).to.be.false();
+    });
+  });
+
+  describe('find', () => {
+    it('returns matching binding', () => {
+      const b1 = ctx.bind('foo');
+      const b2 = ctx.bind('bar');
+      const result = ctx.find('foo');
+      expect(result).to.be.eql([b1]);
+    });
+
+    it('returns matching binding with *', () => {
+      const b1 = ctx.bind('foo');
+      const b2 = ctx.bind('bar');
+      const b3 = ctx.bind('baz');
+      let result = ctx.find('*');
+      expect(result).to.be.eql([b1, b2, b3]);
+      result = ctx.find('ba*');
+      expect(result).to.be.eql([b2, b3]);
+    });
+  });
+
+  describe('findByTag', () => {
+    it('returns matching binding', () => {
+      const b1 = ctx.bind('foo').tag('t1');
+      const b2 = ctx.bind('bar').tag('t2');
+      const result = ctx.findByTag('t1');
+      expect(result).to.be.eql([b1]);
+    });
+
+    it('returns matching binding with *', () => {
+      const b1 = ctx.bind('foo').tag('t1');
+      const b2 = ctx.bind('bar').tag('t2');
+      const result = ctx.findByTag('t*');
+      expect(result).to.be.eql([b1, b2]);
     });
   });
 
@@ -60,9 +98,49 @@ describe('Context', () => {
       expect(result).to.equal('bar');
     });
 
+    it('returns the value with property separator', () => {
+      const SEP = Binding.PROPERTY_SEPARATOR;
+      const val = {x: {y: 'Y'}};
+      ctx.bind('foo').to(val);
+      let result = ctx.getSync('foo');
+      expect(result).to.equal(val);
+      result = ctx.getSync(`foo${SEP}x`);
+      expect(result).to.eql({y: `Y`});
+      result = ctx.getSync(`foo${SEP}x.y`);
+      expect(result).to.eql('Y');
+      result = ctx.getSync(`foo${SEP}z`);
+      expect(result).to.be.undefined();
+      result = ctx.getSync(`foo${SEP}x.y.length`);
+      expect(result).to.eql(1);
+    });
+
     it('throws a helpful error when the binding is async', () => {
       ctx.bind('foo').toDynamicValue(() => Promise.resolve('bar'));
-      expect(() => ctx.getSync('foo')).to.throw(/foo.*async/);
+      expect(() => ctx.getSync('foo')).to.throw(/foo.*the value is a promise/);
+    });
+  });
+
+  describe('get', () => {
+    it('returns a promise when the binding is async', async () => {
+      ctx.bind('foo').to(Promise.resolve('bar'));
+      const result = await ctx.get('foo');
+      expect(result).to.equal('bar');
+    });
+
+    it('returns the value with property separator', async () => {
+      const SEP = Binding.PROPERTY_SEPARATOR;
+      const val = {x: {y: 'Y'}};
+      ctx.bind('foo').to(Promise.resolve(val));
+      let result = await ctx.get('foo');
+      expect(result).to.equal(val);
+      result = await ctx.get(`foo${SEP}x`);
+      expect(result).to.eql({y: `Y`});
+      result = await ctx.get(`foo${SEP}x.y`);
+      expect(result).to.eql('Y');
+      result = await ctx.get(`foo${SEP}z`);
+      expect(result).to.be.undefined();
+      result = await ctx.get(`foo${SEP}x.y.length`);
+      expect(result).to.eql(1);
     });
   });
 


### PR DESCRIPTION
1. Allow separator for nested properties
2. Allow multiple tags for a binding

cc @bajtos @raymondfeng @ritch @superkhau

See https://github.com/strongloop/loopback-next/issues/258

With this change, we now support `ctx.get('x.y#a.b')` now.