### PR TITLE
feat(rest): Improve http error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build:current": "lerna run --loglevel=silent build:current",
     "pretest": "npm run build:current",
     "test": "node packages/build/bin/run-nyc npm run mocha",
-    "mocha": "node packages/build/bin/select-dist mocha --exit --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\"",
+    "mocha": "node packages/build/bin/select-dist mocha --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\"",
     "posttest": "npm run lint"
   },
   "config": {

--- a/packages/rest/src/providers/log-error-provider.ts
+++ b/packages/rest/src/providers/log-error-provider.ts
@@ -9,13 +9,15 @@ import {ServerRequest} from '../';
 export class LogErrorProvider implements Provider<BoundValue> {
   value() {
     return (err: Error, statusCode: number, req: ServerRequest) => {
-      console.error(
-        'Unhandled error in %s %s: %s %s',
-        req.method,
-        req.url,
-        statusCode,
-        err.stack || err,
-      );
+      if (statusCode >= 500) {
+        console.error(
+          'Unhandled error in %s %s: %s %s',
+          req.method,
+          req.url,
+          statusCode,
+          err.stack || err,
+        );
+      }
     };
   }
 }

--- a/packages/rest/src/providers/reject.ts
+++ b/packages/rest/src/providers/reject.ts
@@ -7,6 +7,7 @@ import {LogError, Reject} from '../internal-types';
 import {inject} from '@loopback/context';
 import {ServerResponse, ServerRequest} from 'http';
 import {HttpError} from 'http-errors';
+import {writeErrorToResponse} from '../writer';
 import {RestBindings} from '../keys';
 
 export class RejectProvider {
@@ -17,11 +18,9 @@ export class RejectProvider {
 
   value(): Reject {
     return (response: ServerResponse, request: ServerRequest, error: Error) => {
-      const err = error as HttpError;
+      const err = <HttpError>error;
       const statusCode = err.statusCode || err.status || 500;
-      response.statusCode = statusCode;
-      response.end();
-
+      writeErrorToResponse(response, err);
       this.logError(error, statusCode, request);
     };
   }

--- a/packages/rest/test/unit/writer.test.ts
+++ b/packages/rest/test/unit/writer.test.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {ServerResponse, writeResultToResponse} from '../..';
-
+import {Duplex} from 'stream';
 import {expect, mockResponse, ShotObservedResponse} from '@loopback/testlab';
 
 describe('writer', () => {
@@ -31,20 +31,41 @@ describe('writer', () => {
     expect(result.payload).to.equal('{"name":"Joe"}');
   });
 
-  it('writes boolean result to response as text', async () => {
+  it('writes boolean result to response as json', async () => {
     writeResultToResponse(response, true);
     const result = await observedResponse;
 
-    expect(result.headers['content-type']).to.eql('text/plain');
+    expect(result.headers['content-type']).to.eql('application/json');
     expect(result.payload).to.equal('true');
   });
 
-  it('writes number result to response as text', async () => {
+  it('writes number result to response as json', async () => {
     writeResultToResponse(response, 2);
     const result = await observedResponse;
 
-    expect(result.headers['content-type']).to.eql('text/plain');
+    expect(result.headers['content-type']).to.eql('application/json');
     expect(result.payload).to.equal('2');
+  });
+
+  it('writes buffer result to response as binary', async () => {
+    const buf = Buffer.from('ABC123');
+    writeResultToResponse(response, buf);
+    const result = await observedResponse;
+
+    expect(result.headers['content-type']).to.eql('application/octet-stream');
+    expect(result.payload).to.equal('ABC123');
+  });
+
+  it('writes stream result to response as binary', async () => {
+    const buf = Buffer.from('ABC123');
+    const stream = new Duplex();
+    stream.push(buf);
+    stream.push(null);
+    writeResultToResponse(response, stream);
+    const result = await observedResponse;
+
+    expect(result.headers['content-type']).to.eql('application/octet-stream');
+    expect(result.payload).to.equal('ABC123');
   });
 
   function setupResponseMock() {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --recursive
+--exit


### PR DESCRIPTION
Error are now sent back as json object per HttpError structure
Error properties are controlled by `expose`
Only log http 5xx errors to console

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

