### PR TITLE
build: Fix build script for tsc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,5 @@ https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
 -->
 
 - [ ] New tests added or existing tests modified to cover all changes
-- [ ] Code conforms with the [style
-  guide](http://loopback.io/doc/en/contrib/style-guide.html)
+- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
+

--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -72,6 +72,10 @@ function run(argv, dryRun) {
       // No local tsconfig.build.json or tsconfig.json found
       var baseConfigFile = path.join(rootDir, 'config/tsconfig.common.json');
       baseConfigFile = path.relative(packageDir, baseConfigFile);
+      if (baseConfigFile.indexOf('../') !== 0) {
+        // tsconfig only supports relative or rooted path
+        baseConfigFile = './' + baseConfigFile;
+      }
       // Create tsconfig.json under the package as it's required to parse
       // include/exclude correctly
       tsConfigFile = path.join(packageDir, 'tsconfig.json');

--- a/packages/build/bin/utils.js
+++ b/packages/build/bin/utils.js
@@ -67,15 +67,22 @@ function getConfigFile(name, defaultName) {
   var dir = getPackageDir();
   var configFile = path.join(dir, name);
   if (!fs.existsSync(configFile)) {
+    debug('%s does not exist', configFile);
     if (defaultName) {
-      configFile = path.join(dir, name);
+      configFile = path.join(dir, defaultName);
       if (!fs.existsSync(configFile)) {
+        debug('%s does not exist', configFile);
         configFile = path.join(getRootDir(), 'config/' + name);
+      } else {
+        debug('%s found', configFile);
       }
     } else {
       // Fall back to config/
       configFile = path.join(getRootDir(), 'config/' + name);
+      debug('%s found', configFile);
     }
+  } else {
+    debug('%s found', configFile);
   }
   return configFile;
 }


### PR DESCRIPTION
### Description

Fix two issues in the lb-tsc:
1. tsconfig requires relative path to be started with `./` or `../`
2. getConfigFile debug for default name

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
