### PR TITLE
Add `@param` decorator + shortcuts

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@
 // package dependencies
 export {Application} from './application';
 export {Component} from './component';
-export {api, get, operation} from './router/metadata';
+export * from './router/metadata';
 export * from './sequence';
 
 // loopback dependencies

--- a/packages/core/src/router/metadata.ts
+++ b/packages/core/src/router/metadata.ts
@@ -203,7 +203,7 @@ export function param(paramSpec: ParameterObject) {
       operationSpec.parameters = [];
     }
 
-    operationSpec.parameters.push(paramSpec);
+    operationSpec.parameters.unshift(paramSpec);
 
     Reflector.defineMetadata(
       'loopback:operation-spec',

--- a/packages/core/src/router/metadata.ts
+++ b/packages/core/src/router/metadata.ts
@@ -5,7 +5,11 @@
 
 import * as assert from 'assert';
 import {Reflector} from '@loopback/context';
-import {OpenApiSpec, OperationObject} from '@loopback/openapi-spec';
+import {
+  OpenApiSpec,
+  OperationObject,
+  ParameterObject,
+} from '@loopback/openapi-spec';
 
 const debug = require('debug')('loopback:core:router:metadata');
 
@@ -125,7 +129,7 @@ function addControllerMethodToSpec(
  * @param spec The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
-export function get(path: string, spec: OperationObject) {
+export function get(path: string, spec?: OperationObject) {
   return operation('get', path, spec);
 }
 
@@ -137,7 +141,7 @@ export function get(path: string, spec: OperationObject) {
  * @param spec The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
-export function operation(verb: string, path: string, spec: OperationObject) {
+export function operation(verb: string, path: string, spec?: OperationObject) {
   // tslint:disable-next-line:no-any
   return function(
     target: object,
@@ -152,12 +156,10 @@ export function operation(verb: string, path: string, spec: OperationObject) {
       propertyKey,
     );
 
-    /* TODO(bajtos)
     if (!spec) {
       // Users can define parameters and responses using decorators
       return;
     }
-    */
 
     Reflector.defineMetadata(
       'loopback:operation-spec',
@@ -165,5 +167,105 @@ export function operation(verb: string, path: string, spec: OperationObject) {
       target,
       propertyKey,
     );
+  };
+}
+
+/**
+ * Describe an input parameter of a Controller method.
+ *
+ * @param paramSpec Parameter specification.
+ */
+export function param(paramSpec: ParameterObject) {
+  return function(
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    assert(
+      typeof target[propertyKey] === 'function',
+      '@param decorator can be applied to methods only',
+    );
+
+    let operationSpec: OperationObject = Reflector.getMetadata(
+      'loopback:operation-spec',
+      target,
+      propertyKey,
+    );
+
+    if (!operationSpec) {
+      operationSpec = {
+        responses: {},
+      };
+    }
+
+    if (!operationSpec.parameters) {
+      operationSpec.parameters = [];
+    }
+
+    operationSpec.parameters.push(paramSpec);
+
+    Reflector.defineMetadata(
+      'loopback:operation-spec',
+      operationSpec,
+      target,
+      propertyKey,
+    );
+  };
+}
+
+// TODO(bajtos) @param.IN.TYPE('foo', {required: true})
+export namespace param {
+  export const query = {
+    /**
+     * Define a parameter of "string" type that's read from the query string.
+     *
+     * @param name Parameter name.
+     */
+    string: (name: string) => {
+      return param({
+        name: name,
+        in: 'query',
+        type: 'string',
+      });
+    },
+
+    /**
+     * Define a parameter of "number" type that's read from the query string.
+     *
+     * @param name Parameter name.
+     */
+    number: (name: string) => {
+      return param({
+        name: name,
+        in: 'query',
+        type: 'number',
+      });
+    },
+
+    /**
+     * Define a parameter of "integer" type that's read from the query string.
+     *
+     * @param name Parameter name.
+     */
+    integer: (name: string) => {
+      return param({
+        name: name,
+        in: 'query',
+        type: 'integer',
+      });
+    },
+
+    /**
+     * Define a parameter of "boolean" type that's read from the query string.
+     *
+     * @param name Parameter name.
+     */
+    boolean: (name: string) => {
+      return param({
+        name: name,
+        in: 'query',
+        type: 'boolean',
+      });
+    },
   };
 }

--- a/packages/core/src/router/metadata.ts
+++ b/packages/core/src/router/metadata.ts
@@ -95,15 +95,16 @@ function addControllerMethodToSpec(
   const {verb, path} = endpoint;
   const endpointName = `${fullMethodName} (${verb} ${path})`;
 
-  const operationSpec = Reflector.getMetadata(
+  let operationSpec = Reflector.getMetadata(
     'loopback:operation-spec',
     proto,
     methodName,
   );
   if (!operationSpec) {
-    throw new Error(
-      `Missing OpenAPI specification for controller method ${endpointName}`,
-    );
+    // The operation was defined via @operation(verb, path) with no spec
+    operationSpec = {
+      responses: {},
+    };
   }
 
   if (!spec.paths[path]) {

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -14,6 +14,7 @@ import {
   ServerResponse,
   ResponseObject,
   Route,
+  param,
 } from '../../..';
 import {expect, Client, createClientForApp} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
@@ -62,10 +63,8 @@ describe('Routing', () => {
   });
 
   it('allows controllers to define the API using decorators', async () => {
-    const app = givenAnApplication();
-
     const spec = anOperationSpec()
-      .withParameter({name: 'msg', in: 'query', type: 'string'})
+      .withParameter({name: 'name', in: 'query', type: 'string'})
       .withStringResponse()
       .build();
 
@@ -76,6 +75,28 @@ describe('Routing', () => {
         }
       }
 
+    const app = givenAnApplication();
+    givenControllerInApp(app, MyController);
+
+    return whenIMakeRequestTo(app).get('/greet?name=world')
+      // Then I get the result `hello world` from the `Method`
+      .expect('hello world');
+  });
+
+  it('allows controllers to define params via decorators', async () => {
+    class MyController {
+      @get('/greet')
+      @param.query.string('name')
+      greet(name: string) {
+        return `hello ${name}`;
+      }
+    }
+
+    const app = givenAnApplication();
+    givenControllerInApp(app, MyController);
+    return whenIMakeRequestTo(app).get('/greet?name=world')
+      // Then I get the result `hello world` from the `Method`
+      .expect('hello world');
   });
 
   it('injects controller constructor arguments', () => {

--- a/packages/core/test/unit/router/metadata.test.ts
+++ b/packages/core/test/unit/router/metadata.test.ts
@@ -3,10 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, api} from '../../..';
+import {get, api, param, ParameterObject, getApiSpec} from '../../..';
 import {expect} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
-import {getApiSpec} from '../../../src/router/metadata';
 
 describe('Routing metadata', () => {
   it('returns spec defined via @api()', () => {
@@ -101,7 +100,9 @@ describe('Routing metadata', () => {
 
     const actualSpec = getApiSpec(Child);
 
-    expect(actualSpec.paths['/name']['get'])
-      .to.have.property('x-operation-name', 'getChildName');
+    expect(actualSpec.paths['/name']['get']).to.have.property(
+      'x-operation-name',
+      'getChildName',
+    );
   });
 });

--- a/packages/core/test/unit/router/metadata.test.ts
+++ b/packages/core/test/unit/router/metadata.test.ts
@@ -3,7 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, api, param, ParameterObject, getApiSpec} from '../../..';
+import {
+  get,
+  api,
+  param,
+  ParameterObject,
+  getApiSpec,
+  operation,
+} from '../../..';
 import {expect} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
 
@@ -24,7 +31,7 @@ describe('Routing metadata', () => {
     expect(actualSpec).to.eql(expectedSpec);
   });
 
-  it('returns spec defined via method decorators', () => {
+  it('returns spec defined via @get decorator', () => {
     const operationSpec = anOperationSpec().withStringResponse().build();
 
     class MyController {
@@ -44,6 +51,54 @@ describe('Routing metadata', () => {
       )
       .build();
     expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('returns spec defined via @operation decorator', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class MyController {
+      @operation('post', '/greeting', operationSpec)
+      createGreeting() {}
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    const expectedSpec = anOpenApiSpec()
+      .withOperation(
+        'post',
+        '/greeting',
+        Object.assign({'x-operation-name': 'createGreeting'}, operationSpec),
+      )
+      .build();
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('returns default spec for @get with no spec', () => {
+    class MyController {
+      @get('/greet')
+      greet() {}
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    expect(actualSpec.paths['/greet']['get']).to.eql({
+      'x-operation-name': 'greet',
+      responses: {},
+    });
+  });
+
+  it('returns default spec for @operation with no spec', () => {
+    class MyController {
+      @operation('post', '/greeting')
+      createGreeting() {}
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    expect(actualSpec.paths['/greeting']['post']).to.eql({
+      'x-operation-name': 'createGreeting',
+      responses: {},
+    });
   });
 
   it('honours specifications from inherited methods', () => {

--- a/packages/core/test/unit/router/metadata/param.test.ts
+++ b/packages/core/test/unit/router/metadata/param.test.ts
@@ -31,6 +31,34 @@ describe('Routing metadata for parameters', () => {
 
       expect(actualSpec.paths['/greet']['get']).to.eql(expectedSpec);
     });
+
+    it('can define multiple parameters in order', () => {
+      const offsetSpec: ParameterObject = {
+        name: 'offset',
+        type: 'number',
+        in: 'query',
+      };
+
+      const pageSizeSpec: ParameterObject = {
+        name: 'pageSize',
+        type: 'number',
+        in: 'query',
+      };
+
+      class MyController {
+        @get('/')
+        @param(offsetSpec)
+        @param(pageSizeSpec)
+        list(offset?: number, pageSize?: number) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/']['get'].parameters).to.eql([
+        offsetSpec,
+        pageSizeSpec,
+      ]);
+    });
   });
 
   describe('@param.query.string', () => {

--- a/packages/core/test/unit/router/metadata/param.test.ts
+++ b/packages/core/test/unit/router/metadata/param.test.ts
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {get, api, param, ParameterObject, getApiSpec} from '../../../..';
+import {expect} from '@loopback/testlab';
+import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
+
+describe('Routing metadata for parameters', () => {
+  describe('@param', () => {
+    it('defines a new parameter', () => {
+      const paramSpec: ParameterObject = {
+        name: 'name',
+        type: 'string',
+        in: 'query',
+      };
+
+      class MyController {
+        @get('/greet')
+        @param(paramSpec)
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      const expectedSpec = anOperationSpec()
+        .withOperationName('greet')
+        .withParameter(paramSpec)
+        .build();
+
+      expect(actualSpec.paths['/greet']['get']).to.eql(expectedSpec);
+    });
+  });
+
+  describe('@param.query.string', () => {
+    it('defines a parameter with in:query type:string', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.string('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'string',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.query.number', () => {
+    it('defines a parameter with in:query type:number', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.number('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'number',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.query.integer', () => {
+    it('defines a parameter with in:query type:integer', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.integer('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'integer',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.query.boolean', () => {
+    it('defines a parameter with in:query type:boolean', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.boolean('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'boolean',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
 - `@param(spec)`
 - `@param.query.string(name)`
 - `@param.query.number(name)`
 - `@param.query.integer(name)`
 - `@param.query.boolean(name)`

See [wiki](https://github.com/strongloop/loopback-next/wiki/Controllers#writing-controller-methods) for more details.

Connect to #404 

cc @bajtos @raymondfeng @ritch @superkhau
