### PR TITLE
Expose "GET /openapi.json", implement spec validation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "body": "^5.1.0",
     "debug": "^2.6.0",
     "http-errors": "^1.6.1",
+    "lodash": "^4.17.4",
     "path-to-regexp": "^1.7.0"
   },
   "devDependencies": {

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -10,9 +10,9 @@ import {
   BoundValue,
   Constructor,
 } from '@loopback/context';
-import {OpenApiSpec} from '@loopback/openapi-spec';
+import {PathsObject} from '@loopback/openapi-spec';
 import {ServerRequest, ServerResponse} from 'http';
-import {getApiSpec} from './router/metadata';
+import {getControllerSpec, ControllerSpec} from './router/metadata';
 
 import {SequenceHandler} from './sequence';
 import {
@@ -43,12 +43,16 @@ export class HttpHandler {
     this.handleRequest = (req, res) => this._handleRequest(req, res);
   }
 
-  registerController(name: ControllerClass, spec: OpenApiSpec) {
+  registerController(name: ControllerClass, spec: ControllerSpec) {
     this._routes.registerController(name, spec);
   }
 
   registerRoute(route: RouteEntry) {
     this._routes.registerRoute(route);
+  }
+
+  describeApiPaths(): PathsObject {
+    return this._routes.describeApiPaths();
   }
 
   protected async _handleRequest(

--- a/packages/core/src/router/routing-table.ts
+++ b/packages/core/src/router/routing-table.ts
@@ -4,9 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  OpenApiSpec,
   OperationObject,
   ParameterObject,
+  PathsObject,
 } from '@loopback/openapi-spec';
 import {Context, Constructor, instantiateClass} from '@loopback/context';
 import {ServerRequest} from 'http';
@@ -18,6 +18,8 @@ import {
   OperationArgs,
   OperationRetval,
 } from '../internal-types';
+
+import {ControllerSpec} from './metadata';
 
 import * as assert from 'assert';
 import * as url from 'url';
@@ -53,7 +55,7 @@ export type ControllerClass = Constructor<any>;
 export class RoutingTable {
   private readonly _routes: RouteEntry[] = [];
 
-  registerController(controller: ControllerClass, spec: OpenApiSpec) {
+  registerController(controller: ControllerClass, spec: ControllerSpec) {
     assert(
       typeof spec === 'object' && !!spec,
       'API specification must be a non-null object',
@@ -84,6 +86,20 @@ export class RoutingTable {
       describeOperationParameters(route.spec),
     );
     this._routes.push(route);
+  }
+
+  describeApiPaths(): PathsObject {
+    const paths: PathsObject = {};
+
+    for (const route of this._routes) {
+      if (!paths[route.path]) {
+        paths[route.path] = {};
+      }
+
+      paths[route.path][route.verb] = route.spec;
+    }
+
+    return paths;
   }
 
   find(request: ParsedRequest): ResolvedRoute {

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -7,7 +7,6 @@ import {
   Application,
   api,
   get,
-  OpenApiSpec,
   ParameterObject,
   OperationObject,
   ServerRequest,

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -6,7 +6,6 @@
 import {
   Application,
   api,
-  OpenApiSpec,
   ParameterObject,
   ServerRequest,
   ServerResponse,

--- a/packages/core/test/integration/application.integration.ts
+++ b/packages/core/test/integration/application.integration.ts
@@ -4,7 +4,13 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect, createClientForApp} from '@loopback/testlab';
-import {Application} from '../..';
+import {
+  Application,
+  Route,
+  ResponseObject,
+  SchemaObject,
+  ReferenceObject,
+} from '../..';
 import {Context} from '@loopback/context';
 
 describe('Application (integration)', () => {
@@ -31,5 +37,28 @@ describe('Application (integration)', () => {
     });
 
     return createClientForApp(app).get('/').expect(500);
+  });
+
+  it('exposes "GET /openapi.json" endpoint', async () => {
+    const app = new Application({http: {port: 0}});
+    const greetSpec = {
+      responses: {
+        200: {
+          type: 'string',
+          description: 'greeting of the day',
+        },
+      },
+    };
+    app.route(new Route('get', '/greet', greetSpec, function greet() {}));
+
+    const response = await createClientForApp(app).get('/openapi.json');
+    expect(response.body).to.containDeep({
+      basePath: '/',
+      paths: {
+        '/greet': {
+          get: greetSpec,
+        },
+      },
+    });
   });
 });

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -9,10 +9,11 @@ import {
   ServerRequest,
   writeResultToResponse,
   RejectProvider,
+  ControllerSpec,
 } from '../..';
 import {Context} from '@loopback/context';
 import {expect, Client, createClientForHandler} from '@loopback/testlab';
-import {OpenApiSpec, ParameterObject} from '@loopback/openapi-spec';
+import {ParameterObject} from '@loopback/openapi-spec';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 
 describe('HttpHandler', () => {
@@ -403,7 +404,7 @@ describe('HttpHandler', () => {
   function givenControllerClass(
     // tslint:disable-next-line:no-any
     ctor: new (...args: any[]) => Object,
-    spec: OpenApiSpec,
+    spec: ControllerSpec,
   ) {
     handler.registerController(ctor, spec);
   }

--- a/packages/core/test/unit/application/application.open-api-spec.test.ts
+++ b/packages/core/test/unit/application/application.open-api-spec.test.ts
@@ -1,0 +1,109 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, validateApiSpec} from '@loopback/testlab';
+import {Application, api, get, Route} from '../../..';
+import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
+
+describe('Application.getApiSpec()', () => {
+  let app: Application;
+  beforeEach(givenApplication);
+
+  it('comes with a valid default spec', async () => {
+    await validateApiSpec(app.getApiSpec());
+  });
+
+  it('honours API defined via app.api()', () => {
+    app.api({
+      swagger: '2.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      host: 'example.com:8080',
+      basePath: '/api',
+      paths: {},
+      'x-foo': 'bar',
+    });
+
+    const spec = app.getApiSpec();
+    expect(spec).to.deepEqual({
+      swagger: '2.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      host: 'example.com:8080',
+      basePath: '/api',
+      paths: {},
+      'x-foo': 'bar',
+    });
+  });
+
+  it('returns routes registered via app.route(route)', () => {
+    function greet() {}
+    app.route(new Route('get', '/greet', {responses: {}}, greet));
+
+    const spec = app.getApiSpec();
+    expect(spec.paths).to.eql({
+      '/greet': {
+        get: {
+          responses: {},
+        },
+      },
+    });
+  });
+
+  it('returns routes registered via app.controller()', () => {
+    class MyController {
+      @get('/greet')
+      greet() {}
+    }
+    app.controller(MyController);
+
+    const spec = app.getApiSpec();
+    expect(spec.paths).to.eql({
+      '/greet': {
+        get: {
+          responses: {},
+          'x-operation-name': 'greet',
+        },
+      },
+    });
+  });
+
+  it('preserves routes specified in app.api()', () => {
+    function status() {}
+    app.api(
+      anOpenApiSpec()
+        .withOperation('get', '/status', {
+          'x-operation': status,
+          responses: {},
+        })
+        .build(),
+    );
+
+    function greet() {}
+    app.route(new Route('get', '/greet', {responses: {}}, greet));
+
+    const spec = app.getApiSpec();
+    expect(spec.paths).to.eql({
+      '/greet': {
+        get: {
+          responses: {},
+        },
+      },
+      '/status': {
+        get: {
+          responses: {},
+        },
+      },
+    });
+  });
+
+  function givenApplication() {
+    app = new Application();
+  }
+});

--- a/packages/core/test/unit/router/metadata.test.ts
+++ b/packages/core/test/unit/router/metadata.test.ts
@@ -8,7 +8,7 @@ import {
   api,
   param,
   ParameterObject,
-  getApiSpec,
+  getControllerSpec,
   operation,
   post,
   put,
@@ -31,7 +31,7 @@ describe('Routing metadata', () => {
       }
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
     expect(actualSpec).to.eql(expectedSpec);
   });
 
@@ -45,16 +45,18 @@ describe('Routing metadata', () => {
       }
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
-    const expectedSpec = anOpenApiSpec()
-      .withOperation(
-        'get',
-        '/greet',
-        Object.assign({'x-operation-name': 'greet'}, operationSpec),
-      )
-      .build();
-    expect(actualSpec).to.eql(expectedSpec);
+    expect(actualSpec).to.eql({
+      paths: {
+        '/greet': {
+          get: {
+            'x-operation-name': 'greet',
+            ...operationSpec,
+          },
+        },
+      },
+    });
   });
 
   it('returns spec defined via @post decorator', () => {
@@ -65,16 +67,18 @@ describe('Routing metadata', () => {
       createGreeting() {}
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
-    const expectedSpec = anOpenApiSpec()
-      .withOperation(
-        'post',
-        '/greeting',
-        Object.assign({'x-operation-name': 'createGreeting'}, operationSpec),
-      )
-      .build();
-    expect(actualSpec).to.eql(expectedSpec);
+    expect(actualSpec).to.eql({
+      paths: {
+        '/greeting': {
+          post: {
+            'x-operation-name': 'createGreeting',
+            ...operationSpec,
+          },
+        },
+      },
+    });
   });
 
   it('returns spec defined via @put decorator', () => {
@@ -85,16 +89,18 @@ describe('Routing metadata', () => {
       updateGreeting() {}
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
-    const expectedSpec = anOpenApiSpec()
-      .withOperation(
-        'put',
-        '/greeting',
-        Object.assign({'x-operation-name': 'updateGreeting'}, operationSpec),
-      )
-      .build();
-    expect(actualSpec).to.eql(expectedSpec);
+    expect(actualSpec).to.eql({
+      paths: {
+        '/greeting': {
+          put: {
+            'x-operation-name': 'updateGreeting',
+            ...operationSpec,
+          },
+        },
+      },
+    });
   });
 
   it('returns spec defined via @patch decorator', () => {
@@ -105,16 +111,18 @@ describe('Routing metadata', () => {
       patchGreeting() {}
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
-    const expectedSpec = anOpenApiSpec()
-      .withOperation(
-        'patch',
-        '/greeting',
-        Object.assign({'x-operation-name': 'patchGreeting'}, operationSpec),
-      )
-      .build();
-    expect(actualSpec).to.eql(expectedSpec);
+    expect(actualSpec).to.eql({
+      paths: {
+        '/greeting': {
+          patch: {
+            'x-operation-name': 'patchGreeting',
+            ...operationSpec,
+          },
+        },
+      },
+    });
   });
 
   it('returns spec defined via @del decorator', () => {
@@ -125,16 +133,18 @@ describe('Routing metadata', () => {
       deleteGreeting() {}
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
-    const expectedSpec = anOpenApiSpec()
-      .withOperation(
-        'del',
-        '/greeting',
-        Object.assign({'x-operation-name': 'deleteGreeting'}, operationSpec),
-      )
-      .build();
-    expect(actualSpec).to.eql(expectedSpec);
+    expect(actualSpec).to.eql({
+      paths: {
+        '/greeting': {
+          delete: {
+            'x-operation-name': 'deleteGreeting',
+            ...operationSpec,
+          },
+        },
+      },
+    });
   });
 
   it('returns spec defined via @operation decorator', () => {
@@ -145,16 +155,18 @@ describe('Routing metadata', () => {
       createGreeting() {}
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
-    const expectedSpec = anOpenApiSpec()
-      .withOperation(
-        'post',
-        '/greeting',
-        Object.assign({'x-operation-name': 'createGreeting'}, operationSpec),
-      )
-      .build();
-    expect(actualSpec).to.eql(expectedSpec);
+    expect(actualSpec).to.eql({
+      paths: {
+        '/greeting': {
+          post: {
+            'x-operation-name': 'createGreeting',
+            ...operationSpec,
+          },
+        },
+      },
+    });
   });
 
   it('returns default spec for @get with no spec', () => {
@@ -163,7 +175,7 @@ describe('Routing metadata', () => {
       greet() {}
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
     expect(actualSpec.paths['/greet']['get']).to.eql({
       'x-operation-name': 'greet',
@@ -177,7 +189,7 @@ describe('Routing metadata', () => {
       createGreeting() {}
     }
 
-    const actualSpec = getApiSpec(MyController);
+    const actualSpec = getControllerSpec(MyController);
 
     expect(actualSpec.paths['/greeting']['post']).to.eql({
       'x-operation-name': 'createGreeting',
@@ -202,22 +214,24 @@ describe('Routing metadata', () => {
       }
     }
 
-    const actualSpec = getApiSpec(Child);
+    const actualSpec = getControllerSpec(Child);
 
-    const expectedSpec = anOpenApiSpec()
-      .withOperation(
-        'get',
-        '/parent',
-        Object.assign({'x-operation-name': 'getParentName'}, operationSpec),
-      )
-      .withOperation(
-        'get',
-        '/child',
-        Object.assign({'x-operation-name': 'getChildName'}, operationSpec),
-      )
-      .build();
-
-    expect(actualSpec).to.eql(expectedSpec);
+    expect(actualSpec).to.eql({
+      paths: {
+        '/parent': {
+          get: {
+            'x-operation-name': 'getParentName',
+            ...operationSpec,
+          },
+        },
+        '/child': {
+          get: {
+            'x-operation-name': 'getChildName',
+            ...operationSpec,
+          },
+        },
+      },
+    });
   });
 
   it('allows children to override parent REST endpoints', () => {
@@ -237,7 +251,7 @@ describe('Routing metadata', () => {
       }
     }
 
-    const actualSpec = getApiSpec(Child);
+    const actualSpec = getControllerSpec(Child);
 
     expect(actualSpec.paths['/name']['get']).to.have.property(
       'x-operation-name',

--- a/packages/core/test/unit/router/metadata/param-body.test.ts
+++ b/packages/core/test/unit/router/metadata/param-body.test.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {post, param, getApiSpec} from '../../../..';
+import {post, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
 
 describe('Routing metadata for parameters', () => {
@@ -15,7 +15,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
         {

--- a/packages/core/test/unit/router/metadata/param-form-data.test.ts
+++ b/packages/core/test/unit/router/metadata/param-form-data.test.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {post, param, getApiSpec} from '../../../..';
+import {post, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
 
 describe('Routing metadata for parameters', () => {
@@ -15,7 +15,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
         {
@@ -35,7 +35,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
         {
@@ -55,7 +55,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
         {
@@ -75,7 +75,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greeting']['post'].parameters).to.eql([
         {

--- a/packages/core/test/unit/router/metadata/param-header.test.ts
+++ b/packages/core/test/unit/router/metadata/param-header.test.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, param, getApiSpec} from '../../../..';
+import {get, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
 
 describe('Routing metadata for parameters', () => {
@@ -15,7 +15,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {
@@ -35,7 +35,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {
@@ -55,7 +55,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {
@@ -75,7 +75,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {

--- a/packages/core/test/unit/router/metadata/param-path.test.ts
+++ b/packages/core/test/unit/router/metadata/param-path.test.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, param, getApiSpec} from '../../../..';
+import {get, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
 
 describe('Routing metadata for parameters', () => {
@@ -15,7 +15,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
         {
@@ -35,7 +35,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
         {
@@ -55,7 +55,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
         {
@@ -75,7 +75,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet/{name}']['get'].parameters).to.eql([
         {

--- a/packages/core/test/unit/router/metadata/param-query.test.ts
+++ b/packages/core/test/unit/router/metadata/param-query.test.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, param, getApiSpec} from '../../../..';
+import {get, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
 
 describe('Routing metadata for parameters', () => {
@@ -15,7 +15,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {
@@ -35,7 +35,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {
@@ -55,7 +55,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {
@@ -75,7 +75,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/greet']['get'].parameters).to.eql([
         {

--- a/packages/core/test/unit/router/metadata/param.test.ts
+++ b/packages/core/test/unit/router/metadata/param.test.ts
@@ -8,7 +8,7 @@ import {
   api,
   param,
   ParameterObject,
-  getApiSpec,
+  getControllerSpec,
   operation,
   OperationObject,
   ResponsesObject,
@@ -31,7 +31,7 @@ describe('Routing metadata for parameters', () => {
         greet(name: string) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       const expectedSpec = anOperationSpec()
         .withOperationName('greet')
@@ -61,7 +61,7 @@ describe('Routing metadata for parameters', () => {
         list(offset?: number, pageSize?: number) {}
       }
 
-      const actualSpec = getApiSpec(MyController);
+      const actualSpec = getControllerSpec(MyController);
 
       expect(actualSpec.paths['/']['get'].parameters).to.eql([
         offsetSpec,
@@ -96,7 +96,7 @@ describe('Routing metadata for parameters', () => {
         list(offset?: number, pageSize?: number) {}
       }
 
-      const apiSpec = getApiSpec(MyController);
+      const apiSpec = getControllerSpec(MyController);
       const opSpec: OperationObject = apiSpec.paths['/']['get'];
 
       expect(opSpec.responses).to.eql(responses);

--- a/packages/example-codehub/src/codehub-application.ts
+++ b/packages/example-codehub/src/codehub-application.ts
@@ -11,6 +11,17 @@ export class CodeHubApplication extends Application {
     super();
 
     const app = this;
+
+    app.api({
+      swagger: '2.0',
+      info: {
+        title: 'CodeHub',
+        version: require('../package.json').version,
+      },
+      basePath: '/',
+      paths: {},
+    });
+
     app.controller(UserController);
     app.controller(HealthController);
 

--- a/packages/example-codehub/src/controllers/health-controller.api.ts
+++ b/packages/example-codehub/src/controllers/health-controller.api.ts
@@ -3,7 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export const def = {
+import {ControllerSpec} from '@loopback/core';
+
+export const def: ControllerSpec = {
   basePath: '/',
   paths: {
     '/health': {
@@ -11,10 +13,13 @@ export const def = {
         'x-operation-name': 'getHealth',
         responses: {
           200: {
+            description: 'Health status of the server',
             schema: {
-              uptime: {
-                type: 'number',
-                description: 'the uptime of the server',
+              properties: {
+                uptime: {
+                  type: 'number',
+                  description: 'the uptime of the server',
+                },
               },
             },
           },

--- a/packages/example-codehub/src/controllers/user-controller.api.ts
+++ b/packages/example-codehub/src/controllers/user-controller.api.ts
@@ -3,8 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export const def = {
-  // IMPORTANT: this controller implements enpoints at different root paths
+import {ControllerSpec} from '@loopback/core';
+
+export const def: ControllerSpec = {
+  // IMPORTANT: this controller implements endpoints at different root paths
   // GET /users, GET /user, etc.
   basePath: '/',
   paths: {
@@ -25,6 +27,7 @@ export const def = {
         ],
         responses: {
           200: {
+            description: 'A list of user profiles.',
             schema: {
               type: 'array',
               items: {
@@ -43,6 +46,7 @@ export const def = {
         'x-operation-name': 'getAuthenticatedUser',
         responses: {
           200: {
+            description: 'User profile.',
             schema: {
               // TODO(bajtos) We should $ref a shared definition of User
               // Response/Model
@@ -51,6 +55,7 @@ export const def = {
             },
           },
           404: {
+            description: 'User not found error.',
             schema: {
               // TODO(bajtos) Refer to a shared definition of Error responses
               // as provided by strong-error-handler and/or API Connect
@@ -79,6 +84,7 @@ export const def = {
         ],
         responses: {
           200: {
+            description: 'User profile.',
             schema: {
               // TODO(bajtos) We should $ref a shared definition of User
               // Response/Model

--- a/packages/example-codehub/test/acceptance/smoke.test.ts
+++ b/packages/example-codehub/test/acceptance/smoke.test.ts
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {CodeHubApplication} from '../../src/codehub-application';
+import {validateApiSpec} from '@loopback/testlab';
+
+describe('Application', () => {
+  it('has a valid OpenAPI spec', async () => {
+    const app = new CodeHubApplication();
+    await validateApiSpec(app.getApiSpec());
+  });
+});

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -10,6 +10,7 @@ import {
   OperationObject,
   ResponseObject,
   ParameterObject,
+  createEmptyApiSpec,
 } from '@loopback/openapi-spec';
 
 /**
@@ -17,8 +18,8 @@ import {
  *
  * @param basePath The base path on which the API is served.
  */
-export function anOpenApiSpec(basePath?: string) {
-  return new OpenApiSpecBuilder(basePath);
+export function anOpenApiSpec() {
+  return new OpenApiSpecBuilder();
 }
 
 /**
@@ -69,11 +70,8 @@ export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
   /**
    * @param basePath The base path on which the API is served.
    */
-  constructor(basePath: string = '/') {
-    super({
-      basePath,
-      paths: {},
-    });
+  constructor() {
+    super(createEmptyApiSpec());
   }
 
   /**

--- a/packages/openapi-spec/src/openapi-spec-v2.ts
+++ b/packages/openapi-spec/src/openapi-spec-v2.ts
@@ -23,6 +23,19 @@ export type ExtensionValue = any;
  */
 export interface OpenApiSpec {
   /**
+   * Specifies the Swagger Specification version being used.
+   * It can be used by the Swagger UI and other clients to interpret
+   * the API listing. The value MUST be "2.0".
+   */
+  swagger: '2.0';
+
+  /**
+   * Provides metadata about the API.
+   * The metadata can be used by the clients if needed.
+   */
+  info: InfoObject;
+
+  /**
    * The host (name or ip) serving the API.
    * This MUST be the host only and does not include the scheme nor sub-paths.
    * It MAY include a port. If the host is not included,
@@ -50,6 +63,40 @@ export interface OpenApiSpec {
 
   // Allow users to use extensions
   [extension: string]: ExtensionValue;
+}
+
+/**
+ * The object provides metadata about the API.
+ * The metadata can be used by the clients if needed,
+ * and can be presented in the Swagger-UI for convenience.
+ * <p>Specification:
+ * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#infoObject
+ */
+export interface InfoObject {
+  /**
+   * The title of the application.
+   */
+  title: string;
+
+  /**
+   * A short description of the application.
+   * [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown)
+   * can be used for rich text representation.
+   */
+  description?: string;
+
+  /**
+   * The Terms of Service for the API.
+   */
+  termsOfService?: string;
+
+  // TODO(bajtos) contact, license
+
+  /**
+   * Provides the version of the application API
+   * (not to be confused with the specification version).
+   */
+  version: string;
 }
 
 /**
@@ -338,4 +385,19 @@ export interface SchemaItem {
   additionalProperties: boolean;
 
   [extension: string]: ExtensionValue;
+}
+
+/**
+ * Create an empty OpenApiSpec object that's still a valid Swagger document.
+ */
+export function createEmptyApiSpec(): OpenApiSpec {
+  return {
+    swagger: '2.0',
+    basePath: '/',
+    info: {
+      title: 'LoopBack Application',
+      version: '1.0.0',
+    },
+    paths: {},
+  };
 }

--- a/packages/testlab/README.md
+++ b/packages/testlab/README.md
@@ -12,15 +12,15 @@ Test utilities to help writing loopback-next tests:
    - mocks: fake methods (like spies) with pre-programmed behavior (like stubs) as well as pre-programmed expectations
 - Helpers for creating `supertest` clients for LoopBack applications
 - HTTP request/response stubs for writing tests without a listening HTTP server
+- Swagger/OpenAPI spec validation
 
 ## Installation
 
 ```
 $ npm install --save-dev @loopback/testlab
 ```
-```
+
 _This package is typically used in tests, save it to `devDependencies` via `--save-dev`._
-```
 
 ## Basic use
 
@@ -45,6 +45,21 @@ Spies, mocks and stubs. Learn more at [http://sinonjs.org/](http://sinonjs.org/)
 ### `shot`
 
 Shot [API Reference](https://github.com/hapijs/shot/blob/master/API.md)
+
+### `validateApiSpec`
+
+Verify that your application API specification is a valid OpenAPI spec document.
+
+```js
+import {validateApiSpec} from '@loopback/testlab';
+
+describe('MyApp', () => {)
+  it('has valid spec', async () => {
+    const app = new MyApp();
+    await validateApiSpec(app.getApiSpec());
+  })
+});
+```
 
 ## Related resources
 

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -16,14 +16,17 @@
   "author": "IBM",
   "license": "MIT",
   "dependencies": {
+    "@loopback/openapi-spec": "^4.0.0-alpha.6",
     "@types/shot": "^3.4.0",
     "@types/sinon": "^2.3.2",
     "@types/supertest": "^2.0.0",
+    "@types/swagger-parser": "^4.0.1",
     "shot": "^3.4.0",
     "should": "^11.2.1",
     "should-sinon": "0.0.5",
     "sinon": "^2.4.0",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "swagger-parser": "^3.4.1"
   },
   "files": [
     "README.md",

--- a/packages/testlab/src/testlab.ts
+++ b/packages/testlab/src/testlab.ts
@@ -20,3 +20,4 @@ export {sinon, SinonSpy};
 
 export * from './client';
 export * from './shot';
+export * from './validate-api-spec';

--- a/packages/testlab/src/validate-api-spec.ts
+++ b/packages/testlab/src/validate-api-spec.ts
@@ -1,0 +1,32 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as SwaggerParser from 'swagger-parser';
+import {OpenApiSpec} from '@loopback/openapi-spec';
+
+export async function validateApiSpec(spec: OpenApiSpec): Promise<void> {
+  const opts: SwaggerParser.Options = {
+    $refs: {
+      internal: false,
+      external: false,
+    },
+  } as SwaggerParser.Options;
+
+  // workaround for unhelpful message returned by SwaggerParser
+  // TODO(bajtos) contribute these improvements to swagger-parser
+  if (!spec.swagger) {
+    throw new Error('Missing required property: swagger at #/');
+  }
+
+  if (!spec.info) {
+    throw new Error('Missing required property: info at #/');
+  }
+
+  if (!spec.paths) {
+    throw new Error('Missing required property: paths at #/');
+  }
+
+  await SwaggerParser.validate(spec, opts);
+}


### PR DESCRIPTION
The first commit implements a new method `app.getApiSpec()` for obtaining the OpenAPI spec containing paths (routes) contributed by all different means we support (`app.api()`, `app.route()`, `app.controller()`). It also exposes a new HTTP endpoint "GET /openapi.json" that returns this specification. This endpoint is excluded from the spec.

With this change in place, I tried what happens when I take OpenAPI spec from our CodeHub application and validate it in http://editor.swagger.io/. There was a bunch of validation errors reported, thus I decided to fix them.

I started with adding a new helper function `app.validateApiSpec()` that uses [swagger-parser](https://www.npmjs.com/package/swagger-parser) under the hood to validate the spec. In order to be able to do that, I had to beef up our OpenAPI spec types to include all required fields, otherwise TypeScript was complaining, and then I had to fix all places where we were building specs without these required fields.

Finally, I added a new smoke test to CodeHub application that runs `app.validateApiSpec()`, and fixed validation errors found in the app. (BTW, this is what we need for https://github.com/strongloop/loopback-next/issues/473 too.)

Close #439

cc @bajtos @raymondfeng @ritch @superkhau
