### PR TITLE
ci: fix commit linter rebase PR git range error

### DIFF
--- a/bin/lint-commits.sh
+++ b/bin/lint-commits.sh
@@ -3,15 +3,20 @@ set -e
 set -u
 
 if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
-	# This is a Pull Request from a different slug, hence a forked repository
-	git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
-	git fetch "$TRAVIS_PULL_REQUEST_SLUG"
+  # This is a Pull Request from a different slug, hence a forked repository
+  git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
+  git fetch "$TRAVIS_PULL_REQUEST_SLUG"
 
-	# Use the fetched remote pointing to the source clone for comparison
-	TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
+  # Use the fetched remote pointing to the source clone for comparison
+  TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
 else
-	# This is a Pull Request from the same remote, no clone repository
-	TO=$TRAVIS_COMMIT
+  # This is a Pull Request from the same remote, no clone repository
+  TO=$TRAVIS_COMMIT
+
+  if [[ $TRAVIS_PULL_REQUEST_SHA != "" && $TRAVIS_PULL_REQUEST_SHA != $TRAVIS_COMMIT ]]; then
+    echo "TO => TRAVIS_PULL_REQUEST_SHA"
+    TO=$TRAVIS_PULL_REQUEST_SHA
+  fi
 fi
 
 echo "TRAVIS_BRANCH => $TRAVIS_BRANCH"


### PR DESCRIPTION
Rebased PR's would often encounter a git range error because travis ENV
set COMMIT SHA to original (before rebase). So this updates it to the
PR SHA.

Example of a failed Travis Build where the $TRAVIS_COMMIT SHA can be seen to be outdated (compared against GitHub) but $TRAVIS_PULL_REQUEST_SHA is correct (again verified in GitHub). This was noticed as a result of the debug info seen in the Commit Linting check now. 

Failed PR: https://travis-ci.org/strongloop/loopback-next/jobs/277095188

Log incase Travis Log disappears:
```
0.93s$ /bin/bash ./bin/lint-commits.sh
TRAVIS_BRANCH => master
TRAVIS_COMMIT => 839f313f632406b140ee86be05f0ee4dac8255c4
TRAVIS_COMMIT_MSG => Merge a12bc147695746493c32af4b15deb14bd1488c70 into ae0bec96a06c98ab8219eb9a0733b3aae38dba0b
TRAVIS_COMMIT_RANGE => ae0bec96a06c98ab8219eb9a0733b3aae38dba0b...a12bc147695746493c32af4b15deb14bd1488c70
TRAVIS_EVENT_TYPE => pull_request
TRAVIS_PULL_REQUEST => 573
TRAVIS_PULL_REQUEST_BRANCH => docs/repository-mixin
TRAVIS_PULL_REQUEST_SHA => a12bc147695746493c32af4b15deb14bd1488c70
TRAVIS_PULL_REQUEST_SLUG => strongloop/loopback-next
TRAVIS_REPO_SLUG => strongloop/loopback-next
/home/travis/build/strongloop/loopback-next/node_modules/@commitlint/cli/cli.js:126
		throw err;
		^
Error: fatal: Invalid revision range master..839f313f632406b140ee86be05f0ee4dac8255c4
    at DestroyableTransform._transform (/home/travis/build/strongloop/loopback-next/node_modules/git-raw-commits/index.js:67:30)
    at DestroyableTransform.Transform._read (/home/travis/build/strongloop/loopback-next/node_modules/readable-stream/lib/_stream_transform.js:182:10)
    at DestroyableTransform.Transform._write (/home/travis/build/strongloop/loopback-next/node_modules/readable-stream/lib/_stream_transform.js:170:83)
    at doWrite (/home/travis/build/strongloop/loopback-next/node_modules/readable-stream/lib/_stream_writable.js:406:64)
    at writeOrBuffer (/home/travis/build/strongloop/loopback-next/node_modules/readable-stream/lib/_stream_writable.js:395:5)
    at DestroyableTransform.Writable.write (/home/travis/build/strongloop/loopback-next/node_modules/readable-stream/lib/_stream_writable.js:322:11)
    at Socket.ondata (_stream_readable.js:642:20)
    at emitOne (events.js:120:20)
    at Socket.emit (events.js:210:7)
    at addChunk (_stream_readable.js:266:12)
The command "/bin/bash ./bin/lint-commits.sh" exited with 1.
Skipping the after_success stage due to the configuration.
Done. Your build exited with 1.
```