### PR TITLE
Speed up "npm test" by compiling single target

### DIFF
--- a/bin/compile-package.js
+++ b/bin/compile-package.js
@@ -32,7 +32,12 @@ const rootDir = path.resolve(__dirname, '..');
 const packageDir = path.relative(rootDir, process.cwd());
 
 const compilerOpts = process.argv.slice(2);
-const target = compilerOpts.shift();
+let target = compilerOpts.shift();
+
+if (!target) {
+  const nodeMajorVersion = +process.versions.node.split('.')[0];
+  target = nodeMajorVersion >= 7 ? 'es2017' : 'es2015';
+}
 
 let outDir;
 switch (target) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint:fix": "npm run lint -- --fix",
     "clean": "lerna run --loglevel=silent clean",
     "build": "lerna run --loglevel=silent build",
-    "pretest": "npm run build",
+    "build:current": "lerna run --loglevel=silent build:current",
+    "pretest": "npm run build:current",
     "test": "nyc mocha --opts test/mocha.opts \"packages/*/test/**/*.ts\"",
     "posttest": "npm run lint"
   },

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -5,12 +5,13 @@
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",
+    "build:current": "node ../../bin/compile-package",
     "build:lib": "node ../../bin/compile-package es2017",
     "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -rf loopback-authentication*.tgz lib* package",
     "integration": "mocha --opts ../../test/mocha.opts 'test/integration/**/*.ts'",
     "prepublish": "npm run build",
-    "pretest": "npm run build",
+    "pretest": "npm run build:current",
     "test": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts' 'test/integration/**/*.ts' 'test/acceptance/**/*.ts'",
     "unit": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts'",
     "verify": "npm pack && tar xf loopback-authentication*.tgz && tree package && npm run clean"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -5,11 +5,12 @@
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",
+    "build:current": "node ../../bin/compile-package",
     "build:lib": "node ../../bin/compile-package es2017",
     "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -rf loopback-context*.tgz lib* package",
     "prepublish": "npm run build",
-    "pretest": "npm run build",
+    "pretest": "npm run build:current",
     "test": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts' 'test/acceptance/**/*.ts'",
     "unit": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts'",
     "verify": "npm pack && tar xf loopback-context*.tgz && tree package && npm run clean"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,11 +5,12 @@
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",
+    "build:current": "node ../../bin/compile-package",
     "build:lib": "node ../../bin/compile-package es2017",
     "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -rf loopback-core*.tgz lib* package",
     "prepublish": "npm run build",
-    "pretest": "npm run build",
+    "pretest": "npm run build:current",
     "integration": "mocha --opts ../../test/mocha.opts 'test/integration/**/*.ts'",
     "test": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts' 'test/integration/**/*.ts' 'test/acceptance/**/*.ts'",
     "unit": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts'",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -4,6 +4,7 @@
   "description": "Make it easy to create OpenAPI (Swagger) specification documents in your tests using the builder pattern.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
+    "build:current": "node ../../bin/compile-package",
     "build:lib": "node ../../bin/compile-package es2017",
     "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -rf loopback-openapi-spec*.tgz lib* package",

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -4,6 +4,7 @@
   "description": "TypeScript type definitions for OpenAPI Spec/Swagger documents.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
+    "build:current": "node ../../bin/compile-package",
     "build:lib": "node ../../bin/compile-package es2017",
     "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -rf loopback-openapi-spec*.tgz lib* package",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",
+    "build:current": "node ../../bin/compile-package",
     "build:lib": "node ../../bin/compile-package es2017",
     "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -rf loopback-context*.tgz lib* package",
     "prepublish": "npm run build",
-    "pretest": "npm run build",
+    "pretest": "npm run build:current",
     "test": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts' 'test/acceptance/**/*.ts'",
     "unit": "mocha --opts ../../test/mocha.opts 'test/unit/**/*.ts'",
     "verify": "npm pack && tar xf loopback-juggler*.tgz && tree package && npm run clean"

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -4,11 +4,12 @@
   "description": "A collection of test utilities we use to write LoopBack tests.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
+    "build:current": "node ../../bin/compile-package",
     "build:lib": "node ../../bin/compile-package es2017",
     "build:lib6": "node ../../bin/compile-package es2015",
     "clean": "rm -rf loopback-testlab*.tgz lib* package",
     "prepublish": "npm run build",
-    "pretest": "npm run build",
+    "pretest": "npm run build:current",
     "test": "mocha",
     "verify": "npm pack && tar xf loopback-testlab*.tgz && tree package && npm run clean"
   },


### PR DESCRIPTION
Rework the build system to compile only for the current target (based on `node --version`) before running the tests.

This change speeds up `npm test` by 40% (approximately).

Before:

```
$ time npm test
[...]
real  0m29.338s
user  0m52.340s
sys  0m3.597s
```

After:

```
$ time npm test
[...]
real  0m17.657s
user  0m29.461s
sys  0m1.887s
```

cc @bajtos @raymondfeng @ritch @superkhau
