### PR TITLE
Bumped up versions, and published

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/authentication",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "A LoopBack component for authentication support.",
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/context",
-  "version": "4.0.0-alpha.9",
+  "version": "4.0.0-alpha.10",
   "description": "LoopBack's container for Inversion of Control",
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/core",
-  "version": "4.0.0-alpha.9",
+  "version": "4.0.0-alpha.10",
   "description": "",
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/openapi-spec-builder",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.0-alpha.5",
   "description": "Make it easy to create OpenAPI (Swagger) specification documents in your tests using the builder pattern.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/openapi-spec",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-alpha.7",
   "description": "TypeScript type definitions for OpenAPI Spec/Swagger documents.",
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/repository",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "Repository for LoopBack.next",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
cc @bajtos @raymondfeng @ritch @superkhau 
Bumped up versions, and published all packages. This is done for story connects to strongloop-internal/scrum-asteroid#233
```
@loopback/core@4.0.0-alpha.10
@loopback/context@4.0.0-alpha.10
@loopback/authentication@4.0.0-alpha.4
@loopback/openapi-spec@4.0.0-alpha.7
@loopback/openapi-spec-builder@4.0.0-alpha.5
@loopback/repository@4.0.0-alpha.4
```
The newly published versions now have the docs bundled inside them, which are viewable on `apidocs.strongloop.com`. This completes the whole cycle. To see the documentation from the published npm versions, follow these steps.
```
1. git clone https://github.com/strongloop-internal/apidocs.strongloop.com/
2. cd apidocs.strongloop.com
3. npm install
4. node app.js
5. Go to http://localhost:3000/@loopback%2fcore/v/4.0.0-alpha.10/
```