### PR TITLE
authentication: support anonymous access

### DIFF
--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -52,13 +52,17 @@ import {
 import {Strategy} from 'passport';
 import {BasicStrategy} from 'passport-http';
 
-export class MyAuthStrategyProvider implements Provider<Strategy> {
+export class MyAuthStrategyProvider implements Provider<Strategy | undefined> {
   constructor(
     @inject(AuthenticationBindings.METADATA)
     private metadata: AuthenticationMetadata,
   ) {}
 
   value() : ValueOrPromise<Strategy> {
+    if (!this.metadata) {
+      return undefined;
+    }
+
     const name = this.metadata.strategy;
     if (name === 'BasicStrategy') {
       return new BasicStrategy(this.verify);

--- a/packages/authentication/src/providers/authenticate.ts
+++ b/packages/authentication/src/providers/authenticate.ts
@@ -15,7 +15,7 @@ import {AuthenticationBindings} from '../keys';
  * and returns an authenticated user
  */
 export interface AuthenticateFn {
-  (request: ParsedRequest): Promise<UserProfile>;
+  (request: ParsedRequest): Promise<UserProfile | undefined>;
 }
 
 /**
@@ -73,8 +73,12 @@ async function authenticateRequest(
   getStrategy: Getter<Strategy>,
   request: ParsedRequest,
   setCurrentUser: Setter<UserProfile>,
-): Promise<UserProfile> {
+): Promise<UserProfile | undefined> {
   const strategy = await getStrategy();
+  if (!strategy) {
+    // The invoked operation does not require authentication.
+    return undefined;
+  }
   if (!strategy.authenticate) {
     return Promise.reject(new Error('invalid strategy parameter'));
   }

--- a/packages/authentication/test/unit/authenticate-action.test.ts
+++ b/packages/authentication/test/unit/authenticate-action.test.ts
@@ -41,7 +41,7 @@ describe('AuthenticationProvider', () => {
         provider.value(),
       );
       const request = <ParsedRequest> {};
-      const user: UserProfile = await authenticate(request);
+      const user = await authenticate(request);
       expect(user).to.be.equal(mockUser);
     });
 


### PR DESCRIPTION
Improve authentication component to handle the use case where a controller method is not decorated with `@authenticate`, therefore allowing anonymous access.

The solution is not ideal, because when a method is not annotated with `@authenticate`, then we will never try to authenticate the current user, even if the request includes authorization header. I consider this patch as a stop gap needed to finish https://github.com/strongloop/loopback-next/wiki/Thinking-in-LoopBack. If you think we should find a better solution for longer term, then I'll open a GH issue - just let me know.

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

Connect to #393