### PR TITLE
core: handle invocation of an unknown method

### DIFF
--- a/packages/core/src/router/routing-table.ts
+++ b/packages/core/src/router/routing-table.ts
@@ -285,6 +285,11 @@ export class ControllerRoute extends BaseRoute {
     args: OperationArgs,
   ): Promise<OperationRetval> {
     const controller = await this._createControllerInstance(requestContext);
+    if (typeof controller[this._methodName] !== 'function') {
+      throw new HttpErrors.NotFound(
+        `Controller method not found: ${this.describe()}`,
+      );
+    }
     return await controller[this._methodName](...args);
   }
 

--- a/packages/core/test/integration/http-handler.integration.ts
+++ b/packages/core/test/integration/http-handler.integration.ts
@@ -16,7 +16,7 @@ import {
 import {Context} from '@loopback/context';
 import {expect, Client, createClientForHandler} from '@loopback/testlab';
 import {ParameterObject} from '@loopback/openapi-spec';
-import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
+import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
 import {FindRouteProvider} from '../../src/router/providers/find-route';
 import {InvokeMethodProvider} from '../../src/router/providers/invoke-method';
 
@@ -382,6 +382,23 @@ describe('HttpHandler', () => {
 
       logErrorsExcept(500);
       return client.get('/hello').expect(500);
+    });
+
+    it('handles invocation of an unknown method', async () => {
+      const spec = anOpenApiSpec()
+        .withOperation(
+          'get',
+          '/hello',
+          anOperationSpec().withOperationName('unknownMethod'),
+        )
+        .build();
+
+      class TestController {}
+
+      givenControllerClass(TestController, spec);
+      logErrorsExcept(404);
+
+      await client.get('/hello').expect(404);
     });
   });
 


### PR DESCRIPTION
Throw an 404 error when an operation endpoint is mapped to a controller method that's not implemented by the controller class.

Before this change:

```
Unhandled error in GET /product/ink-pen:
500 TypeError: controller[this._methodName] is not a function
```

After this change:

```
Unhandled error in GET /product/ink-pen:
404 Error: Controller method not found: ProductController.getDetails
```

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

Connect to #393 