### PR TITLE
Configure prettier to add trailing commas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
   "prettier.bracketSpacing": false,
   "prettier.singleQuote": true,
   "prettier.printWidth": 80,
+  "prettier.trailingComma": "all",
 
   "tslint.ignoreDefinitionFiles": true,
   "typescript.tsdk": "./node_modules/typescript/lib"


### PR DESCRIPTION
Trailing-comma is already required by our tslint config, see https://github.com/strongloop/loopback-next/blob/4a90d66bc6ac08bb253e1b35eb809b42d0e3fe65/tslint.json#L37-L40

cc @bajtos @raymondfeng @ritch @superkhau @kjdelisle 
