### PR TITLE
Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners,
+# the last matching pattern has the most precedence.
+
+# Core team members from IBM
+* @bajtos @raymondfeng
+packages/authentication/* @bajtos
+packages/context/* @bajtos @raymondfeng @superkhau
+packages/core/* @bajtos @superkhau
+packages/example-codehub/* @bajtos
+packages/openapi-spec-builder/*  @bajtos
+packages/openapi-spec/*  @bajtos
+packages/repository/* @raymondfeng
+packages/testlab/* @bajtos @rashmihunt


### PR DESCRIPTION
Add CODEOWNERS for automatically requests reviews from code owners
Connect to: https://github.com/strongloop/loopback-next/issues/517

The codeowners are derived from looking at the committers of a few selected files for each package, so this may not be accurate.  It would be great if @bajtos and/or @raymondfeng could review this. 