### PR TITLE
feat(repository): simplify usage of juggler bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "build": "lerna run --loglevel=silent build",
     "build:current": "lerna run --loglevel=silent build:current",
     "pretest": "npm run build:current",
-    "test": "nyc mocha --opts test/mocha.opts \"packages/*/test/**/*.ts\"",
+    "test": "nyc npm run mocha",
+    "mocha": "mocha --opts test/mocha.opts \"packages/*/test/**/*.ts\"",
     "posttest": "npm run lint"
   },
   "nyc": {

--- a/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
@@ -27,9 +27,10 @@ const ds: juggler.DataSource = new DataSourceConstructor({
   });
 
 class Note extends Entity {
-  static definition = new ModelDefinition('note',
-    {title: 'string', content: 'string'},
-    {});
+  static definition = new ModelDefinition({
+    name: 'note',
+    properties: {title: 'string', content: 'string'},
+  });
 }
 
 class MyNoteRepository extends DefaultCrudRepository<Note, string> {

--- a/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
@@ -13,6 +13,7 @@ import {
   Entity,
   EntityCrudRepository,
   DefaultCrudRepository,
+  ModelDefinition,
 } from '../../';
 
 class NoteController {
@@ -25,16 +26,15 @@ const ds: juggler.DataSource = new DataSourceConstructor({
     connector: 'memory',
   });
 
-/* tslint:disable-next-line:variable-name */
-const Note = ds.createModel<typeof juggler.PersistedModel>(
-  'note',
-  {title: 'string', content: 'string'},
-  {},
-);
+class Note extends Entity {
+  static definition = new ModelDefinition('note',
+    {title: 'string', content: 'string'},
+    {});
+}
 
-class MyNoteRepository extends DefaultCrudRepository<Entity, string> {
+class MyNoteRepository extends DefaultCrudRepository<Note, string> {
   constructor(
-    @inject('models.Note') myModel: typeof juggler.PersistedModel,
+    @inject('models.Note') myModel: typeof Note,
     // FIXME For some reason ts-node fails by complaining that
     // juggler is undefined if the following is used:
     // @inject('dataSources.memory') dataSource: juggler.DataSource

--- a/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
@@ -16,6 +16,7 @@ import {
   Filter,
   EntityCrudRepository,
   DefaultCrudRepository,
+  ModelDefinition,
 } from '../../';
 
 // The Controller for Note
@@ -39,12 +40,11 @@ const ds: juggler.DataSource = new DataSourceConstructor({
   connector: 'memory',
 });
 
-/* tslint:disable-next-line:variable-name */
-const Note = ds.createModel<typeof juggler.PersistedModel>(
-  'note',
-  {title: 'string', content: 'string'},
-  {},
-);
+class Note extends Entity {
+  static definition = new ModelDefinition('note',
+    {title: 'string', content: 'string'},
+    {});
+}
 
 async function main() {
   // Create a context

--- a/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
@@ -41,9 +41,10 @@ const ds: juggler.DataSource = new DataSourceConstructor({
 });
 
 class Note extends Entity {
-  static definition = new ModelDefinition('note',
-    {title: 'string', content: 'string'},
-    {});
+  static definition = new ModelDefinition({
+    name: 'note',
+    properties: {title: 'string', content: 'string'},
+  });
 }
 
 async function main() {

--- a/packages/repository/examples/models/order.ts
+++ b/packages/repository/examples/models/order.ts
@@ -11,6 +11,8 @@ import {Customer} from './customer';
 @model()
 class Order extends Entity {
   @property({
+    // TODO(bajtos) type should be optional for TypeScript based properties,
+    // as simple types string, number, boolean can be inferred
     type: 'number',
     mysql: {
       column: 'QTY',
@@ -18,6 +20,8 @@ class Order extends Entity {
   })
   quantity: number;
 
+  // TODO(bajtos) type should be optional for TypeScript based properties,
+  // as simple types string, number, boolean can be inferred
   @property({type: 'string', id: true, generated: true})
   id: string;
   customerId: string;

--- a/packages/repository/examples/models/order.ts
+++ b/packages/repository/examples/models/order.ts
@@ -11,14 +11,14 @@ import {Customer} from './customer';
 @model()
 class Order extends Entity {
   @property({
-    name: 'qty',
+    type: 'number',
     mysql: {
       column: 'QTY',
     },
   })
   quantity: number;
 
-  @property({name: 'id', id: true, generated: true})
+  @property({type: 'string', id: true, generated: true})
   id: string;
   customerId: string;
 

--- a/packages/repository/src/decorators/model.ts
+++ b/packages/repository/src/decorators/model.ts
@@ -5,7 +5,7 @@
 
 import {Class} from '../common-types';
 import {Reflector} from '@loopback/context';
-import {ModelDefinition, PropertyType} from '../model';
+import {ModelDefinition, PropertyType, ModelDefinitionSyntax} from '../model';
 import {PropertyDefinition} from '../index';
 
 export const MODEL_KEY = 'loopback:model';
@@ -21,11 +21,7 @@ type PropertyMap = {[name: string]: PropertyDefinition};
  * @param definition
  * @returns {(target:any)}
  */
-export function model(definition?: {
-  name: string;
-  properties?: {[name: string]: PropertyDefinition | PropertyType};
-  settings?: {[name: string]: any};
-}) {
+export function model(definition?: ModelDefinitionSyntax) {
   return function(target: any) {
     if (!definition) {
       definition = {name: target.name};
@@ -35,11 +31,7 @@ export function model(definition?: {
     Reflector.defineMetadata(MODEL_KEY, definition, target);
 
     // Build "ModelDefinition" and store it on model constructor
-    const modelDef = new ModelDefinition(
-      definition.name,
-      definition.properties,
-      definition.settings,
-    );
+    const modelDef = new ModelDefinition(definition);
 
     const propertyMap: PropertyMap = Reflector.getMetadata(
       MODEL_PROPERTIES_KEY,

--- a/packages/repository/src/decorators/model.ts
+++ b/packages/repository/src/decorators/model.ts
@@ -5,9 +5,14 @@
 
 import {Class} from '../common-types';
 import {Reflector} from '@loopback/context';
+import {ModelDefinition, PropertyType} from '../model';
+import {PropertyDefinition} from '../index';
 
 export const MODEL_KEY = 'loopback:model';
 export const PROPERTY_KEY = 'loopback:property';
+export const MODEL_PROPERTIES_KEY = 'loopback:model-properties';
+
+type PropertyMap = {[name: string]: PropertyDefinition};
 
 // tslint:disable:no-any
 
@@ -16,10 +21,36 @@ export const PROPERTY_KEY = 'loopback:property';
  * @param definition
  * @returns {(target:any)}
  */
-export function model(definition?: Object) {
+export function model(definition?: {
+  name: string;
+  properties?: {[name: string]: PropertyDefinition | PropertyType};
+  settings?: {[name: string]: any};
+}) {
   return function(target: any) {
+    if (!definition) {
+      definition = {name: target.name};
+    }
+
     // Apply model definition to the model class
     Reflector.defineMetadata(MODEL_KEY, definition, target);
+
+    // Build "ModelDefinition" and store it on model constructor
+    const modelDef = new ModelDefinition(
+      definition.name,
+      definition.properties,
+      definition.settings,
+    );
+
+    const propertyMap: PropertyMap = Reflector.getMetadata(
+      MODEL_PROPERTIES_KEY,
+      target.prototype,
+    );
+
+    for (const p in propertyMap) {
+      modelDef.addProperty(p, propertyMap[p]);
+    }
+
+    target.definition = modelDef;
   };
 }
 
@@ -28,9 +59,19 @@ export function model(definition?: Object) {
  * @param definition
  * @returns {(target:any, key:string)}
  */
-export function property(definition?: Object) {
+export function property(definition: PropertyDefinition) {
   return function(target: any, key: string) {
     // Apply model definition to the model class
     Reflector.defineMetadata(PROPERTY_KEY, definition, target, key);
+
+    // Because there is no way how to iterate decorated properties at runtime,
+    // we need to keep an explicit map of decorated properties
+    let map: PropertyMap = Reflector.getMetadata(MODEL_PROPERTIES_KEY, target);
+    if (!map) {
+      map = Object.create(null);
+      Reflector.defineMetadata(MODEL_PROPERTIES_KEY, map, target);
+    }
+
+    map[key] = definition;
   };
 }

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -18,3 +18,4 @@ export * from './crud-connector';
 export * from './kv-connector';
 export * from './kv-repository';
 export * from './legacy-juggler-bridge';
+export * from './loopback-datasource-juggler';

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -115,7 +115,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
     const models = await ensurePromise(
       this.modelClass.create(entities, options),
     );
-    return this.toEntities(models);
+    return this.toEntities(models as DataObject<T>[]);
   }
 
   save(entity: T, options?: Options): Promise<T | null> {
@@ -206,7 +206,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
     return new this.entityClass(model.toObject()) as T;
   }
 
-  protected toEntities(models: AnyObject): T[] {
-    return models.map((m: DataObject<T>) => this.toEntity(m));
+  protected toEntities(models: DataObject<T>[]): T[] {
+    return models.map(m => this.toEntity(m));
   }
 }

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -5,15 +5,24 @@
 
 export const jugglerModule = require('loopback-datasource-juggler');
 
+import * as assert from 'assert';
 import {isPromise} from '@loopback/context';
 import {MixinBuilder} from './mixin';
-import {Class, DataObject, Options} from './common-types';
+import {
+  Class,
+  DataObject,
+  Options,
+  AnyObject,
+} from './common-types';
 import {Entity} from './model';
 import {Filter, Where} from './query';
 import {EntityCrudRepository} from './repository';
 
-import {juggler} from './loopback-datasource-juggler';
 export * from './loopback-datasource-juggler';
+import {juggler} from './loopback-datasource-juggler';
+
+type DataSourceType = juggler.DataSource;
+export {DataSourceType};
 
 /* tslint:disable-next-line:variable-name */
 export const DataSourceConstructor =
@@ -43,7 +52,7 @@ export function bindModel<T extends typeof juggler.ModelBase>(
  * @param p Promise or void
  */
 /* tslint:disable-next-line:no-any */
-function ensurePromise(p: juggler.PromiseOrVoid<any>): Promise<any> {
+function ensurePromise<T>(p: juggler.PromiseOrVoid<T>): Promise<T> {
   if (p && isPromise(p)) {
     return p;
   } else {
@@ -65,23 +74,51 @@ export class DefaultCrudRepository<T extends Entity, ID>
    * @param dataSource Legacy data source
    */
   constructor(
-    modelClass: typeof juggler.PersistedModel,
+    // entityClass should have type "typeof T", but that's not supported by TSC
+    public entityClass: typeof Entity & {prototype: T},
     dataSource: juggler.DataSource,
   ) {
-    // Bind the legacy model class to the datasource to create
-    // a subclass of the model
-    this.modelClass = bindModel(modelClass, dataSource);
+    const definition = entityClass.definition;
+    assert(
+      !!definition,
+      `Entity ${entityClass.name} must have valid model definition.`,
+    );
+
+    assert(
+      definition.idProperties().length > 0,
+      `Entity ${entityClass.name} must have at least one id/pk property.`,
+    );
+
+    // Create an internal legacy Model attached to the datasource
+
+    // We need to convert property definitions from PropertyDefinition
+    // to plain data object because of a juggler limitation
+    const properties: {[name: string]: object} = {};
+    for (const p in definition.properties) {
+      properties[p] = Object.assign({}, definition.properties[p]);
+    }
+
+    this.modelClass = dataSource.createModel(
+      definition.name,
+      properties,
+      definition.settings,
+    );
+    this.modelClass.attachTo(dataSource);
   }
 
-  create(entity: DataObject<T>, options?: Options): Promise<T> {
-    return ensurePromise(this.modelClass.create(entity, options));
+  async create(entity: Partial<T>, options?: Options): Promise<T> {
+    const model = await ensurePromise(this.modelClass.create(entity, options));
+    return this.toEntity(model);
   }
 
-  createAll(entities: DataObject<T>[], options?: Options): Promise<T[]> {
-    return ensurePromise(this.modelClass.create(entities, options));
+  async createAll(entities: Partial<T>[], options?: Options): Promise<T[]> {
+    const models = await ensurePromise(
+      this.modelClass.create(entities, options),
+    );
+    return this.toEntities(models);
   }
 
-  save(entity: DataObject<T>, options?: Options): Promise<T | null> {
+  save(entity: T, options?: Options): Promise<T | null> {
     const idName = this.modelClass.definition.idName();
     let id;
     if (typeof entity.getId === 'function') {
@@ -93,29 +130,33 @@ export class DefaultCrudRepository<T extends Entity, ID>
       return this.create(entity, options);
     } else {
       return this.replaceById(id, entity, options).then(
-        result => (result ? entity as T: null),
+        result => (result ? this.toEntity(entity): null),
       );
     }
   }
 
-  find(filter?: Filter, options?: Options): Promise<T[]> {
-    return ensurePromise(this.modelClass.find(filter, options));
+  async find(filter?: Filter, options?: Options): Promise<T[]> {
+    const models = await ensurePromise(this.modelClass.find(filter, options));
+    return this.toEntities(models);
   }
 
-  findById(id: ID, filter?: Filter, options?: Options): Promise<T> {
-    return ensurePromise(this.modelClass.findById(id, filter, options));
+  async findById(id: ID, filter?: Filter, options?: Options): Promise<T> {
+    const model = await ensurePromise(
+      this.modelClass.findById(id, filter, options),
+    );
+    return this.toEntity(model);
   }
 
-  update(entity: DataObject<T>, options?: Options): Promise<boolean> {
+  update(entity: T, options?: Options): Promise<boolean> {
     return this.updateById(entity.getId(), entity, options);
   }
 
-  delete(entity: DataObject<T>, options?: Options): Promise<boolean> {
+  delete(entity: T, options?: Options): Promise<boolean> {
     return this.deleteById(entity.getId(), options);
   }
 
   updateAll(
-    data: DataObject<T>,
+    data: Partial<T>,
     where?: Where,
     options?: Options,
   ): Promise<number> {
@@ -124,7 +165,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
     );
   }
 
-  updateById(id: ID, data: DataObject<T>, options?: Options): Promise<boolean> {
+  updateById(id: ID, data: Partial<T>, options?: Options): Promise<boolean> {
     const idProp = this.modelClass.definition.idName();
     const where = {} as Where;
     where[idProp] = id;
@@ -133,7 +174,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
 
   replaceById(
     id: ID,
-    data: DataObject<T>,
+    data: Partial<T>,
     options?: Options,
   ): Promise<boolean> {
     return ensurePromise(this.modelClass.replaceById(id, data, options)).then(
@@ -159,5 +200,13 @@ export class DefaultCrudRepository<T extends Entity, ID>
 
   exists(id: ID, options?: Options): Promise<boolean> {
     return ensurePromise(this.modelClass.exists(id, options));
+  }
+
+  protected toEntity(model: DataObject<T>): T {
+    return new this.entityClass(model.toObject()) as T;
+  }
+
+  protected toEntities(models: AnyObject): T[] {
+    return models.map((m: DataObject<T>) => this.toEntity(m));
   }
 }

--- a/packages/repository/src/loopback-datasource-juggler.ts
+++ b/packages/repository/src/loopback-datasource-juggler.ts
@@ -458,7 +458,7 @@ export declare namespace juggler {
       filter?: Filter,
       options?: Options,
       callback?: Callback<PersistedData>,
-    ): PromiseOrVoid<PersistedData>;
+    ): PromiseOrVoid<PersistedData[]>;
 
     /**
      * Find one model instance that matches `filter` specification.

--- a/packages/repository/src/loopback-datasource-juggler.ts
+++ b/packages/repository/src/loopback-datasource-juggler.ts
@@ -77,7 +77,7 @@ export declare namespace juggler {
       properties?: {[name: string]: PropertyDefinition},
       settings?: AnyObject,
     );
-    constructor(modelBuidler: ModelBuilder | null | undefined, schema: Schema);
+    constructor(modelBuilder: ModelBuilder | null | undefined, schema: Schema);
 
     tableName(connectorType: string): string;
     columnName(connectorType: string, propertyName: string): string;

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -36,6 +36,19 @@ export interface PropertyForm {
   name?: string; // Custom name for this form
 }
 
+export interface PropertyDefinitionMap {
+}
+
+/**
+ * DSL for building a model definition.
+ */
+export interface ModelDefinitionSyntax {
+  name: string;
+  properties?: {[name: string]: PropertyDefinition | PropertyType};
+  settings?: {[name: string]: any};
+}
+
+
 /**
  * Definition for a model
  */
@@ -46,11 +59,12 @@ export class ModelDefinition {
   // indexes: Map<string, any>;
   [attribute: string]: any; // Other attributes
 
-  constructor(
-    name: string,
-    properties?: {[name: string]: PropertyDefinition | PropertyType},
-    settings?: {[name: string]: any},
-  ) {
+  constructor(nameOrDef: string | ModelDefinitionSyntax) {
+    if (typeof nameOrDef === 'string') {
+      nameOrDef = {name: nameOrDef};
+    }
+    const {name, properties, settings} = nameOrDef;
+
     this.name = name;
 
     this.properties = {};

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -209,11 +209,7 @@ export abstract class Entity extends Model implements Persistable {
           'missing primary key (id) property',
       );
     }
-    const idObj = {} as any;
-    for (const idProp of idProps) {
-      idObj[idProp] = this[idProp];
-    }
-    return idObj;
+    return this.getIdObject();
   }
 
   /**

--- a/packages/repository/test/acceptance/thinking-in-loopback/models/product.model.ts
+++ b/packages/repository/test/acceptance/thinking-in-loopback/models/product.model.ts
@@ -1,0 +1,26 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/loopback-next-hello-world
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {model, property, Entity} from '../../../..';
+
+@model()
+export class Product extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    description: 'The unique identifier for a product',
+  })
+  id: number;
+
+  @property({type: 'string'})
+  name: string;
+
+  @property({type: 'string'})
+  slug: string;
+
+  constructor(data?: Partial<Product>) {
+    super(data);
+  }
+}

--- a/packages/repository/test/acceptance/thinking-in-loopback/repositories/product.repository.ts
+++ b/packages/repository/test/acceptance/thinking-in-loopback/repositories/product.repository.ts
@@ -1,0 +1,17 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/loopback-next-hello-world
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {juggler, DefaultCrudRepository} from '../../../..';
+import {Product} from '../models/product.model';
+export {Product};
+
+export class ProductRepository extends DefaultCrudRepository<
+  Product,
+  typeof Product.prototype.id
+> {
+  constructor(dataSource: juggler.DataSource) {
+    super(Product, dataSource);
+  }
+}

--- a/packages/repository/test/acceptance/thinking-in-loopback/thinking-in-loopback.acceptance.ts
+++ b/packages/repository/test/acceptance/thinking-in-loopback/thinking-in-loopback.acceptance.ts
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {juggler, DataSourceConstructor} from '../../..';
+import {Product} from './models/product.model';
+import {ProductRepository} from './repositories/product.repository';
+import {expect} from '@loopback/testlab';
+
+// This test shows the recommended way how to use @loopback/repository
+// together with existing connectors when building LoopBack applications
+describe('Repository in Thinking in LoopBack', () => {
+  let repo: ProductRepository;
+  beforeEach(givenProductRepository);
+
+  it('counts models in empty database', async () => {
+    expect(await repo.count()).to.equal(0);
+  });
+
+  it('creates a new model', async () => {
+    const p: Product = await repo.create({name: 'Ink Pen', slug: 'pen'});
+    expect(p).instanceof(Product);
+    expect.exists(p.id);
+  });
+
+  it('can save a model', async () => {
+    const p = await repo.create({slug: 'pencil'});
+
+    p.name = 'Red Pencil';
+    await repo.save(p);
+
+    const saved = await repo.findById(p.id);
+    expect(p).to.have.properties({
+      slug: 'pencil',
+      name: 'Red Pencil',
+    });
+  });
+
+  function givenProductRepository() {
+    const db = new DataSourceConstructor({
+      connector: 'memory',
+    });
+    repo = new ProductRepository(db);
+  }
+});

--- a/packages/repository/test/unit/decorator/model-and-relation.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.ts
@@ -54,14 +54,14 @@ describe('model decorator', () => {
   @model({name: 'order'})
   class Order extends Entity {
     @property({
-      name: 'qty',
+      type: 'number',
       mysql: {
         column: 'QTY',
       },
     })
     quantity: number;
 
-    @property({name: 'id', id: true, generated: true})
+    @property({type: 'string', id: true, generated: true})
     id: string;
     customerId: string;
 
@@ -107,7 +107,7 @@ describe('model decorator', () => {
       'quantity',
     );
     expect(meta).to.eql({
-      name: 'qty',
+      type: 'number',
       mysql: {
         column: 'QTY',
       },

--- a/packages/repository/test/unit/decorator/repository-with-di.ts
+++ b/packages/repository/test/unit/decorator/repository-with-di.ts
@@ -34,9 +34,14 @@ describe('repository class', () => {
     });
 
     class Note extends Entity {
-      static definition = new ModelDefinition('note',
-        {title: 'string', content: 'string', id: {type: 'number', id: true}},
-        {});
+      static definition = new ModelDefinition({
+        name: 'note',
+        properties: {
+          title: 'string',
+          content: 'string',
+          id: {type: 'number', id: true},
+        },
+      });
 
       title: string;
       content: string;

--- a/packages/repository/test/unit/decorator/repository-with-di.ts
+++ b/packages/repository/test/unit/decorator/repository-with-di.ts
@@ -13,13 +13,14 @@ import {
   jugglerModule,
   bindModel,
   DataSourceConstructor,
-  juggler,
   DefaultCrudRepository,
+  ModelDefinition,
+  DataSourceType,
 } from '../../../';
 
 class MyController {
   constructor(
-    @repository('noteRepo') public noteRepo: Repository<juggler.PersistedModel>,
+    @repository('noteRepo') public noteRepo: Repository<Entity>,
   ) {}
 }
 
@@ -27,26 +28,28 @@ describe('repository class', () => {
   let ctx: Context;
 
   before(function() {
-    const ds: juggler.DataSource = new DataSourceConstructor({
+    const ds: DataSourceType = new DataSourceConstructor({
       name: 'db',
       connector: 'memory',
     });
 
-    /* tslint:disable-next-line:variable-name */
-    const Note = ds.createModel<typeof juggler.PersistedModel>(
-      'note',
-      {title: 'string', content: 'string'},
-      {},
-    );
+    class Note extends Entity {
+      static definition = new ModelDefinition('note',
+        {title: 'string', content: 'string', id: {type: 'number', id: true}},
+        {});
+
+      title: string;
+      content: string;
+
+      constructor(data?: Partial<Note>) {
+        super(data);
+      }
+    }
 
     class MyRepository extends DefaultCrudRepository<Entity, string> {
       constructor(
-        @inject('models.Note') myModel: typeof juggler.PersistedModel,
-        // FIXME For some reason ts-node fails by complaining that
-        // juggler is undefined if the following is used:
-        // @inject('dataSources.memory') dataSource: juggler.DataSource
-        // tslint:disable-next-line:no-any
-        @inject('dataSources.memory') dataSource: any) {
+        @inject('models.Note') myModel: typeof Note,
+        @inject('dataSources.memory') dataSource: DataSourceType) {
         super(myModel, dataSource);
       }
     }
@@ -64,5 +67,4 @@ describe('repository class', () => {
     );
     expect(myController.noteRepo instanceof DefaultCrudRepository).to.be.true();
   });
-
 });

--- a/packages/repository/test/unit/decorator/repository-with-value-provider.ts
+++ b/packages/repository/test/unit/decorator/repository-with-value-provider.ts
@@ -48,9 +48,14 @@ describe('repository class', () => {
     });
 
     class Note extends Entity {
-      static definition = new ModelDefinition('note',
-        {title: 'string', content: 'string', id: {type: 'number', id: true}},
-        {});
+      static definition = new ModelDefinition({
+        name: 'note',
+        properties: {
+          title: 'string',
+          content: 'string',
+          id: {type: 'number', id: true},
+        },
+      });
     }
 
     ctx = new Context();

--- a/packages/repository/test/unit/decorator/repository.ts
+++ b/packages/repository/test/unit/decorator/repository.ts
@@ -102,4 +102,18 @@ describe('repository decorator', () => {
     );
     expect(myController.noteRepo).to.be.not.null();
   });
+
+  it('rejects @repository("")', async () => {
+    class Controller4 {
+      constructor(@repository('') public noteRepo: Repository<Note>) {}
+    }
+    ctx.bind('controllers.Controller4').toClass(Controller4);
+
+    try {
+      await ctx.get('controllers.Controller4');
+      throw new Error('Repository resolver should have thrown an error.');
+    } catch (err) {
+      expect(err).to.match(/invalid repository/i);
+    }
+  });
 });

--- a/packages/repository/test/unit/decorator/repository.ts
+++ b/packages/repository/test/unit/decorator/repository.ts
@@ -14,22 +14,28 @@ import {
   DataSourceConstructor,
   juggler,
   DefaultCrudRepository,
+  Entity,
+  ModelDefinition,
 } from '../../../';
 
 class MyController {
   constructor(
-    @repository('noteRepo') public noteRepo: Repository<juggler.PersistedModel>,
+    @repository('noteRepo') public noteRepo: Repository<Entity>,
   ) {}
 
-  @repository('noteRepo') noteRepo2: Repository<juggler.PersistedModel>;
+  @repository('noteRepo') noteRepo2: Repository<Entity>;
 }
 
 describe('repository decorator', () => {
   let ctx: Context;
-  let repo: Repository<juggler.PersistedModel>;
-  /* tslint:disable-next-line:variable-name */
-  let Note: typeof juggler.PersistedModel;
+  let repo: Repository<Note>;
   let ds: juggler.DataSource;
+
+  class Note extends Entity {
+    static definition = new ModelDefinition('note',
+      {title: 'string', content: 'string', id: {type: 'number', id: true}},
+      {});
+  }
 
   before(function() {
     ds = new DataSourceConstructor({
@@ -37,11 +43,6 @@ describe('repository decorator', () => {
       connector: 'memory',
     });
 
-    Note = ds.createModel<typeof juggler.PersistedModel>(
-      'note',
-      {title: 'string', content: 'string'},
-      {},
-    );
     repo = new DefaultCrudRepository(Note, ds);
     ctx = new Context();
     ctx.bind('models.Note').to(Note);
@@ -76,7 +77,7 @@ describe('repository decorator', () => {
   it('supports @repository(model, dataSource) by names', async () => {
     class Controller2 {
       constructor(@repository('Note', 'memory')
-        public noteRepo: Repository<juggler.PersistedModel>) {}
+        public noteRepo: Repository<Note>) {}
     }
     ctx.bind('controllers.Controller2').toClass(Controller2);
     const myController: MyController = await ctx.get(
@@ -88,7 +89,7 @@ describe('repository decorator', () => {
   it('supports @repository(model, dataSource)', async () => {
     class Controller3 {
       constructor(@repository(Note, ds)
-        public noteRepo: Repository<juggler.PersistedModel>) {}
+        public noteRepo: Repository<Note>) {}
     }
     ctx.bind('controllers.Controller3').toClass(Controller3);
     const myController: MyController = await ctx.get(

--- a/packages/repository/test/unit/decorator/repository.ts
+++ b/packages/repository/test/unit/decorator/repository.ts
@@ -32,9 +32,14 @@ describe('repository decorator', () => {
   let ds: juggler.DataSource;
 
   class Note extends Entity {
-    static definition = new ModelDefinition('note',
-      {title: 'string', content: 'string', id: {type: 'number', id: true}},
-      {});
+    static definition = new ModelDefinition({
+      name: 'note',
+      properties: {
+        title: 'string',
+        content: 'string',
+        id: {type: 'number', id: true},
+      },
+    });
   }
 
   before(function() {

--- a/packages/repository/test/unit/model/model.ts
+++ b/packages/repository/test/unit/model/model.ts
@@ -10,41 +10,36 @@ import {Model, Entity, ModelDefinition, PropertyDefinition} from '../../../';
 describe('model', () => {
   const customerDef = new ModelDefinition('Customer');
   customerDef
-    .addProperty(new PropertyDefinition('id', 'string'))
+    .addProperty('id', 'string')
     .addProperty('email', 'string')
     .addProperty('firstName', String)
     .addProperty('lastName', STRING)
     .addSetting('id', 'id');
 
-  const relamCustomerDef = new ModelDefinition('RealmCustomer');
-  relamCustomerDef
-    .addProperty(new PropertyDefinition('realm', 'string'))
+  const realmCustomerDef = new ModelDefinition('RealmCustomer');
+  realmCustomerDef
+    .addProperty('realm', 'string')
     .addProperty('email', 'string')
     .addProperty('firstName', String)
     .addProperty('lastName', STRING)
     .addSetting('id', ['realm', 'email']);
 
   const userDef = new ModelDefinition('User');
-  const idProp = new PropertyDefinition('id', 'string');
-  idProp.id = true;
   userDef
-    .addProperty(idProp)
+    .addProperty('id', {type: 'string', id: true})
     .addProperty('email', 'string')
     .addProperty('firstName', String)
     .addProperty('lastName', STRING);
 
   class Customer extends Entity {
-    static modelName = 'Customer';
     static definition = customerDef;
   }
 
   class RealmCustomer extends Entity {
-    static modelName = 'RealmCustomer';
-    static definition = relamCustomerDef;
+    static definition = realmCustomerDef;
   }
 
   class User extends Entity {
-    static modelName = 'User';
     static definition = userDef;
   }
 
@@ -70,9 +65,7 @@ describe('model', () => {
       'lastName',
       'firstName',
     );
-    expect(customerDef.properties.lastName).to.eql(
-      new PropertyDefinition('lastName', STRING),
-    );
+    expect(customerDef.properties.lastName).to.eql({type: STRING});
   });
 
   it('adds settings', () => {
@@ -80,12 +73,9 @@ describe('model', () => {
   });
 
   it('lists id properties', () => {
-    expect(customerDef.idProperties()).to.eql([customerDef.properties.id]);
-    expect(userDef.idProperties()).to.eql([userDef.properties.id]);
-    expect(relamCustomerDef.idProperties()).to.eql([
-      relamCustomerDef.properties.realm,
-      relamCustomerDef.properties.email,
-    ]);
+    expect(customerDef.idProperties()).to.eql(['id']);
+    expect(userDef.idProperties()).to.eql(['id']);
+    expect(realmCustomerDef.idProperties()).to.eql(['realm', 'email']);
   });
 
   it('converts to json', () => {

--- a/packages/repository/test/unit/model/model.ts
+++ b/packages/repository/test/unit/model/model.ts
@@ -129,4 +129,13 @@ describe('model', () => {
     });
     expect(where).to.eql({realm: 'org1', email: 'xyz@example.com'});
   });
+
+  it('reports helpful error when getting ids of a model with no ids', () => {
+    class NoId extends Entity {
+      static definition = new ModelDefinition('NoId');
+    }
+
+    const instance = new NoId();
+    expect(() => instance.getId()).to.throw(/missing.*id/);
+  });
 });

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -49,10 +49,13 @@ describe('DefaultCrudRepository', () => {
   let ds: juggler.DataSource;
 
   class Note extends Entity {
-    static definition = new ModelDefinition('note3', {
-      title: 'string',
-      content: 'string',
-      id: {name: 'id', type: 'number', id: true},
+    static definition = new ModelDefinition({
+      name: 'note3',
+      properties: {
+        title: 'string',
+        content: 'string',
+        id: {name: 'id', type: 'number', id: true},
+      },
     });
   }
 


### PR DESCRIPTION
**Fix `DefaultCrudRepository` methods to return expected instances**

Before, the type annotation of DefaultCrudRepository said that CRUD methods are returning Entity instances, but in fact these methods were returning PersistedModel instances.

Note that PersistedModel is inheriting from juggler's ModelBase class, while Entity is inheriting from our new Model base class, and these two inheritance chains never meet.

This commit fixes DefaultCrudRepository to convert internal PersistedModel instances into the correct Entity instances expected by the users of this class.

Under the hood, DefaultCrudRepository was changed to expect the Entity model constructor function in the constructor argument, and build the backing PersistedModel as an internal implementation detail. This is possible thanks to static `definition` property required by
all `Model`/`Entity` classes.

**Decouple Entity/Model definition from datasources**

Before:

In order to define a model, one has to already have the datasource the model will be eventually attached to. This makes dependency injection impossible, because only the datasource used to create the model could be used to build a repository instance for that model.

```ts
/* tslint:disable-next-line:variable-name */
const Note = ds.createModel<typeof juggler.PersistedModel>(
  'note',
  {title: 'string', content: 'string'},
  {},
);
```

Now:

Models are defined independently on backing datasources and repositories, using `class` and `extends` keywords. No magic!

```ts
export class Note extends Entity {
  static definition = new ModelDefinition('note',
    {title: 'string', content: 'string'},
    {});
}
```

**Improve `@model` to build full model definition**

`DefaultCrudRepository` requires Entity-based models to provide their model definition in the static `definition` property. This was not supported by `@model` decorator before.

This commit improves `@model` implementation to build full model definition including properties described via `@property` decorator, and store this full definition in the static `definition` property.

This makes it easy to use `@model`-decorated entities together with `DefaultCrudRepository`

**Simplify the process of defining properties**

Before, a property definition has to contain the property name, despite the fact that the property name is also used as the key in the property-name to property-definition map.

`PropertyDefinition` was defined as a class, which has two problems:
 - juggler supports only plain objects for property definitions
 - users cannot use plain objects to define properties

This commit changes `PropertyDefinition` to a mere interface, removes extraneous `name` property and generally simplifies model definition API to support the syntax we are used to in the existing LB 3.x version.

**Add an acceptance test for Thinking in LoopBack**

This whole effort was driven by an acceptance test to verify that the approach described in Thinking in LoopBack actually works in practice. This test is included to make sure we don't accidentally break in in the future.

---

Connect to #393

Next steps:

 - Update https://github.com/strongloop/loopback-next/wiki/Persisting-Data-with-Repositories
 - Consider moving `examples` to `test/acceptance` and converting them into runnable tests.