### PR TITLE
core: add binding "sequence.actions.parseParams"

### DIFF
--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -7,8 +7,8 @@ import {
   Application,
   api,
   ServerResponse,
-  parseOperationArgs,
   ParsedRequest,
+  ParseParams,
   FindRoute,
   InvokeMethod,
   GetFromContext,
@@ -110,6 +110,8 @@ describe('Basic Authentication', () => {
     class MySequence implements SequenceHandler {
       constructor(
         @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
+        @inject('sequence.actions.parseParams')
+        protected parseParams: ParseParams,
         @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') protected send: Send,
         @inject('sequence.actions.reject') protected reject: Reject,
@@ -130,7 +132,7 @@ describe('Basic Authentication', () => {
           else throw new HttpErrors.InternalServerError('auth error');
 
           // Authentication successful, proceed to invoke controller
-          const args = await parseOperationArgs(req, route);
+          const args = await this.parseParams(req, route);
           const result = await this.invoke(route, args);
           this.send(res, result);
         } catch (err) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export {
   GetFromContext,
   BindElement,
   PathParameterValues,
+  ParseParams,
   Reject,
   Send,
 } from './internal-types';

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -25,6 +25,14 @@ export interface ParsedRequest extends ServerRequest {
 export type FindRoute = (request: ParsedRequest) => ResolvedRoute;
 
 /**
+ *
+ */
+export type ParseParams = (
+  request: ParsedRequest,
+  route: ResolvedRoute,
+) => Promise<OperationArgs>;
+
+/**
  * Invokes a method defined in the Application Controller
  *
  * @param controller Name of end-user's application controller

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -14,8 +14,8 @@ import {
   ParsedRequest,
   Send,
   Reject,
+  ParseParams,
 } from './internal-types';
-import {parseOperationArgs} from './parser';
 import {writeResultToResponse} from './writer';
 import {HttpError} from 'http-errors';
 
@@ -71,6 +71,7 @@ export class DefaultSequence implements SequenceHandler {
    */
   constructor(
     @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
+    @inject('sequence.actions.parseParams') protected parseParams: ParseParams,
     @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
     @inject('sequence.actions.send') public send: Send,
     @inject('sequence.actions.reject') public reject: Reject,
@@ -96,7 +97,7 @@ export class DefaultSequence implements SequenceHandler {
   async handle(req: ParsedRequest, res: ServerResponse) {
     try {
       const route = this.findRoute(req);
-      const args = await parseOperationArgs(req, route);
+      const args = await this.parseParams(req, route);
       const result = await this.invoke(route, args);
 
       debug('%s result -', route.describe(), result);

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -9,7 +9,6 @@ import {
   ParameterObject,
   ServerRequest,
   ServerResponse,
-  parseOperationArgs,
   ParsedRequest,
   OperationArgs,
   FindRoute,
@@ -17,6 +16,7 @@ import {
   Send,
   Reject,
   SequenceHandler,
+  ParseParams,
 } from '../../..';
 import {expect, Client, createClientForApp} from '@loopback/testlab';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
@@ -61,13 +61,15 @@ describe('Sequence', () => {
     class MySequence {
       constructor(
         @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
+        @inject('sequence.actions.parseParams')
+        protected parseParams: ParseParams,
         @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
         @inject('sequence.actions.send') protected send: Send,
       ) {}
 
       async handle(req: ParsedRequest, res: ServerResponse) {
         const route = this.findRoute(req);
-        const args = await parseOperationArgs(req, route);
+        const args = await this.parseParams(req, route);
         const result = await this.invoke(route, args);
         this.send(res, `MySequence ${result}`);
       }

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -10,6 +10,7 @@ import {
   writeResultToResponse,
   RejectProvider,
   ControllerSpec,
+  parseOperationArgs,
 } from '../..';
 import {Context} from '@loopback/context';
 import {expect, Client, createClientForHandler} from '@loopback/testlab';
@@ -383,6 +384,7 @@ describe('HttpHandler', () => {
   let handler: HttpHandler;
   function givenHandler() {
     rootContext = new Context();
+    rootContext.bind('sequence.actions.parseParams').to(parseOperationArgs);
     rootContext.bind('sequence.actions.logError').to(logger);
     rootContext.bind('sequence.actions.send').to(writeResultToResponse);
     rootContext.bind('sequence.actions.reject').toProvider(RejectProvider);


### PR DESCRIPTION
Rework DefaultSequence to allow injection of "parseParams" action.

While reviewing [Sequence wiki](https://github.com/strongloop/loopback-next/wiki/Sequence), I realised that `parseParams` was a hard-coded dependency that cannot be injected. This pull request fixes that problem :)

cc @bajtos @raymondfeng @ritch @superkhau
