### PR TITLE
apidocs: fix the script to forward stdout/stderr

### DIFF
--- a/bin/generate-apidocs.js
+++ b/bin/generate-apidocs.js
@@ -3,5 +3,6 @@ const spawn = require('child_process').spawn;
 // Call sdocs
 spawn(
   process.execPath,
-  [require.resolve('strong-docs/bin/cli'), '-o', 'api-docs']
+  [require.resolve('strong-docs/bin/cli'), '-o', 'api-docs'],
+  {stdio: 'inherit'}
 ).on('close', (number, signal) => (process.exitCode = number));


### PR DESCRIPTION
Fix the script running strong-docs to generate api-docs, so that it correctly forwards strong-doc's stdout and stderr.

cc @bajtos @raymondfeng @ritch @superkhau @mpatsute 
