### PR TITLE
build: skip CI of feature branches with an open PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ jobs:
       after_success: skip
       node_js:
         - "8"
+
+branches:
+  only:
+    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,3 +14,4 @@ test_script:
   - npm test
 
 build: off
+skip_branch_with_pr: true


### PR DESCRIPTION
For pull requests sent from a feature branch living in the same
repository, both AppVeyor and Travis CI is running two CI jobs,
which is unnecessarily slowing down our feedback cycle:

 - continuous-integration/appveyor/branch
 - continuous-integration/appveyor/pr

and

 - continuous-integration/travis-ci/pr
 - continuous-integration/travis-ci/push

This commit changes AppVeyor config to skip CI for the branch
and run it for the pull request only.

In order to achieve the same on Travis, we are restricting the branches
built by CI to "master" only. (This means we will need to update Travis
config when forking a long-living "N.x" branch.)st only.

See also https://github.com/appveyor/ci/issues/882 and https://github.com/voxpupuli/modulesync_config/commit/bcccf0035903b35006d0f65af3ac708eaf20f8d6