### PR TITLE
refactor(rest): Index rest config with hash

### DIFF
--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -7,7 +7,7 @@ import {CoreBindings} from '@loopback/core';
 
 export namespace RestBindings {
   // RestServer-specific bindings
-  export const CONFIG = 'rest.config';
+  export const CONFIG = `${CoreBindings.APPLICATION_CONFIG}#rest`;
   export const PORT = 'rest.port';
   export const HANDLER = 'rest.handler';
 

--- a/packages/rest/src/rest-component.ts
+++ b/packages/rest/src/rest-component.ts
@@ -46,23 +46,11 @@ export class RestComponent implements Component {
   servers: Constructor<Server>[] = [];
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) app: Application,
-    @inject(CoreBindings.APPLICATION_CONFIG, undefined, getRestConfig)
-    config?: RestComponentConfig,
+    @inject(RestBindings.CONFIG) config?: RestComponentConfig,
   ) {
     if (!config) config = {};
-    app.bind(RestBindings.CONFIG).to(config);
     this.servers.push(RestServer);
   }
-}
-
-function getRestConfig(
-  ctx: Context,
-  injection: Injection,
-): ValueOrPromise<BoundValue> {
-  // FIXME(kevin): This is a workaround for the hash (#) keyed property
-  // resolving not working!
-  const conf = ctx.getSync(injection.bindingKey) as ApplicationConfig;
-  return conf.rest || {};
 }
 
 export interface RestComponentConfig extends RestServerConfig {


### PR DESCRIPTION
### Description
Remove the workaround for retrieving "rest" config options and instead use the original hash-based property retrieval.

#### Related issues
#567 
### Checklist
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
