### PR TITLE
chore: disable prettier-eslint integration in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,8 +20,6 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
 
-  "prettier.eslintIntegration": true,
-
   "tslint.ignoreDefinitionFiles": true,
   "typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
Disable prettier-eslint integration in order to avoid the following
error:

    ImportDeclaration should appear when the mode is ES6 and in the module context.

See the following two GitHub issues for more details:
 - https://github.com/eslint/eslint/issues/4344
 - https://github.com/eslint/typescript-eslint-parser/issues/117

This change should not have any negative side effects, since we are
not using eslint in this project.

@raymondfeng PTAL