### PR TITLE
feat: Add exit() to abort generation

### DIFF
--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -35,6 +35,7 @@ module.exports = class extends ProjectGenerator {
   }
 
   promptApplication() {
+    if (this.shouldExit()) return false;
     const prompts = [
       {
         type: 'input',
@@ -62,6 +63,7 @@ module.exports = class extends ProjectGenerator {
   }
 
   end() {
+    if (!super.end()) return false;
     this.log();
     this.log(
       'Application %s is now created in %s.',

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -31,6 +31,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
 
   scaffold() {
     super.scaffold();
+    if (this.shouldExit()) return false;
     this.artifactInfo.filename =
       utils.kebabCase(this.artifactInfo.name) + '.controller.ts';
 
@@ -46,6 +47,8 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
   }
 
   end() {
+    super.end();
+    if (this.shouldExit()) return false;
     // logs a message if there is no file conflict
     if (
       this.conflicter.generationStatus[this.artifactInfo.filename] !== 'skip' &&

--- a/packages/cli/generators/extension/index.js
+++ b/packages/cli/generators/extension/index.js
@@ -39,6 +39,7 @@ module.exports = class extends ProjectGenerator {
   }
 
   promptComponent() {
+    if (this.shouldExit()) return false;
     const prompts = [
       {
         type: 'input',
@@ -64,5 +65,9 @@ module.exports = class extends ProjectGenerator {
 
   install() {
     return super.install();
+  }
+
+  end() {
+    return super.end();
   }
 };

--- a/packages/cli/lib/artifact-generator.js
+++ b/packages/cli/lib/artifact-generator.js
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
-const Generator = require('yeoman-generator');
+const BaseGenerator = require('./base-generator');
 const utils = require('./utils');
 const StatusConflicter = utils.StatusConflicter;
 
-module.exports = class ArtifactGenerator extends Generator {
+module.exports = class ArtifactGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);
@@ -35,33 +35,43 @@ module.exports = class ArtifactGenerator extends Generator {
   }
 
   /**
-   * Override the usage text by replacing `yo loopback4:` with `lb4 `.
-   */
-  usage() {
-    const text = super.usage();
-    return text.replace(/^yo loopback4:/g, 'lb4 ');
-  }
-
-  /**
    * Checks if current directory is a LoopBack project by checking for
    * keyword 'loopback' under 'keywords' attribute in package.json.
    * 'keywords' is an array
    */
   checkLoopBackProject() {
+    if (this.shouldExit()) return false;
     const pkg = this.fs.readJSON(this.destinationPath('package.json'));
     const key = 'loopback';
-    if (!pkg) throw new Error('unable to load package.json');
-    if (!pkg.keywords || !pkg.keywords.includes(key))
-      throw new Error('keywords does not map to loopback in package.json');
-    return;
+    if (!pkg) {
+      const err = new Error(
+        'No package.json found in ' +
+          this.destinationRoot() +
+          '. ' +
+          'The command must be run in a LoopBack project.'
+      );
+      this.exit(err);
+      return;
+    }
+    if (!pkg.keywords || !pkg.keywords.includes(key)) {
+      const err = new Error(
+        'No `loopback` keyword found in ' +
+          this.destinationPath('package.json') +
+          '. ' +
+          'The command must be run in a LoopBack project.'
+      );
+      this.exit(err);
+    }
   }
 
   promptArtifactName() {
+    if (this.shouldExit()) return false;
     const prompts = [
       {
         type: 'input',
         name: 'name',
-        message: utils.toClassName(this.artifactInfo.type) + ' class name:', // capitalization
+        // capitalization
+        message: utils.toClassName(this.artifactInfo.type) + ' class name:',
         when: this.artifactInfo.name === undefined,
         validate: utils.validateClassName,
       },
@@ -73,6 +83,7 @@ module.exports = class ArtifactGenerator extends Generator {
   }
 
   scaffold() {
+    if (this.shouldExit()) return false;
     // Capitalize class name
     this.artifactInfo.name = utils.toClassName(this.artifactInfo.name);
 
@@ -85,6 +96,5 @@ module.exports = class ArtifactGenerator extends Generator {
       {},
       {globOptions: {dot: true}}
     );
-    return;
   }
 };

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const Generator = require('yeoman-generator');
+const path = require('path');
+const utils = require('./utils');
+const chalk = require('chalk');
+
+/**
+ * Base Generator for LoopBack 4
+ */
+module.exports = class BaseGenerator extends Generator {
+  // Note: arguments and options should be defined in the constructor.
+  constructor(args, opts) {
+    super(args, opts);
+    this._setupGenerator();
+  }
+
+  /**
+   * Subclasses can extend _setupGenerator() to set up the generator
+   */
+  _setupGenerator() {
+    // No operation
+  }
+
+  /**
+   * Override the usage text by replacing `yo loopback4:` with `lb4 `.
+   */
+  usage() {
+    const text = super.usage();
+    return text.replace(/^yo loopback4:/g, 'lb4 ');
+  }
+
+  /**
+   * Tell this generator to exit with the given reason
+   * @param {string|Error} reason
+   */
+  exit(reason) {
+    // exit(false) should not exit
+    if (reason === false) return;
+    // exit(), exit(undefined), exit('') should exit
+    if (!reason) reason = true;
+    this.exitGeneration = reason;
+  }
+
+  /**
+   * Check if the generator should exit
+   */
+  shouldExit() {
+    return !!this.exitGeneration;
+  }
+
+  /**
+   * Print out the exit reason if this generator is told to exit before it ends
+   */
+  end() {
+    if (this.shouldExit()) {
+      this.log(chalk.red('Generation is aborted:', this.exitGeneration));
+      return false;
+    }
+    return true;
+  }
+};

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
-const Generator = require('yeoman-generator');
+const BaseGenerator = require('./base-generator');
 const path = require('path');
 const utils = require('./utils');
 
-module.exports = class extends Generator {
+module.exports = class ProjectGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);
@@ -53,14 +53,6 @@ module.exports = class extends Generator {
     });
   }
 
-  /**
-   * Override the usage text by replacing `yo loopback4:` with `lb4 `.
-   */
-  usage() {
-    const text = super.usage();
-    return text.replace(/^yo loopback4:/g, 'lb4 ');
-  }
-
   setOptions() {
     this.projectInfo = {projectType: this.projectType};
     [
@@ -80,6 +72,7 @@ module.exports = class extends Generator {
   }
 
   promptProjectName() {
+    if (this.shouldExit()) return false;
     const prompts = [
       {
         type: 'input',
@@ -103,6 +96,7 @@ module.exports = class extends Generator {
   }
 
   promptProjectDir() {
+    if (this.shouldExit()) return false;
     const prompts = [
       {
         type: 'input',
@@ -122,6 +116,7 @@ module.exports = class extends Generator {
   }
 
   promptOptions() {
+    if (this.shouldExit()) return false;
     const choices = [];
     ['tslint', 'prettier', 'mocha', 'loopbackBuild'].forEach(f => {
       if (!this.options[f]) {
@@ -155,6 +150,7 @@ module.exports = class extends Generator {
   }
 
   scaffold() {
+    if (this.shouldExit()) return false;
     this.destinationRoot(this.projectInfo.outdir);
 
     // First copy common files from ../../project/templates
@@ -210,6 +206,7 @@ module.exports = class extends Generator {
   }
 
   install() {
+    if (this.shouldExit()) return false;
     this.npmInstall(null, {}, {cwd: this.destinationRoot()});
   }
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "camelcase-keys": "^4.1.0",
+    "chalk": "^2.3.0",
     "debug": "^3.1.0",
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Throwing an error in yeoman is ugly. This PR allows a generator
to abort with a reason. The reason will be logged at the end.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

