### PR TITLE
Add shortcut decorators for HTTP verbs

### DIFF
--- a/packages/core/src/router/metadata.ts
+++ b/packages/core/src/router/metadata.ts
@@ -79,7 +79,6 @@ function addControllerMethodToSpec(
 ) {
   const className = proto.constructor.name || '<UnknownClass>';
   const fullMethodName = `${className}.${methodName}`;
-  console.log('    ADDING CONTROLLER METHOD %s', fullMethodName);
 
   const endpoint: RestEndpoint = Reflector.getMetadata(
     'loopback:operation-endpoint',
@@ -132,6 +131,54 @@ function addControllerMethodToSpec(
  */
 export function get(path: string, spec?: OperationObject) {
   return operation('get', path, spec);
+}
+
+/**
+ * Expose a Controller method as a REST API operation
+ * mapped to `POST` request method.
+ *
+ * @param path The URL path of this operation, e.g. `/product/{id}`
+ * @param spec The OpenAPI specification describing parameters and responses
+ *   of this operation.
+ */
+export function post(path: string, spec?: OperationObject) {
+  return operation('post', path, spec);
+}
+
+/**
+ * Expose a Controller method as a REST API operation
+ * mapped to `PUT` request method.
+ *
+ * @param path The URL path of this operation, e.g. `/product/{id}`
+ * @param spec The OpenAPI specification describing parameters and responses
+ *   of this operation.
+ */
+export function put(path: string, spec?: OperationObject) {
+  return operation('put', path, spec);
+}
+
+/**
+ * Expose a Controller method as a REST API operation
+ * mapped to `PATCH` request method.
+ *
+ * @param path The URL path of this operation, e.g. `/product/{id}`
+ * @param spec The OpenAPI specification describing parameters and responses
+ *   of this operation.
+ */
+export function patch(path: string, spec?: OperationObject) {
+  return operation('patch', path, spec);
+}
+
+/**
+ * Expose a Controller method as a REST API operation
+ * mapped to `DELETE` request method.
+ *
+ * @param path The URL path of this operation, e.g. `/product/{id}`
+ * @param spec The OpenAPI specification describing parameters and responses
+ *   of this operation.
+ */
+export function del(path: string, spec?: OperationObject) {
+  return operation('del', path, spec);
 }
 
 /**

--- a/packages/core/test/unit/router/metadata.test.ts
+++ b/packages/core/test/unit/router/metadata.test.ts
@@ -10,6 +10,10 @@ import {
   ParameterObject,
   getApiSpec,
   operation,
+  post,
+  put,
+  patch,
+  del,
 } from '../../..';
 import {expect} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
@@ -48,6 +52,86 @@ describe('Routing metadata', () => {
         'get',
         '/greet',
         Object.assign({'x-operation-name': 'greet'}, operationSpec),
+      )
+      .build();
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('returns spec defined via @post decorator', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class MyController {
+      @post('/greeting', operationSpec)
+      createGreeting() {}
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    const expectedSpec = anOpenApiSpec()
+      .withOperation(
+        'post',
+        '/greeting',
+        Object.assign({'x-operation-name': 'createGreeting'}, operationSpec),
+      )
+      .build();
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('returns spec defined via @put decorator', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class MyController {
+      @put('/greeting', operationSpec)
+      updateGreeting() {}
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    const expectedSpec = anOpenApiSpec()
+      .withOperation(
+        'put',
+        '/greeting',
+        Object.assign({'x-operation-name': 'updateGreeting'}, operationSpec),
+      )
+      .build();
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('returns spec defined via @patch decorator', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class MyController {
+      @patch('/greeting', operationSpec)
+      patchGreeting() {}
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    const expectedSpec = anOpenApiSpec()
+      .withOperation(
+        'patch',
+        '/greeting',
+        Object.assign({'x-operation-name': 'patchGreeting'}, operationSpec),
+      )
+      .build();
+    expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('returns spec defined via @del decorator', () => {
+    const operationSpec = anOperationSpec().withStringResponse().build();
+
+    class MyController {
+      @del('/greeting', operationSpec)
+      deleteGreeting() {}
+    }
+
+    const actualSpec = getApiSpec(MyController);
+
+    const expectedSpec = anOpenApiSpec()
+      .withOperation(
+        'del',
+        '/greeting',
+        Object.assign({'x-operation-name': 'deleteGreeting'}, operationSpec),
       )
       .build();
     expect(actualSpec).to.eql(expectedSpec);


### PR DESCRIPTION
 - `@post()`
 - `@put()`
 - `@patch()`
 - `@del()`

Note that `delete` is a reserved keyword that cannot be used
as a function name.

Connect to #404 

cc @bajtos @raymondfeng @ritch @superkhau
