### PR TITLE
Add app.route() API for controller-based routes

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -231,8 +231,8 @@ export class Application extends Context {
     methodName?: string,
   ): Binding {
     if (typeof routeOrVerb === 'object') {
-      const route = routeOrVerb;
-      return this.bind(`routes.${route.verb} ${route.path}`).to(route);
+      const r = routeOrVerb;
+      return this.bind(`routes.${r.verb} ${r.path}`).to(r);
     }
 
     assert(!!path, 'path is required for a controller-based route');
@@ -240,13 +240,12 @@ export class Application extends Context {
     assert(!!controller, 'controller is required for a controller-based route');
     assert(!!methodName, 'methodName is required for a controller-based route');
 
-    const route = new ControllerRoute(
+    return this.route(new ControllerRoute(
       routeOrVerb,
       path!,
       spec!,
       controller!,
-      methodName);
-    return this.route(route);
+      methodName));
   }
 
   api(spec: OpenApiSpec): Binding {

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -20,6 +20,7 @@ import {
   parseRequestUrl,
   ResolvedRoute,
   RouteEntry,
+  ControllerClass,
 } from './router/routing-table';
 import {
   FindRoute,
@@ -42,7 +43,7 @@ export class HttpHandler {
     this.handleRequest = (req, res) => this._handleRequest(req, res);
   }
 
-  registerController<T>(name: Constructor<T>, spec: OpenApiSpec) {
+  registerController(name: ControllerClass, spec: OpenApiSpec) {
     this._routes.registerController(name, spec);
   }
 

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, Context, ValueOrPromise, BoundValue} from '@loopback/context';
+import {
+  Binding,
+  Context,
+  ValueOrPromise,
+  BoundValue,
+  Constructor,
+} from '@loopback/context';
 import {OpenApiSpec} from '@loopback/openapi-spec';
 import {ServerRequest, ServerResponse} from 'http';
 import {getApiSpec} from './router/metadata';
@@ -36,7 +42,7 @@ export class HttpHandler {
     this.handleRequest = (req, res) => this._handleRequest(req, res);
   }
 
-  registerController(name: string, spec: OpenApiSpec) {
+  registerController<T>(name: Constructor<T>, spec: OpenApiSpec) {
     this._routes.registerController(name, spec);
   }
 

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -17,6 +17,7 @@ import {
 import {expect, Client, createClientForApp} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';
+import {ControllerClass} from '../../../src/router/routing-table';
 
 /* # Feature: Routing
  * - In order to build REST APIs
@@ -323,9 +324,9 @@ describe('Routing', () => {
     return new Application();
   }
 
-  function givenControllerInApp<T>(
+  function givenControllerInApp(
     app: Application,
-    controller: Constructor<T>,
+    controller: ControllerClass,
   ) {
     app.controller(controller);
   }

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -298,6 +298,25 @@ describe('Routing', () => {
     );
   });
 
+  it('supports controller routes defined via app.route()', async () => {
+    const app = givenAnApplication();
+
+    class MyController {
+      greet(name: string) {
+        return `hello ${name}`;
+      }
+    }
+
+    const spec = anOperationSpec()
+      .withParameter({name: 'name', in: 'query', type: 'string'})
+      .build();
+
+    app.route('get', '/greet', spec, MyController, 'greet');
+
+    const client = whenIMakeRequestTo(app);
+    await client.get('/greet?name=world').expect(200, 'hello world');
+  });
+
   /* ===== HELPERS ===== */
 
   function givenAnApplication() {

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -22,6 +22,7 @@ import {
 import {expect, Client, createClientForApp} from '@loopback/testlab';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';
+import {ControllerClass} from '../../../src/router/routing-table';
 
 /* # Feature: Sequence
  * - In order to build REST APIs
@@ -133,7 +134,7 @@ describe('Sequence', () => {
     app = new Application();
   }
 
-  function givenControllerInApp<T>(controller: Constructor<T>) {
+  function givenControllerInApp(controller: ControllerClass) {
     app.controller(controller);
   }
 

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -405,8 +405,7 @@ describe('HttpHandler', () => {
     ctor: new (...args: any[]) => Object,
     spec: OpenApiSpec,
   ) {
-    rootContext.bind('controllers.test-controller').toClass(ctor);
-    handler.registerController('test-controller', spec);
+    handler.registerController(ctor, spec);
   }
 
   function givenClient() {

--- a/packages/core/test/unit/http-handler.ts
+++ b/packages/core/test/unit/http-handler.ts
@@ -24,7 +24,6 @@ describe('HttpHandler', () => {
 
   describe('has inbuilt methods to inject into a request context', ()=> {
     beforeEach(setupRequestContext);
-
     describe('bindElement()', () => {
       it('returns a binding to a context', async () => {
         const fn: BindElement = await requestContext.get('bindElement');
@@ -32,6 +31,7 @@ describe('HttpHandler', () => {
         expect(binding).to.be.instanceof(Binding);
       });
     });
+
     describe('getFromContext()', () => {
       it('returns a value from the context', async () => {
         requestContext.bind('foo').to('bar');
@@ -56,7 +56,7 @@ describe('HttpHandler', () => {
           .withStringResponse(200)
           .withOperationName('hello')
           .build();
-        const route = new ControllerRoute('get', '/', spec, 'test-controller');
+        const route = new ControllerRoute('get', '/', spec, HelloController);
         const val: OperationRetval = await fn(route, []);
         expect(val).to.eql('hello');
       });

--- a/packages/core/test/unit/router/controller-route.test.ts
+++ b/packages/core/test/unit/router/controller-route.test.ts
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ControllerRoute} from '../../..';
+import {expect} from '@loopback/testlab';
+import {anOperationSpec} from '@loopback/openapi-spec-builder';
+
+describe('ControllerRoute', () => {
+  it('rejects routes with no methodName', () => {
+    class MyController {}
+    const spec = anOperationSpec().build();
+
+    expect(
+      () => new ControllerRoute('get', '/greet', spec, MyController),
+    ).to.throw(/methodName must be provided.*"get \/greet".*MyController/);
+  });
+});

--- a/packages/core/test/unit/router/reject.test.ts
+++ b/packages/core/test/unit/router/reject.test.ts
@@ -9,7 +9,7 @@ import {
   Reject,
   RejectProvider,
   LogError,
-} from '../..';
+} from '../../..';
 
 import {
   expect,

--- a/packages/core/test/unit/router/routing-table.test.ts
+++ b/packages/core/test/unit/router/routing-table.test.ts
@@ -10,7 +10,7 @@ import {
   RoutingTable,
   ResolvedRoute,
   ControllerRoute,
-} from '../..';
+} from '../../..';
 import {expect, ShotRequestOptions, ShotRequest} from '@loopback/testlab';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
@@ -21,8 +21,11 @@ describe('RoutingTable', () => {
       .withOperationReturningString('get', '/hello', 'greet')
       .build();
 
+    class TestController {
+    }
+
     const table = new RoutingTable();
-    table.registerController('TestController', spec);
+    table.registerController(TestController, spec);
 
     const request = givenRequest({
       method: 'get',

--- a/packages/example-codehub/src/controllers/user-controller.api.ts
+++ b/packages/example-codehub/src/controllers/user-controller.api.ts
@@ -60,9 +60,10 @@ export const def = {
           },
         },
       },
+      /* TODO(ritch) please fill in details
       patch: {
-        // TODO(ritch) please fill in details
       },
+      */
     },
     '/users/{username}': {
       get: {


### PR DESCRIPTION
Example usage:

```ts
class MyController {
  greet(name: string) {
    return `hello ${name}`;
  }
}

const spec = {parameters: {name: 'string', source: 'query'}};
app.route('get', '/greet', spec, MyController, 'greet');
```

I have also modified `app.route()` API to accept any instance implementing `RouteEntry` interface - a handler-function based `Route`, a `ControllerRoute`, but possibly also custom 3rd-party route type. The last line in the example above can be rewritten as follows:

```ts
app.route(new ControllerRoute('get', '/greet', spec, MyController, 'greet'));
```

In the second part of this patch, I simplified internal implementation by reworking `ControllerRoute` class to always expect a controller constructor, even for routes registered for controllers bound via `app.controller()` API. 

Connect to #402 (I figure out there is little to spike on and I can implement the full feature in the time allocated for this task.)

cc @bajtos @raymondfeng @ritch @superkhau
