### PR TITLE
Add API doc for Sequence, writer, parser & InvokeMethod

### DIFF
--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -19,9 +19,9 @@ export interface ParsedRequest extends ServerRequest {
 
 export type FindRoute = (request: ParsedRequest) => ResolvedRoute<string>;
 /**
- * Invokes method which is defined in the Application Controller
+ * Invokes a method defined in the Application Controller
  *
- * @param controller Name of End user's application controller
+ * @param controller Name of end-user's application controller
  *  class which defines the methods.
  * @param method Method name in application controller class
  * @param args Operation arguments for the method

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -18,6 +18,15 @@ export interface ParsedRequest extends ServerRequest {
 }
 
 export type FindRoute = (request: ParsedRequest) => ResolvedRoute<string>;
+/**
+ * Invokes API which is defined in the Application Controller
+ *
+ * @param controller Name of End user's application controller
+ *  class which defines the APIs.
+ * @param method API method name in application controller class
+ * @param args Operation arguments for the API
+ * @returns OperationRetval Result from API invocation
+ */
 export type InvokeMethod = (
   controller: string,
   method: string,

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -19,13 +19,13 @@ export interface ParsedRequest extends ServerRequest {
 
 export type FindRoute = (request: ParsedRequest) => ResolvedRoute<string>;
 /**
- * Invokes API which is defined in the Application Controller
+ * Invokes method which is defined in the Application Controller
  *
  * @param controller Name of End user's application controller
- *  class which defines the APIs.
- * @param method API method name in application controller class
- * @param args Operation arguments for the API
- * @returns OperationRetval Result from API invocation
+ *  class which defines the methods.
+ * @param method Method name in application controller class
+ * @param args Operation arguments for the method
+ * @returns OperationRetval Result from method invocation
  */
 export type InvokeMethod = (
   controller: string,

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -45,7 +45,8 @@ function getContentType(req: ServerRequest): string | undefined {
 }
 
 /**
- * Parses the request to derive arguments to be passed in for the API
+ * Parses the request to derive arguments to be passed in for the Application
+ * controller method
  *
  * @param request Incoming HTTP request
  * @param operationSpec Swagger spec defined in the controller

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -44,6 +44,13 @@ function getContentType(req: ServerRequest): string | undefined {
   return undefined;
 }
 
+/**
+ * Parses the request to derive arguments to be passed in for the API
+ *
+ * @param request Incoming HTTP request
+ * @param operationSpec Swagger spec defined in the controller
+ * @param pathParams Path parameters in incoming HTTP request
+ */
 export async function parseOperationArgs(
   request: ParsedRequest,
   operationSpec: OperationObject,

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -16,14 +16,49 @@ import {
 import {parseOperationArgs} from './parser';
 import {writeResultToResponse} from './writer';
 import {HttpError} from 'http-errors';
-
+/**
+ * The default implementation of Sequence.
+ *
+ * This class implements default Sequence for the loopback-next framework.
+ * Default sequence is used if user hasn't defined their own Sequence
+ * for their application.
+ *
+ * Sequence constructor() and run() methods are invoked from [[http-handler]]
+ * when the API request comes in.
+ *
+ * Sequence executes these steps
+ *  - Finds the appropriate controller method, swagger spec
+ *    and args for invocation
+ *  - Parses HTTP request to get API argument list
+ *  - Invokes the API which is defined in the Application Controller
+ *  - Writes the result from API into the HTTP response
+ *
+ * User can bind their own Sequence to app as shown below
+ * ```ts
+ * app.bind('sequence').toClass(MySequence);
+ * ```
+ */
 export class Sequence {
+   /**
+   * Constructor: Injects findRoute, invokeMethod & logError
+   * methods as promises.
+   *
+   * @param findRoute Finds the appropriate controller method,
+   *  spec and args for invocation
+   * @param invoke Invokes the API
+   * @param logError Logs error
+   */
   constructor(
     @inject('findRoute') protected findRoute: FindRoute,
     @inject('invokeMethod') protected invoke: InvokeMethod,
     @inject('logError') protected logError: LogError,
   ) {}
-
+  /**
+   * Runs the sequence
+   *
+   * @param req Parsed incoming HTTP request
+   * @param res HTTP server response with result from API invocation
+   */
   async run(req: ParsedRequest, res: ServerResponse) {
     try {
       const {controller, methodName, spec, pathParams} = this.findRoute(req);
@@ -35,11 +70,21 @@ export class Sequence {
       this.sendError(res, req, err);
     }
   }
-
+   /**
+   * Sends API result in HTTP response
+   *
+   * @param res HTTP server response to write the result of API invocation
+   * @param result Result from API invocation
+   */
   sendResponse(response: ServerResponse, result: OperationRetval) {
     writeResultToResponse(response, result);
   }
-
+   /**
+   * Logs error
+   *
+   * @param res HTTP server response to write the error status and error code
+   * @param req Incoming HTTP request
+   */
   sendError(res: ServerResponse, req: ServerRequest, err: HttpError) {
     const statusCode = err.statusCode || err.status || 500;
     res.statusCode = statusCode;

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -19,12 +19,13 @@ import {HttpError} from 'http-errors';
 /**
  * The default implementation of Sequence.
  *
- * This class implements default Sequence for the loopback framework.
+ * This class implements default Sequence for the LoopBack framework.
  * Default sequence is used if user hasn't defined their own Sequence
  * for their application.
  *
  * Sequence constructor() and run() methods are invoked from [[http-handler]]
- * when the API request comes in.
+ * when the API request comes in. User defines APIs in their Application
+ * Controller class.
  *
  * Sequence executes these steps
  *  - Finds the appropriate controller method, swagger spec
@@ -45,7 +46,7 @@ export class Sequence {
    *
    * @param findRoute Finds the appropriate controller method,
    *  spec and args for invocation
-   * @param invoke Invokes the API
+   * @param invoke Invokes the method
    * @param logError Logs error
    */
   constructor(
@@ -57,7 +58,8 @@ export class Sequence {
    * Runs the sequence
    *
    * @param req Parsed incoming HTTP request
-   * @param res HTTP server response with result from API invocation
+   * @param res HTTP server response with result from Application controller
+   *  method invocation
    */
   async run(req: ParsedRequest, res: ServerResponse) {
     try {
@@ -73,8 +75,8 @@ export class Sequence {
    /**
    * Sends API result in HTTP response
    *
-   * @param res HTTP server response to write the result of API invocation
-   * @param result Result from API invocation
+   * @param res HTTP server response to write the result of method invocation
+   * @param result Result from method invocation
    */
   sendResponse(response: ServerResponse, result: OperationRetval) {
     writeResultToResponse(response, result);

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -27,13 +27,6 @@ import {HttpError} from 'http-errors';
  * when the API request comes in. User defines APIs in their Application
  * Controller class.
  *
- * Sequence executes these steps
- *  - Finds the appropriate controller method, swagger spec
- *    and args for invocation
- *  - Parses HTTP request to get API argument list
- *  - Invokes the API which is defined in the Application Controller
- *  - Writes the result from API into the HTTP response
- *
  * User can bind their own Sequence to app as shown below
  * ```ts
  * app.bind('sequence').toClass(MySequence);
@@ -54,9 +47,20 @@ export class Sequence {
     @inject('invokeMethod') protected invoke: InvokeMethod,
     @inject('logError') protected logError: LogError,
   ) {}
+
+
   /**
-   * Runs the sequence
+   * Rus the default sequence. Given a request and response, running the
+   * sequence will produce a response or an error.
    *
+   * Default sequence executes these steps
+   *  - Finds the appropriate controller method, swagger spec
+   *    and args for invocation
+   *  - Parses HTTP request to get API argument list
+   *  - Invokes the API which is defined in the Application Controller
+   *  - Writes the result from API into the HTTP response
+   *  - Error is caught and logged using 'logError' if any of the above steps
+   *    in the sequence fails with an error.
    * @param req Parsed incoming HTTP request
    * @param res HTTP server response with result from Application controller
    *  method invocation
@@ -72,21 +76,11 @@ export class Sequence {
       this.sendError(res, req, err);
     }
   }
-   /**
-   * Sends API result in HTTP response
-   *
-   * @param res HTTP server response to write the result of method invocation
-   * @param result Result from method invocation
-   */
+
   sendResponse(response: ServerResponse, result: OperationRetval) {
     writeResultToResponse(response, result);
   }
-   /**
-   * Logs error
-   *
-   * @param res HTTP server response to write the error status and error code
-   * @param req Incoming HTTP request
-   */
+
   sendError(res: ServerResponse, req: ServerRequest, err: HttpError) {
     const statusCode = err.statusCode || err.status || 500;
     res.statusCode = statusCode;

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -19,7 +19,7 @@ import {HttpError} from 'http-errors';
 /**
  * The default implementation of Sequence.
  *
- * This class implements default Sequence for the loopback-next framework.
+ * This class implements default Sequence for the loopback framework.
  * Default sequence is used if user hasn't defined their own Sequence
  * for their application.
  *

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -50,7 +50,7 @@ export class Sequence {
 
 
   /**
-   * Rus the default sequence. Given a request and response, running the
+   * Runs the default sequence. Given a request and response, running the
    * sequence will produce a response or an error.
    *
    * Default sequence executes these steps

--- a/packages/core/src/writer.ts
+++ b/packages/core/src/writer.ts
@@ -5,7 +5,12 @@
 
 import {ServerResponse as Response} from 'http';
 import {OperationRetval} from './internal-types';
-
+/**
+ * Writes the result from API into the HTTP response
+ *
+ * @param response HTTP Response
+ * @param result Result from the API to write into HTTP Response
+ */
 export function writeResultToResponse(
   // not needed and responsibility should be in the sequence.send
   response: Response,

--- a/packages/core/src/writer.ts
+++ b/packages/core/src/writer.ts
@@ -6,7 +6,8 @@
 import {ServerResponse as Response} from 'http';
 import {OperationRetval} from './internal-types';
 /**
- * Writes the result from API into the HTTP response
+ * Writes the result from Application controller method
+ * into the HTTP response
  *
  * @param response HTTP Response
  * @param result Result from the API to write into HTTP Response


### PR DESCRIPTION
@raymondfeng @crandmck  @mpatsute  @ritch PTAL
Please review docs for below APIs. This PR covers APIs in issue #https://github.com/strongloop-internal/scrum-asteroid/issues/231 
APIs covered in this work item/PR
1. Sequence class
2. InvokeMethod in internal-types.ts 
3. parseOperationArgs () in parser.ts - Rest of the methods in this file are internal methods and hence doesn’t need API doc
4. writeResultToResponse() in writer.ts 

There are different work items opened for other APIs in loopback-next which are in different team-members board.
