### PR TITLE
feat(context): withDependencies binding

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -203,6 +203,27 @@ export class Context {
     }
     return json;
   }
+
+  /**
+   * Whether or not this context instance has a parent context instance.
+   *
+   * @returns {boolean}
+   * @memberof Context
+   */
+  hasParent(): boolean {
+    return !!this._parent;
+  }
+
+  /**
+   * Directly set the parent context of this context.
+   *
+   * @param {Context} ctx
+   * @memberof Context
+   */
+  setParent(ctx: Context) {
+    // FIXME(kev): This is definitely open to circular linking (bad!)
+    this._parent = ctx;
+  }
 }
 
 function getDeepProperty(value: BoundValue, path: string) {

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -9,7 +9,7 @@ import {isPromise} from './is-promise';
 export class Context {
   private registry: Map<string, Binding>;
 
-  constructor(private _parent?: Context) {
+  constructor(protected _parent?: Context) {
     this.registry = new Map();
   }
 
@@ -221,8 +221,26 @@ export class Context {
    * @memberof Context
    */
   setParent(ctx: Context) {
-    // FIXME(kev): This is definitely open to circular linking (bad!)
+    const circular = 'circular parent reference detected';
+    if (this === ctx) {
+      throw new Error(circular);
+    }
+    const currentParent = this._parent;
+    let parent = ctx._parent;
+    // For now, set the parent.
     this._parent = ctx;
+    // Ensure that this instance is not the parent/grandparent/etc of ctx.
+    while (parent) {
+      if (parent === ctx) {
+        this._parent = currentParent; // Restore the previous parent (if any);
+        throw new Error(circular);
+      }
+      if (parent._parent) {
+        parent = parent._parent;
+      } else {
+        parent = undefined;
+      }
+    }
   }
 }
 

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -186,26 +186,26 @@ describe('Binding', () => {
       const product1 = (await ctx.get(key)) as FakeProduct;
       const product2 = (await ctx.get(otherKey)) as FakeProduct;
 
-      function checkConfig(prod: FakeProduct, expected: string) {
-        expect(prod).to.not.be.null();
-        expect(prod.config).to.not.be.null();
-        expect(prod.config.foo).to.equal(expected);
-      }
-
       // Check in reverse order (in case the 2nd binding is masking the 1st)
       checkConfig(product2, 'baz');
       checkConfig(product1, 'bar');
     });
-
-    class FakeProduct {
-      // tslint:disable-next-line:no-any
-      constructor(@inject('config') public config: any) {}
-    }
   });
 
   function givenBinding() {
     ctx = new Context();
     binding = new Binding(key);
+  }
+
+  class FakeProduct {
+    // tslint:disable-next-line:no-any
+    constructor(@inject('config') public config: any) {}
+  }
+
+  function checkConfig(prod: FakeProduct, expected: string) {
+    expect(prod).to.not.be.null();
+    expect(prod.config).to.not.be.null();
+    expect(prod.config.foo).to.equal(expected);
   }
 
   class MyProvider implements Provider<string> {

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -162,6 +162,47 @@ describe('Binding', () => {
     });
   });
 
+  describe('options(Dependencies))', () => {
+    it('binds dependencies without overlap', async () => {
+      const otherKey = 'bar';
+      ctx
+        .bind(key)
+        .toClass(FakeProduct)
+        .options({
+          config: {
+            foo: 'bar',
+          },
+        });
+
+      ctx
+        .bind(otherKey)
+        .toClass(FakeProduct)
+        .options({
+          config: {
+            foo: 'baz',
+          },
+        });
+
+      const product1 = (await ctx.get(key)) as FakeProduct;
+      const product2 = (await ctx.get(otherKey)) as FakeProduct;
+
+      function checkConfig(prod: FakeProduct, expected: string) {
+        expect(prod).to.not.be.null();
+        expect(prod.config).to.not.be.null();
+        expect(prod.config.foo).to.equal(expected);
+      }
+
+      // Check in reverse order (in case the 2nd binding is masking the 1st)
+      checkConfig(product2, 'baz');
+      checkConfig(product1, 'bar');
+    });
+
+    class FakeProduct {
+      // tslint:disable-next-line:no-any
+      constructor(@inject('config') public config: any) {}
+    }
+  });
+
   function givenBinding() {
     ctx = new Context();
     binding = new Binding(key);

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -375,6 +375,51 @@ describe('Context', () => {
     });
   });
 
+  describe('getParent', () => {
+    it('links parent to child', () => {
+      const parent = new TestContext();
+      const child = new TestContext();
+      child.setParent(parent);
+
+      expect(child.getParent()).to.equal(parent);
+    });
+
+    it('throws on self-linking', () => {
+      const context = new Context();
+      expect.throws(() => {
+        context.setParent(context);
+      });
+      expect(context.hasParent()).to.be.false();
+    });
+
+    it('throws on circular linking', () => {
+      const grandparent = new TestContext();
+      grandparent.name = 'grandma';
+      const parent = new TestContext();
+      parent.setParent(grandparent);
+      parent.name = 'mom';
+      const child = new TestContext();
+      child.name = 'daughter';
+      child.setParent(parent);
+      expect.throws(() => {
+        grandparent.setParent(child);
+      });
+      expect(grandparent.hasParent()).to.be.false();
+    });
+
+    /**
+     * Custom extension to allow retrieval of parent for testing.
+     * @class TestContext
+     * @extends {Context}
+     */
+    class TestContext extends Context {
+      public name: string;
+      getParent() {
+        return this._parent;
+      }
+    }
+  });
+
   describe('toJSON()', () => {
     it('converts to plain JSON object', () => {
       ctx


### PR DESCRIPTION
withDependencies allows you to create multiple bindings that resolve
different values for the same injection key(s).

```ts
// in your application
app.bind('foo').toClass(Magician).withDependencies({ alignment: 'good' });
app.bind('bar').toClass(Magician).withDependencies({ alignment: 'evil' });

// magician.ts
class Magician {
  constructor(@inject('alignment') public alignment: string) {
    // The 'foo' version will have a 'good' alignment.
    // The 'bar' version will have a 'bad' alignment.

  }
}
```

### Description


#### Related issues

connect to https://github.com/strongloop/loopback-next/issues/543

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
