### PR TITLE
feat(context): introduce GetValueOptions

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -105,25 +105,6 @@ export class Binding {
     return key;
   }
 
-  /**
-   * Parse a string containing both the binding key and the path to the deeply
-   * nested property to retrieve.
-   *
-   * @param keyWithPath The key with an optional path,
-   *  e.g. "application.instance" or "config#rest.port".
-   */
-  static parseKeyWithPath(keyWithPath: string) {
-    const index = keyWithPath.indexOf(Binding.PROPERTY_SEPARATOR);
-    if (index === -1) {
-      return {key: keyWithPath, path: undefined};
-    }
-
-    return {
-      key: keyWithPath.substr(0, index).trim(),
-      path: keyWithPath.substr(index+1),
-    };
-  }
-
   public readonly key: string;
   public readonly tags: Set<string> = new Set();
   public scope: BindingScope = BindingScope.TRANSIENT;

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -7,6 +7,18 @@ import {Binding, BoundValue, ValueOrPromise} from './binding';
 import {inject} from './inject';
 import {isPromise} from './is-promise';
 
+/**
+ * Options supported by Context#get and Context#getSync methods,
+ * @inject decorator, etc.
+ */
+export interface GetValueOptions {
+  /**
+   * When resolving the bound value, return a (deeply) nested property.
+   * Use dot character to build a deep path, e.g. "rest.port".
+   */
+  property?: string;
+}
+
 export class Context {
   private registry: Map<string, Binding>;
 
@@ -97,9 +109,9 @@ export class Context {
    *   (deeply) nested property to retrieve.
    * @returns A promise of the bound value.
    */
-  get(key: string): Promise<BoundValue> {
+  get(key: string, options?: GetValueOptions): Promise<BoundValue> {
     try {
-      return Promise.resolve(this.getValueOrPromise(key));
+      return Promise.resolve(this.getValueOrPromise(key, options));
     } catch (err) {
       return Promise.reject(err);
     }
@@ -127,8 +139,8 @@ export class Context {
    *   (deeply) nested property to retrieve.
    * @returns A promise of the bound value.
    */
-  getSync(key: string): BoundValue {
-    const valueOrPromise = this.getValueOrPromise(key);
+  getSync(key: string, options?: GetValueOptions): BoundValue {
+    const valueOrPromise = this.getValueOrPromise(key, options);
 
     if (isPromise(valueOrPromise)) {
       throw new Error(
@@ -178,8 +190,11 @@ export class Context {
    *   on how the binding was configured.
    * @internal
    */
-  getValueOrPromise(keyWithPath: string): ValueOrPromise<BoundValue> {
-    const {key, path} = Binding.parseKeyWithPath(keyWithPath);
+  getValueOrPromise(
+    key: string,
+    options?: GetValueOptions,
+  ): ValueOrPromise<BoundValue> {
+    const path = options && options.property;
     const boundValue = this.getBinding(key).getValue(this);
     if (path === undefined || path === '') {
       return boundValue;

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import {Reflector} from './reflect';
 import {BoundValue, ValueOrPromise} from './binding';
-import {Context} from './context';
+import {Context, GetValueOptions} from './context';
 
 const PARAMETERS_KEY = 'inject:parameters';
 const PROPERTIES_KEY = 'inject:properties';
@@ -18,13 +18,29 @@ export interface ResolverFunction {
   (ctx: Context, injection: Injection): ValueOrPromise<BoundValue>;
 }
 
+export type InjectMetadata = GetValueOptions & {
+  [attribute: string]: BoundValue;
+};
+
 /**
  * Descriptor for an injection point
  */
 export interface Injection {
-  bindingKey: string; // Binding key
-  metadata?: {[attribute: string]: BoundValue}; // Related metadata
-  resolve?: ResolverFunction; // A custom resolve function
+  /**
+   * The binding key to use.
+   */
+  bindingKey: string;
+
+  /**
+   * Metadata to customize resolution of this dependency.
+   */
+  metadata?: InjectMetadata;
+
+  /**
+   * A custom resolver function that should be used instead of the built-in
+   * resolver provided by the framework.
+   */
+  resolve?: ResolverFunction;
 }
 
 /**
@@ -55,7 +71,7 @@ export interface Injection {
  */
 export function inject(
   bindingKey: string,
-  metadata?: Object,
+  metadata?: InjectMetadata,
   resolve?: ResolverFunction,
 ) {
   return function markParameterOrPropertyAsInjected(

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -75,7 +75,7 @@ function resolve<T>(ctx: Context, injection: Injection): ValueOrPromise<T> {
     return injection.resolve(ctx, injection);
   }
   // Default to resolve the value from the context by binding key
-  return ctx.getValueOrPromise(injection.bindingKey);
+  return ctx.getValueOrPromise(injection.bindingKey, injection.metadata);
 }
 
 /**

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -174,7 +174,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
   it('injects a nested property', async () => {
     class TestComponent {
       constructor(
-        @inject('config#test')
+        @inject('config', {property: 'test'})
         public config: string,
       ) {}
     }

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -102,11 +102,10 @@ describe('Context', () => {
       expect(result).to.equal('bar');
     });
 
-    it('returns the value with property separator', () => {
-      const SEP = Binding.PROPERTY_SEPARATOR;
+    it('returns a nested property of the value', () => {
       const val = {x: {y: 'Y'}};
       ctx.bind('foo').to(val);
-      const value = ctx.getSync(`foo${SEP}x`);
+      const value = ctx.getSync('foo', {property: 'x'});
       expect(value).to.eql({y: 'Y'});
     });
 
@@ -205,11 +204,10 @@ describe('Context', () => {
       expect(result).to.equal('bar');
     });
 
-    it('returns the value with property separator', async () => {
-      const SEP = Binding.PROPERTY_SEPARATOR;
+    it('returns a nested property of the value', async () => {
       const val = {x: {y: 'Y'}};
       ctx.bind('foo').to(Promise.resolve(val));
-      const value = await ctx.get(`foo${SEP}x`);
+      const value = await ctx.get('foo', {property: 'x'});
       expect(value).to.eql({y: 'Y'});
     });
 
@@ -293,25 +291,25 @@ describe('Context', () => {
 
     it('returns nested property (synchronously)', () => {
       ctx.bind('key').to({test: 'test-value'});
-      const value = ctx.getValueOrPromise('key#test');
+      const value = ctx.getValueOrPromise('key', {property: 'test'});
       expect(value).to.equal('test-value');
     });
 
     it('returns nested property (asynchronously)', async () => {
       ctx.bind('key').to(Promise.resolve({test: 'test-value'}));
-      const value = await ctx.getValueOrPromise('key#test');
+      const value = await ctx.getValueOrPromise('key', {property: 'test'});
       expect(value).to.equal('test-value');
     });
 
     it('supports deeply nested property path', () => {
       ctx.bind('key').to({x: {y: 'z'}});
-      const value = ctx.getValueOrPromise('key#x.y');
+      const value = ctx.getValueOrPromise('key', {property: 'x.y'});
       expect(value).to.equal('z');
     });
 
     it('returns undefined when nested property does not exist', () => {
       ctx.bind('key').to({test: 'test-value'});
-      const value = ctx.getValueOrPromise('key#x.y');
+      const value = ctx.getValueOrPromise('key', {property: 'x.y'});
       expect(value).to.equal(undefined);
     });
 
@@ -325,11 +323,11 @@ describe('Context', () => {
         })
         .inScope(BindingScope.TRANSIENT);
       // verify the initial state & populate the cache
-      expect(ctx.getSync('state')).to.deepEqual({count: 1});
+      expect(ctx.getValueOrPromise('state')).to.deepEqual({count: 1});
       // retrieve a nested property (expect a new value)
-      expect(ctx.getSync('state#count')).to.equal(2);
+      expect(ctx.getValueOrPromise('state', {property: 'count'})).to.equal(2);
       // retrieve the full object again (expect another new value)
-      expect(ctx.getSync('state')).to.deepEqual({count: 3});
+      expect(ctx.getValueOrPromise('state')).to.deepEqual({count: 3});
     });
 
     it('honours CONTEXT scope when retrieving a nested property', () => {
@@ -342,11 +340,11 @@ describe('Context', () => {
         })
         .inScope(BindingScope.CONTEXT);
       // verify the initial state & populate the cache
-      expect(ctx.getSync('state')).to.deepEqual({count: 1});
+      expect(ctx.getValueOrPromise('state')).to.deepEqual({count: 1});
       // retrieve a nested property (expect the cached value)
-      expect(ctx.getSync('state#count')).to.equal(1);
+      expect(ctx.getValueOrPromise('state', {property: 'count'})).to.equal(1);
       // retrieve the full object again (verify that cache was not modified)
-      expect(ctx.getSync('state')).to.deepEqual({count: 1});
+      expect(ctx.getValueOrPromise('state')).to.deepEqual({count: 1});
     });
 
     it('honours SINGLETON scope when retrieving a nested property', () => {
@@ -360,18 +358,22 @@ describe('Context', () => {
         .inScope(BindingScope.SINGLETON);
 
       // verify the initial state & populate the cache
-      expect(ctx.getSync('state')).to.deepEqual({count: 1});
+      expect(ctx.getValueOrPromise('state')).to.deepEqual({count: 1});
 
       // retrieve a nested property from a child context
       const childContext1 = new Context(ctx);
-      expect(childContext1.getValueOrPromise('state#count')).to.equal(1);
+      expect(
+        childContext1.getValueOrPromise('state', {property: 'count'}),
+      ).to.equal(1);
 
       // retrieve a nested property from another child context
       const childContext2 = new Context(ctx);
-      expect(childContext2.getValueOrPromise('state#count')).to.equal(1);
+      expect(
+        childContext2.getValueOrPromise('state', {property: 'count'}),
+      ).to.equal(1);
 
       // retrieve the full object again (verify that cache was not modified)
-      expect(ctx.getSync('state')).to.deepEqual({count: 1});
+      expect(ctx.getValueOrPromise('state')).to.deepEqual({count: 1});
     });
   });
 


### PR DESCRIPTION
Introduce a second optional parameter of getter methods in Context class. Modify `@inject` to accept GetValueOptions as part of the second "metadata" argument. Modify `resolve` to pass `@inject` metadata to the context getter method.

With this foundation in place, rework the way how nested properties are retrieved: drop support for string-encoded "key#path" pair, use a new option "property" instead.

**BREAKING CHANGE**

Injection keys using "#" to build a key+path pair are no longer supported. The property path should be specified via the new options argument.

Before:

```ts
const port = ctx.getSync('config#rest.port');
@inject('config#rest.port')
```

Now:

```ts
const port = ctx.getSync('config', {property: 'rest.port'});
@inject('config', {property: 'rest.port'});
```

See https://github.com/strongloop/loopback-next/pull/587#issuecomment-332190574 for background context.

Other related issues/pull requests: #576, #377 and #587.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
