### PR TITLE
Refactor routing to support handlerFn-based routes

### DIFF
--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -25,7 +25,7 @@ import {
   SequenceHandler,
 } from '@loopback/core';
 import {expect, Client, createClientForServer} from '@loopback/testlab';
-import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
+import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {inject,
   Provider,
   ValueOrPromise,
@@ -90,7 +90,7 @@ describe('Basic Authentication', () => {
   }
 
   function givenControllerInApp() {
-    const apispec = givenOpenApiSpec()
+    const apispec = anOpenApiSpec()
       .withOperation('get', '/whoAmI', {
         'x-operation-name': 'whoAmI',
         responses: {

--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -138,12 +138,7 @@ describe('Basic Authentication', () => {
 
       async handle(req: ParsedRequest, res: ServerResponse) {
         try {
-          const {
-            controller,
-            methodName,
-            spec: routeSpec,
-            pathParams,
-          } = this.findRoute(req);
+          const route = this.findRoute(req);
 
           // Authenticate
           const user: UserProfile = await this.authenticate(req);
@@ -153,8 +148,8 @@ describe('Basic Authentication', () => {
           else throw new HttpErrors.InternalServerError('auth error');
 
           // Authentication successful, proceed to invoke controller
-          const args = await parseOperationArgs(req, routeSpec, pathParams);
-          const result = await this.invoke(controller, methodName, args);
+          const args = await parseOperationArgs(req, route);
+          const result = await this.invoke(route, args);
           this.send(res, result);
         } catch (err) {
           this.reject(res, req, err);

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -112,13 +112,26 @@ export class Application extends Context {
    * app.controller(MyController).lock();
    * ```
    */
-  public controller<T>(controllerCtor: Constructor<T>): Binding {
+  controller<T>(controllerCtor: Constructor<T>): Binding {
     return this.bind('controllers.' + controllerCtor.name).toClass(
       controllerCtor,
     );
   }
 
-  public route(route: Route): Binding {
+  /**
+   * Register a new route.
+   *
+   * ```ts
+   * function greet(name: string) {
+   *  return `hello ${name}`;
+   * }
+   * const route = new Route('get', '/', operationSpec, greet);
+   * app.route(route);
+   * ```
+   *
+   * @param route The route to add.
+   */
+  route(route: Route): Binding {
     return this.bind(`routes.${route.verb} ${route.path}`).to(route);
   }
 

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Binding, Context, Constructor, Provider} from '@loopback/context';
-import {OpenApiSpec} from '.';
+import {OpenApiSpec, Route} from '.';
 import {ServerRequest, ServerResponse} from 'http';
 import {Component, mountComponent} from './component';
 import {getApiSpec} from './router/metadata';
@@ -88,6 +88,12 @@ export class Application extends Context {
       const apiSpec = getApiSpec(ctor);
       this._httpHandler.registerController(b.key, apiSpec);
     }
+
+    for (const b of this.find('routes.*')) {
+      // TODO(bajtos) should we support routes defined asynchronously?
+      const route = this.getSync(b.key);
+      this._httpHandler.registerRoute(route);
+    }
   }
 
   /**
@@ -110,6 +116,10 @@ export class Application extends Context {
     return this.bind('controllers.' + controllerCtor.name).toClass(
       controllerCtor,
     );
+  }
+
+  public route(route: Route): Binding {
+    return this.bind(`routes.${route.verb} ${route.path}`).to(route);
   }
 
   protected _logError(

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -21,7 +21,7 @@ import {
 const debug = require('debug')('loopback:core:http-handler');
 
 export class HttpHandler {
-  protected _routes: RoutingTable<string> = new RoutingTable<string>();
+  protected _routes: RoutingTable = new RoutingTable();
 
   public handleRequest: (
     request: ServerRequest,

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -10,13 +10,18 @@ import {getApiSpec} from './router/metadata';
 import * as HttpErrors from 'http-errors';
 
 import {Sequence} from './sequence';
-import {RoutingTable, parseRequestUrl} from './router/routing-table';
+import {
+  RoutingTable,
+  parseRequestUrl,
+  isHandlerRoute,
+} from './router/routing-table';
 import {
   FindRoute,
   InvokeMethod,
   ParsedRequest,
   OperationArgs,
 } from './internal-types';
+import {ResolvedRoute, Route} from './index';
 
 const debug = require('debug')('loopback:core:http-handler');
 
@@ -34,6 +39,10 @@ export class HttpHandler {
 
   registerController(name: string, spec: OpenApiSpec) {
     this._routes.registerController(name, spec);
+  }
+
+  registerRoute(route: Route) {
+    this._routes.registerRoute(route);
   }
 
   protected async _handleRequest(
@@ -82,13 +91,16 @@ export class HttpHandler {
           );
 
         // bind routing information to context
-        const ctor = context.getBinding(found.controller).valueConstructor;
-        if (!ctor)
-          throw new Error(
-            `The controller ${found.controller} was not bound via .toClass()`,
-          );
-        context.bind('controller.current.ctor').to(ctor);
-        context.bind('controller.current.operation').to(found.methodName);
+        if (!isHandlerRoute(found)) {
+          const controllerName = found.controllerName;
+          const ctor = context.getBinding(controllerName).valueConstructor;
+          if (!ctor)
+            throw new Error(
+              `The controller ${controllerName} was not bound via .toClass()`,
+            );
+          context.bind('controller.current.ctor').to(ctor);
+          context.bind('controller.current.operation').to(found.methodName);
+        }
 
         return found;
       };
@@ -98,14 +110,24 @@ export class HttpHandler {
   protected _bindInvokeMethod(context: Context) {
     context.bind('invokeMethod').toDynamicValue(() => {
       return async (
-        controllerName: string,
-        method: string,
+        route: ResolvedRoute,
         args: OperationArgs,
       ) => {
+        if (isHandlerRoute(route)) {
+          const result = await route.handler(...args);
+          return result;
+        }
+
+        if (!(route.controllerName && route.methodName)) {
+          throw new Error(
+            'Invalid route: either handler or controllerName + methodName' +
+              ' is required.');
+        }
+
         const controller: {[opName: string]: Function} = await context.get(
-          controllerName,
+          route.controllerName,
         );
-        const result = await controller[method](...args);
+        const result = await controller[route.methodName](...args);
         return result;
       };
     });

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -14,6 +14,8 @@ import {
   RoutingTable,
   parseRequestUrl,
   isHandlerRoute,
+  ResolvedRoute,
+  Route,
 } from './router/routing-table';
 import {
   FindRoute,
@@ -21,7 +23,6 @@ import {
   ParsedRequest,
   OperationArgs,
 } from './internal-types';
-import {ResolvedRoute, Route} from './index';
 
 const debug = require('debug')('loopback:core:http-handler');
 
@@ -114,8 +115,7 @@ export class HttpHandler {
         args: OperationArgs,
       ) => {
         if (isHandlerRoute(route)) {
-          const result = await route.handler(...args);
-          return result;
+          return await route.handler(...args);
         }
 
         if (!(route.controllerName && route.methodName)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,12 +33,18 @@ export {
   OperationArgs,
   getFromContext,
   bindElement,
+  PathParameterValues,
   Reject,
   Send,
 } from './internal-types';
 export {parseOperationArgs} from './parser';
 export {parseRequestUrl} from './router/routing-table';
-export {RoutingTable, ResolvedRoute} from './router/routing-table';
+export {
+  RoutingTable,
+  Route,
+  ResolvedRoute,
+  isHandlerRoute,
+} from './router/routing-table';
 export {HttpHandler} from './http-handler';
 export {writeResultToResponse} from './writer';
 export {RejectProvider} from './router/reject';

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -22,7 +22,7 @@ export interface ParsedRequest extends ServerRequest {
  * Find a route matching the incoming request.
  * Throw an error when no route was found.
  */
-export type FindRoute = (request: ParsedRequest) => ResolvedRoute<string>;
+export type FindRoute = (request: ParsedRequest) => ResolvedRoute;
 
 /**
  * Invokes a method defined in the Application Controller

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -34,8 +34,7 @@ export type FindRoute = (request: ParsedRequest) => ResolvedRoute;
  * @returns OperationRetval Result from method invocation
  */
 export type InvokeMethod = (
-  controller: string,
-  method: string,
+  route: ResolvedRoute,
   args: OperationArgs,
 ) => Promise<OperationRetval>;
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -12,7 +12,7 @@ import {
   ParsedRequest,
   PathParameterValues,
 } from './internal-types';
-import {ResolvedRoute} from '../index';
+import {ResolvedRoute} from './router/routing-table';
 
 type HttpError = HttpErrors.HttpError;
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -12,6 +12,7 @@ import {
   ParsedRequest,
   PathParameterValues,
 } from './internal-types';
+import {ResolvedRoute} from '../index';
 
 type HttpError = HttpErrors.HttpError;
 
@@ -54,10 +55,10 @@ function getContentType(req: ServerRequest): string | undefined {
  */
 export async function parseOperationArgs(
   request: ParsedRequest,
-  operationSpec: OperationObject,
-  pathParams: PathParameterValues,
+  route: ResolvedRoute,
 ): Promise<OperationArgs> {
-  const args: OperationArgs = [];
+  const operationSpec = route.spec;
+  const pathParams = route.pathParams;
   const body = await loadRequestBodyIfNeeded(operationSpec, request);
   return buildOperationArguments(operationSpec, request, pathParams, body);
 }

--- a/packages/core/src/router/routing-table.ts
+++ b/packages/core/src/router/routing-table.ts
@@ -87,16 +87,16 @@ export class RoutingTable {
   }
 }
 
-export interface ResolvedRouteCommon {
+export interface ResolvedRouteBase {
   readonly spec: OperationObject;
   readonly pathParams: PathParameterValues;
 }
 
-export interface ResolvedHandlerRoute extends ResolvedRouteCommon {
+export interface ResolvedHandlerRoute extends ResolvedRouteBase {
   readonly handler: Function;
 }
 
-export interface ResolvedControllerRoute extends ResolvedRouteCommon {
+export interface ResolvedControllerRoute extends ResolvedRouteBase {
   readonly controllerName: string;
   readonly methodName: string;
 }
@@ -143,9 +143,7 @@ export class Route {
     return this._createResolvedRoute(pathParams);
   }
 
-  private _createResolvedRoute(
-    pathParams: PathParameterValues,
-  ): ResolvedRoute {
+  private _createResolvedRoute(pathParams: PathParameterValues): ResolvedRoute {
     return this._handler ?
       this._createResolvedHandlerRoute(pathParams) :
       this._createResolvedControllerRoute(pathParams);

--- a/packages/core/src/router/routing-table.ts
+++ b/packages/core/src/router/routing-table.ts
@@ -39,10 +39,10 @@ export function parseRequestUrl(request: ServerRequest): ParsedRequest {
   return parsedRequest;
 }
 
-export class RoutingTable<ControllerType> {
-  private readonly _routes: RouteEntry<ControllerType>[] = [];
+export class RoutingTable {
+  private readonly _routes: RouteEntry[] = [];
 
-  registerController(controller: ControllerType, spec: OpenApiSpec) {
+  registerController(controller: string, spec: OpenApiSpec) {
     assert(
       typeof spec === 'object' && !!spec,
       'API specification must be a non-null object',
@@ -71,7 +71,7 @@ export class RoutingTable<ControllerType> {
     }
   }
 
-  find(request: ParsedRequest): ResolvedRoute<ControllerType> | undefined {
+  find(request: ParsedRequest): ResolvedRoute | undefined {
     for (const entry of this._routes) {
       const match = entry.match(request);
       if (match) return match;
@@ -80,14 +80,14 @@ export class RoutingTable<ControllerType> {
   }
 }
 
-export interface ResolvedRoute<ControllerType> {
-  readonly controller: ControllerType;
+export interface ResolvedRoute {
+  readonly controller: string;
   readonly methodName: string;
   readonly spec: OperationObject;
   readonly pathParams: PathParameterValues;
 }
 
-class RouteEntry<ControllerType> {
+class RouteEntry {
   private readonly _verb: string;
   private readonly _pathRegexp: pathToRegexp.PathRegExp;
 
@@ -95,7 +95,7 @@ class RouteEntry<ControllerType> {
     path: string,
     verb: string,
     private readonly _spec: OperationObject,
-    private readonly _controller: ControllerType,
+    private readonly _controller: string,
   ) {
     this._verb = verb.toLowerCase();
 
@@ -105,7 +105,7 @@ class RouteEntry<ControllerType> {
     this._pathRegexp = pathToRegexp(path, [], {strict: false, end: true});
   }
 
-  match(request: ParsedRequest): ResolvedRoute<ControllerType> | undefined {
+  match(request: ParsedRequest): ResolvedRoute | undefined {
     debug('trying endpoint', this);
     if (this._verb !== request.method!.toLowerCase()) {
       debug(' -> verb mismatch');
@@ -126,7 +126,7 @@ class RouteEntry<ControllerType> {
 
   private _createResolvedRoute(
     pathParams: PathParameterValues,
-  ): ResolvedRoute<ControllerType> {
+  ): ResolvedRoute {
     return {
       controller: this._controller,
       methodName: this._spec['x-operation-name']!,

--- a/packages/core/src/router/routing-table.ts
+++ b/packages/core/src/router/routing-table.ts
@@ -40,7 +40,7 @@ export function parseRequestUrl(request: ServerRequest): ParsedRequest {
 }
 
 export class RoutingTable {
-  private readonly _routes: RouteEntry[] = [];
+  private readonly _routes: Route[] = [];
 
   registerController(controller: string, spec: OpenApiSpec) {
     assert(
@@ -62,13 +62,20 @@ export class RoutingTable {
           verb,
           path,
           opSpec['x-operation-name'],
-          ((opSpec.parameters as ParameterObject[]) || [])
-            .map(p => p.name)
-            .join(', '),
+          describeOperationParameters(opSpec),
         );
-        this._routes.push(new RouteEntry(path, verb, opSpec, controller));
+        this._routes.push(new Route(verb, path, opSpec, undefined, controller));
       }
     }
+  }
+
+  registerRoute(route: Route) {
+    debug(
+      'Registering route %s %s with args',
+       route.verb,
+       route.path,
+       describeOperationParameters(route.spec));
+    this._routes.push(route);
   }
 
   find(request: ParsedRequest): ResolvedRoute | undefined {
@@ -80,24 +87,36 @@ export class RoutingTable {
   }
 }
 
-export interface ResolvedRoute {
-  readonly controller: string;
-  readonly methodName: string;
+export interface ResolvedRouteCommon {
   readonly spec: OperationObject;
   readonly pathParams: PathParameterValues;
 }
 
-class RouteEntry {
-  private readonly _verb: string;
+export interface ResolvedHandlerRoute extends ResolvedRouteCommon {
+  readonly handler: Function;
+}
+
+export interface ResolvedControllerRoute extends ResolvedRouteCommon {
+  readonly controllerName: string;
+  readonly methodName: string;
+}
+
+export type ResolvedRoute =  ResolvedHandlerRoute | ResolvedControllerRoute;
+
+export class Route {
+  public readonly verb: string;
+  public readonly path: string;
   private readonly _pathRegexp: pathToRegexp.PathRegExp;
 
   constructor(
-    path: string,
     verb: string,
-    private readonly _spec: OperationObject,
-    private readonly _controller: string,
+    path: string,
+    public readonly spec: OperationObject,
+    private readonly _handler?: Function,
+    private readonly _controllerName?: string,
   ) {
-    this._verb = verb.toLowerCase();
+    this.verb = verb.toLowerCase();
+    this.path = path;
 
     // In Swagger, path parameters are wrapped in `{}`.
     // In Express.js, path parameters are prefixed with `:`
@@ -107,7 +126,7 @@ class RouteEntry {
 
   match(request: ParsedRequest): ResolvedRoute | undefined {
     debug('trying endpoint', this);
-    if (this._verb !== request.method!.toLowerCase()) {
+    if (this.verb !== request.method!.toLowerCase()) {
       debug(' -> verb mismatch');
       return undefined;
     }
@@ -127,10 +146,28 @@ class RouteEntry {
   private _createResolvedRoute(
     pathParams: PathParameterValues,
   ): ResolvedRoute {
+    return this._handler ?
+      this._createResolvedHandlerRoute(pathParams) :
+      this._createResolvedControllerRoute(pathParams);
+  }
+
+  private _createResolvedHandlerRoute(
+    pathParams: PathParameterValues,
+  ): ResolvedHandlerRoute {
     return {
-      controller: this._controller,
-      methodName: this._spec['x-operation-name']!,
-      spec: this._spec,
+      handler: this._handler!,
+      spec: this.spec,
+      pathParams: pathParams,
+    };
+  }
+
+  private _createResolvedControllerRoute(
+    pathParams: PathParameterValues,
+  ): ResolvedControllerRoute {
+    return {
+      controllerName: this._controllerName!,
+      methodName: this.spec['x-operation-name']!,
+      spec: this.spec,
       pathParams: pathParams,
     };
   }
@@ -144,4 +181,22 @@ class RouteEntry {
     }
     return pathParams;
   }
+}
+
+export function isHandlerRoute(
+  route: ResolvedRoute,
+): route is ResolvedHandlerRoute {
+  return (route as ResolvedHandlerRoute).handler !== undefined;
+}
+
+export function getRouteName(route: ResolvedRoute) {
+  return isHandlerRoute(route) ?
+    route.handler.name : // TODO(bajtos) return VERB+PATH when name is not set
+    `${route.controllerName}.${route.methodName}()`;
+}
+
+function describeOperationParameters(opSpec: OperationObject) {
+  return ((opSpec.parameters as ParameterObject[]) || [])
+      .map(p => p.name)
+      .join(', ');
 }

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -17,8 +17,8 @@ import {
 } from '../../..';
 import {expect, Client, createClientForServer} from '@loopback/testlab';
 import {
-  givenOpenApiSpec,
-  givenOperationSpec,
+  anOpenApiSpec,
+  anOperationSpec,
 } from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';
 
@@ -39,23 +39,15 @@ describe('Routing', () => {
   it('supports basic usage', async () => {
     const app = givenAnApplication();
 
-    const spec = givenOpenApiSpec()
-      .withOperation('get', '/echo', {
-        'x-operation-name': 'echo',
-        parameters: [
-          // the type cast is not required, but improves Intellisense
-          <ParameterObject> {
+    const spec = anOpenApiSpec()
+      .withOperation('get', '/echo', anOperationSpec()
+        .withOperationName('echo')
+        .withParameter({
             name: 'msg',
             in: 'query',
             type: 'string',
-          },
-        ],
-        responses: {
-          '200': {
-            type: 'string',
-          },
-        },
-      })
+          })
+        .withStringResponse())
       .build();
 
     @api(spec)
@@ -77,15 +69,10 @@ describe('Routing', () => {
     const app = givenAnApplication();
     app.bind('application.name').to('TestApp');
 
-    const spec = givenOpenApiSpec()
-      .withOperation('get', '/name', {
-        'x-operation-name': 'getName',
-        responses: {
-          '200': {
-            type: 'string',
-          },
-        },
-      })
+    const spec = anOpenApiSpec()
+      .withOperation('get', '/name', anOperationSpec()
+        .withOperationName('getName')
+        .withStringResponse())
       .build();
 
     @api(spec)
@@ -111,7 +98,7 @@ describe('Routing', () => {
     // create a special binding returning the current context instance
     app.bind('context').getValue = ctx => ctx;
 
-    const spec = givenOpenApiSpec()
+    const spec = anOpenApiSpec()
       .withOperationReturningString('put', '/flag', 'setFlag')
       .withOperationReturningString('get', '/flag', 'getFlag')
       .build();
@@ -149,7 +136,7 @@ describe('Routing', () => {
   it('binds request and response objects', () => {
     const app = givenAnApplication();
 
-    const spec = givenOpenApiSpec()
+    const spec = anOpenApiSpec()
       .withOperationReturningString('get', '/status', 'getStatus')
       .build();
 
@@ -176,7 +163,7 @@ describe('Routing', () => {
   it('binds controller constructor object and operation', () => {
     const app = givenAnApplication();
 
-    const spec = givenOpenApiSpec()
+    const spec = anOpenApiSpec()
       .withOperationReturningString('get', '/name', 'getControllerName')
       .build();
 
@@ -216,7 +203,7 @@ describe('Routing', () => {
         <ParameterObject> {name: 'name', in: 'query', type: 'string'},
       ],
       responses: {
-        '200': <ResponseObject> {
+        200: <ResponseObject> {
           description: 'greeting text',
           schema: {type: 'string'},
         },

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -12,9 +12,14 @@ import {
   OperationObject,
   ServerRequest,
   ServerResponse,
+  ResponseObject,
+  Route,
 } from '../../..';
 import {expect, Client, createClientForServer} from '@loopback/testlab';
-import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
+import {
+  givenOpenApiSpec,
+  givenOperationSpec,
+} from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';
 
 /* # Feature: Routing
@@ -201,6 +206,32 @@ describe('Routing', () => {
       });
 
     });
+  });
+
+  it('supports function-based routes', async () => {
+    const app = givenAnApplication();
+
+    const routeSpec = <OperationObject> {
+      parameters: [
+        <ParameterObject> {name: 'name', in: 'query', type: 'string'},
+      ],
+      responses: {
+        '200': <ResponseObject> {
+          description: 'greeting text',
+          schema: {type: 'string'},
+        },
+      },
+    };
+
+    function greet(name: string) {
+      return `hello ${name}`;
+    }
+
+    const route = new Route('get', '/greet', routeSpec, greet);
+    app.route(route);
+
+    const client = await whenIMakeRequestTo(app);
+    await client.get('/greet?name=world').expect(200, 'hello world');
   });
 
   /* ===== HELPERS ===== */

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -22,7 +22,7 @@ import {
   SequenceHandler,
 } from '../../..';
 import {expect, Client, createClientForServer} from '@loopback/testlab';
-import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
+import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';
 
 /* # Feature: Sequence
@@ -92,7 +92,7 @@ describe('Sequence - ', () => {
     givenAnApplication();
     app.bind('application.name').to('SequenceApp');
 
-    const apispec = givenOpenApiSpec()
+    const apispec = anOpenApiSpec()
       .withOperation('get', '/name', {
         'x-operation-name': 'getName',
         responses: {

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -49,14 +49,9 @@ describe('Sequence - ', () => {
       ) {}
 
       async handle(req: ParsedRequest, res: ServerResponse) {
-        const {
-          controller,
-          methodName,
-          spec: routeSpec,
-          pathParams,
-        } = this.findRoute(req);
-        const args = await parseOperationArgs(req, routeSpec, pathParams);
-        const result = await this.invoke(controller, methodName, args);
+        const route = this.findRoute(req);
+        const args = await parseOperationArgs(req, route);
+        const result = await this.invoke(route, args);
         // Prepend 'MySequence' to the result of invoke to allow for
         // execution verification of this user-defined sequence
         writeResultToResponse(res, `MySequence ${result}`);

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -13,7 +13,7 @@ import {
 import {Context} from '@loopback/context';
 import {expect, Client, createClientForHandler} from '@loopback/testlab';
 import {OpenApiSpec, ParameterObject} from '@loopback/openapi-spec';
-import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
+import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 
 describe('HttpHandler', () => {
   let client: Client;
@@ -22,7 +22,7 @@ describe('HttpHandler', () => {
 
   context('with a simple HelloWorld controller', () => {
     beforeEach(function setupHelloController() {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperationReturningString('get', '/hello', 'greet')
         .build();
 
@@ -46,7 +46,7 @@ describe('HttpHandler', () => {
 
   context('with a controller with operations at different paths/verbs', () => {
     beforeEach(function setupHelloController() {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperationReturningString('get', '/hello', 'hello')
         .withOperationReturningString('get', '/bye', 'bye')
         .withOperationReturningString('post', '/hello', 'postHello')
@@ -94,7 +94,7 @@ describe('HttpHandler', () => {
 
   context('with an operation echoing a string parameter from query', () => {
     beforeEach(function setupEchoController() {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperation('get', '/echo', {
           'x-operation-name': 'echo',
           parameters: [
@@ -143,7 +143,7 @@ describe('HttpHandler', () => {
     });
 
     function givenRouteParamController() {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperation('get', '/users/{username}', {
           'x-operation-name': 'getUserByUsername',
           parameters: [
@@ -186,7 +186,7 @@ describe('HttpHandler', () => {
     });
 
     function givenHeaderParamController() {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperation('get', '/show-authorization', {
           'x-operation-name': 'showAuthorization',
           parameters: [
@@ -243,7 +243,7 @@ describe('HttpHandler', () => {
     });
 
     function givenFormDataParamController() {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperation('post', '/show-formdata', {
           'x-operation-name': 'showFormData',
           parameters: [
@@ -300,7 +300,7 @@ describe('HttpHandler', () => {
     });
 
     function givenBodyParamController() {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperation('post', '/show-body', {
           'x-operation-name': 'showBody',
           parameters: [
@@ -334,7 +334,7 @@ describe('HttpHandler', () => {
 
   context('response serialization', () => {
     it('converts object result to a JSON response', () => {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperation('get', '/object', {
           'x-operation-name': 'getObject',
           responses: {
@@ -361,7 +361,7 @@ describe('HttpHandler', () => {
 
   context('error handling', () => {
     it('handles errors throws by controller constructor', () => {
-      const spec = givenOpenApiSpec()
+      const spec = anOpenApiSpec()
         .withOperationReturningString('get', '/hello', 'greet')
         .build();
 

--- a/packages/core/test/unit/http-handler.ts
+++ b/packages/core/test/unit/http-handler.ts
@@ -13,7 +13,7 @@ import {
 } from '../..';
 import {Context, Binding, BoundValue} from '@loopback/context';
 import {expect} from '@loopback/testlab';
-import {givenOperationSpec} from '@loopback/openapi-spec-builder';
+import {anOperationSpec} from '@loopback/openapi-spec-builder';
 
 describe('HttpHandler', () => {
   let requestContext: Context;
@@ -42,7 +42,7 @@ describe('HttpHandler', () => {
     describe('invokeMethod()', () => {
       it('invokes a controller method', async () => {
         class HelloController {
-          public async hello(): Promise<string> {
+          async hello(): Promise<string> {
             return 'hello';
           }
         }
@@ -52,7 +52,7 @@ describe('HttpHandler', () => {
         const route: ResolvedRoute = {
           controllerName: 'test-controller',
           methodName: 'hello',
-          spec: givenOperationSpec().withStringResponse(200).build(),
+          spec: anOperationSpec().withStringResponse(200).build(),
           pathParams: [],
         };
         const val: OperationRetval = await fn(route, []);
@@ -63,7 +63,7 @@ describe('HttpHandler', () => {
         const fn: InvokeMethod = await requestContext.get('invokeMethod');
         const route: ResolvedRoute = {
           handler: () => Promise.resolve('hello'),
-          spec: givenOperationSpec().withStringResponse(200).build(),
+          spec: anOperationSpec().withStringResponse(200).build(),
           pathParams: [],
         };
         const val: OperationRetval = await fn(route, []);

--- a/packages/core/test/unit/parser.test.ts
+++ b/packages/core/test/unit/parser.test.ts
@@ -8,12 +8,15 @@ import {
   ServerRequest,
   ParsedRequest,
   parseRequestUrl,
+  ResolvedRoute,
+  PathParameterValues,
 } from '../..';
 import {expect, ShotRequest, ShotRequestOptions} from '@loopback/testlab';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
 
 describe('operationArgsParser', () => {
   it('parses path parameters', async () => {
+    const req = givenRequest();
     const spec = givenOperationWithParameters([
       {
         name: 'id',
@@ -21,14 +24,19 @@ describe('operationArgsParser', () => {
         in: 'path',
       },
     ]);
-    const req = givenRequest();
+    const route = givenResolvedRoute(spec, {id: 1});
 
-    const args = await parseOperationArgs(req, spec, {id: 1});
+    const args = await parseOperationArgs(req, route);
 
     expect(args).to.eql([1]);
   });
 
   it('parsed body parameter', async () => {
+    const req = givenRequest({
+      url: '/',
+      payload: {key: 'value'},
+    });
+
     const spec = givenOperationWithParameters([
       {
         name: 'data',
@@ -36,13 +44,9 @@ describe('operationArgsParser', () => {
         in: 'body',
       },
     ]);
+    const route = givenResolvedRoute(spec, {});
 
-    const req = givenRequest({
-      url: '/',
-      payload: {key: 'value'},
-    });
-
-    const args = await parseOperationArgs(req, spec, {});
+    const args = await parseOperationArgs(req, route);
 
     expect(args).to.eql([{key: 'value'}]);
   });
@@ -57,5 +61,16 @@ describe('operationArgsParser', () => {
 
   function givenRequest(options?: ShotRequestOptions): ParsedRequest {
     return parseRequestUrl(new ShotRequest(options || {url: '/'}));
+  }
+
+  function givenResolvedRoute(
+    spec: OperationObject,
+    pathParams: PathParameterValues,
+  ): ResolvedRoute {
+    return {
+      handler: () => {},
+      spec: spec,
+      pathParams: pathParams,
+    };
   }
 });

--- a/packages/core/test/unit/routing-table.test.ts
+++ b/packages/core/test/unit/routing-table.test.ts
@@ -20,7 +20,7 @@ describe('RoutingTable', () => {
       .withOperationReturningString('get', '/hello', 'greet')
       .build();
 
-    const table = new RoutingTable<string>();
+    const table = new RoutingTable();
     table.registerController('TestController', spec);
 
     const request = givenRequest({

--- a/packages/core/test/unit/routing-table.test.ts
+++ b/packages/core/test/unit/routing-table.test.ts
@@ -31,7 +31,7 @@ describe('RoutingTable', () => {
     const route = table.find(request);
 
     expect(route).to.deepEqual({
-      controller: 'TestController',
+      controllerName: 'TestController',
       methodName: 'greet',
       pathParams: Object.create(null),
       spec: spec.paths['/hello'].get,

--- a/packages/core/test/unit/routing-table.test.ts
+++ b/packages/core/test/unit/routing-table.test.ts
@@ -12,11 +12,11 @@ import {
 } from '../..';
 import {expect, ShotRequestOptions, ShotRequest} from '@loopback/testlab';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
-import {givenOpenApiSpec} from '@loopback/openapi-spec-builder';
+import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 
 describe('RoutingTable', () => {
   it('finds simple "GET /hello" endpoint', () => {
-    const spec = givenOpenApiSpec()
+    const spec = anOpenApiSpec()
       .withOperationReturningString('get', '/hello', 'greet')
       .build();
 

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -15,14 +15,14 @@ import {
  *
  * @param basePath The base path on which the API is served.
  */
-export function givenOpenApiSpec(basePath?: string) {
+export function anOpenApiSpec(basePath?: string) {
   return new OpenApiSpecBuilder(basePath);
 }
 
 /**
  * Create a new instance of OperationSpecBuilder.
  */
-export function givenOperationSpec() {
+export function anOperationSpec() {
   return new OperationSpecBuilder();
 }
 
@@ -73,7 +73,7 @@ export class OpenApiSpecBuilder {
     path: string,
     operationName: string,
   ): this {
-    return this.withOperation(verb, path, givenOperationSpec()
+    return this.withOperation(verb, path, anOperationSpec()
         .withOperationName(operationName)
         .withStringResponse(200));
   }
@@ -106,7 +106,7 @@ export class OperationSpecBuilder {
     return this;
   }
 
-  withStringResponse(status: number | 'default'): this {
+  withStringResponse(status: number | 'default' = 200): this {
     return this.withResponse(status, {
       description: 'The string result.',
       schema: {type: 'string'},

--- a/packages/openapi-spec/src/openapi-spec-v2.ts
+++ b/packages/openapi-spec/src/openapi-spec-v2.ts
@@ -308,7 +308,7 @@ export interface SchemaObject {
   // TODO(bajtos) describe all properties,
   // enforce polymorphic fields based on "type" value
   type: string;
-  items: SchemaItem;
+  items?: SchemaItem;
 
   [extension: string]: ExtensionValue;
 }


### PR DESCRIPTION
Rework the internal implementation to support the new `app.route()` API as described in [wiki](https://github.com/strongloop/loopback-next/wiki/Routing#creating-routes)

```ts
// greet is a basic operation
function greet(name) {
  return `hello ${name}`;
}

const spec = {
  parameters: [{name: 'name', in: 'query', type: 'string'},
  responses: {
    '200': {
      description: 'greeting text',
      schema: {type: 'string'},
    }
  }
};
const route = new Route('get', '/', spec, greet);
app.route(route);
```

Notable changes:

 - Renamed `RouteEntry` to `Route` and made it public
 - Reworked `ResolvedRoute` to support both handler and controller+method
 - Reworked `parseArgs` and `invoke` to accept a resolved route instead of controller+method

cc @bajtos @raymondfeng @ritch @superkhau
