### PR TITLE
Refactor ResolvedRoute to {route, pathParams}

### DIFF
--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -138,7 +138,7 @@ describe('Basic Authentication', () => {
 
       async handle(req: ParsedRequest, res: ServerResponse) {
         try {
-          const route = this.findRoute(req);
+          const {route, pathParams} = this.findRoute(req);
 
           // Authenticate
           const user: UserProfile = await this.authenticate(req);
@@ -148,7 +148,7 @@ describe('Basic Authentication', () => {
           else throw new HttpErrors.InternalServerError('auth error');
 
           // Authentication successful, proceed to invoke controller
-          const args = await parseOperationArgs(req, route);
+          const args = await parseOperationArgs(req, route, pathParams);
           const result = await this.invoke(route, args);
           this.send(res, result);
         } catch (err) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,10 +40,11 @@ export {
 export {parseOperationArgs} from './parser';
 export {parseRequestUrl} from './router/routing-table';
 export {
+  ControllerRoute,
   RoutingTable,
   Route,
+  RouteEntry,
   ResolvedRoute,
-  isHandlerRoute,
 } from './router/routing-table';
 export {HttpHandler} from './http-handler';
 export {writeResultToResponse} from './writer';

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -5,7 +5,7 @@
 
 import {Binding, BoundValue, ValueOrPromise} from '@loopback/context';
 import {ServerRequest, ServerResponse} from 'http';
-import {ResolvedRoute} from './router/routing-table';
+import {ResolvedRoute, Route, RouteEntry} from './router/routing-table';
 
 export interface ParsedRequest extends ServerRequest {
   // see http://expressjs.com/en/4x/api.html#req.path
@@ -34,7 +34,7 @@ export type FindRoute = (request: ParsedRequest) => ResolvedRoute;
  * @returns OperationRetval Result from method invocation
  */
 export type InvokeMethod = (
-  route: ResolvedRoute,
+  route: RouteEntry,
   args: OperationArgs,
 ) => Promise<OperationRetval>;
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {ServerRequest} from 'http';
-import {HttpErrors} from './';
+import {HttpErrors, Route, RouteEntry} from './';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
 import {promisify} from './promisify';
 import {
@@ -55,10 +55,10 @@ function getContentType(req: ServerRequest): string | undefined {
  */
 export async function parseOperationArgs(
   request: ParsedRequest,
-  route: ResolvedRoute,
+  route: RouteEntry,
+  pathParams: PathParameterValues,
 ): Promise<OperationArgs> {
   const operationSpec = route.spec;
-  const pathParams = route.pathParams;
   const body = await loadRequestBodyIfNeeded(operationSpec, request);
   return buildOperationArguments(operationSpec, request, pathParams, body);
 }

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -18,7 +18,6 @@ import {
 import {parseOperationArgs} from './parser';
 import {writeResultToResponse} from './writer';
 import {HttpError} from 'http-errors';
-import {getRouteName} from './router/routing-table';
 
 /**
  * A sequence function is a function implementing a custom
@@ -96,14 +95,11 @@ export class DefaultSequence implements SequenceHandler {
    */
   async handle(req: ParsedRequest, res: ServerResponse) {
     try {
-      const route = this.findRoute(req);
-      const args = await parseOperationArgs(req, route);
+      const {route, pathParams} = this.findRoute(req);
+      const args = await parseOperationArgs(req, route, pathParams);
       const result = await this.invoke(route, args);
 
-      if (debug.enabled) {
-        const routeName = getRouteName(route) || `"${req.method} ${req.path}"`;
-        debug('%s result -', routeName, result);
-      }
+      debug('%s result -', route.describe(), result);
       this.send(res, result);
     } catch (err) {
       this.reject(res, req, err);

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -70,8 +70,8 @@ describe('Sequence', () => {
       ) {}
 
       async handle(req: ParsedRequest, res: ServerResponse) {
-        const route = this.findRoute(req);
-        const args = await parseOperationArgs(req, route);
+        const {route, pathParams} = this.findRoute(req);
+        const args = await parseOperationArgs(req, route, pathParams);
         const result = await this.invoke(route, args);
         this.send(res, `MySequence ${result}`);
       }

--- a/packages/core/test/unit/http-handler.ts
+++ b/packages/core/test/unit/http-handler.ts
@@ -10,6 +10,8 @@ import {
   InvokeMethod,
   ResolvedRoute,
   OperationRetval,
+  ControllerRoute,
+  Route,
 } from '../..';
 import {Context, Binding, BoundValue} from '@loopback/context';
 import {expect} from '@loopback/testlab';
@@ -49,23 +51,20 @@ describe('HttpHandler', () => {
 
         requestContext.bind('test-controller').toClass(HelloController);
         const fn: InvokeMethod = await requestContext.get('invokeMethod');
-        const route: ResolvedRoute = {
-          controllerName: 'test-controller',
-          methodName: 'hello',
-          spec: anOperationSpec().withStringResponse(200).build(),
-          pathParams: [],
-        };
+        const spec = anOperationSpec()
+          .withStringResponse(200)
+          .withOperationName('hello')
+          .build();
+        const route = new ControllerRoute('get', '/', spec, 'test-controller');
         const val: OperationRetval = await fn(route, []);
         expect(val).to.eql('hello');
       });
 
       it('invokes a route handler', async () => {
         const fn: InvokeMethod = await requestContext.get('invokeMethod');
-        const route: ResolvedRoute = {
-          handler: () => Promise.resolve('hello'),
-          spec: anOperationSpec().withStringResponse(200).build(),
-          pathParams: [],
-        };
+        const spec = anOperationSpec().withStringResponse(200).build();
+        function hello() { return 'hello'; }
+        const route = new Route('get', '/', spec, hello);
         const val: OperationRetval = await fn(route, []);
         expect(val).to.eql('hello');
       });

--- a/packages/core/test/unit/parser.test.ts
+++ b/packages/core/test/unit/parser.test.ts
@@ -10,6 +10,7 @@ import {
   parseRequestUrl,
   ResolvedRoute,
   PathParameterValues,
+  Route,
 } from '../..';
 import {expect, ShotRequest, ShotRequestOptions} from '@loopback/testlab';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
@@ -24,9 +25,10 @@ describe('operationArgsParser', () => {
         in: 'path',
       },
     ]);
-    const route = givenResolvedRoute(spec, {id: 1});
+    const route = givenRoute(spec);
+    const pathParams = {id: 1};
 
-    const args = await parseOperationArgs(req, route);
+    const args = await parseOperationArgs(req, route, pathParams);
 
     expect(args).to.eql([1]);
   });
@@ -44,9 +46,10 @@ describe('operationArgsParser', () => {
         in: 'body',
       },
     ]);
-    const route = givenResolvedRoute(spec, {});
+    const route = givenRoute(spec);
+    const pathParams = {};
 
-    const args = await parseOperationArgs(req, route);
+    const args = await parseOperationArgs(req, route, pathParams);
 
     expect(args).to.eql([{key: 'value'}]);
   });
@@ -63,14 +66,7 @@ describe('operationArgsParser', () => {
     return parseRequestUrl(new ShotRequest(options || {url: '/'}));
   }
 
-  function givenResolvedRoute(
-    spec: OperationObject,
-    pathParams: PathParameterValues,
-  ): ResolvedRoute {
-    return {
-      handler: () => {},
-      spec: spec,
-      pathParams: pathParams,
-    };
+  function givenRoute(spec: OperationObject) {
+    return new Route('get', '/', spec, () => {});
   }
 });

--- a/packages/core/test/unit/routing-table.test.ts
+++ b/packages/core/test/unit/routing-table.test.ts
@@ -9,6 +9,7 @@ import {
   parseRequestUrl,
   RoutingTable,
   ResolvedRoute,
+  ControllerRoute,
 } from '../..';
 import {expect, ShotRequestOptions, ShotRequest} from '@loopback/testlab';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
@@ -28,14 +29,11 @@ describe('RoutingTable', () => {
       url: '/hello',
     });
 
-    const route = table.find(request);
+    const {route, pathParams} = table.find(request);
 
-    expect(route).to.deepEqual({
-      controllerName: 'TestController',
-      methodName: 'greet',
-      pathParams: Object.create(null),
-      spec: spec.paths['/hello'].get,
-    });
+    expect(route).to.be.instanceOf(ControllerRoute);
+    expect(route).to.have.property('spec', spec.paths['/hello'].get);
+    expect(route.describe()).to.equal('TestController.greet');
   });
 
   function givenRequest(options?: ShotRequestOptions): ParsedRequest {


### PR DESCRIPTION
Rework `findRoute` action to return an object containing two properties:
 - the immutable `RouteEntry` registered at app start
 - `pathParams` parsed from the request URL

Refactor `Route` class into three classes:
 - Abstract `RouteEntry` providing the shared implementation
   of route matching and defining the common API

 - `Route` implementing invocation of handler-function-based routes

 - `ControllerRoute` implementing invocation of controller-based routes

Closes #400

cc @bajtos @raymondfeng @ritch @superkhau
