### PR TITLE
refactor(core): Allow configuration of multiple identical Server types

### DIFF
--- a/packages/core/test/unit/application.test.ts
+++ b/packages/core/test/unit/application.test.ts
@@ -30,7 +30,9 @@ describe('Application', () => {
       const name = 'abc123';
       const app = new Application({
         servers: {
-          abc123: FakeServer,
+          abc123: {
+            type: FakeServer,
+          },
         },
       });
       const result = await app.getServer(name);

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -3,11 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {CoreBindings} from '@loopback/core';
-
 export namespace RestBindings {
   // RestServer-specific bindings
-  export const CONFIG = `${CoreBindings.APPLICATION_CONFIG}#rest`;
   export const PORT = 'rest.port';
   export const HANDLER = 'rest.handler';
 

--- a/packages/rest/src/rest-component.ts
+++ b/packages/rest/src/rest-component.ts
@@ -43,7 +43,7 @@ export class RestComponent implements Component {
 
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) app: Application,
-    @inject(RestBindings.CONFIG) config?: RestComponentConfig,
+    @inject(CoreBindings.APPLICATION_CONFIG) config?: RestComponentConfig,
   ) {
     if (!config) config = {};
   }

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -78,7 +78,7 @@ export class RestServer extends Context implements Server {
 
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) app: Application,
-    @inject(RestBindings.CONFIG) options?: RestServerConfig,
+    options?: RestServerConfig,
   ) {
     super(app);
 

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -74,7 +74,12 @@ describe('RestServer', () => {
     it('can set port 0', async () => {
       const app = new Application({
         components: [RestComponent],
-        rest: {port: 0},
+        servers: {
+          RestServer: {
+            type: RestServer,
+            port: 0,
+          },
+        },
       });
       const server = await app.getServer(RestServer);
       expect(server.getSync(RestBindings.PORT)).to.equal(0);


### PR DESCRIPTION
### Description

**BREAKING CHANGE**: This will require configuration that uses the
"rest" configuration key to be renamed to match the constructor name
or given name of the registered Server instance.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
