### PR TITLE
feat(rest): Make rest host and explorer configurable

### DIFF
--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -8,6 +8,7 @@ import {CoreBindings} from '@loopback/core';
 export namespace RestBindings {
   // RestServer-specific bindings
   export const CONFIG = `${CoreBindings.APPLICATION_CONFIG}#rest`;
+  export const HOST = 'rest.host';
   export const PORT = 'rest.port';
   export const HANDLER = 'rest.handler';
 

--- a/packages/rest/test/integration/rest-server.integration.ts
+++ b/packages/rest/test/integration/rest-server.integration.ts
@@ -175,6 +175,7 @@ paths:
     expect(response.get('Access-Control-Allow-Credentials')).to.equal('true');
     expect(response.get('Access-Control-Allow-Max-Age')).to.equal('86400');
   });
+
   it('exposes "GET /swagger-ui" endpoint', async () => {
     const app = new Application({
       components: [RestComponent],
@@ -196,8 +197,40 @@ paths:
     await server.get(RestBindings.PORT);
     const url = new RegExp(
       [
+        'https://loopback.io/api-explorer',
+        '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/swagger.json',
+      ].join(''),
+    );
+    expect(response.get('Location')).match(url);
+    expect(response.get('Access-Control-Allow-Origin')).to.equal('*');
+    expect(response.get('Access-Control-Allow-Credentials')).to.equal('true');
+    expect(response.get('Access-Control-Allow-Max-Age')).to.equal('86400');
+  });
+
+  it('exposes "GET /swagger-ui" endpoint with apiExplorerUrl', async () => {
+    const app = new Application({
+      components: [RestComponent],
+      rest: {apiExplorerUrl: 'http://petstore.swagger.io'},
+    });
+    const server = await app.getServer(RestServer);
+    const greetSpec = {
+      responses: {
+        200: {
+          schema: {type: 'string'},
+          description: 'greeting of the day',
+        },
+      },
+    };
+    server.route(new Route('get', '/greet', greetSpec, function greet() {}));
+
+    const response = await createClientForHandler(server.handleHttp).get(
+      '/swagger-ui',
+    );
+    await server.get(RestBindings.PORT);
+    const url = new RegExp(
+      [
         'http://petstore.swagger.io',
-        '/\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/swagger.json',
+        '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/swagger.json',
       ].join(''),
     );
     expect(response.get('Location')).match(url);

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -71,6 +71,15 @@ describe('RestServer', () => {
       expect(server.getSync(RestBindings.PORT)).to.equal(3000);
     });
 
+    it('uses http host localhost by default', async () => {
+      const app = new Application({
+        components: [RestComponent],
+      });
+      const server = await app.getServer(RestServer);
+      const host = await server.getSync(RestBindings.HOST);
+      expect(host).to.equal('localhost');
+    });
+
     it('can set port 0', async () => {
       const app = new Application({
         components: [RestComponent],
@@ -78,6 +87,16 @@ describe('RestServer', () => {
       });
       const server = await app.getServer(RestServer);
       expect(server.getSync(RestBindings.PORT)).to.equal(0);
+    });
+
+    it('honors host/port', async () => {
+      const app = new Application({
+        components: [RestComponent],
+        rest: {port: 4000, host: 'my-host'},
+      });
+      const server = await app.getServer(RestServer);
+      expect(server.getSync(RestBindings.PORT)).to.equal(4000);
+      expect(server.getSync(RestBindings.HOST)).to.equal('my-host');
     });
   });
 


### PR DESCRIPTION
Introduce host and apiExplorerUrl rest config options
Use https://loopback.io/api-explorer as the hosted UI
See https://github.com/strongloop/loopback.io/pull/530

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback.io/pull/530

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

