### PR TITLE
build: Force typedoc to use the project-level TypeScript

### DIFF
--- a/bin/generate-apidocs.js
+++ b/bin/generate-apidocs.js
@@ -1,4 +1,22 @@
 'use strict';
+var fs = require('fs');
+var path = require('path');
+var tsPath;
+try {
+  tsPath = require.resolve('typedoc/node_modules/typescript/package.json');
+} catch (e) {
+  // Ignore the error
+}
+if (tsPath) {
+  tsPath = path.resolve(tsPath, '..');
+  // Rename the nested typescript module for typedoc so that it uses the
+  // typescript version for our projects
+  try {
+    fs.renameSync(tsPath, tsPath + '.bak');
+  } catch (e) {
+    // Ignore the error
+  }
+}
 const spawn = require('child_process').spawn;
 // Call sdocs
 spawn(


### PR DESCRIPTION
### Description
This is a workaround for typedoc, which does not always have the same
version of TypeScript for our project. The script forces typdoc to use
project-level TypeScript dependency by renaming
`typedoc/node_modules/typescript` to `typedoc/node_modules/typescript.bak`.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
