### PR TITLE
feat(context): Improve bindings with options, resolution tracking, and error propagation

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -150,11 +150,11 @@ export class Binding {
   public scope: BindingScope = BindingScope.TRANSIENT;
   public type: BindingType;
 
-  private _cache: BoundValue;
+  private _cache: WeakMap<Context, BoundValue>;
   private _getValue: (
     ctx?: Context,
     session?: ResolutionSession,
-  ) => BoundValue | Promise<BoundValue>;
+  ) => ValueOrPromise<BoundValue>;
 
   // For bindings bound via toClass, this property contains the constructor
   // function
@@ -172,40 +172,31 @@ export class Binding {
    */
   private _cacheValue(
     ctx: Context,
-    result: BoundValue | Promise<BoundValue>,
-  ): BoundValue | Promise<BoundValue> {
+    result: ValueOrPromise<BoundValue>,
+  ): ValueOrPromise<BoundValue> {
+    // Initialize the cache as a weakmap keyed by context
+    if (!this._cache) this._cache = new WeakMap<Context, BoundValue>();
     if (isPromise(result)) {
       if (this.scope === BindingScope.SINGLETON) {
-        // Cache the value
+        // Cache the value at owning context level
         result = result.then(val => {
-          this._cache = val;
+          this._cache.set(ctx.getOwner(this.key)!, val);
           return val;
         });
       } else if (this.scope === BindingScope.CONTEXT) {
-        // Cache the value
+        // Cache the value at the current context
         result = result.then(val => {
-          if (ctx.contains(this.key)) {
-            // The ctx owns the binding
-            this._cache = val;
-          } else {
-            // Create a binding of the cached value for the current context
-            ctx.bind(this.key).to(val);
-          }
+          this._cache.set(ctx, val);
           return val;
         });
       }
     } else {
       if (this.scope === BindingScope.SINGLETON) {
         // Cache the value
-        this._cache = result;
+        this._cache.set(ctx.getOwner(this.key)!, result);
       } else if (this.scope === BindingScope.CONTEXT) {
-        if (ctx.contains(this.key)) {
-          // The ctx owns the binding
-          this._cache = result;
-        } else {
-          // Create a binding of the cached value for the current context
-          ctx.bind(this.key).to(result);
-        }
+        // Cache the value at the current context
+        this._cache.set(ctx, result);
       }
     }
     return result;
@@ -238,21 +229,25 @@ export class Binding {
   getValue(
     ctx: Context,
     session?: ResolutionSession,
-  ): BoundValue | Promise<BoundValue> {
+  ): ValueOrPromise<BoundValue> {
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Get value for binding %s', this.key);
     }
+    let isCached = false; // Use a flag to see the ctx key exists in the cache
+    let cachedValue: BoundValue;
     // First check cached value for non-transient
-    if (this._cache !== undefined) {
+    if (this._cache) {
       if (this.scope === BindingScope.SINGLETON) {
-        return this._cache;
+        const ownerCtx = ctx.getOwner(this.key)!;
+        isCached = this._cache.has(ownerCtx);
+        cachedValue = isCached && this._cache.get(ownerCtx);
       } else if (this.scope === BindingScope.CONTEXT) {
-        if (ctx.contains(this.key)) {
-          return this._cache;
-        }
+        isCached = this._cache.has(ctx);
+        cachedValue = isCached && this._cache.get(ctx);
       }
     }
+    if (isCached) return cachedValue;
     if (this._getValue) {
       let result = ResolutionSession.runWithBinding(
         s => this._getValue(ctx, s),
@@ -348,7 +343,7 @@ export class Binding {
    * );
    * ```
    */
-  toDynamicValue(factoryFn: () => BoundValue | Promise<BoundValue>): this {
+  toDynamicValue(factoryFn: () => ValueOrPromise<BoundValue>): this {
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Bind %s to dynamic value:', this.key, factoryFn);

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -271,16 +271,32 @@ export class Context {
     }
 
     if (isPromise(boundValue)) {
-      return boundValue.then(v => getDeepProperty(v, path));
+      return boundValue.then(v => Binding.getDeepProperty(v, path));
     }
 
-    return getDeepProperty(boundValue, path);
+    return Binding.getDeepProperty(boundValue, path);
   }
 
-  clone() {
+  /**
+   * Clone the context with an optional new parent context
+   * @param parent Optional parent context
+   */
+  clone(parent?: Context) {
     const copy = new Context();
-    copy._parent = this._parent;
+    copy._parent = parent || this._parent;
     copy.registry = new Map(this.registry);
+    return copy;
+  }
+
+  /**
+   * Merge bindings from the given context into this one
+   * @param ctx Another context
+   */
+  mergeWith(ctx: Context) {
+    for (const kv of ctx.registry.entries()) {
+      this.registry.set(kv[0], kv[1]);
+    }
+    return this;
   }
 
   /**
@@ -293,20 +309,4 @@ export class Context {
     }
     return json;
   }
-}
-
-/**
- * Get nested properties by path
- * @param value Value of an object
- * @param path Path to the property
- */
-function getDeepProperty(value: BoundValue, path: string) {
-  const props = path.split('.');
-  for (const p of props) {
-    value = value[p];
-    if (value === undefined || value === null) {
-      return value;
-    }
-  }
-  return value;
 }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -72,6 +72,18 @@ export class Context {
   }
 
   /**
+   * Get the owning context for a binding key
+   * @param key Binding key
+   */
+  getOwner(key: string): Context | undefined {
+    if (this.contains(key)) return this;
+    if (this._parent) {
+      return this._parent.getOwner(key);
+    }
+    return undefined;
+  }
+
+  /**
    * Find bindings using the key pattern
    * @param pattern Key regexp or pattern with optional `*` wildcards
    */
@@ -263,6 +275,12 @@ export class Context {
     }
 
     return getDeepProperty(boundValue, path);
+  }
+
+  clone() {
+    const copy = new Context();
+    copy._parent = this._parent;
+    copy.registry = new Map(this.registry);
   }
 
   /**

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -184,7 +184,7 @@ export function resolveInjectedArguments(
 
   let nonInjectedIndex = 0;
   for (let ix = 0; ix < argLength; ix++) {
-    const injection = ix < injectedArgs.length ? injectedArgs[ix] : undefined;
+    let injection = ix < injectedArgs.length ? injectedArgs[ix] : undefined;
     if (injection == null || (!injection.bindingKey && !injection.resolve)) {
       if (nonInjectedIndex < nonInjectedArgs.length) {
         // Set the argument from the non-injected list
@@ -309,7 +309,7 @@ export function resolveInjectedProperties(
     (properties[p] = v);
 
   for (const p in injectedProperties) {
-    const injection = injectedProperties[p];
+    let injection = injectedProperties[p];
     if (!injection.bindingKey && !injection.resolve) {
       const name = getTargetName(constructor, p);
       throw new Error(
@@ -324,6 +324,7 @@ export function resolveInjectedProperties(
       injection,
       ResolutionSession.fork(session),
     );
+
     if (isPromise(valueOrPromise)) {
       if (!asyncResolvers) asyncResolvers = [];
       asyncResolvers.push(valueOrPromise.then(propertyResolver(p)));

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -11,6 +11,7 @@ import {
   Context,
   inject,
   Provider,
+  BoundValue,
 } from '../..';
 
 const key = 'foo';
@@ -69,6 +70,78 @@ describe('Binding', () => {
         key: 'foo',
         path: 'bar',
       });
+    });
+  });
+
+  describe('withOptions', () => {
+    /**
+     * Get a plain object for all options of the given binding
+     */
+    async function getOptions(b: Binding) {
+      const obj: {[name: string]: BoundValue} = {};
+      if (!b.options) return obj;
+      const bindings = b.options.find('*');
+
+      for (const i of bindings) {
+        obj[i.key] = await b.options.get(i.key);
+      }
+      return obj;
+    }
+
+    it('sets options for the binding', async () => {
+      binding.withOptions({x: 1});
+      expect(await getOptions(binding)).to.eql({x: 1});
+    });
+
+    it('clones options', () => {
+      const options = {x: 1};
+      binding.withOptions(options);
+      expect(binding.options).to.not.exactly(options);
+    });
+
+    it('merges options for the binding if called more than once', async () => {
+      binding.withOptions({x: 1});
+      binding.withOptions({y: 2});
+      expect(await getOptions(binding)).to.eql({x: 1, y: 2});
+    });
+
+    it('accepts options as context', async () => {
+      const options = new Context();
+      options.bind('x').toDynamicValue(async () => 1);
+      binding.withOptions(options);
+      const val = await getOptions(binding);
+      expect(val).to.eql({x: 1});
+    });
+
+    it('merges an object and a context for options', async () => {
+      binding.withOptions({y: 'a'});
+      const options = new Context();
+      options.bind('x').toDynamicValue(() => 1);
+      binding.withOptions(options);
+      const val = await getOptions(binding);
+      expect(val).to.eql({x: 1, y: 'a'});
+    });
+
+    it('merges a context and an object of options', async () => {
+      const options = new Context();
+      options.bind('x').toDynamicValue(() => 1);
+      binding.withOptions(options);
+      binding.withOptions({y: 'a'});
+      const val = await getOptions(binding);
+      expect(val).to.eql({x: 1, y: 'a'});
+    });
+
+    it('merges a context and another context of options', async () => {
+      const options = new Context();
+      options.bind('x').toDynamicValue(() => 1);
+      binding.withOptions(options);
+
+      const anotherOptions = new Context();
+      options.bind('y').to('a');
+      binding.withOptions(options);
+
+      const val = await getOptions(binding);
+      expect(val).to.eql({x: 1, y: 'a'});
     });
   });
 


### PR DESCRIPTION
### Description
The PR adds the following features:

1. Allow options to be provided for a binding
    - Add options property and withOptions method for a binding
    - Add @injection.options to receive injection of options
    - Fix routing table to use dependency injection

2. Introduce ResolutionSession to track dependency resolution chain 
    - Pass binding to dependency resolution
    - Track a stack of bindings to provide resolution path and detect circular dependencies

3. Improve the error handling to propagate errors gracefully through the promise/async/await chain
    - Introduce RejectionError
    - Add utilities to handle RejectionError for values or promises injection

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/pull/631
- connect to https://github.com/strongloop/loopback-next/issues/543
- connect to https://github.com/strongloop/loopback-next/issues/535

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
