### PR TITLE
Allow controller API to be specified via app.api()

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -296,6 +296,10 @@ export class Application extends Context {
    * Start the application (e.g. HTTP/HTTPS servers).
    */
   async start(): Promise<void> {
+    // Setup the HTTP handler so that we can verify the configuration
+    // of API spec, controllers and routes at startup time.
+    this._setupHandlerIfNeeded();
+
     const httpPort = await this.get('http.port');
     const server = createServer(this.handleHttp);
 

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -11,7 +11,13 @@ import {
   Provider,
   inject,
 } from '@loopback/context';
-import {OpenApiSpec, Route, ParsedRequest, OperationObject} from '.';
+import {
+  OpenApiSpec,
+  Route,
+  ParsedRequest,
+  OperationObject,
+  ControllerRoute,
+} from '.';
 import {ServerRequest, ServerResponse, createServer} from 'http';
 import {Component, mountComponent} from './component';
 import {getApiSpec} from './router/metadata';
@@ -51,6 +57,7 @@ export class Application extends Context {
     if (!options) options = {};
 
     this.bind('http.port').to(options.http ? options.http.port : 3000);
+    this.api({basePath: '/', paths: {}});
 
     if (options.components) {
       for (const component of options.components) {
@@ -91,12 +98,18 @@ export class Application extends Context {
 
     this._httpHandler = new HttpHandler(this);
     for (const b of this.find('controllers.*')) {
+      const controllerName = b.key.replace(/^controllers\./, '');
       const ctor = b.valueConstructor;
       if (!ctor) {
-        throw new Error(`The controller ${b.key} was not bound via .toClass()`);
+        throw new Error(
+          `The controller ${controllerName} was not bound via .toClass()`);
       }
       const apiSpec = getApiSpec(ctor);
-      this._httpHandler.registerController(b.key, apiSpec);
+      if (!apiSpec) {
+        // controller methods are specified through app.api() spec
+        continue;
+      }
+      this._httpHandler.registerController(controllerName, apiSpec);
     }
 
     for (const b of this.find('routes.*')) {
@@ -104,6 +117,40 @@ export class Application extends Context {
       const route = this.getSync(b.key);
       this._httpHandler.registerRoute(route);
     }
+
+    // TODO(bajtos) should we support API spec defined asynchronously?
+    const spec: OpenApiSpec = this.getSync('api-spec');
+    for (const path in spec.paths) {
+      for (const verb in spec.paths[path]) {
+        const routeSpec: OperationObject = spec.paths[path][verb];
+        this._setupOperation(verb, path, routeSpec);
+      }
+    }
+  }
+
+  private _setupOperation(verb: string, path: string, spec: OperationObject) {
+    const handler = spec['x-operation'];
+    if (typeof handler === 'function') {
+      const route = new Route(verb, path, spec, handler);
+      this._httpHandler.registerRoute(route);
+      return;
+    }
+
+    const controllerName = spec['x-controller'];
+    if (typeof controllerName === 'string') {
+      const b = this.find(`controllers.${controllerName}`)[0];
+      if (!b) {
+        throw new Error(
+          `Unknown controller ${controllerName} used by "${verb} ${path}"`);
+      }
+
+      const route = new ControllerRoute(verb, path, spec, controllerName);
+      this._httpHandler.registerRoute(route);
+      return;
+    }
+
+    throw new Error(
+      `There is no handler configured for operation "${verb} ${path}`);
   }
 
   /**
@@ -145,19 +192,8 @@ export class Application extends Context {
     return this.bind(`routes.${route.verb} ${route.path}`).to(route);
   }
 
-  api(spec: OpenApiSpec) {
-    for (const path in spec.paths) {
-      for (const verb in spec.paths[path]) {
-        const routeSpec: OperationObject = spec.paths[path][verb];
-        const handler = routeSpec['x-operation'];
-        assert(
-          typeof handler === 'function',
-          `"x-operation" field of "${verb} ${path}" must be a function`);
-
-        const route = new Route(verb, path, routeSpec, handler);
-        this.route(route);
-      }
-    }
+  api(spec: OpenApiSpec): Binding {
+    return this.bind('api-spec').to(spec);
   }
 
   protected _logError(

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -13,7 +13,7 @@ import {
   RoutingTable,
   parseRequestUrl,
   ResolvedRoute,
-  Route,
+  RouteEntry,
 } from './router/routing-table';
 import {
   FindRoute,
@@ -40,7 +40,7 @@ export class HttpHandler {
     this._routes.registerController(name, spec);
   }
 
-  registerRoute(route: Route) {
+  registerRoute(route: RouteEntry) {
     this._routes.registerRoute(route);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,10 +39,10 @@ export {
 export {parseOperationArgs} from './parser';
 export {parseRequestUrl} from './router/routing-table';
 export {
-  ControllerRoute,
+  RouteEntry,
   RoutingTable,
   Route,
-  RouteEntry,
+  ControllerRoute,
   ResolvedRoute,
   createResolvedRoute,
 } from './router/routing-table';

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -264,6 +264,40 @@ describe('Routing', () => {
     await client.get('/greet?name=world').expect(200, 'hello world');
   });
 
+  it('reports operations bound to unknown controller', () => {
+    const app = givenAnApplication();
+    const spec = anOpenApiSpec()
+      .withOperation(
+        'get',
+        '/greet',
+        anOperationSpec()
+          .withOperationName('greet')
+          .withExtension('x-controller', 'UnknownController'),
+      )
+      .build();
+
+    app.api(spec);
+
+    return app.start().then(
+      ok => { throw new Error('app.start() should have failed'); },
+      err => expect(err.message).to.match(/UnknownController/),
+    );
+  });
+
+  it('reports operations with no handler', () => {
+    const app = givenAnApplication();
+    const spec = anOpenApiSpec()
+      .withOperationReturningString('get', '/greet')
+      .build();
+
+    app.api(spec);
+
+    return app.start().then(
+      ok => { throw new Error('app.start() should have failed'); },
+      err => expect(err.message).to.match(/no handler/),
+    );
+  });
+
   /* ===== HELPERS ===== */
 
   function givenAnApplication() {

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -200,7 +200,7 @@ describe('Routing', () => {
     await client.get('/greet?name=world').expect(200, 'hello world');
   });
 
-  it('supports routes declared via API specification', async () => {
+  it('supports handler routes declared via API specification', async () => {
     const app = givenAnApplication();
 
     function greet(name: string) {
@@ -235,6 +235,33 @@ describe('Routing', () => {
     const spec = anOpenApiSpec().build();
     spec.paths = {'/greet': {}};
     app.api(spec);
+  });
+
+  it('supports controller routes declared via API spec', async () => {
+    const app = givenAnApplication();
+
+    class MyController {
+      greet(name: string) {
+        return `hello ${name}`;
+      }
+    }
+
+    const spec = anOpenApiSpec()
+      .withOperation(
+        'get',
+        '/greet',
+        anOperationSpec()
+          .withParameter({name: 'name', in: 'query', type: 'string'})
+          .withExtension('x-operation-name', 'greet')
+          .withExtension('x-controller', 'MyController'),
+      )
+      .build();
+
+    app.api(spec);
+    app.controller(MyController);
+
+    const client = whenIMakeRequestTo(app);
+    await client.get('/greet?name=world').expect(200, 'hello world');
   });
 
   /* ===== HELPERS ===== */

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -405,7 +405,7 @@ describe('HttpHandler', () => {
     ctor: new (...args: any[]) => Object,
     spec: OpenApiSpec,
   ) {
-    rootContext.bind('test-controller').toClass(ctor);
+    rootContext.bind('controllers.test-controller').toClass(ctor);
     handler.registerController('test-controller', spec);
   }
 

--- a/packages/core/test/unit/http-handler.ts
+++ b/packages/core/test/unit/http-handler.ts
@@ -49,7 +49,8 @@ describe('HttpHandler', () => {
           }
         }
 
-        requestContext.bind('test-controller').toClass(HelloController);
+        requestContext.bind('controllers.test-controller')
+          .toClass(HelloController);
         const fn: InvokeMethod = await requestContext.get('invokeMethod');
         const spec = anOperationSpec()
           .withStringResponse(200)

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -105,11 +105,13 @@ export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
   withOperationReturningString(
     verb: string,
     path: string,
-    operationName: string,
+    operationName?: string,
   ): this {
-    return this.withOperation(verb, path, anOperationSpec()
-        .withOperationName(operationName)
-        .withStringResponse(200));
+    const spec = anOperationSpec().withStringResponse(200);
+    if (operationName)
+        spec.withOperationName(operationName);
+
+    return this.withOperation(verb, path, spec);
   }
 }
 


### PR DESCRIPTION
```ts
app.api({
  baseURL: '/',
  paths: {
    '/greet': {
      get: {
        params: {name: 'string', source: 'query'}
        'x-operation-name': 'greet',
        'x-controller': 'MyController'
      }
    }
  }
});
app.controller(MyController);
```

Refactor `registerRoute()` methods to accept arbitrary `RouteEntry` instance (a handler function or a controller method).

Closes #403

cc @bajtos @raymondfeng @ritch @superkhau
