### PR TITLE
refactor(core): Component servers are now key-value pairs

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -14,7 +14,9 @@ export interface Component {
   // tslint:disable-next-line:no-any
   controllers?: Constructor<any>[];
   providers?: ProviderMap;
-  servers?: Constructor<Server>[];
+  servers?: {
+    [name: string]: Constructor<Server>;
+  };
 
   // tslint:disable-next-line:no-any
   [prop: string]: any;
@@ -41,8 +43,8 @@ export function mountComponent(app: Application, component: Component) {
   }
 
   if (component.servers) {
-    for (const server of component.servers) {
-      app.server(server);
+    for (const serverKey in component.servers) {
+      app.server(component.servers[serverKey], serverKey);
     }
   }
 }

--- a/packages/core/test/unit/application.test.ts
+++ b/packages/core/test/unit/application.test.ts
@@ -65,9 +65,14 @@ describe('Application', () => {
 });
 
 class FakeComponent implements Component {
-  servers: Constructor<Server>[] = [];
+  servers: {
+    [name: string]: Constructor<Server>;
+  };
   constructor() {
-    this.servers.push(FakeServer);
+    this.servers = {
+      FakeServer,
+      FakeServer2: FakeServer,
+    };
   }
 }
 

--- a/packages/rest/src/rest-component.ts
+++ b/packages/rest/src/rest-component.ts
@@ -43,13 +43,18 @@ export class RestComponent implements Component {
     [RestBindings.SequenceActions.PARSE_PARAMS]: ParseParamsProvider,
     [RestBindings.SequenceActions.SEND]: SendProvider,
   };
-  servers: Constructor<Server>[] = [];
+  servers: {
+    [name: string]: Constructor<Server>;
+  };
+
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) app: Application,
     @inject(RestBindings.CONFIG) config?: RestComponentConfig,
   ) {
     if (!config) config = {};
-    this.servers.push(RestServer);
+    this.servers = {
+      RestServer: RestServer,
+    };
   }
 }
 


### PR DESCRIPTION
### Description
BREAKING CHANGE: Components whose servers were originally in an array called "servers" must now provide key-value pairs in an object called "servers".




#### Related issues
#567

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
