### PR TITLE
fix(testlab): Remove sinon-should integration

### DIFF
--- a/packages/rest/test/unit/router/reject.test.ts
+++ b/packages/rest/test/unit/router/reject.test.ts
@@ -35,7 +35,7 @@ describe('reject', () => {
     reject(mock.response, mock.request, testError);
     await mock.result;
 
-    expect(logger).to.be.calledWith(testError, 500, mock.request);
+    sinon.assert.calledWith(logger, testError, 500, mock.request);
   });
 
   function givenMockedResponse() {

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -21,13 +21,12 @@
   "dependencies": {
     "@loopback/openapi-spec": "^4.0.0-alpha.10",
     "@types/shot": "^3.4.0",
-    "@types/sinon": "^2.3.2",
+    "@types/sinon": "^2.3.6",
     "@types/supertest": "^2.0.0",
     "@types/swagger-parser": "^4.0.1",
-    "shot": "^3.4.0",
-    "should": "^11.2.1",
-    "should-sinon": "0.0.5",
-    "sinon": "^2.4.0",
+    "shot": "^4.0.2",
+    "should": "^13.1.2",
+    "sinon": "^4.0.1",
     "supertest": "^3.0.0",
     "swagger-parser": "^3.4.1"
   },

--- a/packages/testlab/src/testlab.ts
+++ b/packages/testlab/src/testlab.ts
@@ -6,7 +6,6 @@
 /// <reference path="../should-as-function.d.ts" />
 
 const shouldAsFunction: Internal = require('should/as-function');
-import 'should-sinon';
 
 import sinon = require('sinon');
 import {SinonSpy} from 'sinon';


### PR DESCRIPTION
The sinon-should integration has some bad side effects, for example:

expect(() => throw new Error()).to.throw(...) is broken.

Also see https://github.com/strongloop/loopback-next/issues/641

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
