### PR TITLE
chore: Fix vscode settings to exclude dist and dist6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,8 +13,8 @@
     "**/CVS": true,
     ".nyc_output": true,
     "coverage": true,
-    "packages/*/lib": true,
-    "packages/*/lib6": true,
+    "packages/*/dist": true,
+    "packages/*/dist6": true,
     "packages/*/api-docs": true
   },
   "files.insertFinalNewline": true,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "coverage": "open coverage/index.html",
     "lint": "npm run prettier:check && npm run tslint",
     "lint:fix": "npm run prettier:fix && npm run tslint:fix",
-    "tslint": "tslint -c tslint.full.json --project tsconfig.json --type-check",
+    "tslint": "tslint -c tslint.full.json --project tsconfig.json",
     "tslint:fix": "npm run tslint -- --fix",
     "prettier:cli": "prettier \"**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",


### PR DESCRIPTION
### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
