### PR TITLE
fix(rest): Move server instantiation to class definition

### DIFF
--- a/packages/rest/src/rest-component.ts
+++ b/packages/rest/src/rest-component.ts
@@ -10,10 +10,7 @@ import {
   Server,
   Application,
 } from '@loopback/core';
-import {
-  inject,
-  Constructor,
-} from '@loopback/context';
+import {inject, Constructor} from '@loopback/context';
 import {RestBindings} from './keys';
 import {LogErrorProvider} from './providers';
 import {
@@ -40,6 +37,8 @@ export class RestComponent implements Component {
   };
   servers: {
     [name: string]: Constructor<Server>;
+  } = {
+    RestServer,
   };
 
   constructor(
@@ -47,9 +46,6 @@ export class RestComponent implements Component {
     @inject(RestBindings.CONFIG) config?: RestComponentConfig,
   ) {
     if (!config) config = {};
-    this.servers = {
-      RestServer: RestServer,
-    };
   }
 }
 


### PR DESCRIPTION
### Description
Moving it up to the definition rather than having it in the constructor means that overriding implementations can change which servers to instantiate as a default (or to opt out of doing so entirely!)

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
