### PR TITLE
build: add "engines" to all "package.json" files

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/authentication",
   "version": "4.0.0-alpha.10",
   "description": "A LoopBack component for authentication support.",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/context",
   "version": "4.0.0-alpha.14",
   "description": "LoopBack's container for Inversion of Control",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/core",
   "version": "4.0.0-alpha.16",
   "description": "",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",

--- a/packages/example-codehub/package.json
+++ b/packages/example-codehub/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/example-codehub",
   "version": "4.0.0-alpha.9",
   "description": "",
+  "engines": {
+    "node": ">=6"
+  },
   "private": true,
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/openapi-spec-builder",
   "version": "4.0.0-alpha.7",
   "description": "Make it easy to create OpenAPI (Swagger) specification documents in your tests using the builder pattern.",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
     "build:current": "node ../../bin/compile-package",

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/openapi-spec",
   "version": "4.0.0-alpha.10",
   "description": "TypeScript type definitions for OpenAPI Spec/Swagger documents.",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
     "build:current": "node ../../bin/compile-package",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/repository",
   "version": "4.0.0-alpha.10",
   "description": "Repository for LoopBack.next",
+  "engines": {
+    "node": ">=6"
+  },
   "main": "index",
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/rest",
   "version": "4.0.0-alpha.3",
   "description": "",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "acceptance": "mocha --opts ../../test/mocha.opts 'test/acceptance/**/*.ts'",
     "build": "npm run build:lib && npm run build:lib6",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -2,6 +2,9 @@
   "name": "@loopback/testlab",
   "version": "4.0.0-alpha.9",
   "description": "A collection of test utilities we use to write LoopBack tests.",
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "build": "npm run build:lib && npm run build:lib6",
     "build:current": "node ../../bin/compile-package",


### PR DESCRIPTION
Add missing `engines` field to specify the minimum supported Node.js version, which is Node.js 6.x