### PR TITLE
core: support @get and @operation decorators

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@
 // package dependencies
 export {Application} from './application';
 export {Component} from './component';
-export {api} from './router/metadata';
+export {api, get, operation} from './router/metadata';
 export * from './sequence';
 
 // loopback dependencies

--- a/packages/core/src/router/metadata.ts
+++ b/packages/core/src/router/metadata.ts
@@ -5,8 +5,11 @@
 
 import * as assert from 'assert';
 import {Reflector} from '@loopback/context';
+import {OpenApiSpec, OperationObject} from '@loopback/openapi-spec';
 
-import {OpenApiSpec} from '@loopback/openapi-spec';
+const debug = require('debug')('loopback:core:router:metadata');
+
+// tslint:disable:no-any
 
 /**
  * Decorate the given Controller constructor with metadata describing
@@ -27,7 +30,140 @@ export function api(spec: OpenApiSpec) {
   };
 }
 
-// TODO(bajtos) Add unit-tests
+interface RestEndpoint {
+  verb: string;
+  path: string;
+}
+
 export function getApiSpec(constructor: Function): OpenApiSpec {
-  return Reflector.getMetadata('loopback:api-spec', constructor);
+  debug(`Retrieving OpenAPI specification for controller ${constructor.name}`);
+
+  let spec: OpenApiSpec = Reflector.getMetadata(
+    'loopback:api-spec',
+    constructor,
+  );
+
+  if (spec) {
+    debug('  using class-level spec defined via @api()', spec);
+    return spec;
+  }
+
+  spec = {basePath: '/', paths: {}};
+  for (
+    let proto = constructor.prototype;
+    proto && proto !== Object.prototype;
+    proto = Object.getPrototypeOf(proto)
+  ) {
+    addPrototypeMethodsToSpec(spec, proto);
+  }
+  return spec;
+}
+
+function addPrototypeMethodsToSpec(spec: OpenApiSpec, proto: any) {
+  const controllerMethods = Object.getOwnPropertyNames(proto).filter(
+    key => key !== 'constructor' && typeof proto[key] === 'function',
+  );
+  for (const methodName of controllerMethods) {
+    addControllerMethodToSpec(spec, proto, methodName);
+  }
+}
+
+function addControllerMethodToSpec(
+  spec: OpenApiSpec,
+  proto: any,
+  methodName: string,
+) {
+  const className = proto.constructor.name || '<UnknownClass>';
+  const fullMethodName = `${className}.${methodName}`;
+  console.log('    ADDING CONTROLLER METHOD %s', fullMethodName);
+
+  const endpoint: RestEndpoint = Reflector.getMetadata(
+    'loopback:operation-endpoint',
+    proto,
+    methodName,
+  );
+
+  if (!endpoint) {
+    debug(`  skipping ${fullMethodName} - no endpoint is defined`);
+    return;
+  }
+
+  const {verb, path} = endpoint;
+  const endpointName = `${fullMethodName} (${verb} ${path})`;
+
+  const operationSpec = Reflector.getMetadata(
+    'loopback:operation-spec',
+    proto,
+    methodName,
+  );
+  if (!operationSpec) {
+    throw new Error(
+      `Missing OpenAPI specification for controller method ${endpointName}`,
+    );
+  }
+
+  if (!spec.paths[path]) {
+    spec.paths[path] = {};
+  }
+
+  if (spec.paths[path][verb]) {
+    debug(`  skipping ${endpointName} - endpoint was already defined`);
+    return;
+  }
+
+  debug(`  adding ${endpointName}`, operationSpec);
+  spec.paths[path][verb] = Object.assign({}, operationSpec, {
+    'x-operation-name': methodName,
+  });
+}
+
+/**
+ * Expose a Controller method as a REST API operation
+ * mapped to `GET` request method.
+ *
+ * @param path The URL path of this operation, e.g. `/product/{id}`
+ * @param spec The OpenAPI specification describing parameters and responses
+ *   of this operation.
+ */
+export function get(path: string, spec: OperationObject) {
+  return operation('get', path, spec);
+}
+
+/**
+ * Expose a Controller method as a REST API operation.
+ *
+ * @param verb HTTP verb, e.g. `GET` or `POST`.
+ * @param path The URL path of this operation, e.g. `/product/{id}`
+ * @param spec The OpenAPI specification describing parameters and responses
+ *   of this operation.
+ */
+export function operation(verb: string, path: string, spec: OperationObject) {
+  // tslint:disable-next-line:no-any
+  return function(
+    target: object,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const endpoint: RestEndpoint = {verb, path};
+    Reflector.defineMetadata(
+      'loopback:operation-endpoint',
+      endpoint,
+      target,
+      propertyKey,
+    );
+
+    /* TODO(bajtos)
+    if (!spec) {
+      // Users can define parameters and responses using decorators
+      return;
+    }
+    */
+
+    Reflector.defineMetadata(
+      'loopback:operation-spec',
+      spec,
+      target,
+      propertyKey,
+    );
+  };
 }

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -6,6 +6,7 @@
 import {
   Application,
   api,
+  get,
   OpenApiSpec,
   ParameterObject,
   OperationObject,
@@ -58,6 +59,23 @@ describe('Routing', () => {
     return whenIMakeRequestTo(app).get('/echo?msg=hello%20world')
       // Then I get the result `hello world` from the `Method`
       .expect('hello world');
+  });
+
+  it('allows controllers to define the API using decorators', async () => {
+    const app = givenAnApplication();
+
+    const spec = anOperationSpec()
+      .withParameter({name: 'msg', in: 'query', type: 'string'})
+      .withStringResponse()
+      .build();
+
+      class MyController {
+        @get('/greet', spec)
+        greet(name: string) {
+          return `hello ${name}`;
+        }
+      }
+
   });
 
   it('injects controller constructor arguments', () => {

--- a/packages/core/test/unit/router/metadata.test.ts
+++ b/packages/core/test/unit/router/metadata.test.ts
@@ -1,0 +1,107 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {get, api} from '../../..';
+import {expect} from '@loopback/testlab';
+import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
+import {getApiSpec} from '../../../src/router/metadata';
+
+describe('Routing metadata', () => {
+  it('returns spec defined via @api()', () => {
+    const expectedSpec = anOpenApiSpec()
+      .withOperationReturningString('get', '/greet', 'greet')
+      .build();
+
+    @api(expectedSpec)
+    class MyController {
+      greet() {
+        return 'Hello world!';
+      }
+    }
+
+    const actualSpec = getApiSpec(MyController);
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('returns spec defined via method decorators', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class MyController {
+      @get('/greet', operationSpec)
+      greet() {
+        return 'Hello world!';
+      }
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    const expectedSpec = anOpenApiSpec()
+      .withOperation(
+        'get',
+        '/greet',
+        Object.assign({'x-operation-name': 'greet'}, operationSpec),
+      )
+      .build();
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('honours specifications from inherited methods', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class Parent {
+      @get('/parent', operationSpec)
+      getParentName() {
+        return 'The Parent';
+      }
+    }
+
+    class Child extends Parent {
+      @get('/child', operationSpec)
+      getChildName() {
+        return 'The Child';
+      }
+    }
+
+    const actualSpec = getApiSpec(Child);
+
+    const expectedSpec = anOpenApiSpec()
+      .withOperation(
+        'get',
+        '/parent',
+        Object.assign({'x-operation-name': 'getParentName'}, operationSpec),
+      )
+      .withOperation(
+        'get',
+        '/child',
+        Object.assign({'x-operation-name': 'getChildName'}, operationSpec),
+      )
+      .build();
+
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('allows children to override parent REST endpoints', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class Parent {
+      @get('/name', operationSpec)
+      getParentName() {
+        return 'The Parent';
+      }
+    }
+
+    class Child extends Parent {
+      @get('/name', operationSpec)
+      getChildName() {
+        return 'The Child';
+      }
+    }
+
+    const actualSpec = getApiSpec(Child);
+
+    expect(actualSpec.paths['/name']['get'])
+      .to.have.property('x-operation-name', 'getChildName');
+  });
+});


### PR DESCRIPTION
Allow Controller authors to describe REST API methods using per-method decorations via @get and @operation, as described on [wiki](https://github.com/strongloop/loopback-next/wiki/Controllers#routing-to-controllers).

```ts
class MyController {
  @get('/greet', {parameters: {name: 'string', type: 'string', in: 'query'}})
  greet(name) {
    return `Hello ${name}.`;
  }
}
```

I created this pull request as an outcome of my spike on #402, I am intentionally omitting `@post` etc. decorators - that will be part of the follow-up work (mostly in #404).

cc @bajtos @raymondfeng @ritch @superkhau
