### PR TITLE
fix: Fix help text for cli

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -53,6 +53,14 @@ module.exports = class extends Generator {
     });
   }
 
+  /**
+   * Override the usage text by replacing `yo loopback4:` with `lb4 `.
+   */
+  usage() {
+    const text = super.usage();
+    return text.replace(/^yo loopback4:/g, 'lb4 ');
+  }
+
   setOptions() {
     this.projectInfo = {};
     [

--- a/packages/cli/test/project.js
+++ b/packages/cli/test/project.js
@@ -7,9 +7,22 @@
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
+const yeoman = require('yeoman-environment');
 
 module.exports = function(appGenerator, props) {
   return function() {
+    describe('help', () => {
+      it('prints lb4', () => {
+        const env = yeoman.createEnv();
+        const name = appGenerator.substring(appGenerator.lastIndexOf('/') + 1);
+        env.register(appGenerator, 'loopback4:' + name);
+        const generator = env.create('loopback4:' + name);
+        const helpText = generator.help();
+        assert(helpText.match(/lb4 /));
+        assert(!helpText.match(/loopback4:/));
+      });
+    });
+
     describe('without settings', () => {
       before(() => {
         return helpers.run(appGenerator).withPrompts(props);


### PR DESCRIPTION
### Description

Replace `yo loopback4:` with `lb4 ` in the help text.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

