### PR TITLE
Add more `@param.*` shortcuts

### DIFF
--- a/packages/core/src/router/metadata.ts
+++ b/packages/core/src/router/metadata.ts
@@ -8,7 +8,10 @@ import {Reflector} from '@loopback/context';
 import {
   OpenApiSpec,
   OperationObject,
+  ParameterLocation,
   ParameterObject,
+  SchemaObject,
+  ParameterTypeValue,
 } from '@loopback/openapi-spec';
 
 const debug = require('debug')('loopback:core:router:metadata');
@@ -261,7 +264,6 @@ export function param(paramSpec: ParameterObject) {
   };
 }
 
-// TODO(bajtos) @param.IN.TYPE('foo', {required: true})
 export namespace param {
   export const query = {
     /**
@@ -269,51 +271,149 @@ export namespace param {
      *
      * @param name Parameter name.
      */
-    string: (name: string) => {
-      return param({
-        name: name,
-        in: 'query',
-        type: 'string',
-      });
-    },
+    string: createParamShortcut('query', 'string'),
 
     /**
      * Define a parameter of "number" type that's read from the query string.
      *
      * @param name Parameter name.
      */
-    number: (name: string) => {
-      return param({
-        name: name,
-        in: 'query',
-        type: 'number',
-      });
-    },
+    number: createParamShortcut('query', 'number'),
 
     /**
      * Define a parameter of "integer" type that's read from the query string.
      *
      * @param name Parameter name.
      */
-    integer: (name: string) => {
-      return param({
-        name: name,
-        in: 'query',
-        type: 'integer',
-      });
-    },
+    integer: createParamShortcut('query', 'integer'),
 
     /**
      * Define a parameter of "boolean" type that's read from the query string.
      *
      * @param name Parameter name.
      */
-    boolean: (name: string) => {
-      return param({
-        name: name,
-        in: 'query',
-        type: 'boolean',
-      });
-    },
+    boolean: createParamShortcut('query', 'boolean'),
+  };
+
+  export const header = {
+    /**
+     * Define a parameter of "string" type that's read from a request header.
+     *
+     * @param name Parameter name, it must match the header name
+     *   (e.g. `Content-Type`).
+     */
+    string: createParamShortcut('header', 'string'),
+
+    /**
+     * Define a parameter of "number" type that's read from a request header.
+     *
+     * @param name Parameter name, it must match the header name
+     *   (e.g. `Content-Length`).
+     */
+    number: createParamShortcut('header', 'number'),
+
+    /**
+     * Define a parameter of "integer" type that's read from a request header.
+     *
+     * @param name Parameter name, it must match the header name
+     *   (e.g. `Content-Length`).
+     */
+    integer: createParamShortcut('header', 'integer'),
+
+    /**
+     * Define a parameter of "boolean" type that's read from a request header.
+     *
+     * @param name Parameter name, it must match the header name,
+     *   (e.g. `DNT` or `X-Do-Not-Track`).
+     */
+    boolean: createParamShortcut('header', 'boolean'),
+  };
+
+  export const path = {
+    /**
+     * Define a parameter of "string" type that's read from request path.
+     *
+     * @param name Parameter name matching one of the placeholders in the path
+     *   string.
+     */
+    string: createParamShortcut('path', 'string'),
+
+    /**
+     * Define a parameter of "number" type that's read from request path.
+     *
+     * @param name Parameter name matching one of the placeholders in the path
+     *   string.
+     */
+    number: createParamShortcut('path', 'number'),
+
+    /**
+     * Define a parameter of "integer" type that's read from request path.
+     *
+     * @param name Parameter name matching one of the placeholders in the path
+     *   string.
+     */
+    integer: createParamShortcut('path', 'integer'),
+
+    /**
+     * Define a parameter of "boolean" type that's read from request path.
+     *
+     * @param name Parameter name matching one of the placeholders in the path
+     *   string.
+     */
+    boolean: createParamShortcut('path', 'boolean'),
+  };
+
+  export const formData = {
+    /**
+     * Define a parameter of "string" type that's read
+     * from a field in the request body.
+     *
+     * @param name Parameter name.
+     */
+    string: createParamShortcut('formData', 'string'),
+
+    /**
+     * Define a parameter of "number" type that's read
+     * from a field in the request body.
+     *
+     * @param name Parameter name.
+     */
+    number: createParamShortcut('formData', 'number'),
+
+    /**
+     * Define a parameter of "integer" type that's read
+     * from a field in the request body.
+     *
+     * @param name Parameter name.
+     */
+    integer: createParamShortcut('formData', 'integer'),
+
+    /**
+     * Define a parameter of "boolean" type that's read
+     * from a field in the request body.
+     *
+     * @param name Parameter name.
+     */
+    boolean: createParamShortcut('formData', 'boolean'),
+  };
+
+  /**
+   * Define a parameter that's set to the full request body.
+   *
+   * @param name Parameter name
+   * @param schema The schema defining the type used for the body parameter.
+   */
+  export const body = function(name: string, schema: SchemaObject) {
+    return param({name, in: 'body', schema});
+  };
+}
+
+function createParamShortcut(
+  source: ParameterLocation,
+  type: ParameterTypeValue,
+) {
+  // TODO(bajtos) @param.IN.TYPE('foo', {required: true})
+  return (name: string) => {
+    return param({name, in: source, type});
   };
 }

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -309,7 +309,7 @@ describe('HttpHandler', () => {
               in: 'body',
               description: 'Any object value.',
               required: true,
-              type: 'object',
+              schema: {type: 'object'},
             },
           ],
           responses: {

--- a/packages/core/test/unit/parser.test.ts
+++ b/packages/core/test/unit/parser.test.ts
@@ -42,7 +42,7 @@ describe('operationArgsParser', () => {
     const spec = givenOperationWithParameters([
       {
         name: 'data',
-        type: 'object',
+        schema: {type: 'object'},
         in: 'body',
       },
     ]);

--- a/packages/core/test/unit/router/metadata/param-body.test.ts
+++ b/packages/core/test/unit/router/metadata/param-body.test.ts
@@ -1,0 +1,29 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {post, param, getApiSpec} from '../../../..';
+import {expect} from '@loopback/testlab';
+
+describe('Routing metadata for parameters', () => {
+  describe('@param.body', () => {
+    it('defines a parameter with in:body', () => {
+      class MyController {
+        @post('/greeting')
+        @param.body('data', {type: 'object'})
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
+        {
+          name: 'data',
+          in: 'body',
+          schema: {type: 'object'},
+        },
+      ]);
+    });
+  });
+});

--- a/packages/core/test/unit/router/metadata/param-form-data.test.ts
+++ b/packages/core/test/unit/router/metadata/param-form-data.test.ts
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {post, param, getApiSpec} from '../../../..';
+import {expect} from '@loopback/testlab';
+
+describe('Routing metadata for parameters', () => {
+  describe('@param.formData.string', () => {
+    it('defines a parameter with in:formData type:string', () => {
+      class MyController {
+        @post('/greeting')
+        @param.formData.string('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'string',
+          in: 'formData',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.formData.number', () => {
+    it('defines a parameter with in:formData type:number', () => {
+      class MyController {
+        @post('/greeting')
+        @param.formData.number('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'number',
+          in: 'formData',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.formData.integer', () => {
+    it('defines a parameter with in:formData type:integer', () => {
+      class MyController {
+        @post('/greeting')
+        @param.formData.integer('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'integer',
+          in: 'formData',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.formData.boolean', () => {
+    it('defines a parameter with in:formData type:boolean', () => {
+      class MyController {
+        @post('/greeting')
+        @param.formData.boolean('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'boolean',
+          in: 'formData',
+        },
+      ]);
+    });
+  });
+});
+

--- a/packages/core/test/unit/router/metadata/param-header.test.ts
+++ b/packages/core/test/unit/router/metadata/param-header.test.ts
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {get, param, getApiSpec} from '../../../..';
+import {expect} from '@loopback/testlab';
+
+describe('Routing metadata for parameters', () => {
+  describe('@param.header.string', () => {
+    it('defines a parameter with in:header type:string', () => {
+      class MyController {
+        @get('/greet')
+        @param.header.string('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'string',
+          in: 'header',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.header.number', () => {
+    it('defines a parameter with in:header type:number', () => {
+      class MyController {
+        @get('/greet')
+        @param.header.number('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'number',
+          in: 'header',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.header.integer', () => {
+    it('defines a parameter with in:header type:integer', () => {
+      class MyController {
+        @get('/greet')
+        @param.header.integer('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'integer',
+          in: 'header',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.header.boolean', () => {
+    it('defines a parameter with in:header type:boolean', () => {
+      class MyController {
+        @get('/greet')
+        @param.header.boolean('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'boolean',
+          in: 'header',
+        },
+      ]);
+    });
+  });
+});
+

--- a/packages/core/test/unit/router/metadata/param-path.test.ts
+++ b/packages/core/test/unit/router/metadata/param-path.test.ts
@@ -1,0 +1,89 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {get, param, getApiSpec} from '../../../..';
+import {expect} from '@loopback/testlab';
+
+describe('Routing metadata for parameters', () => {
+  describe('@param.path.string', () => {
+    it('defines a parameter with in:path type:string', () => {
+      class MyController {
+        @get('/greet/{name}')
+        @param.path.string('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'string',
+          in: 'path',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.path.number', () => {
+    it('defines a parameter with in:path type:number', () => {
+      class MyController {
+        @get('/greet/{name}')
+        @param.path.number('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'number',
+          in: 'path',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.path.integer', () => {
+    it('defines a parameter with in:path type:integer', () => {
+      class MyController {
+        @get('/greet/{name}')
+        @param.path.integer('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'integer',
+          in: 'path',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.path.boolean', () => {
+    it('defines a parameter with in:path type:boolean', () => {
+      class MyController {
+        @get('/greet/{name}')
+        @param.path.boolean('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'boolean',
+          in: 'path',
+        },
+      ]);
+    });
+  });
+});

--- a/packages/core/test/unit/router/metadata/param-query.test.ts
+++ b/packages/core/test/unit/router/metadata/param-query.test.ts
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {get, param, getApiSpec} from '../../../..';
+import {expect} from '@loopback/testlab';
+
+describe('Routing metadata for parameters', () => {
+  describe('@param.query.string', () => {
+    it('defines a parameter with in:query type:string', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.string('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'string',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.query.number', () => {
+    it('defines a parameter with in:query type:number', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.number('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'number',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.query.integer', () => {
+    it('defines a parameter with in:query type:integer', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.integer('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'integer',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('@param.query.boolean', () => {
+    it('defines a parameter with in:query type:boolean', () => {
+      class MyController {
+        @get('/greet')
+        @param.query.boolean('name')
+        greet(name: string) {}
+      }
+
+      const actualSpec = getApiSpec(MyController);
+
+      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
+        {
+          name: 'name',
+          type: 'boolean',
+          in: 'query',
+        },
+      ]);
+    });
+  });
+});
+

--- a/packages/core/test/unit/router/metadata/param.test.ts
+++ b/packages/core/test/unit/router/metadata/param.test.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, api, param, ParameterObject, getApiSpec} from '../../../..';
+import {get, param, ParameterObject, getApiSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
-import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
+import {anOperationSpec} from '@loopback/openapi-spec-builder';
 
 describe('Routing metadata for parameters', () => {
   describe('@param', () => {
@@ -57,86 +57,6 @@ describe('Routing metadata for parameters', () => {
       expect(actualSpec.paths['/']['get'].parameters).to.eql([
         offsetSpec,
         pageSizeSpec,
-      ]);
-    });
-  });
-
-  describe('@param.query.string', () => {
-    it('defines a parameter with in:query type:string', () => {
-      class MyController {
-        @get('/greet')
-        @param.query.string('name')
-        greet(name: string) {}
-      }
-
-      const actualSpec = getApiSpec(MyController);
-
-      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
-        {
-          name: 'name',
-          type: 'string',
-          in: 'query',
-        },
-      ]);
-    });
-  });
-
-  describe('@param.query.number', () => {
-    it('defines a parameter with in:query type:number', () => {
-      class MyController {
-        @get('/greet')
-        @param.query.number('name')
-        greet(name: string) {}
-      }
-
-      const actualSpec = getApiSpec(MyController);
-
-      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
-        {
-          name: 'name',
-          type: 'number',
-          in: 'query',
-        },
-      ]);
-    });
-  });
-
-  describe('@param.query.integer', () => {
-    it('defines a parameter with in:query type:integer', () => {
-      class MyController {
-        @get('/greet')
-        @param.query.integer('name')
-        greet(name: string) {}
-      }
-
-      const actualSpec = getApiSpec(MyController);
-
-      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
-        {
-          name: 'name',
-          type: 'integer',
-          in: 'query',
-        },
-      ]);
-    });
-  });
-
-  describe('@param.query.boolean', () => {
-    it('defines a parameter with in:query type:boolean', () => {
-      class MyController {
-        @get('/greet')
-        @param.query.boolean('name')
-        greet(name: string) {}
-      }
-
-      const actualSpec = getApiSpec(MyController);
-
-      expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
-        {
-          name: 'name',
-          type: 'boolean',
-          in: 'query',
-        },
       ]);
     });
   });

--- a/packages/openapi-spec/src/openapi-spec-v2.ts
+++ b/packages/openapi-spec/src/openapi-spec-v2.ts
@@ -147,6 +147,14 @@ export interface OperationObject {
   [extension: string]: ExtensionValue;
 }
 
+export type ParameterTypeValue =
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'array'
+  | 'file';
+
 /**
  * Describes a single operation parameter.
  * <p>Specification:
@@ -197,7 +205,13 @@ export interface ParameterObject {
    * "multipart/form-data", " application/x-www-form-urlencoded" or both
    * and the parameter MUST be `in` "formData".
    */
-  type: string;
+  type?: ParameterTypeValue;
+
+  /**
+   * _If in is "body":_
+   * The schema defining the type used for the body parameter.
+   */
+  schema?: SchemaObject;
 
   [extension: string]: ExtensionValue;
 }


### PR DESCRIPTION
 - `@param.header.string(name)`
 - `@param.header.number(name)`
 - `@param.header.integer(name)`
 - `@param.header.boolean(name)`
 - `@param.path.string(name)`
 - `@param.path.number(name)`
 - `@param.path.integer(name)`
 - `@param.path.boolean(name)`
 - `@param.formData.string(name)`
 - `@param.formData.number(name)`
 - `@param.formData.integer(name)`
 - `@param.formData.boolean(name)`
 - `@param.body(name, schema)`

Fix ParameterObject definition to restrict allowed `type` values and also to support `body` parameter definition with `schema` property. The change discovered invalid Swagger spec objects used in few tests, this commit fixes them along the way.

Connect to #404

We should probably wait until #459 is landed, so that tests using `body` and `formData` source can we reworked to use `POST` verb, because `GET` requests are not allowed to have a request body.

cc @bajtos @raymondfeng @ritch @superkhau
