### PR TITLE
build: fix select-dist to preserve args

### DIFF
--- a/bin/select-dist.js
+++ b/bin/select-dist.js
@@ -37,7 +37,9 @@ console.log(command, args.join(' '));
 
 spawn(
   command,
-  args,
+  // wrap all arguments in double-quotes to prevent Unix shell from
+  // incorrectly resolving '**' as '*'
+  args.map(a => JSON.stringify(a)),
   {
     stdio: 'inherit',
     // On Windows, npm creates `.cmd` files instead of symlinks in


### PR DESCRIPTION
Fix "bin/select-dist.js" used to run Mocha tests to quote all arguments in order to preserve glob patterns like `test/**/*.js` and pass them as-is to Mocha, instead of letting the Unix shell incorrectly expand "**" as "*".

Before this change (but after 3698d76), we were running only tests that are exactly two-levels deep in the `test` directory tree, e.g. `test/acceptance/{name}.js`. With this change in place, we are running tests nested more deeply again, e.g. `test/unit/router/metadata/param-body.test.js`

Thank you @raymondfeng and @kjdelisle for spotting the problem!