### PR TITLE
test: use dot reporter

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --recursive
 --exit
+--reporter dot


### PR DESCRIPTION
With more than 400 hundred test cases, the output of the default Mocha reporter produces several screens of text, which is no longer useful.

This commit changes the test reporter to `dot`, which is the same reporter we are already using in LoopBack3 repositories.