### PR TITLE
[WIP] feat(core): Add support for extension point/extension pattern on top of Context

### DIFF
--- a/packages/authentication/src/authentication.ts
+++ b/packages/authentication/src/authentication.ts
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/authentication
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ParsedRequest} from '@loopback/rest';
+
+/**
+ * interface definition of a function which accepts a request
+ * and returns an authenticated user
+ */
+export interface AuthenticateFn {
+  (request: ParsedRequest): Promise<UserProfile | undefined>;
+}
+
+/**
+ * interface definition of a user profile
+ * http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+ */
+export interface UserProfile {
+  id: string;
+  name?: string;
+  email?: string;
+}
+
+/**
+ * Authentication metadata stored via Reflection API
+ */
+export interface AuthenticationMetadata {
+  /**
+   * Name of the authentication strategy
+   */
+  strategy: string;
+  /**
+   * Options for authentication
+   */
+  options?: Object;
+}
+
+/**
+ * Interface for authentication providers
+ */
+export interface Authenticator {
+  /**
+   * Check if the given strategy is supported by the authenticator
+   * @param stragety Name of the authentication strategy
+   */
+  isSupported(strategy: string): boolean;
+
+  /**
+   * Authenticate a request with given options
+   * @param request HTTP request
+   * @param metadata Authentication metadata
+   */
+  authenticate(
+    request: ParsedRequest,
+    metadata?: AuthenticationMetadata,
+  ): Promise<UserProfile | undefined>;
+}
+
+/**
+ * Passport monkey-patches Node.js' IncomingMessage prototype
+ * and adds extra methods like "login" and "isAuthenticated"
+ */
+export type PassportRequest = ParsedRequest & Express.Request;

--- a/packages/authentication/src/decorators/authenticate.decorator.ts
+++ b/packages/authentication/src/decorators/authenticate.decorator.ts
@@ -9,14 +9,7 @@ import {
   MethodDecoratorFactory,
 } from '@loopback/context';
 import {AUTHENTICATION_METADATA_KEY} from '../keys';
-
-/**
- * Authentication metadata stored via Reflection API
- */
-export interface AuthenticationMetadata {
-  strategy: string;
-  options?: Object;
-}
+import {AuthenticationMetadata} from '../authentication';
 
 /**
  * Mark a controller method as requiring authenticated user.

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -3,8 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+export * from './authentication';
 export * from './authentication.component';
-export * from './decorators';
+export * from './decorators/authenticate.decorator';
 export * from './keys';
 export * from './strategy-adapter';
 

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -4,8 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Strategy} from 'passport';
-import {AuthenticateFn, UserProfile} from './providers/authentication.provider';
-import {AuthenticationMetadata} from './decorators/authenticate.decorator';
+import {
+  AuthenticateFn,
+  UserProfile,
+  AuthenticationMetadata,
+} from './authentication';
 import {BindingKey, MetadataAccessor} from '@loopback/context';
 
 /**

--- a/packages/authentication/src/providers/auth-extension-point.ts
+++ b/packages/authentication/src/providers/auth-extension-point.ts
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/authentication
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ExtensionPoint, Context} from '@loopback/core';
+import {ParsedRequest} from '@loopback/rest';
+import {
+  UserProfile,
+  AuthenticationMetadata,
+  Authenticator,
+} from '../authentication';
+import {AuthenticationBindings} from '../keys';
+
+export class AuthenticationExtensionPoint extends ExtensionPoint<
+  Authenticator
+> {
+  static extensionPointName = 'authenticators';
+
+  async authenticate(
+    ctx: Context,
+    request: ParsedRequest,
+  ): Promise<UserProfile | undefined> {
+    const meta: AuthenticationMetadata | undefined = await ctx.get(
+      AuthenticationBindings.METADATA,
+    );
+    if (meta == undefined) {
+      return undefined;
+    }
+    const authenticators = await this.getAllExtensions(ctx);
+    let user: UserProfile | undefined = undefined;
+    for (const authenticator of authenticators) {
+      if (authenticator.isSupported(meta.strategy)) {
+        user = await authenticator.authenticate(request, meta);
+        if (user === undefined) continue;
+      }
+    }
+    return user;
+  }
+}

--- a/packages/authentication/src/providers/auth-metadata.provider.ts
+++ b/packages/authentication/src/providers/auth-metadata.provider.ts
@@ -5,10 +5,8 @@
 
 import {CoreBindings} from '@loopback/core';
 import {Constructor, Provider, inject} from '@loopback/context';
-import {
-  AuthenticationMetadata,
-  getAuthenticateMetadata,
-} from '../decorators/authenticate.decorator';
+import {getAuthenticateMetadata} from '../decorators/authenticate.decorator';
+import {AuthenticationMetadata} from '../authentication';
 
 /**
  * @description Provides authentication metadata of a controller method

--- a/packages/authentication/src/providers/authentication.provider.ts
+++ b/packages/authentication/src/providers/authentication.provider.ts
@@ -9,30 +9,7 @@ import {Provider, Getter, Setter} from '@loopback/context';
 import {Strategy} from 'passport';
 import {StrategyAdapter} from '../strategy-adapter';
 import {AuthenticationBindings} from '../keys';
-
-/**
- * Passport monkey-patches Node.js' IncomingMessage prototype
- * and adds extra methods like "login" and "isAuthenticated"
- */
-export type PassportRequest = ParsedRequest & Express.Request;
-
-/**
- * interface definition of a function which accepts a request
- * and returns an authenticated user
- */
-export interface AuthenticateFn {
-  (request: ParsedRequest): Promise<UserProfile | undefined>;
-}
-
-/**
- * interface definition of a user profile
- * http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
- */
-export interface UserProfile {
-  id: string;
-  name?: string;
-  email?: string;
-}
+import {AuthenticateFn, UserProfile} from '../authentication';
 
 /**
  * @description Provider of a function which authenticates

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -104,8 +104,19 @@ export class BindingKey<ValueType> {
     );
   }
 
-  static CONFIG_KEY = '$config';
-  static buildKeyForConfig(key?: string) {
-    return key ? `${key}:${BindingKey.CONFIG_KEY}` : BindingKey.CONFIG_KEY;
+  static CONFIG_NAMESPACE = '$config';
+  /**
+   * Build a binding key for the configuration of the given binding and env.
+   * The format is `$config.<env>:<key>`
+   *
+   * @param key The binding key that accepts the configuration
+   * @param env The environment such as `dev`, `test`, and `prod`
+   */
+  static buildKeyForConfig(key: string = '', env: string = '') {
+    const namespace = env
+      ? `${BindingKey.CONFIG_NAMESPACE}.${env}`
+      : BindingKey.CONFIG_NAMESPACE;
+    const bindingKey = key ? `${namespace}${key}` : BindingKey.CONFIG_NAMESPACE;
+    return bindingKey;
   }
 }

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -103,4 +103,9 @@ export class BindingKey<ValueType> {
       keyWithPath.substr(index + 1),
     );
   }
+
+  static OPTIONS_KEY = '$options';
+  static buildKeyForOptions(key?: string) {
+    return key ? `${key}:${BindingKey.OPTIONS_KEY}` : BindingKey.OPTIONS_KEY;
+  }
 }

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -104,8 +104,8 @@ export class BindingKey<ValueType> {
     );
   }
 
-  static OPTIONS_KEY = '$options';
-  static buildKeyForOptions(key?: string) {
-    return key ? `${key}:${BindingKey.OPTIONS_KEY}` : BindingKey.OPTIONS_KEY;
+  static CONFIG_KEY = '$config';
+  static buildKeyForConfig(key?: string) {
+    return key ? `${key}:${BindingKey.CONFIG_KEY}` : BindingKey.CONFIG_KEY;
   }
 }

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -210,11 +210,18 @@ export class Binding<T = BoundValue> {
     );
   }
 
+  /**
+   * Lock the binding so that it cannot be rebound
+   */
   lock(): this {
     this.isLocked = true;
     return this;
   }
 
+  /**
+   * Add a tag to the binding
+   * @param tagName Tag name or an array of tag names
+   */
   tag(tagName: string | string[]): this {
     if (typeof tagName === 'string') {
       this.tags.add(tagName);
@@ -226,6 +233,10 @@ export class Binding<T = BoundValue> {
     return this;
   }
 
+  /**
+   * Set the binding scope
+   * @param scope Binding scope
+   */
   inScope(scope: BindingScope): this {
     this.scope = scope;
     return this;
@@ -357,11 +368,17 @@ export class Binding<T = BoundValue> {
     return this;
   }
 
+  /**
+   * Unlock the binding
+   */
   unlock(): this {
     this.isLocked = false;
     return this;
   }
 
+  /**
+   * Convert to a plain JSON object
+   */
   toJSON(): Object {
     // tslint:disable-next-line:no-any
     const json: {[name: string]: any} = {

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -12,6 +12,7 @@ import {
   isPromiseLike,
   BoundValue,
   ValueOrPromise,
+  resolveValueOrPromise,
 } from './value-promise';
 import {Provider} from './provider';
 
@@ -129,30 +130,16 @@ export class Binding<T = BoundValue> {
   ): ValueOrPromise<T> {
     // Initialize the cache as a weakmap keyed by context
     if (!this._cache) this._cache = new WeakMap<Context, T>();
-    if (isPromiseLike(result)) {
-      if (this.scope === BindingScope.SINGLETON) {
-        // Cache the value at owning context level
-        result = result.then(val => {
-          this._cache.set(ctx.getOwnerContext(this.key)!, val);
-          return val;
-        });
-      } else if (this.scope === BindingScope.CONTEXT) {
-        // Cache the value at the current context
-        result = result.then(val => {
-          this._cache.set(ctx, val);
-          return val;
-        });
-      }
-    } else {
+    return resolveValueOrPromise(result, val => {
       if (this.scope === BindingScope.SINGLETON) {
         // Cache the value
-        this._cache.set(ctx.getOwnerContext(this.key)!, result);
+        this._cache.set(ctx.getOwnerContext(this.key)!, val);
       } else if (this.scope === BindingScope.CONTEXT) {
         // Cache the value at the current context
-        this._cache.set(ctx, result);
+        this._cache.set(ctx, val);
       }
-    }
-    return result;
+      return val;
+    });
   }
 
   /**
@@ -169,7 +156,7 @@ export class Binding<T = BoundValue> {
    *
    * ```
    * const result = binding.getValue(ctx);
-   * if (isPromise(result)) {
+   * if (isPromiseLike(result)) {
    *   result.then(doSomething)
    * } else {
    *   doSomething(result);
@@ -341,11 +328,7 @@ export class Binding<T = BoundValue> {
         ctx!,
         session,
       );
-      if (isPromiseLike(providerOrPromise)) {
-        return providerOrPromise.then(p => p.value());
-      } else {
-        return providerOrPromise.value();
-      }
+      return resolveValueOrPromise(providerOrPromise, p => p.value());
     };
     return this;
   }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -105,11 +105,11 @@ export class Context {
    * - optional: if not set or set to `true`, `undefined` will be returned if
    * no corresponding value is found. Otherwise, an error will be thrown.
    */
-  getConfigAsValueOrPromise(
+  getConfigAsValueOrPromise<T>(
     key: string,
     configPath?: string,
     resolutionOptions?: ResolutionOptions,
-  ): ValueOrPromise<BoundValue> {
+  ): ValueOrPromise<T | undefined> {
     configPath = configPath || '';
     const configKeyAndPath = BindingKey.create(
       BindingKey.buildKeyForConfig(key),
@@ -180,12 +180,12 @@ export class Context {
    * @param resolutionOptions Options for the resolution. If `localOnly` is
    * set to true, no parent namespaces will be looked up.
    */
-  async getConfig(
+  async getConfig<T>(
     key: string,
     configPath?: string,
     resolutionOptions?: ResolutionOptions,
-  ): Promise<BoundValue> {
-    return await this.getConfigAsValueOrPromise(
+  ): Promise<T | undefined> {
+    return await this.getConfigAsValueOrPromise<T>(
       key,
       configPath,
       resolutionOptions,
@@ -210,12 +210,12 @@ export class Context {
    * @param resolutionOptions Options for the resolution. If `localOnly` is
    * set to true, no parent namespaces will be looked up.
    */
-  getConfigSync(
+  getConfigSync<T>(
     key: string,
     configPath?: string,
     resolutionOptions?: ResolutionOptions,
-  ): BoundValue {
-    const valueOrPromise = this.getConfigAsValueOrPromise(
+  ): T | undefined {
+    const valueOrPromise = this.getConfigAsValueOrPromise<T>(
       key,
       configPath,
       resolutionOptions,

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -8,8 +8,10 @@ import {BindingKey, BindingAddress} from './binding-key';
 import {
   isPromiseLike,
   getDeepProperty,
-  ValueOrPromise,
   BoundValue,
+  ValueOrPromise,
+  resolveUntil,
+  resolveValueOrPromise,
 } from './value-promise';
 import {ResolutionOptions, ResolutionSession} from './resolution-session';
 
@@ -78,9 +80,10 @@ export class Context {
    * create binding `controllers.MyController:$config` with value `{x: 1}`.
    *
    * @param key The key for the binding that accepts the config
+   * @param env The env (such as `dev`, `test`, and `prod`) for the config
    */
-  configure(key: string = ''): Binding {
-    const keyForConfig = BindingKey.buildKeyForConfig(key);
+  configure(key: string = '', env: string = ''): Binding {
+    const keyForConfig = BindingKey.buildKeyForConfig(key, env);
     const bindingForConfig = this.bind(keyForConfig).tag(`config:${key}`);
     return bindingForConfig;
   }
@@ -110,56 +113,88 @@ export class Context {
     configPath?: string,
     resolutionOptions?: ResolutionOptions,
   ): ValueOrPromise<T | undefined> {
+    const env = resolutionOptions && resolutionOptions.environment;
     configPath = configPath || '';
-    const configKeyAndPath = BindingKey.create(
-      BindingKey.buildKeyForConfig(key),
-      configPath || '',
-    );
-    // Set `optional` to `true` to resolve config locally
-    const configBindingResolutionOptions = Object.assign(
-      {}, // Make sure resolutionOptions is copied
-      resolutionOptions,
-      {optional: true}, // Force optional to be true
-    );
-    let valueOrPromise = this.getValueOrPromise(
-      configKeyAndPath,
-      configBindingResolutionOptions,
+    const configKey = BindingKey.create(
+      BindingKey.buildKeyForConfig(key, env),
+      configPath,
     );
 
-    const evaluateConfig = (val: BoundValue) => {
-      // Found the corresponding config
-      if (val !== undefined) return val;
+    const localConfigOnly =
+      resolutionOptions && resolutionOptions.localConfigOnly;
 
-      // We have tried all levels
-      if (!key) {
-        if (resolutionOptions && resolutionOptions.optional === false) {
-          throw Error(`Configuration '${configKeyAndPath}' cannot be resolved`);
-        }
-        return undefined;
+    /**
+     * Set up possible keys to resolve the config value
+     */
+    const keys = [];
+    while (true) {
+      const configKeyAndPath = BindingKey.create(
+        BindingKey.buildKeyForConfig(key, env),
+        configPath,
+      );
+      keys.push(configKeyAndPath);
+      if (env) {
+        // The `environment` is set, let's try the non env specific binding too
+        keys.push(
+          BindingKey.create(BindingKey.buildKeyForConfig(key), configPath),
+        );
       }
-
-      if (resolutionOptions && resolutionOptions.localConfigOnly) {
-        // Local only, not trying parent namespaces
-        if (resolutionOptions && resolutionOptions.optional === false) {
-          throw Error(`Configuration '${configKeyAndPath}' cannot be resolved`);
-        }
-        return undefined;
+      if (!key || localConfigOnly) {
+        // No more keys
+        break;
       }
-
       // Shift last part of the key into the path as we'll try the parent
       // namespace in the next iteration
       const index = key.lastIndexOf('.');
-      configPath = `${key.substring(index + 1)}.${configPath}`;
+      configPath = configPath
+        ? `${key.substring(index + 1)}.${configPath}`
+        : `${key.substring(index + 1)}`;
       key = key.substring(0, index);
-      // Continue to try the parent namespace
-      return this.getConfigAsValueOrPromise(key, configPath, resolutionOptions);
+    }
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Configuration keyWithPaths: %j', keys);
+    }
+
+    const resolveConfig = (keyWithPath: string) => {
+      // Set `optional` to `true` to resolve config locally
+      const options = Object.assign(
+        {}, // Make sure resolutionOptions is copied
+        resolutionOptions,
+        {optional: true}, // Force optional to be true
+      );
+      return this.getValueOrPromise<T>(keyWithPath, options);
     };
 
-    if (isPromiseLike(valueOrPromise)) {
-      return valueOrPromise.then(evaluateConfig);
-    } else {
-      return evaluateConfig(valueOrPromise);
-    }
+    const evaluateConfig = (keyWithPath: string, val: T) => {
+      /* istanbul ignore if */
+      if (debug.enabled) {
+        debug('Configuration keyWithPath: %s => value: %j', keyWithPath, val);
+      }
+      // Found the corresponding config
+      if (val !== undefined) return true;
+
+      if (localConfigOnly) {
+        return true;
+      }
+      return false;
+    };
+
+    const required = resolutionOptions && resolutionOptions.optional === false;
+    const valueOrPromise = resolveUntil<string, T>(
+      keys[Symbol.iterator](),
+      resolveConfig,
+      evaluateConfig,
+    );
+    return resolveValueOrPromise<T | undefined, T | undefined>(
+      valueOrPromise,
+      val => {
+        if (val === undefined && required) {
+          throw Error(`Configuration '${configKey}' cannot be resolved`);
+        }
+        return val;
+      },
+    );
   }
 
   /**
@@ -177,7 +212,7 @@ export class Context {
    * @param configPath Property path for the option. For example, `x.y`
    * requests for `config.x.y`. If not set, the `config` object will be
    * returned.
-   * @param resolutionOptions Options for the resolution. If `localOnly` is
+   * @param resolutionOptions Options for the resolution. If `localConfigOnly` is
    * set to true, no parent namespaces will be looked up.
    */
   async getConfig<T>(
@@ -207,8 +242,8 @@ export class Context {
    * @param configPath Property path for the option. For example, `x.y`
    * requests for `config.x.y`. If not set, the `config` object will be
    * returned.
-   * @param resolutionOptions Options for the resolution. If `localOnly` is
-   * set to true, no parent namespaces will be looked up.
+   * @param resolutionOptions Options for the resolution. If `localConfigOnly`
+   * is set to `true`, no parent namespaces will be looked up.
    */
   getConfigSync<T>(
     key: string,

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -181,7 +181,7 @@ export class Context {
     };
 
     const required = resolutionOptions && resolutionOptions.optional === false;
-    const valueOrPromise = resolveUntil<string, T>(
+    const valueOrPromise = resolveUntil<BindingAddress<BoundValue>, T>(
       keys[Symbol.iterator](),
       resolveConfig,
       evaluateConfig,

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -13,6 +13,8 @@ export {
   MapObject,
   resolveList,
   resolveMap,
+  resolveUntil,
+  resolveValueOrPromise,
   tryWithFinally,
   getDeepProperty,
 } from './value-promise';

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -24,7 +24,14 @@ export {Binding, BindingScope, BindingType} from './binding';
 export {Context} from './context';
 export {BindingKey, BindingAddress} from './binding-key';
 export {ResolutionSession} from './resolution-session';
-export {inject, Setter, Getter, Injection, InjectionMetadata} from './inject';
+export {
+  inject,
+  Setter,
+  Getter,
+  Injection,
+  InjectionMetadata,
+  ENVIRONMENT_KEY,
+} from './inject';
 export {Provider} from './provider';
 
 export {instantiateClass, invokeMethod} from './resolver';

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -23,7 +23,7 @@ export {Binding, BindingScope, BindingType} from './binding';
 
 export {Context} from './context';
 export {BindingKey, BindingAddress} from './binding-key';
-export {ResolutionSession} from './resolution-session';
+export {ResolutionSession, ResolutionOptions} from './resolution-session';
 export {
   inject,
   Setter,

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -75,6 +75,12 @@ export interface Injection<ValueType = BoundValue> {
 }
 
 /**
+ * A special binding key for the execution environment, typically set
+ * by `NODE_ENV` environment variable
+ */
+export const ENVIRONMENT_KEY = '$environment';
+
+/**
  * A decorator to annotate method arguments for automatic injection
  * by LoopBack IoC container.
  *
@@ -353,10 +359,15 @@ function resolveFromConfig(
   const meta = injection.metadata || {};
   const binding = session.currentBinding;
 
+  const env =
+    ctx.getSync<string>(ENVIRONMENT_KEY, {optional: true}) ||
+    process.env.NODE_ENV;
+
   return ctx.getConfigAsValueOrPromise(binding.key, meta.configPath, {
     session,
     optional: meta.optional,
     localConfigOnly: meta.localConfigOnly,
+    environment: env,
   });
 }
 

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -342,4 +342,20 @@ export interface ResolutionOptions {
    * will return `undefined` instead of throwing an error.
    */
   optional?: boolean;
+
+  /**
+   * A boolean flag to control if the resolution only looks up properties from
+   * the local configuration of the target binding itself. If not set to `true`,
+   * all namespaces of a binding key will be checked.
+   *
+   * For example, if the binding key is `servers.rest.server1`, we'll try the
+   * following entries:
+   * 1. servers.rest.server1:$config#host (namespace: server1)
+   * 2. servers.rest:$config#server1.host (namespace: rest)
+   * 3. servers.$config#rest.server1.host` (namespace: server)
+   * 4. $config#servers.rest.server1.host (namespace: '' - root)
+   *
+   * The default value is `false`.
+   */
+  localConfigOnly?: boolean;
 }

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -358,4 +358,9 @@ export interface ResolutionOptions {
    * The default value is `false`.
    */
   localConfigOnly?: boolean;
+
+  /**
+   * Environment for resolution, such as `dev`, `test`, `staging`, and `prod`
+   */
+  environment?: string;
 }

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -10,9 +10,9 @@ import {
   Constructor,
   ValueOrPromise,
   MapObject,
-  isPromiseLike,
   resolveList,
   resolveMap,
+  resolveValueOrPromise,
 } from './value-promise';
 
 import {
@@ -56,51 +56,20 @@ export function instantiateClass<T>(
   }
   const argsOrPromise = resolveInjectedArguments(ctor, '', ctx, session);
   const propertiesOrPromise = resolveInjectedProperties(ctor, ctx, session);
-  let inst: ValueOrPromise<T>;
-  if (isPromiseLike(argsOrPromise)) {
-    // Instantiate the class asynchronously
-    inst = argsOrPromise.then(args => {
-      /* istanbul ignore if */
-      if (debug.enabled) {
-        debug('Injected arguments for %s():', ctor.name, args);
-      }
-      return new ctor(...args);
-    });
-  } else {
+  const inst: ValueOrPromise<T> = resolveValueOrPromise(argsOrPromise, args => {
     /* istanbul ignore if */
     if (debug.enabled) {
-      debug('Injected arguments for %s():', ctor.name, argsOrPromise);
+      debug('Injected arguments for %s():', ctor.name, args);
     }
-    // Instantiate the class synchronously
-    inst = new ctor(...argsOrPromise);
-  }
-  if (isPromiseLike(propertiesOrPromise)) {
-    return propertiesOrPromise.then(props => {
-      /* istanbul ignore if */
-      if (debug.enabled) {
-        debug('Injected properties for %s:', ctor.name, props);
-      }
-      if (isPromiseLike(inst)) {
-        // Inject the properties asynchronously
-        return inst.then(obj => Object.assign(obj, props));
-      } else {
-        // Inject the properties synchronously
-        return Object.assign(inst, props);
-      }
-    });
-  } else {
-    if (isPromiseLike(inst)) {
-      /* istanbul ignore if */
-      if (debug.enabled) {
-        debug('Injected properties for %s:', ctor.name, propertiesOrPromise);
-      }
-      // Inject the properties asynchronously
-      return inst.then(obj => Object.assign(obj, propertiesOrPromise));
-    } else {
-      // Inject the properties synchronously
-      return Object.assign(inst, propertiesOrPromise);
+    return new ctor(...args);
+  });
+  return resolveValueOrPromise(propertiesOrPromise, props => {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Injected properties for %s:', ctor.name, props);
     }
-  }
+    return resolveValueOrPromise(inst, obj => Object.assign(obj, props));
+  });
 }
 
 /**
@@ -257,23 +226,13 @@ export function invokeMethod(
     typeof targetWithMethods[method] === 'function',
     `Method ${method} not found`,
   );
-  if (isPromiseLike(argsOrPromise)) {
-    // Invoke the target method asynchronously
-    return argsOrPromise.then(args => {
-      /* istanbul ignore if */
-      if (debug.enabled) {
-        debug('Injected arguments for %s:', methodName, args);
-      }
-      return targetWithMethods[method](...args);
-    });
-  } else {
+  return resolveValueOrPromise(argsOrPromise, args => {
     /* istanbul ignore if */
     if (debug.enabled) {
-      debug('Injected arguments for %s:', methodName, argsOrPromise);
+      debug('Injected arguments for %s:', methodName, args);
     }
-    // Invoke the target method synchronously
-    return targetWithMethods[method](...argsOrPromise);
-  }
+    return targetWithMethods[method](...args);
+  });
 }
 
 /**

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -220,9 +220,9 @@ export function tryWithFinally<T>(
 }
 
 /**
- * Resolve iterable source values into a result until the evaluator returns
- * `true`
- * @param source The iterable source values
+ * Resolve an iterator of source values into a result until the evaluator
+ * returns `true`
+ * @param source The iterator of source values
  * @param resolver The resolve function that maps the source value to a result
  * @param evaluator The evaluate function that decides when to stop
  */
@@ -232,26 +232,25 @@ export function resolveUntil<T, V>(
   evaluator: (sourceVal: T, targetVal: V | undefined) => boolean,
 ): ValueOrPromise<V | undefined> {
   const next = source.next();
-  if (next.done) return undefined;
+  if (next.done) return undefined; // End of the iterator
   const sourceVal = next.value;
   const valueOrPromise = resolver(sourceVal);
-  return resolveValueOrPromise<V, V>(valueOrPromise, v => {
+  return resolveValueOrPromise(valueOrPromise, v => {
     if (evaluator(sourceVal, v)) return v;
-    else {
-      return resolveUntil(source, resolver, evaluator);
-    }
+    else return resolveUntil(source, resolver, evaluator);
   });
 }
 
 /**
- * Resolve a value or promise with a function
+ * Resolve a value or promise with a function that produces a new value or
+ * promise
  * @param valueOrPromise The value or promise
- * @param resolver A function that maps the source value to a result
+ * @param resolver A function that maps the source value to a value or promise
  */
 export function resolveValueOrPromise<T, V>(
-  valueOrPromise: ValueOrPromise<T | undefined>,
-  resolver: (val: T | undefined) => ValueOrPromise<V | undefined>,
-): ValueOrPromise<V | undefined> {
+  valueOrPromise: ValueOrPromise<T>,
+  resolver: (val: T) => ValueOrPromise<V>,
+): ValueOrPromise<V> {
   if (isPromiseLike(valueOrPromise)) {
     return valueOrPromise.then(resolver);
   } else {

--- a/packages/context/test/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/test/acceptance/class-level-bindings.acceptance.ts
@@ -318,27 +318,27 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     await expect(ctx.get('store')).to.be.rejectedWith('Bad');
   });
 
-  it('injects an option', () => {
+  it('injects a config property', () => {
     class Store {
       constructor(
-        @inject.options('x') public optionX: number,
-        @inject.options('y') public optionY: string,
+        @inject.config('x') public optionX: number,
+        @inject.config('y') public optionY: string,
       ) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
     expect(store.optionY).to.eql('a');
   });
 
-  it('injects an option with promise value', async () => {
+  it('injects a config property with promise value', async () => {
     class Store {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
-    ctx.bindOptions('store').toDynamicValue(async () => {
+    ctx.configure('store').toDynamicValue(async () => {
       return {x: 1};
     });
     ctx.bind('store').toClass(Store);
@@ -346,8 +346,8 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.optionX).to.eql(1);
   });
 
-  it('injects an option with a binding provider', async () => {
-    class MyOptionsProvider implements Provider<{}> {
+  it('injects a config property with a binding provider', async () => {
+    class MyConfigProvider implements Provider<{}> {
       constructor(@inject('prefix') private prefix: string) {}
       value() {
         return {
@@ -357,11 +357,11 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     }
 
     class Store {
-      constructor(@inject.options('myOption') public myOption: string) {}
+      constructor(@inject.config('myOption') public myOption: string) {}
     }
 
-    ctx.bind('options.MyOptionProvider').toProvider(MyOptionsProvider);
-    ctx.bindOptions('store').toProvider(MyOptionsProvider);
+    ctx.bind('config').toProvider(MyConfigProvider);
+    ctx.configure('store').toProvider(MyConfigProvider);
     ctx.bind('prefix').to('hello-');
     ctx.bind('store').toClass(Store);
 
@@ -369,13 +369,13 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.myOption).to.eql('hello-my-option');
   });
 
-  it('injects an option with a rejected promise', async () => {
+  it('injects a config property with a rejected promise', async () => {
     class Store {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
     ctx
-      .bindOptions('store')
+      .configure('store')
       .toDynamicValue(() => Promise.reject(Error('invalid')));
 
     ctx.bind('store').toClass(Store);
@@ -383,45 +383,45 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     await expect(ctx.get('store')).to.be.rejectedWith('invalid');
   });
 
-  it('injects an option with nested property', () => {
+  it('injects a config property with nested property', () => {
     class Store {
-      constructor(@inject.options('x.y') public optionXY: string) {}
+      constructor(@inject.config('x.y') public optionXY: string) {}
     }
 
-    ctx.bindOptions('store', {x: {y: 'y'}});
+    ctx.configure('store').to({x: {y: 'y'}});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.optionXY).to.eql('y');
   });
 
-  it('injects options if the binding key is not present', () => {
+  it('injects config if the binding key is not present', () => {
     class Store {
-      constructor(@inject.options() public options: object) {}
+      constructor(@inject.config() public config: object) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
-    expect(store.options).to.eql({x: 1, y: 'a'});
+    expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
-  it("injects options if the binding key is ''", () => {
+  it("injects config if the binding key is ''", () => {
     class Store {
-      constructor(@inject.options('') public options: object) {}
+      constructor(@inject.config('') public config: object) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
-    expect(store.options).to.eql({x: 1, y: 'a'});
+    expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
-  it('injects options if the binding key is a path', () => {
+  it('injects config if the binding key is a path', () => {
     class Store {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
@@ -431,26 +431,26 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     class Store {
       constructor(
         // tslint:disable-next-line:no-any
-        @inject.options('not-exist') public option: string | undefined,
+        @inject.config('not-exist') public option: string | undefined,
       ) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.option).to.be.undefined();
   });
 
-  it('injects an option based on the parent binding', async () => {
+  it('injects a config property based on the parent binding', async () => {
     class Store {
       constructor(
-        @inject.options('x') public optionX: number,
-        @inject.options('y') public optionY: string,
+        @inject.config('x') public optionX: number,
+        @inject.config('y') public optionY: string,
       ) {}
     }
 
-    ctx.bindOptions('store1', {x: 1, y: 'a'});
-    ctx.bindOptions('store2', {x: 2, y: 'b'});
+    ctx.configure('store1').to({x: 1, y: 'a'});
+    ctx.configure('store2').to({x: 2, y: 'b'});
 
     ctx.bind('store1').toClass(Store);
     ctx.bind('store2').toClass(Store);
@@ -464,40 +464,40 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store2.optionY).to.eql('b');
   });
 
-  it('injects undefined option if no binding is present', async () => {
+  it('injects undefined config if no binding is present', async () => {
     class Store {
       constructor(
         // tslint:disable-next-line:no-any
-        @inject.options('x') public option: string | undefined,
+        @inject.config('x') public config: string | undefined,
       ) {}
     }
 
     const store = await instantiateClass(Store, ctx);
-    expect(store.option).to.be.undefined();
+    expect(store.config).to.be.undefined();
   });
 
-  it('injects options from options binding', () => {
+  it('injects config from config binding', () => {
     class MyStore {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
-    ctx.bind('stores.MyStore:$options').to({x: 1, y: 'a'});
+    ctx.configure('stores.MyStore').to({x: 1, y: 'a'});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
     const store = ctx.getSync('stores.MyStore');
     expect(store.optionX).to.eql(1);
   });
 
-  it('injects options from options binding by key namespaces', () => {
+  it('injects config from config binding by key namespaces', () => {
     class MyStore {
       constructor(
-        @inject.options('x') public optionX: number,
-        @inject.options('y') public optionY: string,
+        @inject.config('x') public optionX: number,
+        @inject.config('y') public optionY: string,
       ) {}
     }
 
-    ctx.bind('stores:$options').to({MyStore: {y: 'a'}});
-    ctx.bind('stores.MyStore:$options').to({x: 1});
+    ctx.configure('stores').to({MyStore: {y: 'a'}});
+    ctx.configure('stores.MyStore').to({x: 1});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
     const store = ctx.getSync('stores.MyStore');

--- a/packages/context/test/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/test/acceptance/class-level-bindings.acceptance.ts
@@ -328,7 +328,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
     expect(store.optionY).to.eql('a');
   });
@@ -342,7 +342,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       return {x: 1};
     });
     ctx.bind('store').toClass(Store);
-    const store = await ctx.get('store');
+    const store = await ctx.get<Store>('store');
     expect(store.optionX).to.eql(1);
   });
 
@@ -365,7 +365,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.bind('prefix').to('hello-');
     ctx.bind('store').toClass(Store);
 
-    const store = await ctx.get('store');
+    const store = await ctx.get<Store>('store');
     expect(store.myOption).to.eql('hello-my-option');
   });
 
@@ -390,7 +390,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: {y: 'y'}});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.optionXY).to.eql('y');
   });
 
@@ -401,7 +401,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
@@ -412,7 +412,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
@@ -423,7 +423,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
   });
 
@@ -437,7 +437,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.option).to.be.undefined();
   });
 
@@ -455,11 +455,11 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.bind('store1').toClass(Store);
     ctx.bind('store2').toClass(Store);
 
-    const store1 = await ctx.get('store1');
+    const store1 = await ctx.get<Store>('store1');
     expect(store1.optionX).to.eql(1);
     expect(store1.optionY).to.eql('a');
 
-    const store2 = await ctx.get('store2');
+    const store2 = await ctx.get<Store>('store2');
     expect(store2.optionX).to.eql(2);
     expect(store2.optionY).to.eql('b');
   });
@@ -484,7 +484,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.configure('stores.MyStore').to({x: 1, y: 'a'});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
-    const store = ctx.getSync('stores.MyStore');
+    const store: MyStore = ctx.getSync('stores.MyStore');
     expect(store.optionX).to.eql(1);
   });
 
@@ -500,7 +500,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.configure('stores.MyStore').to({x: 1});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
-    const store = ctx.getSync('stores.MyStore');
+    const store: MyStore = ctx.getSync('stores.MyStore');
     expect(store.optionX).to.eql(1);
     expect(store.optionY).to.eql('a');
   });

--- a/packages/context/test/acceptance/config.feature.md
+++ b/packages/context/test/acceptance/config.feature.md
@@ -1,0 +1,147 @@
+# Feature: Context bindings - injecting configuration for bound artifacts
+
+- In order to receive configuration for a given binding
+- As a developer
+- I want to set up configuration for a binding key
+- So that configuration can be injected by the IoC framework
+
+# Scenario: configure an artifact before it's bound
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+// Bind configuration
+ctx.bind('servers.rest.server1:$config').to({port: 3000});
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Scenario: configure an artifact with a dynamic source
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration factory of `{port: 3000}` to `servers.rest.server1:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+// Bind configuration
+ctx.bind('servers.rest.server1:$config')
+  .toDynamicValue(() => Promise.resolve({port: 3000}));
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Scenario: configure values at parent level(s)
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration object `{server1: {port: 3000}}` to `servers.rest:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+// Bind configuration
+ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Scenario: configure values for different envs
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config.test`
+- And I bind a configuration object `{port: 4000}` to `servers.rest.server1.:$config.dev`
+- And bind the rest server to `servers.rest.server1`
+- And bind the env `'dev'` to `env`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 4000}`
+
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+ctx.bind('env').to('dev');
+
+// Bind configuration
+ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
+ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 4000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Notes
+
+This document only captures the expected behavior at context binding level. It
+establishes conventions to configure and resolve binding.
+
+Sources of configuration can be one or more files, databases, distributed
+registries, or services. How such sources are discovered and loaded is out of
+scope.
+
+See the following modules as candidates for configuration management facilities:
+
+- https://github.com/lorenwest/node-config
+- https://github.com/mozilla/node-convict

--- a/packages/context/test/acceptance/config.feature.md
+++ b/packages/context/test/acceptance/config.feature.md
@@ -11,7 +11,7 @@
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config`
+- When I bind a configuration object `{port: 3000}` to `$config:servers.rest.server1`
 - And bind the rest server to `servers.rest.server1`
 - And resolve the binding for `servers.rest.server1`
 - Then I get a new instance of `RestServer`
@@ -25,7 +25,7 @@ class RestServer {
 const ctx = new Context();
 
 // Bind configuration
-ctx.bind('servers.rest.server1:$config').to({port: 3000});
+ctx.configure('servers.rest.server1').to({port: 3000});
 
 // Bind RestServer
 ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -41,7 +41,7 @@ const server1 = await ctx.get('servers.rest.server1');
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration factory of `{port: 3000}` to `servers.rest.server1:$config`
+- When I bind a configuration factory of `{port: 3000}` to `$config:servers.rest.server1`
 - And bind the rest server to `servers.rest.server1`
 - And resolve the binding for `servers.rest.server1`
 - Then I get a new instance of `RestServer`
@@ -55,7 +55,7 @@ class RestServer {
 const ctx = new Context();
 
 // Bind configuration
-ctx.bind('servers.rest.server1:$config')
+ctx.configure('servers.rest.server1')
   .toDynamicValue(() => Promise.resolve({port: 3000}));
 
 // Bind RestServer
@@ -72,7 +72,7 @@ const server1 = await ctx.get('servers.rest.server1');
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration object `{server1: {port: 3000}}` to `servers.rest:$config`
+- When I bind a configuration object `{server1: {port: 3000}}` to `$config:servers.rest`
 - And bind the rest server to `servers.rest.server1`
 - And resolve the binding for `servers.rest.server1`
 - Then I get a new instance of `RestServer`
@@ -86,7 +86,7 @@ class RestServer {
 const ctx = new Context();
 
 // Bind configuration
-ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+ctx.configure('servers.rest).to({server1: {port: 3000}});
 
 // Bind RestServer
 ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -102,8 +102,8 @@ const server1 = await ctx.get('servers.rest.server1');
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config.test`
-- And I bind a configuration object `{port: 4000}` to `servers.rest.server1.:$config.dev`
+- When I bind a configuration object `{port: 3000}` to `$config.test:servers.rest.server1`
+- And I bind a configuration object `{port: 4000}` to `$config.dev:servers.rest.server1`
 - And bind the rest server to `servers.rest.server1`
 - And bind the env `'dev'` to `env`
 - And resolve the binding for `servers.rest.server1`
@@ -118,11 +118,11 @@ class RestServer {
 
 const ctx = new Context();
 
-ctx.bind('env').to('dev');
+ctx.bind('$environment').to('dev');
 
 // Bind configuration
-ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
-ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+ctx.configure('servers.rest.server1', 'dev').to({port: 4000});
+ctx.bind('servers.rest.server1', 'test').to({port: 3000});
 
 // Bind RestServer
 ctx.bind('servers.rest.server1').toClass(RestServer);

--- a/packages/context/test/acceptance/config.ts
+++ b/packages/context/test/acceptance/config.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, inject} from '../..';
+import {Context, inject, ENVIRONMENT_KEY} from '../..';
 
 interface RestServerConfig {
   host?: string;
@@ -15,12 +15,19 @@ class RestServer {
   constructor(@inject.config() public config: RestServerConfig) {}
 }
 
+class RestServer2 {
+  constructor(
+    @inject.config('host') public host?: string,
+    @inject.config('port') public port?: number,
+  ) {}
+}
+
 describe('Context bindings - injecting configuration for bound artifacts', () => {
   it('binds configuration independent of binding', async () => {
     const ctx = new Context();
 
     // Bind configuration
-    ctx.bind('servers.rest.server1:$config').to({port: 3000});
+    ctx.configure('servers.rest.server1').to({port: 3000});
 
     // Bind RestServer
     ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -37,7 +44,7 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
 
     // Bind configuration
     ctx
-      .bind('servers.rest.server1:$config')
+      .configure('servers.rest.server1')
       .toDynamicValue(() => Promise.resolve({port: 3000}));
 
     // Bind RestServer
@@ -53,7 +60,7 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
     const ctx = new Context();
 
     // Bind configuration
-    ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+    ctx.configure('servers.rest').to({server1: {port: 3000}});
 
     // Bind RestServer
     ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -64,12 +71,13 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
     expect(server1.config).to.eql({port: 3000});
   });
 
-  it.skip('binds configuration for environments', async () => {
+  it('binds configuration for environments', async () => {
     const ctx = new Context();
 
+    ctx.bind('$environment').to('test');
     // Bind configuration
-    ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
-    ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+    ctx.configure('servers.rest.server1', 'dev').to({port: 4000});
+    ctx.configure('servers.rest.server1', 'test').to({port: 3000});
 
     // Bind RestServer
     ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -79,5 +87,25 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
     const server1 = await ctx.get<RestServer>('servers.rest.server1');
 
     expect(server1.config).to.eql({port: 3000});
+  });
+
+  it('binds configuration for environments with defaults', async () => {
+    const ctx = new Context();
+
+    ctx.bind(ENVIRONMENT_KEY).to('dev');
+    // Bind configuration
+    ctx.configure('servers.rest.server1', 'dev').to({port: 4000});
+    ctx.configure('servers.rest.server1', 'test').to({port: 3000});
+    ctx.configure('servers.rest.server1').to({host: 'localhost'});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer2);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer2>('servers.rest.server1');
+
+    expect(server1.host).to.eql('localhost');
+    expect(server1.port).to.eql(4000);
   });
 });

--- a/packages/context/test/acceptance/config.ts
+++ b/packages/context/test/acceptance/config.ts
@@ -1,0 +1,83 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Context, inject} from '../..';
+
+interface RestServerConfig {
+  host?: string;
+  port?: number;
+}
+
+class RestServer {
+  constructor(@inject.config() public config: RestServerConfig) {}
+}
+
+describe('Context bindings - injecting configuration for bound artifacts', () => {
+  it('binds configuration independent of binding', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx.bind('servers.rest.server1:$config').to({port: 3000});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+
+    expect(server1.config).to.eql({port: 3000});
+  });
+
+  it('configure an artifact with a dynamic source', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx
+      .bind('servers.rest.server1:$config')
+      .toDynamicValue(() => Promise.resolve({port: 3000}));
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+    expect(server1.config).to.eql({port: 3000});
+  });
+
+  it('configure values at parent level(s)', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+    expect(server1.config).to.eql({port: 3000});
+  });
+
+  it.skip('binds configuration for environments', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
+    ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+
+    expect(server1.config).to.eql({port: 3000});
+  });
+});

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -296,6 +296,53 @@ describe('Context', () => {
     });
   });
 
+  describe('bindOptions()', () => {
+    it('binds options for a binding before it is bound', () => {
+      const bindingForOptions = ctx.bindOptions('foo', {x: 1});
+      expect(bindingForOptions.key).to.equal(Binding.buildKeyForOptions('foo'));
+    });
+
+    it('binds options for a binding after it is bound', () => {
+      ctx.bind('foo').to('bar');
+      const bindingForOptions = ctx.bindOptions('foo').to({x: 1});
+      expect(bindingForOptions.key).to.equal(Binding.buildKeyForOptions('foo'));
+    });
+  });
+
+  describe('getOptions()', () => {
+    it('gets options for a binding', async () => {
+      ctx.bindOptions('foo').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getOptions('foo')).to.eql({x: 1});
+    });
+
+    it('gets local options for a binding', async () => {
+      ctx
+        .bindOptions('foo')
+        .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
+      ctx.bindOptions('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getOptions('foo.a', 'x', {localOnly: true})).to.eql(1);
+      expect(
+        await ctx.getOptions('foo.a', 'y', {localOnly: true}),
+      ).to.be.undefined();
+    });
+
+    it('gets parent options for a binding', async () => {
+      ctx
+        .bindOptions('foo')
+        .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
+      ctx.bindOptions('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getOptions('foo.a', 'x')).to.eql(1);
+      expect(await ctx.getOptions('foo.a', 'y')).to.eql(0);
+    });
+  });
+
+  describe('getOptionsSync()', () => {
+    it('gets options for a binding', () => {
+      ctx.bindOptions('foo').to({x: 1});
+      expect(ctx.getOptionsSync('foo')).to.eql({x: 1});
+    });
+  });
+
   describe('getSync', () => {
     it('returns the value immediately when the binding is sync', () => {
       ctx.bind('foo').to('bar');

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -384,6 +384,13 @@ describe('Context', () => {
       ctx.configure('foo').to({x: 1});
       expect(ctx.getConfigSync('foo')).to.eql({x: 1});
     });
+
+    it('throws a helpful error when the config is async', () => {
+      ctx.configure('foo').toDynamicValue(() => Promise.resolve('bar'));
+      expect(() => ctx.getConfigSync('foo')).to.throw(
+        /Cannot get config\[\] for foo synchronously: the value is a promise/,
+      );
+    });
   });
 
   describe('getSync', () => {
@@ -490,6 +497,21 @@ describe('Context', () => {
       expect(result).to.equal(2);
       result = childCtx.getSync('foo');
       expect(result).to.equal(1);
+    });
+  });
+
+  describe('getOwnerContext', () => {
+    it('returns owner context', () => {
+      ctx.bind('foo').to('bar');
+      expect(ctx.getOwnerContext('foo')).to.equal(ctx);
+    });
+
+    it('returns owner context with parent', () => {
+      ctx.bind('foo').to('bar');
+      const childCtx = new Context(ctx, 'child');
+      childCtx.bind('xyz').to('abc');
+      expect(childCtx.getOwnerContext('foo')).to.equal(ctx);
+      expect(childCtx.getOwnerContext('xyz')).to.equal(childCtx);
     });
   });
 

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -300,14 +300,18 @@ describe('Context', () => {
   describe('configure()', () => {
     it('configures options for a binding before it is bound', () => {
       const bindingForConfig = ctx.configure('foo').to({x: 1});
-      expect(bindingForConfig.key).to.equal(BindingKey.buildKeyForConfig('foo'));
+      expect(bindingForConfig.key).to.equal(
+        BindingKey.buildKeyForConfig('foo'),
+      );
       expect(bindingForConfig.tags.has('config:foo')).to.be.true();
     });
 
     it('configures options for a binding after it is bound', () => {
       ctx.bind('foo').to('bar');
       const bindingForConfig = ctx.configure('foo').to({x: 1});
-      expect(bindingForConfig.key).to.equal(BindingKey.buildKeyForConfig('foo'));
+      expect(bindingForConfig.key).to.equal(
+        BindingKey.buildKeyForConfig('foo'),
+      );
       expect(bindingForConfig.tags.has('config:foo')).to.be.true();
     });
   });

--- a/packages/core/src/extension-point.ts
+++ b/packages/core/src/extension-point.ts
@@ -1,0 +1,178 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  Context,
+  Binding,
+  inject,
+  resolveList,
+  Injection,
+  ResolutionSession,
+} from '@loopback/context';
+
+// tslint:disable:no-any
+/**
+ * Interface for the extension point configuration
+ */
+export interface ExtensionPointConfig {
+  // Configuration properties for the extension point itself
+  [property: string]: any;
+}
+
+/**
+ * Base class for extension points
+ */
+export abstract class ExtensionPoint<EXT extends object> {
+  /**
+   * Configuration (typically to be injected)
+   */
+  @inject.config() public readonly config: ExtensionPointConfig = {};
+
+  /**
+   * Name of the extension point. The subclass must set the value.
+   */
+  static extensionPointName: string;
+
+  /**
+   * The unique name of this extension point. It also serves as the binding
+   * key prefix for bound extensions
+   */
+  public readonly name: string;
+
+  constructor() {
+    const ctor = this.constructor as typeof ExtensionPoint;
+    this.name = ctor.extensionPointName;
+    if (!this.name) {
+      throw new Error(`${ctor.name}.extensionPointName must be set`);
+    }
+  }
+
+  /**
+   * Find an array of bindings for extensions
+   */
+  getAllExtensionBindings(ctx: Context): Readonly<Binding>[] {
+    return ctx.findByTag(this.getTagForExtensions());
+  }
+
+  /**
+   * Get the binding tag for extensions of this extension point
+   */
+  protected getTagForExtensions(): string {
+    return `extensionPoint:${this.name}`;
+  }
+
+  /**
+   * Get a map of extension bindings by the keys
+   */
+  getExtensionBindingMap(ctx: Context): {[name: string]: Readonly<Binding>} {
+    const extensionBindingMap: {[name: string]: Readonly<Binding>} = {};
+    const bindings = this.getAllExtensionBindings(ctx);
+    bindings.forEach(binding => {
+      extensionBindingMap[binding.key] = binding;
+    });
+    return extensionBindingMap;
+  }
+
+  /**
+   * Look up an extension binding by name
+   * @param extensionName Name of the extension
+   */
+  getExtensionBinding(ctx: Context, extensionName: string): Readonly<Binding> {
+    const bindings = this.getAllExtensionBindings(ctx);
+    const binding = bindings.find(b =>
+      b.tags.has(this.getTagForName(extensionName)),
+    );
+    if (binding == null)
+      throw new Error(
+        `Extension ${extensionName} does not exist for extension point ${
+          this.name
+        }`,
+      );
+    return binding;
+  }
+
+  /**
+   * Get the binding tag for an extension name
+   * @param extensionName Name of the extension
+   */
+  protected getTagForName(extensionName: string): string {
+    return `name:${extensionName}`;
+  }
+
+  /**
+   * Get configuration for this extension point
+   */
+  getConfiguration() {
+    return this.config;
+  }
+
+  /**
+   * Get configuration for an extension of this extension point
+   * @param extensionName Name of the extension
+   */
+  async getExtensionConfiguration(ctx: Context, extensionName: string) {
+    return (await ctx.getConfig(`${this.name}.${extensionName}`)) || {};
+  }
+
+  /**
+   * Get an instance of an extension by name
+   * @param extensionName Name of the extension
+   */
+  async getExtension(ctx: Context, extensionName: string): Promise<EXT> {
+    const binding = this.getExtensionBinding(ctx, extensionName);
+    return binding.getValue(ctx);
+  }
+
+  /**
+   * Get an array of registered extension instances
+   */
+  async getAllExtensions(ctx: Context): Promise<EXT[]> {
+    const bindings = this.getAllExtensionBindings(ctx);
+    return resolveList(bindings, async binding => {
+      return await binding.getValue(ctx);
+    });
+  }
+
+  /**
+   * Get the name tag (name:extension-name) associated with the binding
+   * @param binding
+   */
+  static getExtensionName(binding: Binding) {
+    for (const tag of binding.tags) {
+      if (tag.startsWith('name:')) {
+        return tag.substr('name:'.length);
+      }
+    }
+    return undefined;
+  }
+}
+
+/**
+ * @extensions() - decorator to inject extensions
+ */
+export function extensions() {
+  return inject(
+    '',
+    {decorator: '@extensions'},
+    (ctx: Context, injection: Injection, session?: ResolutionSession) => {
+      const target = injection.target;
+      const ctor: any =
+        target instanceof Function ? target : target.constructor;
+      if (ctor.extensionPointName) {
+        const bindings = ctx.findByTag(
+          `extensionPoint:${ctor.extensionPointName}`,
+        );
+        return resolveList(bindings, b => {
+          // We need to clone the session so that resolution of multiple
+          // bindings can be tracked in parallel
+          return b.getValue(ctx, ResolutionSession.fork(session));
+        });
+      }
+      throw new Error(
+        '@extensions must be used within a extension point class',
+      );
+    },
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,4 @@ export {Server} from './server';
 export * from './application';
 export * from './component';
 export * from './keys';
+export * from './extension-point';

--- a/packages/core/test/acceptance/extension-point.feature.md
+++ b/packages/core/test/acceptance/extension-point.feature.md
@@ -1,0 +1,78 @@
+# Feature: Context bindings - organizing services as extension point/extensions by naming convention
+
+- In order to manage services that follow the extension point/extension pattern
+- As a developer
+- I would like to bind a extension point and its extensions to the context following certain conventions
+- So that an extension point can find all of its extensions or one of them by name
+
+See https://wiki.eclipse.org/FAQ_What_are_extensions_and_extension_points%3F for the pattern.
+
+# Scenario - register an extension to a given extension point
+
+- Given a context
+- Given a class `AuthenticationManager` as the extension point for extensible authentication strategies
+- Given a class `LocalStrategy` that implements the `local` authentication strategy
+- Given a class `LDAPStrategy` that implements the `ldap` authentication strategy
+- Given a class `OAuth2Strategy` that implements the `oauth2` authentication strategy
+- We should be able to add `LocalStrategy` by binding it to `authentication.strategies.local`
+- We should be able to add `LDAPStrategy` by binding it to `authentication.strategies.ldap`
+- We should be able to add `OAuth2Strategy` by binding it to `authentication.strategies.oauth2`
+
+# Scenario - find all of its extensions for a given extension point
+
+- Given a context
+- Given a class `AuthenticationManager` as the extension point for extensible authentication strategies
+- Given a class `LocalStrategy` that implements the `local` authentication strategy
+- Given a class `LDAPStrategy` that implements the `ldap` authentication strategy
+- Given a class `OAuth2Strategy` that implements the `oauth2` authentication strategy
+- When LocalStrategy is bound to `authentication.strategies.local`
+- When LDAPStrategy is bound to `authentication.strategies.ldap`
+- When OAuth2Strategy is bound to `authentication.strategies.oauth2`
+- AuthenticationManager should be able to list all extensions bound to `authentication.strategies.*`
+
+# Scenario - find one of its extensions by name for a given extension point
+
+- Given a context
+- Given a class `AuthenticationManager` as the extension point for extensible authentication strategies
+- Given a class `LocalStrategy` that implements the `local` authentication strategy
+- Given a class `LDAPStrategy` that implements the `ldap` authentication strategy
+- Given a class `OAuth2Strategy` that implements the `oauth2` authentication strategy
+- When LocalStrategy is bound to `authentication.strategies.local`
+- When LDAPStrategy is bound to `authentication.strategies.ldap`
+- When OAuth2Strategy is bound to `authentication.strategies.oauth2`
+- AuthenticationManager should be able to find/get LocalStrategy by `local` from the context
+- AuthenticationManager should be able to find/get LDAPStrategy by `ldap` from the context
+- AuthenticationManager should be able to find/get OAuth2Strategy by `oauth2` from the context
+
+# Scenario - populate configuration for extension points and extension
+
+- Given a context
+- Given a class `AuthenticationManager` as the extension point for extensible authentication strategies
+- Given a class `LocalStrategy` that implements the `local` authentication strategy
+- Given a class `LDAPStrategy` that implements the `ldap` authentication strategy
+- Given a class `OAuth2Strategy` that implements the `oauth2` authentication strategy
+- When LocalStrategy is bound to `authentication.strategies.local`
+- When LDAPStrategy is bound to `authentication.strategies.ldap`
+- When OAuth2Strategy is bound to `authentication.strategies.oauth2`
+- Given a configuration object
+```js
+{
+  'authentication.strategies': {
+    local: { /* config for local strategy */},
+    ldap: { /* config for ldap strategy */}
+    oauth2: { /* config for oauth2 strategy */}
+  }
+}
+```
+- Each of the strategy class should be able to receive its configuration via dependency injection. For example,
+
+```ts
+class LocalStrategy implements AuthenticationStrategy {
+  constructor(@inject('config') private config: LocalConfig) {}
+}
+```
+
+# TBD
+
+- Should we go beyond naming conventions to make ExtensionPoint/Extension first class entity of the context?
+- Should we introduce decorators such as `@extensionPoint` and `@extension`?

--- a/packages/core/test/acceptance/extension-point.ts
+++ b/packages/core/test/acceptance/extension-point.ts
@@ -1,0 +1,267 @@
+// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Node module: loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  Context,
+  BindingScope,
+  inject,
+  Constructor,
+  invokeMethod,
+} from '@loopback/context';
+import {Application, ExtensionPoint, extensions} from '../..';
+
+// tslint:disable:no-any
+interface AuthenticationStrategy {
+  authenticate(credentials: any): Promise<boolean>;
+  config: any;
+}
+
+class LocalStrategy implements AuthenticationStrategy {
+  constructor(@inject.config() public config: any) {}
+
+  authenticate(credentials: any) {
+    return Promise.resolve(true);
+  }
+}
+
+class LDAPStrategy implements AuthenticationStrategy {
+  constructor(@inject.config() public config: any) {}
+
+  authenticate(credentials: any) {
+    return Promise.resolve(true);
+  }
+}
+
+class OAuth2Strategy implements AuthenticationStrategy {
+  constructor(@inject.config() public config: any) {}
+
+  authenticate(credentials: any) {
+    return Promise.resolve(true);
+  }
+}
+
+const AUTH_EXTENSION_POINT = 'authentication.strategies';
+
+class AuthenticationManager extends ExtensionPoint<AuthenticationStrategy> {
+  static extensionPointName = AUTH_EXTENSION_POINT;
+
+  async authenticate(
+    ctx: Context,
+    strategy: string,
+    credentials: any,
+  ): Promise<boolean> {
+    const ext: AuthenticationStrategy = await this.getExtension(ctx, strategy);
+    return ext.authenticate(credentials);
+  }
+
+  async getStrategies(
+    // Use method injection to ensure we pick up all available extensions within
+    // the current context
+    @extensions() authenticators: AuthenticationStrategy[],
+  ) {
+    return authenticators;
+  }
+}
+
+const configs: {[name: string]: object} = {
+  local: {
+    url: 'https://localhost:3000/users/login',
+  },
+  ldap: {
+    url: 'ldap://localhost:1389',
+  },
+  oauth2: {
+    clientId: 'my-client-id',
+    clientSecret: 'my-client-secret',
+    tokenInspectUrl: 'https://localhost:3000/oauth2/inspect',
+  },
+};
+
+// Register multiple extensions
+const strategies: {[name: string]: Constructor<any>} = {
+  local: LocalStrategy,
+  ldap: LDAPStrategy,
+  oauth2: OAuth2Strategy,
+};
+
+describe('Extension point', () => {
+  let ctx: Context;
+  beforeEach('given a context', createContext);
+
+  it('lists all extensions', async () => {
+    const authManager = await ctx.get<AuthenticationManager>(
+      AUTH_EXTENSION_POINT,
+    );
+    const extBindings = authManager.getAllExtensionBindings(ctx);
+    expect(extBindings.length).to.eql(3);
+  });
+
+  it('gets an extension by name', async () => {
+    const authManager = await ctx.get<AuthenticationManager>(
+      AUTH_EXTENSION_POINT,
+    );
+    const binding = authManager.getExtensionBinding(ctx, 'ldap');
+    expect(binding.key).to.eql(`${AUTH_EXTENSION_POINT}.ldap`);
+    expect(binding.valueConstructor).to.exactly(LDAPStrategy);
+  });
+
+  it('gets an extension instance by name', async () => {
+    const authManager = await ctx.get<AuthenticationManager>(
+      AUTH_EXTENSION_POINT,
+    );
+    const ext = await authManager.getExtension(ctx, 'ldap');
+    expect(ext.config).to.eql({
+      url: 'ldap://localhost:1389',
+    });
+    const result = await ext.authenticate({});
+    expect(result).to.be.true();
+  });
+
+  it('delegates to an extension', async () => {
+    const authManager = await ctx.get<AuthenticationManager>(
+      AUTH_EXTENSION_POINT,
+    );
+    const result = await authManager.authenticate(ctx, 'local', {
+      username: 'my-user',
+      password: 'my-pass',
+    });
+    expect(result).to.be.true();
+  });
+
+  it('injects extensions', async () => {
+    const authManager = await ctx.get<AuthenticationManager>(
+      AUTH_EXTENSION_POINT,
+    );
+    const authenticators: AuthenticationStrategy[] = await invokeMethod(
+      authManager,
+      'getStrategies',
+      ctx,
+    );
+    expect(authenticators).have.length(3);
+  });
+
+  function createContext() {
+    ctx = new Context();
+
+    // Register the extension point
+    ctx
+      .bind(AUTH_EXTENSION_POINT)
+      .toClass(AuthenticationManager)
+      .inScope(BindingScope.SINGLETON)
+      .tag('extensionPoint')
+      .tag(`name:${AUTH_EXTENSION_POINT}`);
+
+    for (const e in strategies) {
+      ctx
+        .bind(`authentication.strategies.${e}`)
+        .toClass(strategies[e])
+        .inScope(BindingScope.SINGLETON)
+        .tag(`extensionPoint:${AUTH_EXTENSION_POINT}`)
+        .tag(`name:${e}`);
+      ctx.configure(`authentication.strategies.${e}`).to(configs[e]);
+    }
+  }
+});
+
+describe('Application support for extension points', () => {
+  let app: Application;
+
+  beforeEach(givenApplication);
+
+  it('registers an extension point by class name', () => {
+    app.extensionPoint(AuthenticationManager);
+    const binding = app.getBinding('extensionPoints.AuthenticationManager');
+    expect(binding.valueConstructor).to.be.exactly(AuthenticationManager);
+    expect(binding.scope === BindingScope.SINGLETON);
+    expect(
+      binding.tags.has('name:extensionPoints.AuthenticationManager'),
+    ).to.be.true();
+    expect(binding.tags.has('extensionPoint')).to.be.true();
+  });
+
+  it('registers an extension point by name', () => {
+    app.extensionPoint(AuthenticationManager, AUTH_EXTENSION_POINT);
+    const binding = app.getBinding(AUTH_EXTENSION_POINT);
+    expect(binding.valueConstructor).to.be.exactly(AuthenticationManager);
+    expect(binding.scope === BindingScope.SINGLETON);
+    expect(binding.tags.has(`name:${AUTH_EXTENSION_POINT}`)).to.be.true();
+    expect(binding.tags.has('extensionPoint')).to.be.true();
+  });
+
+  it('registers an extension by class name', () => {
+    app.extensionPoint(AuthenticationManager, AUTH_EXTENSION_POINT);
+    app.extension(AUTH_EXTENSION_POINT, LocalStrategy);
+    const binding = app.getBinding(`${AUTH_EXTENSION_POINT}.LocalStrategy`);
+    expect(binding.valueConstructor).to.be.exactly(LocalStrategy);
+    expect(binding.tags.has('name:LocalStrategy')).to.be.true();
+    expect(
+      binding.tags.has(`extensionPoint:${AUTH_EXTENSION_POINT}`),
+    ).to.be.true();
+  });
+
+  it('registers an extension by class name', () => {
+    app.extensionPoint(AuthenticationManager, AUTH_EXTENSION_POINT);
+    app.extension(AUTH_EXTENSION_POINT, LocalStrategy);
+    const binding = app.getBinding(`${AUTH_EXTENSION_POINT}.LocalStrategy`);
+    expect(binding.valueConstructor).to.be.exactly(LocalStrategy);
+    expect(binding.tags.has('name:LocalStrategy')).to.be.true();
+    expect(
+      binding.tags.has(`extensionPoint:${AUTH_EXTENSION_POINT}`),
+    ).to.be.true();
+  });
+
+  it('registers an extension by name', () => {
+    app.extensionPoint(AuthenticationManager, AUTH_EXTENSION_POINT);
+    app.extension(AUTH_EXTENSION_POINT, LocalStrategy, 'local');
+    const binding = app.getBinding(`${AUTH_EXTENSION_POINT}.local`);
+    expect(binding.valueConstructor).to.be.exactly(LocalStrategy);
+    expect(binding.tags.has('name:local')).to.be.true();
+    expect(
+      binding.tags.has(`extensionPoint:${AUTH_EXTENSION_POINT}`),
+    ).to.be.true();
+  });
+
+  it('configures an extension point', async () => {
+    const config = {auth: true};
+    app.configure(AUTH_EXTENSION_POINT).to(config);
+    app.extensionPoint(AuthenticationManager, AUTH_EXTENSION_POINT);
+    const auth = await app.get<AuthenticationManager>(AUTH_EXTENSION_POINT);
+    expect(auth.config).to.eql(config);
+  });
+
+  it('binds an extension point in context scope', async () => {
+    const config = {auth: true};
+    app.configure(AUTH_EXTENSION_POINT).to(config);
+    app.extensionPoint(AuthenticationManager, AUTH_EXTENSION_POINT);
+    const auth1 = await app.get(AUTH_EXTENSION_POINT);
+    const auth2 = await app.get(AUTH_EXTENSION_POINT);
+    expect(auth1).to.be.exactly(auth2);
+
+    const reqCtx = new Context(app);
+    const auth3 = await reqCtx.get(AUTH_EXTENSION_POINT);
+    const auth4 = await reqCtx.get(AUTH_EXTENSION_POINT);
+    expect(auth3).to.be.exactly(auth4);
+    expect(auth3).to.be.not.exactly(auth1);
+  });
+
+  it('configures extensions', async () => {
+    app.extensionPoint(AuthenticationManager, AUTH_EXTENSION_POINT);
+    app.extension(AUTH_EXTENSION_POINT, LocalStrategy, 'local');
+    app.configure(`${AUTH_EXTENSION_POINT}.local`).to(configs.local);
+    const extensionPoint: ExtensionPoint<
+      AuthenticationStrategy
+    > = await app.get<AuthenticationManager>(AUTH_EXTENSION_POINT);
+    const extension: LocalStrategy = await extensionPoint.getExtension(
+      app,
+      'local',
+    );
+    expect(extension.config).to.eql(configs.local);
+  });
+
+  function givenApplication() {
+    app = new Application();
+  }
+});


### PR DESCRIPTION
Extension point/extension is a pattern for extensibility.
This PR illustrates how we can support it using the Context apis
and naming conventions. It also serves as an invitation to discuss
if we should support such entities out of box.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/543

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
