### PR TITLE
refactor(core): Switch to public accessibility

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -10,7 +10,7 @@ import {isPromise} from './is-promise';
  * Context provides an implementation of Inversion of Control (IoC) container
  */
 export class Context {
-  private registry: Map<string, Binding>;
+  registry: Map<string, Binding>;
 
   /**
    * Create a new context
@@ -102,7 +102,7 @@ export class Context {
     return this._mergeWithParent(bindings, parentBindings);
   }
 
-  protected _mergeWithParent(childList: Binding[], parentList?: Binding[]) {
+  _mergeWithParent(childList: Binding[], parentList?: Binding[]) {
     if (!parentList) return childList;
     const additions = parentList.filter(parentBinding => {
       // children bindings take precedence

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -161,13 +161,12 @@ export class Application extends Context {
 
   /**
    * Helper function for iterating across all registered server components.
-   * @protected
    * @template T
    * @param {(s: Server) => Promise<T>} fn The function to run against all
    * registered servers
    * @memberof Application
    */
-  protected async _forEachServer<T>(fn: (s: Server) => Promise<T>) {
+  public async _forEachServer<T>(fn: (s: Server) => Promise<T>) {
     const bindings = this.find(`${CoreBindings.SERVERS}.*`);
     await Promise.all(
       bindings.map(async binding => {


### PR DESCRIPTION
### Description

Allow mixins to leverage existing class properties and methods
from the Application and Context classes by making them public
instead of protected or private. As of this writing, TypeScript
prohibits use of protected/private properties and methods within
a Mixin, even if they are defined by a superclass.


#### Related issues
blocking strongloop/loopback-typeorm#1

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

