### PR TITLE
Add api-docs folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .DS_Store
 coverage
 .nyc_output
+api-docs


### PR DESCRIPTION
Updating .gitignore to ignore api-docs created during bootstrap process