### PR TITLE
Remove text coverage summary from "npm test"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
       ".ts"
     ],
     "reporter": [
-      "html",
-      "text"
+      "html"
     ]
   }
 }


### PR DESCRIPTION
Disable the text summary of code coverage - it produces a long wall of text that hides the actual test results. Developers wishing to inspect code coverage can `open coverage/index.html` to find the numbers.

cc @bajtos @raymondfeng @ritch @superkhau
