### PR TITLE
Rework ResolvedRoute to inherit from RouteEntry

### DIFF
--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -137,7 +137,7 @@ describe('Basic Authentication', () => {
 
       async handle(req: ParsedRequest, res: ServerResponse) {
         try {
-          const {route, pathParams} = this.findRoute(req);
+          const route = this.findRoute(req);
 
           // Authenticate
           const user: UserProfile = await this.authenticateRequest(req);
@@ -147,7 +147,7 @@ describe('Basic Authentication', () => {
           else throw new HttpErrors.InternalServerError('auth error');
 
           // Authentication successful, proceed to invoke controller
-          const args = await parseOperationArgs(req, route, pathParams);
+          const args = await parseOperationArgs(req, route);
           const result = await this.invoke(route, args);
           this.send(res, result);
         } catch (err) {

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -82,7 +82,7 @@ export class HttpHandler {
   protected _bindFindRoute(context: Context): void {
     const findRoute: FindRoute = (request) => {
       const found = this._routes.find(request);
-      found.route.updateBindings(context);
+      found.updateBindings(context);
       return found;
     };
     context.bind('findRoute').to(findRoute);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   Route,
   RouteEntry,
   ResolvedRoute,
+  createResolvedRoute,
 } from './router/routing-table';
 export {HttpHandler} from './http-handler';
 export {writeResultToResponse} from './writer';

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -55,10 +55,10 @@ function getContentType(req: ServerRequest): string | undefined {
  */
 export async function parseOperationArgs(
   request: ParsedRequest,
-  route: RouteEntry,
-  pathParams: PathParameterValues,
+  route: ResolvedRoute,
 ): Promise<OperationArgs> {
   const operationSpec = route.spec;
+  const pathParams = route.pathParams;
   const body = await loadRequestBodyIfNeeded(operationSpec, request);
   return buildOperationArguments(operationSpec, request, pathParams, body);
 }

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -95,8 +95,8 @@ export class DefaultSequence implements SequenceHandler {
    */
   async handle(req: ParsedRequest, res: ServerResponse) {
     try {
-      const {route, pathParams} = this.findRoute(req);
-      const args = await parseOperationArgs(req, route, pathParams);
+      const route = this.findRoute(req);
+      const args = await parseOperationArgs(req, route);
       const result = await this.invoke(route, args);
 
       debug('%s result -', route.describe(), result);

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -66,8 +66,8 @@ describe('Sequence', () => {
       ) {}
 
       async handle(req: ParsedRequest, res: ServerResponse) {
-        const {route, pathParams} = this.findRoute(req);
-        const args = await parseOperationArgs(req, route, pathParams);
+        const route = this.findRoute(req);
+        const args = await parseOperationArgs(req, route);
         const result = await this.invoke(route, args);
         this.send(res, `MySequence ${result}`);
       }

--- a/packages/core/test/unit/parser.test.ts
+++ b/packages/core/test/unit/parser.test.ts
@@ -11,6 +11,7 @@ import {
   ResolvedRoute,
   PathParameterValues,
   Route,
+  createResolvedRoute,
 } from '../..';
 import {expect, ShotRequest, ShotRequestOptions} from '@loopback/testlab';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
@@ -25,10 +26,9 @@ describe('operationArgsParser', () => {
         in: 'path',
       },
     ]);
-    const route = givenRoute(spec);
-    const pathParams = {id: 1};
+    const route = givenResolvedRoute(spec, {id: 1});
 
-    const args = await parseOperationArgs(req, route, pathParams);
+    const args = await parseOperationArgs(req, route);
 
     expect(args).to.eql([1]);
   });
@@ -46,10 +46,9 @@ describe('operationArgsParser', () => {
         in: 'body',
       },
     ]);
-    const route = givenRoute(spec);
-    const pathParams = {};
+    const route = givenResolvedRoute(spec);
 
-    const args = await parseOperationArgs(req, route, pathParams);
+    const args = await parseOperationArgs(req, route);
 
     expect(args).to.eql([{key: 'value'}]);
   });
@@ -66,7 +65,11 @@ describe('operationArgsParser', () => {
     return parseRequestUrl(new ShotRequest(options || {url: '/'}));
   }
 
-  function givenRoute(spec: OperationObject) {
-    return new Route('get', '/', spec, () => {});
+  function givenResolvedRoute(
+    spec: OperationObject,
+    pathParams: PathParameterValues = {},
+  ) {
+    const route = new Route('get', '/', spec, () => {});
+    return createResolvedRoute(route, pathParams);
   }
 });

--- a/packages/core/test/unit/routing-table.test.ts
+++ b/packages/core/test/unit/routing-table.test.ts
@@ -29,10 +29,11 @@ describe('RoutingTable', () => {
       url: '/hello',
     });
 
-    const {route, pathParams} = table.find(request);
+    const route = table.find(request);
 
     expect(route).to.be.instanceOf(ControllerRoute);
     expect(route).to.have.property('spec', spec.paths['/hello'].get);
+    expect(route).to.have.property('pathParams');
     expect(route.describe()).to.equal('TestController.greet');
   });
 


### PR DESCRIPTION
Per our discussion in #417, simplify the usage of `findRoute` and related methods so that a single `route` entity can be passed around.

```ts
// inside Sequence.prototype.handle
const route = this.findRoute(req);
const args = await parseOperationArgs(req, route);
// etc.
```

Closes #426

cc @bajtos @raymondfeng @ritch @superkhau @kjdelisle 
