### PR TITLE
Rename sequence actions to start with "sequence.actions." prefix

### DIFF
--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -127,7 +127,7 @@ describe('Basic Authentication', () => {
       constructor(
         @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
         @inject('getFromContext') protected getFromContext: GetFromContext,
-        @inject('invokeMethod') protected invoke: InvokeMethod,
+        @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') protected send: Send,
         @inject('sequence.actions.reject') protected reject: Reject,
         @inject('bindElement') protected bindElement: BindElement,

--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -125,7 +125,7 @@ describe('Basic Authentication', () => {
   function givenAuthenticatedSequence() {
     class MySequence implements SequenceHandler {
       constructor(
-        @inject('findRoute') protected findRoute: FindRoute,
+        @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
         @inject('getFromContext') protected getFromContext: GetFromContext,
         @inject('invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') protected send: Send,

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -78,7 +78,7 @@ export class Application extends Context {
       }
     };
 
-    this.bind('logError').to(this._logError.bind(this));
+    this.bind('sequence.actions.logError').to(this._logError.bind(this));
     this.bind('sequence.actions.send').to(writeResultToResponse);
     this.bind('sequence.actions.reject').toProvider(RejectProvider);
   }

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -350,7 +350,7 @@ export class Application extends Context {
       // in order for our DI/IoC framework to inject constructor arguments
       constructor(
         @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-        @inject('invokeMethod') protected invoke: InvokeMethod,
+        @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') public send: Send,
         @inject('sequence.actions.reject') public reject: Reject,
       ) {

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -349,7 +349,7 @@ export class Application extends Context {
       // NOTE(bajtos) Unfortunately, we have to duplicate the constructor
       // in order for our DI/IoC framework to inject constructor arguments
       constructor(
-        @inject('findRoute') protected findRoute: FindRoute,
+        @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
         @inject('invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') public send: Send,
         @inject('sequence.actions.reject') public reject: Reject,

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -92,7 +92,7 @@ export class HttpHandler {
       found.updateBindings(context);
       return found;
     };
-    context.bind('findRoute').to(findRoute);
+    context.bind('sequence.actions.findRoute').to(findRoute);
   }
 
   protected _bindInvokeMethod(context: Context) {

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -99,6 +99,6 @@ export class HttpHandler {
     const invoke: InvokeMethod = async (route, args) => {
       return await route.invokeHandler(context, args);
     };
-    context.bind('invokeMethod').to(invoke);
+    context.bind('sequence.actions.invokeMethod').to(invoke);
   }
 }

--- a/packages/core/src/router/reject.ts
+++ b/packages/core/src/router/reject.ts
@@ -9,7 +9,9 @@ import {ServerResponse, ServerRequest} from '..';
 import {HttpError} from 'http-errors';
 
 export class RejectProvider {
-  constructor(@inject('logError') protected logError: LogError) {}
+  constructor(
+    @inject('sequence.actions.logError') protected logError: LogError,
+  ) {}
 
   value(): Reject {
     return (

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -70,7 +70,7 @@ export class DefaultSequence implements SequenceHandler {
    * @param logError Logs error
    */
   constructor(
-    @inject('findRoute') protected findRoute: FindRoute,
+    @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
     @inject('invokeMethod') protected invoke: InvokeMethod,
     @inject('sequence.actions.send') public send: Send,
     @inject('sequence.actions.reject') public reject: Reject,

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -71,7 +71,7 @@ export class DefaultSequence implements SequenceHandler {
    */
   constructor(
     @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-    @inject('invokeMethod') protected invoke: InvokeMethod,
+    @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
     @inject('sequence.actions.send') public send: Send,
     @inject('sequence.actions.reject') public reject: Reject,
   ) {}

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -61,7 +61,7 @@ describe('Sequence', () => {
   it('allows users to bind a custom sequence class', () => {
     class MySequence {
       constructor(
-        @inject('findRoute') protected findRoute: FindRoute,
+        @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
         @inject('invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') protected send: Send,
       ) {}

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -62,7 +62,7 @@ describe('Sequence', () => {
     class MySequence {
       constructor(
         @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-        @inject('invokeMethod') protected invoke: InvokeMethod,
+        @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') protected send: Send,
       ) {}
 

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -382,7 +382,7 @@ describe('HttpHandler', () => {
   let handler: HttpHandler;
   function givenHandler() {
     rootContext = new Context();
-    rootContext.bind('logError').to(logger);
+    rootContext.bind('sequence.actions.logError').to(logger);
     rootContext.bind('sequence.actions.send').to(writeResultToResponse);
     rootContext.bind('sequence.actions.reject').toProvider(RejectProvider);
     rootContext.bind('sequence').toClass(DefaultSequence);
@@ -420,8 +420,10 @@ describe('HttpHandler', () => {
   }
 
   function logErrorsExcept(ignoreStatusCode: number) {
-    const oldLogger: Function = rootContext.getSync('logError');
-    rootContext.bind('logError').to(conditionalLogger);
+    const oldLogger: Function = rootContext.getSync(
+      'sequence.actions.logError',
+    );
+    rootContext.bind('sequence.actions.logError').to(conditionalLogger);
 
     function conditionalLogger(
       err: Error,

--- a/packages/core/test/unit/application/application.test.ts
+++ b/packages/core/test/unit/application/application.test.ts
@@ -10,7 +10,7 @@ describe('Application', () => {
   describe('"logError" binding', () => {
     it('provides a default', async () => {
       const app = new Application();
-      const logError = await app.get('logError');
+      const logError = await app.get('sequence.actions.logError');
       expect(logError.length).to.equal(3); // (err, statusCode, request)
     });
 
@@ -29,7 +29,7 @@ describe('Application', () => {
       }
 
       const app = new MyApp();
-      const logError = await app.get('logError');
+      const logError = await app.get('sequence.actions.logError');
       logError(new Error('test-error'), 400, new ShotRequest({url: '/'}));
 
       expect(lastLog).to.equal('/ 400 test-error');

--- a/packages/core/test/unit/http-handler.ts
+++ b/packages/core/test/unit/http-handler.ts
@@ -51,7 +51,9 @@ describe('HttpHandler', () => {
 
         requestContext.bind('controllers.test-controller')
           .toClass(HelloController);
-        const fn: InvokeMethod = await requestContext.get('invokeMethod');
+        const fn: InvokeMethod = await requestContext.get(
+          'sequence.actions.invokeMethod',
+        );
         const spec = anOperationSpec()
           .withStringResponse(200)
           .withOperationName('hello')
@@ -62,7 +64,9 @@ describe('HttpHandler', () => {
       });
 
       it('invokes a route handler', async () => {
-        const fn: InvokeMethod = await requestContext.get('invokeMethod');
+        const fn: InvokeMethod = await requestContext.get(
+          'sequence.actions.invokeMethod',
+        );
         const spec = anOperationSpec().withStringResponse(200).build();
         function hello() { return 'hello'; }
         const route = new Route('get', '/', spec, hello);


### PR DESCRIPTION
This fixes a left-over from an earlier work.

 - `logError` -> `sequence.actions.logError`
 - `findRoute` -> `sequence.actions.findRoute`
 - `invokeMethod` -> `sequence.actions.invokeMethod`

The updated `DefaultSequence` constructor is nicely consistent now:

```ts
export class DefaultSequence implements SequenceHandler { 
  constructor(
    @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
    @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
    @inject('sequence.actions.send') public send: Send,
    @inject('sequence.actions.reject') public reject: Reject,
  ) {}

  // ...
}
```


cc @bajtos @raymondfeng @ritch @superkhau
