### PR TITLE
build: Upgrade deps and fix coverage inclusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,24 +11,24 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@commitlint/cli": "^3.2.0",
+    "@commitlint/cli": "^4.1.0",
     "@commitlint/config-angular": "^3.1.1",
-    "@commitlint/config-lerna-scopes": "^3.1.1",
-    "@types/mocha": "^2.2.42",
-    "@types/node": "^8.0.27",
-    "@types/request": "^2.0.3",
-    "@types/request-promise": "^4.1.37",
-    "coveralls": "^2.13.1",
+    "@commitlint/config-lerna-scopes": "^4.1.1",
+    "@types/mocha": "^2.2.43",
+    "@types/node": "^8.0.32",
+    "@types/request": "^2.0.4",
+    "@types/request-promise": "^4.1.38",
+    "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.0.0",
-    "lerna": "^2.1.2",
-    "mocha": "^3.4.0",
+    "lerna": "^2.4.0",
+    "mocha": "^4.0.0",
     "nyc": "^11.2.1",
     "prettier": "^1.7.3",
-    "request": "^2.79.0",
-    "request-promise": "^4.1.1",
+    "request": "^2.83.0",
+    "request-promise": "^4.2.2",
     "strong-docs": "^1.4.0",
     "tslint": "^5.7.0",
-    "typescript": "^2.5.2"
+    "typescript": "^2.5.3"
   },
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",
@@ -47,13 +47,13 @@
     "build:current": "lerna run --loglevel=silent build:current",
     "pretest": "npm run build:current",
     "test": "nyc npm run mocha",
-    "mocha": "node bin/select-dist mocha --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\"",
+    "mocha": "node bin/select-dist mocha --exit --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\"",
     "posttest": "npm run lint"
   },
   "nyc": {
     "include": [
       "packages/example-codehub/src/**",
-      "packages/*/lib*/*"
+      "packages/*/dist*/*"
     ],
     "exclude": [
       "packages/core/*/promisify.*"


### PR DESCRIPTION
Upgrade to mocha 4.0 (use --exit for backward compatibility for now)
Fix coverage inclusion from lib* to dist*
Upgrade commitlint related deps

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
