### PR TITLE
fix(rest): Fix parameter description

### DIFF
--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -89,13 +89,15 @@ export class RoutingTable {
   registerRoute(route: RouteEntry) {
     // TODO(bajtos) handle the case where opSpec.parameters contains $ref
     // See https://github.com/strongloop/loopback-next/issues/435
-    debug(
-      'Registering route %s %s -> %s(%s)',
-      route.verb,
-      route.path,
-      route.describe(),
-      describeOperationParameters(route.spec),
-    );
+    if (debug.enabled) {
+      debug(
+        'Registering route %s %s -> %s(%s)',
+        route.verb,
+        route.path,
+        route.describe(),
+        describeOperationParameters(route.spec),
+      );
+    }
     this._routes.push(route);
   }
 
@@ -322,6 +324,6 @@ export class ControllerRoute extends BaseRoute {
 
 function describeOperationParameters(opSpec: OperationObject) {
   return ((opSpec.parameters as ParameterObject[]) || [])
-    .map(p => p.name)
+    .map(p => (p && p.name) || '')
     .join(', ');
 }


### PR DESCRIPTION
Avoid describing parameters if debug is not on
Check undefined parameters (not decorated with @param) in the array

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

