### PR TITLE
core: add controller/method metadata to OAI spec

### DIFF
--- a/packages/core/src/router/routing-table.ts
+++ b/packages/core/src/router/routing-table.ts
@@ -242,7 +242,18 @@ export class ControllerRoute extends BaseRoute {
     protected readonly _controllerCtor: ControllerClass,
     methodName?: string,
   ) {
-    super(verb, path, spec);
+    super(
+      verb,
+      path,
+      // Add x-controller-name and x-operation-name if not present
+      Object.assign(
+        {
+          'x-controller-name': _controllerCtor.name,
+          'x-operation-name': methodName,
+        },
+        spec,
+      ),
+    );
 
     if (!methodName) {
       methodName = this.spec['x-operation-name'];

--- a/packages/core/test/unit/application/application.open-api-spec.test.ts
+++ b/packages/core/test/unit/application/application.open-api-spec.test.ts
@@ -56,6 +56,25 @@ describe('Application.getApiSpec()', () => {
     });
   });
 
+  it('returns routes registered via app.route(..., Controller, method)', () => {
+    class MyController {
+      greet() {}
+    }
+
+    app.route('get', '/greet', {responses: {}}, MyController, 'greet');
+
+    const spec = app.getApiSpec();
+    expect(spec.paths).to.eql({
+      '/greet': {
+        get: {
+          responses: {},
+          'x-controller-name': 'MyController',
+          'x-operation-name': 'greet',
+        },
+      },
+    });
+  });
+
   it('returns routes registered via app.controller()', () => {
     class MyController {
       @get('/greet')
@@ -68,6 +87,7 @@ describe('Application.getApiSpec()', () => {
       '/greet': {
         get: {
           responses: {},
+          'x-controller-name': 'MyController',
           'x-operation-name': 'greet',
         },
       },

--- a/packages/core/test/unit/router/routing-table.test.ts
+++ b/packages/core/test/unit/router/routing-table.test.ts
@@ -35,7 +35,7 @@ describe('RoutingTable', () => {
     const route = table.find(request);
 
     expect(route).to.be.instanceOf(ControllerRoute);
-    expect(route).to.have.property('spec', spec.paths['/hello'].get);
+    expect(route).to.have.property('spec').containEql(spec.paths['/hello'].get);
     expect(route).to.have.property('pathParams');
     expect(route.describe()).to.equal('TestController.greet');
   });


### PR DESCRIPTION
Set `x-controller-name` and `x-operation-name` for controller routes defined via `app.route()` and `app.controller()`. This way the OAI spec for controller-based routes always contains both extension fields, regardless of the way how the route was registered in the app.

Close #474

cc @bajtos @raymondfeng @ritch @superkhau
