### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,11 +4,11 @@
 
 # Core team members from IBM
 * @bajtos @raymondfeng
-packages/authentication/* @bajtos
-packages/context/* @bajtos @raymondfeng @superkhau
-packages/core/* @bajtos @superkhau
+packages/authentication/* @bajtos @kjdelisle
+packages/context/* @bajtos @raymondfeng  @kjdelisle
+packages/core/* @bajtos @raymondfeng @kjdelisle
 packages/example-codehub/* @bajtos
 packages/openapi-spec-builder/*  @bajtos
 packages/openapi-spec/*  @bajtos
-packages/repository/* @raymondfeng
-packages/testlab/* @bajtos @rashmihunt
+packages/repository/* @raymondfeng @kjdelisle
+packages/testlab/* @bajtos @kjdelisle


### PR DESCRIPTION
- Remove Rashmi and Simon that are not actively involved with the project at the moment.
- Add Kevin as codeowner of most packages.
- Add Raymond as codeowner to few more packages than before.