### PR TITLE
feat(core): allow controllers to be bound via constructor

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -30,6 +30,12 @@ export class Application extends Context {
         this.server(options.servers[name], name);
       }
     }
+
+    if (options.controllers) {
+      for (const ctor of options.controllers) {
+        this.controller(ctor);
+      }
+    }
   }
 
   /**
@@ -190,6 +196,7 @@ export class Application extends Context {
 
 export interface ApplicationConfig {
   components?: Array<Constructor<Component>>;
+  controllers?: Array<ControllerClass>;
   servers?: {
     [name: string]: Constructor<Server>;
   };

--- a/packages/core/test/acceptance/application.acceptance.ts
+++ b/packages/core/test/acceptance/application.acceptance.ts
@@ -39,6 +39,18 @@ describe('Bootstrapping the application', () => {
       expect(value).to.equal('bar');
     });
 
+    it('registers controllers from constructor', () => {
+      class ProductController {}
+
+      const app = new Application({
+        controllers: [ProductController],
+      });
+
+      expect(app.find('controllers.*').map(b => b.key)).to.eql([
+        'controllers.ProductController',
+      ]);
+    });
+
     it('registers all controllers from components', async () => {
       // TODO(bajtos) Beef up this test. Create a real controller with
       // a public API endpoint and verify that this endpoint can be invoked


### PR DESCRIPTION
An array of controllers can now be passed into the array to be bound
automatically.