### PR TITLE
Define constants for all binding keys + cleanup

### DIFF
--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -45,7 +45,7 @@ import {
   ValueOrPromise,
 } from '@loopback/context';
 import {
-  BindingKeys,
+  AuthenticationBindings,
   AuthenticationMetadata,
 } from '@loopback/authentication';
 
@@ -54,7 +54,7 @@ import {BasicStrategy} from 'passport-http';
 
 export class MyAuthStrategyProvider implements Provider<Strategy> {
   constructor(
-    @inject(BindingKeys.Authentication.METADATA)
+    @inject(AuthenticationBindings.METADATA)
     private metadata: AuthenticationMetadata,
   ) {}
 
@@ -127,7 +127,10 @@ Finally, put it all together in your application object:
 
 ```ts
 import {Application} from '@loopback/core';
-import {AuthenticationComponent, BindingKeys} from '@loopback/authentication';
+import {
+  AuthenticationComponent,
+  AuthenticationBindings,
+} from '@loopback/authentication';
 import {MyAuthStrategyProvider} from './providers/auth-strategy';
 import {MyController} from './controllers/my-controller';
 import {MySequence} from './sequence';
@@ -138,7 +141,7 @@ class MyApp extends Application {
       components: [AuthenticationComponent],
     });
 
-    this.bind(BindingKeys.Authentication.STRATEGY)
+    this.bind(AuthenticationBindings.STRATEGY)
       .toProvider(MyAuthStrategyProvider);
     this.sequence(MySequence);
 

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -81,11 +81,12 @@ invoking the authentication at the right time during the request handling.
 ```ts
 // sequence.ts
 import {
+  CoreBindings,
   FindRoute,
   inject,
   InvokeMethod,
   ParsedRequest,
-  parseOperationArgs,
+  ParseParams,
   Reject,
   Send,
   ServerResponse,
@@ -94,15 +95,19 @@ import {
 
 import {
   AuthenticateFn,
+  AuthenticationBindings,
 } from '@loopback/authentication';
+
+const CoreSequenceActions = CoreBindings.SequenceActions;
 
 export class MySequence implements SequenceHandler {
   constructor(
-    @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-    @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
-    @inject('sequence.actions.send') protected send: Send,
-    @inject('sequence.actions.reject') protected reject: Reject,
-    @inject('authentication.actions.authenticate')
+    @inject(CoreSequenceActions.FIND_ROUTE) protected findRoute: FindRoute,
+    @inject(CoreSequenceActions.PARSE_PARAMS) protected parseParams: ParseParams,
+    @inject(CoreSequenceActions.INVOKE_METHOD) protected invoke: InvokeMethod,
+    @inject(CoreSequenceActions.SEND) protected send: Send,
+    @inject(CoreSequenceActions.REJECT) protected reject: Reject,
+    @inject(AuthenticationBindings.AUTH_ACTION)
     protected authenticateRequest: AuthenticateFn,
   ) {}
 
@@ -113,7 +118,7 @@ export class MySequence implements SequenceHandler {
       // This is the important line added to the default sequence implementation
       const user = await this.authenticateRequest(req);
 
-      const args = await parseOperationArgs(req, route);
+      const args = await this.parseParams(req, route);
       const result = await this.invoke(route, args);
       this.send(res, result);
     } catch (err) {

--- a/packages/authentication/src/auth-component.ts
+++ b/packages/authentication/src/auth-component.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKeys} from './keys';
+import {AuthenticationBindings} from './keys';
 import {Constructor} from '@loopback/context';
 import {Component, ProviderMap} from '@loopback/core';
 import {AuthenticationProvider} from './providers/authenticate';
@@ -15,8 +15,8 @@ export class AuthenticationComponent implements Component {
   // TODO(bajtos) inject configuration
   constructor() {
     this.providers = {
-      [BindingKeys.Authentication.AUTH_ACTION]: AuthenticationProvider,
-      [BindingKeys.Authentication.METADATA]: AuthMetadataProvider,
+      [AuthenticationBindings.AUTH_ACTION]: AuthenticationProvider,
+      [AuthenticationBindings.METADATA]: AuthMetadataProvider,
     };
   }
 }

--- a/packages/authentication/src/decorators/authenticate.ts
+++ b/packages/authentication/src/decorators/authenticate.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Reflector, Constructor} from '@loopback/context';
-import {BindingKeys} from '../keys';
+import {AuthenticationBindings} from '../keys';
 
 /**
  * Authentication metadata stored via Reflection API
@@ -27,7 +27,7 @@ export function authenticate(strategyName: string, options?: Object) {
       options: options || {},
     };
     Reflector.defineMetadata(
-      BindingKeys.Authentication.METADATA,
+      AuthenticationBindings.METADATA,
       metadataObj,
       controllerClass,
       methodName,
@@ -46,7 +46,7 @@ export function getAuthenticateMetadata(
   methodName: string,
 ): AuthenticationMetadata | undefined {
   return Reflector.getMetadata(
-    BindingKeys.Authentication.METADATA,
+    AuthenticationBindings.METADATA,
     controllerClass.prototype,
     methodName,
   );

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -6,11 +6,9 @@
 /**
  * Binding keys used by this component.
  */
-export namespace BindingKeys {
-  export namespace Authentication {
-    export const STRATEGY = 'authentication.strategy';
-    export const AUTH_ACTION = 'authentication.actions.authenticate';
-    export const METADATA = 'authentication.operationMetadata';
-    export const CURRENT_USER = 'authentication.currentUser';
-  }
+export namespace AuthenticationBindings {
+  export const STRATEGY = 'authentication.strategy';
+  export const AUTH_ACTION = 'authentication.actions.authenticate';
+  export const METADATA = 'authentication.operationMetadata';
+  export const CURRENT_USER = 'authentication.currentUser';
 }

--- a/packages/authentication/src/providers/auth-metadata.ts
+++ b/packages/authentication/src/providers/auth-metadata.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKeys} from '@loopback/core';
+import {CoreBindings} from '@loopback/core';
 import {Constructor, Provider, inject} from '@loopback/context';
 import {
   AuthenticationMetadata,
@@ -18,9 +18,9 @@ import {
 export class AuthMetadataProvider
   implements Provider<AuthenticationMetadata | undefined> {
   constructor(
-    @inject(BindingKeys.Context.CONTROLLER_CLASS)
+    @inject(CoreBindings.CONTROLLER_CLASS)
     private readonly controllerClass: Constructor<{}>,
-    @inject(BindingKeys.Context.CONTROLLER_METHOD_NAME)
+    @inject(CoreBindings.CONTROLLER_METHOD_NAME)
     private readonly methodName: string,
   ) {}
 

--- a/packages/authentication/src/providers/authenticate.ts
+++ b/packages/authentication/src/providers/authenticate.ts
@@ -8,7 +8,7 @@ import {HttpErrors, inject, ParsedRequest} from '@loopback/core';
 import {Provider, Getter, Setter} from '@loopback/context';
 import {Strategy} from 'passport';
 import {StrategyAdapter} from '../strategy-adapter';
-import {BindingKeys} from '../keys';
+import {AuthenticationBindings} from '../keys';
 
 /**
  * interface definition of a function which accepts a request
@@ -42,9 +42,9 @@ export class AuthenticationProvider implements Provider<AuthenticateFn> {
     // To solve this, we are injecting a getter function that will
     // defer resolution of the strategy until authenticate() action
     // is executed.
-    @inject.getter(BindingKeys.Authentication.STRATEGY)
+    @inject.getter(AuthenticationBindings.STRATEGY)
     readonly getStrategy: Getter<Strategy>,
-    @inject.setter(BindingKeys.Authentication.CURRENT_USER)
+    @inject.setter(AuthenticationBindings.CURRENT_USER)
     readonly setCurrentUser: Setter<UserProfile>,
   ) {}
 

--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -17,6 +17,7 @@ import {
   Send,
   Reject,
   SequenceHandler,
+  CoreBindings,
 } from '@loopback/core';
 import {expect, Client, createClientForApp} from '@loopback/testlab';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
@@ -37,6 +38,8 @@ import {
 import {Strategy} from 'passport';
 import {HttpError} from 'http-errors';
 import {BasicStrategy} from 'passport-http';
+
+const SequenceActions = CoreBindings.SequenceActions;
 
 describe('Basic Authentication', () => {
   let app: Application;
@@ -112,14 +115,13 @@ describe('Basic Authentication', () => {
   function givenAuthenticatedSequence() {
     class MySequence implements SequenceHandler {
       constructor(
-        @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-        @inject('sequence.actions.parseParams')
+        @inject(SequenceActions.FIND_ROUTE) protected findRoute: FindRoute,
+        @inject(SequenceActions.PARSE_PARAMS)
         protected parseParams: ParseParams,
-        @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
-        @inject('sequence.actions.send') protected send: Send,
-        @inject('sequence.actions.reject') protected reject: Reject,
-        @inject('bindElement') protected bindElement: BindElement,
-        @inject('authentication.actions.authenticate')
+        @inject(SequenceActions.INVOKE_METHOD) protected invoke: InvokeMethod,
+        @inject(SequenceActions.SEND) protected send: Send,
+        @inject(SequenceActions.REJECT) protected reject: Reject,
+        @inject(AuthenticationBindings.AUTH_ACTION)
         protected authenticateRequest: AuthenticateFn,
       ) {}
 

--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -28,7 +28,7 @@ import {
 import {
   authenticate,
   UserProfile,
-  BindingKeys,
+  AuthenticationBindings,
   AuthenticateFn,
   AuthMetadataProvider,
   AuthenticationMetadata,
@@ -97,7 +97,7 @@ describe('Basic Authentication', () => {
     @api(apispec)
     class MyController {
       constructor(
-        @inject(BindingKeys.Authentication.CURRENT_USER)
+        @inject(AuthenticationBindings.CURRENT_USER)
         private user: UserProfile,
       ) {}
 
@@ -147,7 +147,7 @@ describe('Basic Authentication', () => {
   function givenProviders() {
     class MyPassportStrategyProvider implements Provider<Strategy> {
       constructor(
-        @inject(BindingKeys.Authentication.METADATA)
+        @inject(AuthenticationBindings.METADATA)
         private metadata: AuthenticationMetadata,
       ) {}
       value() : ValueOrPromise<Strategy> {
@@ -165,7 +165,7 @@ describe('Basic Authentication', () => {
         });
       }
     }
-    app.bind(BindingKeys.Authentication.STRATEGY)
+    app.bind(AuthenticationBindings.STRATEGY)
       .toProvider(MyPassportStrategyProvider);
   }
 

--- a/packages/authentication/test/unit/authenticate-action.test.ts
+++ b/packages/authentication/test/unit/authenticate-action.test.ts
@@ -10,7 +10,7 @@ import {
   AuthenticationProvider,
   AuthenticateFn,
   UserProfile,
-  BindingKeys,
+  AuthenticationBindings,
 } from '../..';
 import {MockStrategy} from './fixtures/mock-strategy';
 
@@ -20,7 +20,7 @@ describe('AuthenticationProvider', () => {
     async () => {
       const context = new Context();
       const strategy = new MockStrategy();
-      context.bind(BindingKeys.Authentication.STRATEGY).to(strategy);
+      context.bind(AuthenticationBindings.STRATEGY).to(strategy);
       const provider = await instantiateClass(AuthenticationProvider, context);
       expect(await provider.getStrategy()).to.be.equal(strategy);
     });
@@ -56,13 +56,13 @@ describe('AuthenticationProvider', () => {
       it('returns a function which authenticates a request and returns a user',
       async () => {
         const context: Context = new Context();
-        context.bind(BindingKeys.Authentication.STRATEGY).to(strategy);
+        context.bind(AuthenticationBindings.STRATEGY).to(strategy);
         context
-          .bind(BindingKeys.Authentication.AUTH_ACTION)
+          .bind(AuthenticationBindings.AUTH_ACTION)
           .toProvider(AuthenticationProvider);
         const request = <ParsedRequest> {};
         const authenticate = await context.get(
-          BindingKeys.Authentication.AUTH_ACTION,
+          AuthenticationBindings.AUTH_ACTION,
         );
         const user: UserProfile = await authenticate(request);
         expect(user).to.be.equal(mockUser);
@@ -71,12 +71,12 @@ describe('AuthenticationProvider', () => {
       it('throws an error if the injected passport strategy is not valid',
       async () => {
         const context: Context = new Context();
-        context.bind(BindingKeys.Authentication.STRATEGY).to({});
+        context.bind(AuthenticationBindings.STRATEGY).to({});
         context
-          .bind(BindingKeys.Authentication.AUTH_ACTION)
+          .bind(AuthenticationBindings.AUTH_ACTION)
           .toProvider(AuthenticationProvider);
         const authenticate = await context.get(
-          BindingKeys.Authentication.AUTH_ACTION,
+          AuthenticationBindings.AUTH_ACTION,
         );
         const request = <ParsedRequest> {};
         let error;
@@ -91,12 +91,12 @@ describe('AuthenticationProvider', () => {
       it('throws Unauthorized error when authentication fails',
       async () => {
         const context: Context = new Context();
-        context.bind(BindingKeys.Authentication.STRATEGY).to(strategy);
+        context.bind(AuthenticationBindings.STRATEGY).to(strategy);
         context
-          .bind(BindingKeys.Authentication.AUTH_ACTION)
+          .bind(AuthenticationBindings.AUTH_ACTION)
           .toProvider(AuthenticationProvider);
         const authenticate = await context.get(
-          BindingKeys.Authentication.AUTH_ACTION,
+          AuthenticationBindings.AUTH_ACTION,
         );
         const request = <ParsedRequest> {};
         request.headers = {testState: 'fail'};

--- a/packages/authentication/test/unit/metadata-provider.test.ts
+++ b/packages/authentication/test/unit/metadata-provider.test.ts
@@ -5,7 +5,7 @@
 
 import {expect} from '@loopback/testlab';
 import {Context, Provider} from '@loopback/context';
-import {ParsedRequest, BindingKeys} from '@loopback/core';
+import {ParsedRequest, CoreBindings} from '@loopback/core';
 import {
   AuthMetadataProvider,
   AuthenticationMetadata,
@@ -42,13 +42,13 @@ describe('AuthMetadataProvider', () => {
       it('returns the authentication metadata of a controller method',
       async () => {
         const context: Context = new Context();
-        context.bind(BindingKeys.Context.CONTROLLER_CLASS).to(TestController);
-        context.bind(BindingKeys.Context.CONTROLLER_METHOD_NAME).to('whoAmI');
+        context.bind(CoreBindings.CONTROLLER_CLASS).to(TestController);
+        context.bind(CoreBindings.CONTROLLER_METHOD_NAME).to('whoAmI');
         context
-          .bind(BindingKeys.Context.CONTROLLER_METHOD_META)
+          .bind(CoreBindings.CONTROLLER_METHOD_META)
           .toProvider(AuthMetadataProvider);
         const authMetadata = await context.get(
-          BindingKeys.Context.CONTROLLER_METHOD_META,
+          CoreBindings.CONTROLLER_METHOD_META,
         );
         expect(authMetadata).to.be.eql({
           strategy: 'my-strategy',
@@ -60,14 +60,14 @@ describe('AuthMetadataProvider', () => {
       async () => {
         const context: Context = new Context();
         context
-          .bind(BindingKeys.Context.CONTROLLER_CLASS)
+          .bind(CoreBindings.CONTROLLER_CLASS)
           .to(ControllerWithNoMetadata);
-        context.bind(BindingKeys.Context.CONTROLLER_METHOD_NAME).to('whoAmI');
+        context.bind(CoreBindings.CONTROLLER_METHOD_NAME).to('whoAmI');
         context
-          .bind(BindingKeys.Context.CONTROLLER_METHOD_META)
+          .bind(CoreBindings.CONTROLLER_METHOD_META)
           .toProvider(AuthMetadataProvider);
         const authMetadata = await context.get(
-          BindingKeys.Context.CONTROLLER_METHOD_META,
+          CoreBindings.CONTROLLER_METHOD_META,
         );
         expect(authMetadata).to.be.undefined();
       });

--- a/packages/core/src/http-handler.ts
+++ b/packages/core/src/http-handler.ts
@@ -28,6 +28,7 @@ import {
   ParsedRequest,
   OperationArgs,
 } from './internal-types';
+import {CoreBindings} from './keys';
 
 const debug = require('debug')('loopback:core:http-handler');
 
@@ -66,7 +67,9 @@ export class HttpHandler {
     const parsedRequest: ParsedRequest = parseRequestUrl(request);
     const requestContext = this._createRequestContext(request, response);
 
-    const sequence: SequenceHandler = await requestContext.get('sequence');
+    const sequence: SequenceHandler = await requestContext.get(
+      CoreBindings.SEQUENCE,
+    );
     await sequence.handle(parsedRequest, response);
   }
 
@@ -75,9 +78,9 @@ export class HttpHandler {
     res: ServerResponse,
   ): Context {
     const requestContext = new Context(this._rootContext);
-    requestContext.bind('http.request').to(req);
-    requestContext.bind('http.response').to(res);
-    requestContext.bind('http.request.context').to(requestContext);
+    requestContext.bind(CoreBindings.Http.REQUEST).to(req);
+    requestContext.bind(CoreBindings.Http.RESPONSE).to(res);
+    requestContext.bind(CoreBindings.Http.CONTEXT).to(requestContext);
     return requestContext;
   }
 }

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -3,11 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export namespace BindingKeys {
-  export namespace Context {
-    export const CONTROLLER_CLASS: string = 'controller.current.ctor';
-    export const CONTROLLER_METHOD_NAME: string =
-      'controller.current.operation';
-    export const CONTROLLER_METHOD_META: string = 'controller.method.meta';
-  }
+export namespace CoreBindings {
+  export const CONTROLLER_CLASS = 'controller.current.ctor';
+  export const CONTROLLER_METHOD_NAME = 'controller.current.operation';
+  export const CONTROLLER_METHOD_META = 'controller.method.meta';
 }

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -4,7 +4,35 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export namespace CoreBindings {
+  // application-wide bindings
+
+  export const HTTP_PORT = 'http.port';
+  export const HTTP_HANDLER = 'http.handler';
+
+  export const API_SPEC = 'application.apiSpec';
+  export const SEQUENCE = 'sequence';
+
+  export namespace SequenceActions {
+    export const FIND_ROUTE = 'sequence.actions.findRoute';
+    export const PARSE_PARAMS = 'sequence.actions.parseParams';
+    export const INVOKE_METHOD = 'sequence.actions.invokeMethod';
+    export const LOG_ERROR = 'sequence.actions.logError';
+    export const SEND = 'sequence.actions.send';
+    export const REJECT = 'sequence.actions.reject';
+  }
+
+  export const GET_FROM_CONTEXT = 'getFromContext';
+  export const BIND_ELEMENT = 'bindElement';
+
+  // request-specific bindings
+
   export const CONTROLLER_CLASS = 'controller.current.ctor';
   export const CONTROLLER_METHOD_NAME = 'controller.current.operation';
   export const CONTROLLER_METHOD_META = 'controller.method.meta';
+
+  export namespace Http {
+    export const REQUEST = 'http.request';
+    export const RESPONSE = 'http.response';
+    export const CONTEXT = 'http.request.context';
+  }
 }

--- a/packages/core/src/router/providers/bind-element.ts
+++ b/packages/core/src/router/providers/bind-element.ts
@@ -5,9 +5,10 @@
 
 import {Binding, Context, inject, Provider} from '@loopback/context';
 import {BindElement} from '../../internal-types';
+import {CoreBindings} from '../../keys';
 
 export class BindElementProvider implements Provider<BindElement> {
-  constructor(@inject('http.request.context') protected context: Context) {}
+  constructor(@inject(CoreBindings.Http.CONTEXT) protected context: Context) {}
 
   value() {
     return (key: string) => this.context.bind(key);

--- a/packages/core/src/router/providers/find-route.ts
+++ b/packages/core/src/router/providers/find-route.ts
@@ -6,11 +6,12 @@
 import {Context, inject, Provider} from '@loopback/context';
 import {FindRoute} from '../../internal-types';
 import {HttpHandler} from '../../http-handler';
+import {CoreBindings} from '../../keys';
 
 export class FindRouteProvider implements Provider<FindRoute> {
   constructor(
-    @inject('http.request.context') protected context: Context,
-    @inject('http.handler') protected handler: HttpHandler) {}
+    @inject(CoreBindings.Http.CONTEXT) protected context: Context,
+    @inject(CoreBindings.HTTP_HANDLER) protected handler: HttpHandler) {}
 
   value(): FindRoute {
     return (request) => {

--- a/packages/core/src/router/providers/get-from-context.ts
+++ b/packages/core/src/router/providers/get-from-context.ts
@@ -5,9 +5,10 @@
 
 import {Context, inject, Provider} from '@loopback/context';
 import {GetFromContext} from '../../internal-types';
+import {CoreBindings} from '../../keys';
 
 export class GetFromContextProvider implements Provider<GetFromContext> {
-  constructor(@inject('http.request.context') protected context: Context) {}
+  constructor(@inject(CoreBindings.Http.CONTEXT) protected context: Context) {}
 
   value() {
     return (key: string) => this.context.get(key);

--- a/packages/core/src/router/providers/invoke-method.ts
+++ b/packages/core/src/router/providers/invoke-method.ts
@@ -5,9 +5,10 @@
 
 import {Context, inject, Provider} from '@loopback/context';
 import {InvokeMethod} from '../../internal-types';
+import {CoreBindings} from '../../keys';
 
 export class InvokeMethodProvider implements Provider<InvokeMethod> {
-  constructor(@inject('http.request.context') protected context: Context) {}
+  constructor(@inject(CoreBindings.Http.CONTEXT) protected context: Context) {}
 
   value(): InvokeMethod {
     return async (route, args) => {

--- a/packages/core/src/router/providers/reject.ts
+++ b/packages/core/src/router/providers/reject.ts
@@ -7,10 +7,12 @@ import {LogError, Reject} from '../../internal-types';
 import {inject} from '@loopback/context';
 import {ServerResponse, ServerRequest} from 'http';
 import {HttpError} from 'http-errors';
+import {CoreBindings} from '../../keys';
 
 export class RejectProvider {
   constructor(
-    @inject('sequence.actions.logError') protected logError: LogError,
+    @inject(CoreBindings.SequenceActions.LOG_ERROR)
+    protected logError: LogError,
   ) {}
 
   value(): Reject {

--- a/packages/core/src/sequence.ts
+++ b/packages/core/src/sequence.ts
@@ -16,8 +16,11 @@ import {
   Reject,
   ParseParams,
 } from './internal-types';
+import {CoreBindings} from './keys';
 import {writeResultToResponse} from './writer';
 import {HttpError} from 'http-errors';
+
+const SequenceActions = CoreBindings.SequenceActions;
 
 /**
  * A sequence function is a function implementing a custom
@@ -56,7 +59,7 @@ export interface SequenceHandler {
  *
  * User can bind their own Sequence to app as shown below
  * ```ts
- * app.bind('sequence').toClass(MySequence);
+ * app.bind(CoreBindings.SEQUENCE).toClass(MySequence);
  * ```
  */
 export class DefaultSequence implements SequenceHandler {
@@ -70,12 +73,13 @@ export class DefaultSequence implements SequenceHandler {
    * @param logError Logs error
    */
   constructor(
-    @inject('http.request.context') public ctx: Context,
-    @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-    @inject('sequence.actions.parseParams') protected parseParams: ParseParams,
-    @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
-    @inject('sequence.actions.send') public send: Send,
-    @inject('sequence.actions.reject') public reject: Reject,
+    @inject(CoreBindings.Http.CONTEXT) public ctx: Context,
+    @inject(SequenceActions.FIND_ROUTE)
+    protected findRoute: FindRoute,
+    @inject(SequenceActions.PARSE_PARAMS) protected parseParams: ParseParams,
+    @inject(SequenceActions.INVOKE_METHOD) protected invoke: InvokeMethod,
+    @inject(SequenceActions.SEND) public send: Send,
+    @inject(SequenceActions.REJECT) public reject: Reject,
   ) {}
 
 

--- a/packages/core/test/acceptance/bootstrapping/application.acceptance.ts
+++ b/packages/core/test/acceptance/bootstrapping/application.acceptance.ts
@@ -5,7 +5,7 @@
 
 import {expect, supertest} from '@loopback/testlab';
 import {Constructor, Provider, inject} from '@loopback/context';
-import {Application, DefaultSequence} from '../../..';
+import {Application, DefaultSequence, CoreBindings} from '../../..';
 
 describe('Bootstrapping the application', () => {
   context('with a user-defined sequence', () => {
@@ -13,7 +13,7 @@ describe('Bootstrapping the application', () => {
     before(givenAppWithUserDefinedSequence);
 
     it('binds the `sequence` key to the user-defined sequence', async () => {
-      const binding = await app.get('sequence');
+      const binding = await app.get(CoreBindings.SEQUENCE);
       expect(binding.constructor.name).to.equal('UserDefinedSequence');
     });
 
@@ -120,7 +120,7 @@ describe('Starting the application', () => {
     });
 
     await app.start();
-    const port = app.getSync('http.port');
+    const port = app.getSync(CoreBindings.HTTP_PORT);
 
     return supertest(`http://localhost:${port}`)
       .get('/')

--- a/packages/core/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/core/test/acceptance/routing/routing.acceptance.ts
@@ -14,6 +14,7 @@ import {
   ResponseObject,
   Route,
   param,
+  CoreBindings,
 } from '../../..';
 import {expect, Client, createClientForApp} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
@@ -168,8 +169,8 @@ describe('Routing', () => {
     @api(spec)
     class StatusController {
       constructor(
-        @inject('http.request') private request: ServerRequest,
-        @inject('http.response') private response: ServerResponse,
+        @inject(CoreBindings.Http.REQUEST) private request: ServerRequest,
+        @inject(CoreBindings.Http.RESPONSE) private response: ServerResponse,
       ) {}
 
       async getStatus(): Promise<string> {

--- a/packages/core/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/core/test/acceptance/sequence/sequence.acceptance.ts
@@ -18,11 +18,14 @@ import {
   SequenceHandler,
   ParseParams,
   DefaultSequence,
+  CoreBindings,
 } from '../../..';
 import {expect, Client, createClientForApp} from '@loopback/testlab';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {inject, Constructor, Context} from '@loopback/context';
 import {ControllerClass} from '../../../src/router/routing-table';
+
+const SequenceActions = CoreBindings.SequenceActions;
 
 /* # Feature: Sequence
  * - In order to build REST APIs
@@ -46,7 +49,7 @@ describe('Sequence', () => {
 
   it('allows users to define a custom sequence as a class', () => {
     class MySequence implements SequenceHandler {
-      constructor(@inject('sequence.actions.send') private send: Send) {}
+      constructor(@inject(SequenceActions.SEND) private send: Send) {}
 
       async handle(req: ParsedRequest, res: ServerResponse) {
         this.send(res, 'hello world');
@@ -61,11 +64,11 @@ describe('Sequence', () => {
   it('allows users to bind a custom sequence class', () => {
     class MySequence {
       constructor(
-        @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-        @inject('sequence.actions.parseParams')
+        @inject(SequenceActions.FIND_ROUTE) protected findRoute: FindRoute,
+        @inject(SequenceActions.PARSE_PARAMS)
         protected parseParams: ParseParams,
-        @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
-        @inject('sequence.actions.send') protected send: Send,
+        @inject(SequenceActions.INVOKE_METHOD) protected invoke: InvokeMethod,
+        @inject(SequenceActions.SEND) protected send: Send,
       ) {}
 
       async handle(req: ParsedRequest, res: ServerResponse) {
@@ -88,7 +91,7 @@ describe('Sequence', () => {
       response.setHeader('content-type', 'text/plain');
       response.end(`CUSTOM FORMAT: ${result}`);
     };
-    app.bind('sequence.actions.send').to(send);
+    app.bind(SequenceActions.SEND).to(send);
 
     return whenIMakeRequestTo(app)
       .get('/name')
@@ -100,7 +103,7 @@ describe('Sequence', () => {
       response.statusCode = 418; // I'm a teapot
       response.end();
     };
-    app.bind('sequence.actions.reject').to(reject);
+    app.bind(SequenceActions.REJECT).to(reject);
 
     return whenIMakeRequestTo(app).get('/unknown-url').expect(418);
   });
@@ -118,13 +121,13 @@ describe('Sequence', () => {
   it('makes ctx available in a custom sequence class', () => {
     class MySequence extends DefaultSequence {
       constructor(
-        @inject('http.request.context') public ctx: Context,
-        @inject('sequence.actions.findRoute') protected findRoute: FindRoute,
-        @inject('sequence.actions.parseParams')
+        @inject(CoreBindings.Http.CONTEXT) public ctx: Context,
+        @inject(SequenceActions.FIND_ROUTE) protected findRoute: FindRoute,
+        @inject(SequenceActions.PARSE_PARAMS)
         protected parseParams: ParseParams,
-        @inject('sequence.actions.invokeMethod') protected invoke: InvokeMethod,
-        @inject('sequence.actions.send') public send: Send,
-        @inject('sequence.actions.reject') public reject: Reject,
+        @inject(SequenceActions.INVOKE_METHOD) protected invoke: InvokeMethod,
+        @inject(SequenceActions.SEND) public send: Send,
+        @inject(SequenceActions.REJECT) public reject: Reject,
       ) {
         super(ctx, findRoute, parseParams, invoke, send, reject);
       }

--- a/packages/core/test/integration/application.integration.ts
+++ b/packages/core/test/integration/application.integration.ts
@@ -10,6 +10,7 @@ import {
   ResponseObject,
   SchemaObject,
   ReferenceObject,
+  CoreBindings,
 } from '../..';
 import {Context} from '@loopback/context';
 
@@ -17,7 +18,7 @@ describe('Application (integration)', () => {
   it('updates http.port binding when listening on ephemeral port', async () => {
     const app = new Application({http: {port: 0}});
     await app.start();
-    expect(app.getSync('http.port')).to.be.above(0);
+    expect(app.getSync(CoreBindings.HTTP_PORT)).to.be.above(0);
   });
 
   it('responds with 500 when Sequence fails with unhandled error', () => {

--- a/packages/core/test/unit/application/application.test.ts
+++ b/packages/core/test/unit/application/application.test.ts
@@ -13,13 +13,16 @@ import {
   GetFromContext,
   Route,
   InvokeMethod,
+  CoreBindings,
 } from '../../..';
+
+const SequenceActions = CoreBindings.SequenceActions;
 
 describe('Application', () => {
   describe('"logError" binding', () => {
     it('provides a default', async () => {
       const app = new Application();
-      const logError = await app.get('sequence.actions.logError');
+      const logError = await app.get(SequenceActions.LOG_ERROR);
       expect(logError.length).to.equal(3); // (err, statusCode, request)
     });
 
@@ -38,7 +41,7 @@ describe('Application', () => {
       }
 
       const app = new MyApp();
-      const logError = await app.get('sequence.actions.logError');
+      const logError = await app.get(SequenceActions.LOG_ERROR);
       logError(new Error('test-error'), 400, new ShotRequest({url: '/'}));
 
       expect(lastLog).to.equal('/ 400 test-error');
@@ -48,7 +51,7 @@ describe('Application', () => {
   describe('"bindElement" binding', () => {
     it('returns a function for creating new bindings', async () => {
       const ctx = givenRequestContext();
-      const bindElement: BindElement = await ctx.get('bindElement');
+      const bindElement: BindElement = await ctx.get(CoreBindings.BIND_ELEMENT);
       const binding = bindElement('foo').to('bar');
       expect(binding).to.be.instanceOf(Binding);
       expect(ctx.getSync('foo')).to.equal('bar');
@@ -58,7 +61,9 @@ describe('Application', () => {
   describe('"getFromContext" binding', () => {
     it('returns a function for getting a value from the context', async () => {
       const ctx = givenRequestContext();
-      const getFromContext: GetFromContext = await ctx.get('getFromContext');
+      const getFromContext: GetFromContext = await ctx.get(
+        CoreBindings.GET_FROM_CONTEXT,
+      );
       ctx.bind('foo').to('bar');
       expect(await getFromContext('foo')).to.equal('bar');
     });
@@ -79,7 +84,7 @@ describe('Application', () => {
 
       const ctx = givenRequestContext();
       const invokeMethod: InvokeMethod = await ctx.get(
-        'sequence.actions.invokeMethod',
+        CoreBindings.SequenceActions.INVOKE_METHOD,
       );
 
       const result = await invokeMethod(route, []);
@@ -90,18 +95,18 @@ describe('Application', () => {
   describe('configuration', () => {
     it('uses http port 3000 by default', () => {
       const app = new Application();
-      expect(app.getSync('http.port')).to.equal(3000);
+      expect(app.getSync(CoreBindings.HTTP_PORT)).to.equal(3000);
     });
 
     it('can set port 0', () => {
       const app = new Application({http: {port: 0}});
-      expect(app.getSync('http.port')).to.equal(0);
+      expect(app.getSync(CoreBindings.HTTP_PORT)).to.equal(0);
     });
   });
 
   function givenRequestContext(rootContext: Context = new Application()) {
     const requestContext = new Context(rootContext);
-    requestContext.bind('http.request.context').to(requestContext);
+    requestContext.bind(CoreBindings.Http.CONTEXT).to(requestContext);
     return requestContext;
   }
 });

--- a/packages/example-codehub/src/codehub-application.ts
+++ b/packages/example-codehub/src/codehub-application.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application} from '@loopback/core';
+import {Application, CoreBindings} from '@loopback/core';
 import {UserController, HealthController} from './controllers';
 
 export class CodeHubApplication extends Application {
@@ -42,7 +42,7 @@ export class CodeHubApplication extends Application {
   }
 
   async info() {
-    const port: Number = await this.get('http.port');
+    const port: Number = await this.get(CoreBindings.HTTP_PORT);
 
     return {
       uptime: Date.now() - this._startTime.getTime(),

--- a/packages/example-codehub/test/support/util.ts
+++ b/packages/example-codehub/test/support/util.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {supertest} from '@loopback/testlab';
+import {CoreBindings} from '@loopback/core';
 import {CodeHubApplication} from '../../src/codehub-application';
 
 export async function createClientForApp(app: CodeHubApplication) {
@@ -13,7 +14,7 @@ export async function createClientForApp(app: CodeHubApplication) {
 
 export function createApp() {
   const app = new CodeHubApplication();
-  app.bind('http.port').to(0);
+  app.bind(CoreBindings.HTTP_PORT).to(0);
   return app;
 }
 


### PR DESCRIPTION
This pull request defines constants for all binding keys used in core. Because I found the old structure of BindingKeys constants sort of weird, so I took an attempt to clean it up a bit - both in `core` and `authentication`. I am looking for more suggestions on how to improve this!

cc @bajtos @raymondfeng @ritch @superkhau

Connect to #483