### PR TITLE
fix(repository): correct types in juggler bridge

### DIFF
--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -98,7 +98,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
       properties[p] = Object.assign({}, definition.properties[p]);
     }
 
-    this.modelClass = dataSource.createModel(
+    this.modelClass = dataSource.createModel<typeof juggler.PersistedModel>(
       definition.name,
       properties,
       definition.settings,


### PR DESCRIPTION
Fix the following problem reported by `npm pack`:

Error: packages/repository/src/legacy-juggler-bridge.ts(100)
  Type 'typeof ModelBase' is not assignable to
  type 'typeof PersistedModel'.
  Property 'create' is missing in type 'typeof ModelBase'.

I think the problem  was introduced by mine #539.