### PR TITLE
fix(repository): findById rejects on no result

### DIFF
--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -136,6 +136,11 @@ export class DefaultCrudRepository<T extends Entity, ID>
     const model = await ensurePromise(
       this.modelClass.findById(id, filter, options),
     );
+    if (!model) {
+      return Promise.reject(
+        new Error(`no ${this.modelClass.name} found with id "${id}"`),
+      );
+    }
     return this.toEntity(model);
   }
 

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -180,4 +180,15 @@ describe('DefaultCrudRepository', () => {
     const ok = await repo.exists(note1.id);
     expect(ok).to.be.true();
   });
+
+  it('throws if findById does not return a value', async () => {
+    const repo = new DefaultCrudRepository(Note, ds);
+    try {
+      await repo.findById(999999);
+    } catch (err) {
+      expect(err).to.match(/no Note was found with id/);
+      return;
+    }
+    throw new Error('No error was returned!');
+  });
 });


### PR DESCRIPTION
### Description

findById will now reject if there is no result returned from the database.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
