### PR TITLE
Clean up Sequence API

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -10,7 +10,7 @@ import {Component, mountComponent} from './component';
 import {getApiSpec} from './router/metadata';
 import {HttpHandler} from './http-handler';
 import {writeResultToResponse} from './writer';
-import {Sequence} from './sequence';
+import {Sequence, SequenceHandler} from './sequence';
 import {RejectProvider} from './router/reject';
 
 const debug = require('debug')('loopback:core:application');
@@ -155,5 +155,5 @@ export class Application extends Context {
 
 export interface ApplicationOptions {
   components?: Array<Constructor<Component>>;
-  sequence?: Constructor<Sequence>;
+  sequence?: Constructor<SequenceHandler>;
 }

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -49,7 +49,7 @@ export class HttpHandler {
     this._bindBindElement(requestContext);
 
     const sequence: Sequence = await requestContext.get('sequence');
-    return sequence.run(parsedRequest, response);
+    return sequence.handle(parsedRequest, response);
   }
 
   protected _createRequestContext(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@
 export {Application} from './application';
 export {Component} from './component';
 export {api} from './router/metadata';
-export {Sequence} from './sequence';
+export {Sequence, SequenceHandler} from './sequence';
 export {Server, ServerConfig, ServerState} from './server';
 
 // loopback dependencies

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -18,8 +18,23 @@ import {
 import {parseOperationArgs} from './parser';
 import {writeResultToResponse} from './writer';
 import {HttpError} from 'http-errors';
+
 /**
- * The default implementation of Sequence.
+ * A sequence handler is a class implementing sequence of actions
+ * required to handle an incoming request.
+ */
+export interface SequenceHandler {
+  /**
+   * Handle the request by running the configured sequence of actions.
+   *
+   * @param request The incoming HTTP request
+   * @param response The HTTP server response where to write the result
+   */
+  handle(request: ParsedRequest, response: ServerResponse): Promise<void>;
+}
+
+/**
+ * The default implementation of SequenceHandler.
  *
  * This class implements default Sequence for the LoopBack framework.
  * Default sequence is used if user hasn't defined their own Sequence
@@ -34,7 +49,7 @@ import {HttpError} from 'http-errors';
  * app.bind('sequence').toClass(MySequence);
  * ```
  */
-export class Sequence {
+export class Sequence implements SequenceHandler{
    /**
    * Constructor: Injects findRoute, invokeMethod & logError
    * methods as promises.
@@ -68,7 +83,7 @@ export class Sequence {
    * @param res HTTP server response with result from Application controller
    *  method invocation
    */
-  async run(req: ParsedRequest, res: ServerResponse) {
+  async handle(req: ParsedRequest, res: ServerResponse) {
     try {
       const {controller, methodName, spec, pathParams} = this.findRoute(req);
       const args = await parseOperationArgs(req, spec, pathParams);

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -19,6 +19,7 @@ import {
   InvokeMethod,
   Send,
   Reject,
+  SequenceHandler,
 } from '../../..';
 import {expect, Client, createClientForServer} from '@loopback/testlab';
 import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
@@ -41,13 +42,13 @@ describe('Sequence - ', () => {
   });
 
   it('user defined sequence', () => {
-    class MySequence {
+    class MySequence implements SequenceHandler {
       constructor(
         @inject('findRoute') protected findRoute: FindRoute,
         @inject('invokeMethod') protected invoke: InvokeMethod,
       ) {}
 
-      async run(req: ParsedRequest, res: ServerResponse) {
+      async handle(req: ParsedRequest, res: ServerResponse) {
         const {
           controller,
           methodName,


### PR DESCRIPTION
 - Rename "run()" to "handle()"
 - Introduce a new interface SequenceHandler describing the public
   contract (API)

cc @bajtos @raymondfeng @ritch @superkhau
