### PR TITLE
Adding conventional commit linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,13 @@ before_script:
 
 after_success:
   - npm run coverage:ci
+
+jobs:
+  include:
+    - stage: commit linting
+      before_install: git fetch --unshallow
+      before_script: skip
+      script: /bin/bash ./bin/lint-commits.sh
+      after_success: skip
+      node_js:
+        - "8"

--- a/bin/lint-commits.sh
+++ b/bin/lint-commits.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+set -u
+
+if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
+	# This is a Pull Request from a different slug, hence a forked repository
+	git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
+	git fetch "$TRAVIS_PULL_REQUEST_SLUG"
+
+	# Use the fetched remote pointing to the source clone for comparison
+	TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
+else
+	# This is a Pull Request from the same remote, no clone repository
+	TO=$TRAVIS_COMMIT
+fi
+
+# Lint all commits in the PR
+# - Covers fork pull requests (when TO=slug/branch)
+# - Covers branch pull requests (when TO=branch)
+./node_modules/.bin/commitlint --from="$TRAVIS_BRANCH" --to="$TO"
+
+# Always lint the triggering commit
+# - Covers direct commits
+./node_modules/.bin/commitlint --from="$TRAVIS_COMMIT"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = {
+  extends: [
+    '@commitlint/config-angular',
+    '@commitlint/config-lerna-scopes'
+  ],
+  rules: {
+    'header-max-length': [2, 'always', 100],
+    'footer-max-length': [2, 'always', 100],
+    'body-tense': [2, 'always', ['present-imperative']],
+    'footer-tense': [2, 'always', ['present-imperative']],
+    'subject-tense': [2, 'always', ['present-imperative']],
+    'lang': [0, 'always', 'eng'],
+    'body-leading-blank': [2, 'always'],
+    'footer-leading-blank': [2, 'always'],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
     "@types/node": "^8.0.27",
     "@types/request": "^2.0.3",
     "@types/request-promise": "^4.1.37",
+    "@commitlint/cli": "^3.2.0",
+    "@commitlint/config-angular": "^3.1.1",
+    "@commitlint/config-lerna-scopes": "^3.1.1",
     "coveralls": "^2.13.1",
     "lerna": "^2.1.2",
+    "cz-conventional-changelog": "^2.0.0",
     "mocha": "^3.4.0",
     "nyc": "^11.2.1",
     "request": "^2.79.0",
@@ -55,5 +59,10 @@
     "reporter": [
       "html"
     ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
This adds a commit message linter that enforces the conventional commit format that will be our new standard moving forward as it allows us to generate CHANGELOG’s using lerna automatically.

connect to #263 