### PR TITLE
fix(testlab): Remove start call from createClientForRestServer

### DIFF
--- a/packages/testlab/src/client.ts
+++ b/packages/testlab/src/client.ts
@@ -29,7 +29,6 @@ export function createClientForHandler(
 export async function createClientForRestServer(
   server: RestServer,
 ): Promise<Client> {
-  await server.start();
   const port =
     server.options && server.options.http ? server.options.http.port : 3000;
   const url = `http://127.0.0.1:${port}`;


### PR DESCRIPTION
### Description

This aligns this creation function with requirements for creating
applications in loopback using the rest package. Applications
will start their registered servers, so this function will no
longer do so.

#### Related issues
#613 -- The Testing-Your-Application.md doc will advise a valid design pattern that the current code cannot satisfy, which is what this fix provides.

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
