### PR TITLE
fix(core): Return binding(s) for app.server/servers

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -78,12 +78,16 @@ export class Application extends Context {
    *
    * @param {Constructor<Server>} server The server constructor.
    * @param {string=} name Optional override for key name.
+   * @returns {Binding} Binding for the server class
    * @memberof Application
    */
-  public server<T extends Server>(ctor: Constructor<T>, name?: string) {
+  public server<T extends Server>(
+    ctor: Constructor<T>,
+    name?: string,
+  ): Binding {
     const suffix = name || ctor.name;
     const key = `${CoreBindings.SERVERS}.${suffix}`;
-    this.bind(key)
+    return this.bind(key)
       .toClass(ctor)
       .inScope(BindingScope.SINGLETON);
   }
@@ -106,10 +110,11 @@ export class Application extends Context {
    * ```
    *
    * @param {Constructor<Server>[]} ctors An array of Server constructors.
+   * @returns {Binding[]} An array of bindings for the registered server classes
    * @memberof Application
    */
-  public servers<T extends Server>(ctors: Constructor<T>[]) {
-    ctors.map(ctor => this.server(ctor));
+  public servers<T extends Server>(ctors: Constructor<T>[]): Binding[] {
+    return ctors.map(ctor => this.server(ctor));
   }
 
   /**


### PR DESCRIPTION
### Description

Make sure `app.server()` and `app.servers()` to return binding(s) so that these apis are consistent with `app.controller` etc.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

