### PR TITLE
core: remove unused dependency on bluebird

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,9 +22,7 @@
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.11",
     "@loopback/openapi-spec": "^4.0.0-alpha.8",
-    "@types/bluebird": "^3.5.8",
     "@types/http-errors": "^1.5.34",
-    "bluebird": "^3.5.0",
     "body": "^5.1.0",
     "debug": "^2.6.0",
     "http-errors": "^1.6.1",


### PR DESCRIPTION
We are using native Promises and async/await instead.