### PR TITLE
fix(rest): Listen on all interfaces if host is not configured

### DIFF
--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -138,7 +138,8 @@ export class RestServer extends Context implements Server {
       options.port = 3000;
     }
     if (options.host == null) {
-      options.host = 'localhost';
+      // Set it to '' so that the http server will listen on all interfaces
+      options.host = undefined;
     }
     this.bind(RestBindings.PORT).to(options.port);
     this.bind(RestBindings.HOST).to(options.host);

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -71,13 +71,13 @@ describe('RestServer', () => {
       expect(server.getSync(RestBindings.PORT)).to.equal(3000);
     });
 
-    it('uses http host localhost by default', async () => {
+    it('uses undefined http host by default', async () => {
       const app = new Application({
         components: [RestComponent],
       });
       const server = await app.getServer(RestServer);
       const host = await server.getSync(RestBindings.HOST);
-      expect(host).to.equal('localhost');
+      expect(host).to.be.undefined();
     });
 
     it('can set port 0', async () => {


### PR DESCRIPTION
### Description

Fix https://github.com/strongloop/loopback4-example-getting-started/issues/9

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback4-example-getting-started/issues/9

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

