### PR TITLE
Make send/reject injectable

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -9,7 +9,9 @@ import {ServerRequest, ServerResponse} from 'http';
 import {Component, mountComponent} from './component';
 import {getApiSpec} from './router/metadata';
 import {HttpHandler} from './http-handler';
+import {writeResultToResponse} from './writer';
 import {Sequence} from './sequence';
+import {RejectProvider} from './router/reject';
 
 const debug = require('debug')('loopback:core:application');
 
@@ -50,6 +52,8 @@ export class Application extends Context {
       this._handleHttpRequest(req, res);
 
     this.bind('logError').to(this._logError.bind(this));
+    this.bind('sequence.actions.send').to(writeResultToResponse);
+    this.bind('sequence.actions.reject').toProvider(RejectProvider);
   }
 
   protected _bindSequence(): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,10 +33,13 @@ export {
   OperationArgs,
   getFromContext,
   bindElement,
+  Reject,
+  Send,
 } from './internal-types';
 export {parseOperationArgs} from './parser';
 export {parseRequestUrl} from './router/routing-table';
 export {RoutingTable, ResolvedRoute} from './router/routing-table';
 export {HttpHandler} from './http-handler';
 export {writeResultToResponse} from './writer';
+export {RejectProvider} from './router/reject';
 export * from './keys';

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Binding, BoundValue, ValueOrPromise} from '@loopback/context';
-import {ServerRequest} from 'http';
+import {ServerRequest, ServerResponse} from 'http';
 import {ResolvedRoute} from './router/routing-table';
 
 export interface ParsedRequest extends ServerRequest {
@@ -18,7 +18,12 @@ export interface ParsedRequest extends ServerRequest {
   method: string;
 }
 
+/**
+ * Find a route matching the incoming request.
+ * Throw an error when no route was found.
+ */
 export type FindRoute = (request: ParsedRequest) => ResolvedRoute<string>;
+
 /**
  * Invokes a method defined in the Application Controller
  *
@@ -33,6 +38,38 @@ export type InvokeMethod = (
   method: string,
   args: OperationArgs,
 ) => Promise<OperationRetval>;
+
+/**
+ * Send the operation response back to the client.
+ *
+ * @param response The response the response to send to.
+ * @param result The operation result to send.
+ */
+export type Send = (
+  response: ServerResponse,
+  result: OperationRetval,
+) => void;
+
+/**
+ * Reject the request with an error.
+ *
+ * @param response The response the response to send to.
+ * @param request The request that triggered the error.
+ * @param err The error.
+ */
+export type Reject = (
+  response: ServerResponse,
+  request: ServerRequest,
+  err: Error,
+) => void;
+
+/**
+ * Log information about a failed request.
+ *
+ * @param err The error reported by request handling code.
+ * @param statusCode Status code of the HTTP response
+ * @param request The request that failed.
+ */
 export type LogError = (
   err: Error,
   statusCode: number,

--- a/packages/core/src/router/reject.ts
+++ b/packages/core/src/router/reject.ts
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {LogError, Reject} from '../internal-types';
+import {inject} from '@loopback/context';
+import {ServerResponse, ServerRequest} from '..';
+import {HttpError} from 'http-errors';
+
+export class RejectProvider {
+  constructor(@inject('logError') protected logError: LogError) {}
+
+  value(): Reject {
+    return (
+      response: ServerResponse,
+      request: ServerRequest,
+      error: Error,
+    ) => {
+      const err = error as HttpError;
+      const statusCode = err.statusCode || err.status || 500;
+      response.statusCode = statusCode;
+      response.end();
+
+      this.logError(error, statusCode, request);
+    };
+  }
+}

--- a/packages/core/test/unit/reject.test.ts
+++ b/packages/core/test/unit/reject.test.ts
@@ -1,0 +1,50 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  ServerRequest,
+  ParsedRequest,
+  Reject,
+  RejectProvider,
+  LogError,
+} from '../..';
+
+import {
+  expect,
+  mockResponse,
+  ShotResponseMock,
+  sinon,
+  SinonSpy,
+} from '@loopback/testlab';
+
+describe('reject', () => {
+  const noopLogger: LogError = () => {};
+  const testError = new Error('test error');
+  let mock: ShotResponseMock;
+
+  beforeEach(givenMockedResponse);
+
+  it('returns HTTP response with status code 500 by default', async () => {
+    const reject = new RejectProvider(noopLogger).value();
+    reject(mock.response, mock.request, testError);
+    const result = await mock.result;
+
+    expect(result).to.have.property('statusCode', 500);
+  });
+
+  it('logs the error', async () => {
+    const logger = sinon.spy() as LogError & SinonSpy;
+    const reject = new RejectProvider(logger).value();
+
+    reject(mock.response, mock.request, testError);
+    const result = await mock.result;
+
+    expect(logger).to.be.calledWith(testError, 500, mock.request);
+  });
+
+  function givenMockedResponse() {
+    mock = mockResponse();
+  }
+});

--- a/packages/core/test/unit/writer.test.ts
+++ b/packages/core/test/unit/writer.test.ts
@@ -7,9 +7,9 @@ import {ServerResponse, OperationRetval, writeResultToResponse} from '../..';
 
 import {
   expect,
-  ShotRequest,
-  ShotResponse,
+  mockResponse,
   ShotObservedResponse,
+  ShotRequest,
 } from '@loopback/testlab';
 
 describe('writer', () => {
@@ -37,10 +37,9 @@ describe('writer', () => {
   });
 
   function setupResponseMock() {
-    const req = new ShotRequest({url: '/'});
-    observedResponse = new Promise(resolve => {
-      response = new ShotResponse(req, resolve);
-    });
+    const responseMock = mockResponse();
+    response = responseMock.response;
+    observedResponse = responseMock.result;
 
     // content-type should be undefined since it's not set in the response yet.
     expect(response.getHeader('content-type')).to.eql(undefined);

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -20,6 +20,7 @@
     "@types/supertest": "^2.0.0",
     "shot": "^3.4.0",
     "should": "^11.2.1",
+    "should-sinon": "0.0.5",
     "sinon": "^2.3.5",
     "supertest": "^3.0.0"
   },

--- a/packages/testlab/src/testlab.ts
+++ b/packages/testlab/src/testlab.ts
@@ -6,14 +6,17 @@
 /// <reference path="../should-as-function.d.ts" />
 
 const shouldAsFunction: Internal = require('should/as-function');
+import 'should-sinon';
+
 import sinon = require('sinon');
+import {SinonSpy} from 'sinon';
 
 shouldAsFunction.use((should, assertion) => {
   assertion.addChain('to');
 });
 
 export const expect = shouldAsFunction;
-export {sinon};
+export {sinon, SinonSpy};
 
 export * from './client';
 export * from './shot';


### PR DESCRIPTION
As I started working on `app.sequence((seq, res, res) => {...})`, I realised that we really need to refactor `sendResponse`/`sendError` into injectable `send`/`reject`.  That's what this pull request presents.

cc @bajtos @raymondfeng @ritch @superkhau
