### PR TITLE
fix(rest): convert other primitive types to string

### DIFF
--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -44,7 +44,7 @@ export class HttpHandler {
     return this._routes.describeApiPaths();
   }
 
-  findRoute(request: ParsedRequest) {
+  findRoute(request: ParsedRequest): ResolvedRoute {
     return this._routes.find(request);
   }
 

--- a/packages/rest/src/writer.ts
+++ b/packages/rest/src/writer.ts
@@ -19,14 +19,18 @@ export function writeResultToResponse(
   result: OperationRetval,
 ): void {
   if (result) {
-    if (typeof result === 'object') {
-      // TODO(ritch) remove this, should be configurable
-      // See https://github.com/strongloop/loopback-next/issues/436
-      response.setHeader('Content-Type', 'application/json');
-      // TODO(bajtos) handle errors - JSON.stringify can throw
-      result = JSON.stringify(result);
-    } else if (typeof result === 'string') {
-      response.setHeader('Content-Type', 'text/plain');
+    switch (typeof result) {
+      case 'object':
+        // TODO(ritch) remove this, should be configurable
+        // See https://github.com/strongloop/loopback-next/issues/436
+        response.setHeader('Content-Type', 'application/json');
+        // TODO(bajtos) handle errors - JSON.stringify can throw
+        result = JSON.stringify(result);
+        break;
+      default:
+        response.setHeader('Content-Type', 'text/plain');
+        result = result.toString();
+        break;
     }
     response.write(result);
   }

--- a/packages/rest/test/unit/writer.test.ts
+++ b/packages/rest/test/unit/writer.test.ts
@@ -31,6 +31,22 @@ describe('writer', () => {
     expect(result.payload).to.equal('{"name":"Joe"}');
   });
 
+  it('writes boolean result to response as text', async () => {
+    writeResultToResponse(response, true);
+    const result = await observedResponse;
+
+    expect(result.headers['content-type']).to.eql('text/plain');
+    expect(result.payload).to.equal('true');
+  });
+
+  it('writes number result to response as text', async () => {
+    writeResultToResponse(response, 2);
+    const result = await observedResponse;
+
+    expect(result.headers['content-type']).to.eql('text/plain');
+    expect(result.payload).to.equal('2');
+  });
+
   function setupResponseMock() {
     const responseMock = mockResponse();
     response = responseMock.response;


### PR DESCRIPTION
### Description


The response.write function requires a string or Buffer for the
final output. This change converts boolean and numeric values to
strings as well to prevent unhandled errors from being thrown
due to the output type.

#### Related issues

connected to https://github.com/strongloop/loopback4-example-getting-started/pull/1

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
