### PR TITLE
feat(repository): Introduce Mixin to support repo binding

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -525,6 +525,9 @@ export interface ApplicationOptions {
   http?: HttpConfig;
   components?: Array<Constructor<Component>>;
   sequence?: Constructor<SequenceHandler>;
+
+  // tslint:disable-next-line:no-any
+  [prop: string]: any;
 }
 
 export interface HttpConfig {

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -15,6 +15,7 @@ export interface ProviderMap {
 export interface Component {
   controllers?: Constructor<any>[];
   providers?: ProviderMap;
+  [prop: string]: any;
 }
 
 export function mountComponent(

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -20,6 +20,7 @@
   "author": "IBM",
   "license": "MIT",
   "devDependencies": {
+    "@loopback/core": "^4.0.0-alpha.12",
     "@loopback/testlab": "^4.0.0-alpha.7"
   },
   "dependencies": {

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -19,3 +19,4 @@ export * from './kv-connector';
 export * from './kv-repository';
 export * from './legacy-juggler-bridge';
 export * from './loopback-datasource-juggler';
+export * from './repository-mixin';

--- a/packages/repository/src/repository-mixin.ts
+++ b/packages/repository/src/repository-mixin.ts
@@ -1,0 +1,118 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import { Class } from './common-types';
+import { MixinBuilder } from './mixin';
+import { Repository } from './repository';
+
+// tslint:disable:no-any
+
+/**
+* A mixin class for Application that creates a .repository()
+* function to register a repository automatically. Also overrides
+* component function to allow it to register repositories automatically.
+*
+* ```ts
+*
+* class MyApplication extends RepositoryMixin(Application) {}
+* ```
+*/
+export function RepositoryMixin<T extends Class<any>>(superClass: T) {
+  return class extends superClass {
+    // A mixin class has to take in a type any[] argument!
+    constructor(...args: any[]) {
+      super(...args);
+      if (!this.options) this.options = {};
+
+      if (this.options.repositories) {
+        for (const repo of this.options.repositories) {
+          this.repository(repo);
+        }
+      }
+
+      if (this.options.components) {
+        // Super would have already mounted the component
+        for (const component of this.options.components) {
+          this.mountComponentRepository(component);
+        }
+      }
+    }
+
+    /**
+    * Add a repository to this application.
+    *
+    * @param repo The repository to add.
+    *
+    * ```ts
+    *
+    * class NoteRepo {
+    *   model: any;
+    *
+    *   constructor() {
+    *     const ds: juggler.DataSource = new DataSourceConstructor({
+    *       name: 'db',
+    *       connector: 'memory',
+    *     });
+    *
+    *     this.model = ds.createModel(
+    *       'note',
+    *       {title: 'string', content: 'string'},
+    *       {}
+    *     );
+    *   }
+    * };
+    *
+    * app.repository(NoteRepo);
+    * ```
+    */
+    repository(repo: Class<Repository<any>>) {
+      const repoKey = `repositories.${repo.name}`;
+      this.bind(repoKey).toClass(repo);
+    }
+
+    /**
+    * Add a component to this application. Also mounts
+    * all the components repositories.
+    *
+    * @param component The component to add.
+    *
+    * ```ts
+    *
+    * export class ProductComponent {
+    *   controllers = [ProductController];
+    *   repositories = [ProductRepo, UserRepo];
+    *   providers = {
+    *     [AUTHENTICATION_STRATEGY]: AuthStrategy,
+    *     [AUTHORIZATION_ROLE]: Role,
+    *   };
+    * };
+    *
+    * app.component(ProductComponent);
+    * ```
+    */
+    public component(component: Class<any>) {
+      super.component(component);
+      this.mountComponentRepository(component);
+    }
+
+    /**
+    * Get an instance of a component and mount all it's
+    * repositories. This function is intended to be used internally
+    * by component()
+    *
+    * @param component The component to mount repositories of
+    */
+    mountComponentRepository(component: Class<any>) {
+      const componentKey = `components.${component.name}`;
+      const compInstance = this.getSync(componentKey);
+
+      if (compInstance.repositories) {
+        for (const repo of compInstance.repositories) {
+          this.repository(repo);
+        }
+      }
+    }
+  };
+}

--- a/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
+++ b/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
@@ -1,0 +1,114 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  RepositoryMixin,
+  juggler,
+  DataSourceConstructor,
+  Class,
+} from '../../../';
+import {Application, Component} from '@loopback/core';
+
+// tslint:disable:no-any
+
+describe('RepositoryMixin', () => {
+  it('mixed class has .repository()', () => {
+    const myApp = new AppWithRepoMixin();
+    expect(typeof myApp.repository).to.be.eql('function');
+  });
+
+  it('binds repository from constructor', () => {
+    const myApp = new AppWithRepoMixin({
+      repositories: [NoteRepo],
+    });
+
+    expectNoteRepoToBeBound(myApp);
+  });
+
+  it('binds repository from app.repository()', () => {
+    const myApp = new AppWithRepoMixin();
+
+    expectNoteRepoToNotBeBound(myApp);
+    myApp.repository(NoteRepo);
+    expectNoteRepoToBeBound(myApp);
+  });
+
+  it('binds user defined component without repository', () => {
+    class EmptyTestComponent {}
+
+    const myApp = new AppWithRepoMixin({
+      components: [EmptyTestComponent],
+    });
+
+    expectComponentToBeBound(myApp, EmptyTestComponent);
+  });
+
+  it('binds user defined component with repository in constructor', () => {
+    const myApp = new AppWithRepoMixin({
+      components: [TestComponent],
+    });
+
+    expectNoteRepoToBeBound(myApp);
+  });
+
+  it('binds user defined component with repository from .component()', () => {
+    const myApp = new AppWithRepoMixin();
+
+    const boundComponentsBefore = myApp.find('components.*').map(b => b.key);
+    expect(boundComponentsBefore).to.be.empty();
+    expectNoteRepoToNotBeBound(myApp);
+
+    myApp.component(TestComponent);
+
+    expectComponentToBeBound(myApp, TestComponent);
+    expectNoteRepoToBeBound(myApp);
+  });
+
+  class AppWithRepoMixin extends RepositoryMixin(Application) {}
+
+  class NoteRepo {
+    model: any;
+
+    constructor() {
+      const ds: juggler.DataSource = new DataSourceConstructor({
+        name: 'db',
+        connector: 'memory',
+      });
+
+      this.model = ds.createModel(
+        'note',
+        {title: 'string', content: 'string'},
+        {},
+      );
+    }
+  }
+
+  class TestComponent {
+    repositories = [NoteRepo];
+  }
+
+  function expectNoteRepoToBeBound(myApp: Application) {
+    const boundRepositories = myApp.find('repositories.*').map(b => b.key);
+    expect(boundRepositories).to.containEql('repositories.NoteRepo');
+    const repoInstance = myApp.getSync('repositories.NoteRepo');
+    expect(repoInstance).to.be.instanceOf(NoteRepo);
+  }
+
+  function expectNoteRepoToNotBeBound(myApp: Application) {
+    const boundRepos = myApp.find('repositories.*').map(b => b.key);
+    expect(boundRepos).to.be.empty();
+  }
+
+  function expectComponentToBeBound(
+    myApp: Application,
+    component: Class<Component>,
+  ) {
+    const boundComponents = myApp.find('components.*').map(b => b.key);
+    expect(boundComponents).to.containEql(`components.${component.name}`);
+    const componentInstance = myApp.getSync(`components.${component.name}`);
+    expect(componentInstance).to.be.instanceOf(component);
+  }
+});


### PR DESCRIPTION
Adds a mixin to allow a user to bind a repository using app.repository(). Also automatically binds repositories passed into a constructor and binds any repositories exported by any components that are registered with the application. 

Connect to #425 