### PR TITLE
feat(cli): remove default option for controller

### DIFF
--- a/packages/cli/lib/artifact-generator.js
+++ b/packages/cli/lib/artifact-generator.js
@@ -61,9 +61,8 @@ module.exports = class ArtifactGenerator extends Generator {
       {
         type: 'input',
         name: 'name',
-        message: utils.toClassName(this.artifactInfo.type) + ' name:', // capitalization
+        message: utils.toClassName(this.artifactInfo.type) + ' class name:', // capitalization
         when: this.artifactInfo.name === undefined,
-        default: this.artifactInfo.defaultName,
         validate: utils.validateClassName,
       },
     ];

--- a/packages/cli/test/controller.js
+++ b/packages/cli/test/controller.js
@@ -51,31 +51,6 @@ describe('lb4 controller', () => {
       assert.fileContent(tmpDir + withInputName, /constructor\(\) {}/);
     });
   });
-  describe('without input', () => {
-    let tmpDir;
-    before(() => {
-      return helpers
-        .run(generator)
-        .inTmpDir(dir => {
-          tmpDir = dir;
-          fs.writeFileSync(
-            path.join(tmpDir, 'package.json'),
-            JSON.stringify({
-              keywords: ['loopback'],
-            })
-          );
-        })
-        .withPrompts(noInputProps);
-    });
-    it('writes correct file name', () => {
-      assert.file(tmpDir + noInputName);
-      assert.noFile(tmpDir + templateName);
-    });
-    it('scaffolds correct files', () => {
-      assert.fileContent(tmpDir + noInputName, /class NewController/);
-      assert.fileContent(tmpDir + noInputName, /constructor\(\) {}/);
-    });
-  });
   describe('with arg', () => {
     let tmpDir;
     before(() => {


### PR DESCRIPTION
### Description
- removed default name for the controller name prompt in favor of forcing user to give the controller a name