### PR TITLE
refactor(rest): Server decorator for controllers

### DIFF
--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -220,9 +220,14 @@ export class RestServer extends Context implements Server {
       // If the controller has been scoped to a particular server...
       if (ctor.prototype._server) {
         // Check if this binding returns the same instance.
-        const server = this.getSync(`servers.${ctor.prototype._server}`);
-        if (server === this) {
-          this._httpHandler.registerController(ctor, apiSpec);
+        try {
+          const server = this.getSync(`servers.${ctor.prototype._server}`);
+          if (server === this) {
+            this._httpHandler.registerController(ctor, apiSpec);
+          }
+        } catch (e) {
+          e.message = `invalid use of @server decorator: ${e.message}`;
+          throw e;
         }
       } else {
         this._httpHandler.registerController(ctor, apiSpec);

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -217,7 +217,16 @@ export class RestServer extends Context implements Server {
         // controller methods are specified through app.api() spec
         continue;
       }
-      this._httpHandler.registerController(ctor, apiSpec);
+      // If the controller has been scoped to a particular server...
+      if (ctor.prototype._server) {
+        // Check if this binding returns the same instance.
+        const server = this.getSync(`servers.${ctor.prototype._server}`);
+        if (server === this) {
+          this._httpHandler.registerController(ctor, apiSpec);
+        }
+      } else {
+        this._httpHandler.registerController(ctor, apiSpec);
+      }
     }
 
     for (const b of this.find('routes.*')) {

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -16,7 +16,7 @@ import {
 import {ServerRequest, ServerResponse, createServer} from 'http';
 import * as Http from 'http';
 import {Application, CoreBindings, Server} from '@loopback/core';
-import {getControllerSpec} from './router/metadata';
+import {getControllerSpec, getControllerScope} from './router/metadata';
 import {HttpHandler} from './http-handler';
 import {DefaultSequence, SequenceHandler, SequenceFunction} from './sequence';
 import {
@@ -218,10 +218,11 @@ export class RestServer extends Context implements Server {
         continue;
       }
       // If the controller has been scoped to a particular server...
-      if (ctor.prototype._server) {
+      const scope = getControllerScope(ctor);
+      if (scope) {
         // Check if this binding returns the same instance.
         try {
-          const server = this.getSync(`servers.${ctor.prototype._server}`);
+          const server = this.getSync(`servers.${scope}`);
           if (server === this) {
             this._httpHandler.registerController(ctor, apiSpec);
           }

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -220,11 +220,13 @@ export class RestServer extends Context implements Server {
       // If the controller has been scoped to a particular server...
       const scope = getControllerScope(ctor);
       if (scope) {
-        // Check if this binding returns the same instance.
         try {
-          const server = this.getSync(`servers.${scope}`);
-          if (server === this) {
-            this._httpHandler.registerController(ctor, apiSpec);
+          for (const name of scope) {
+            const server = this.getSync(`servers.${name}`);
+            if (server === this) {
+              this._httpHandler.registerController(ctor, apiSpec);
+              break;
+            }
           }
         } catch (e) {
           e.message = `invalid use of @server decorator: ${e.message}`;

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -423,6 +423,26 @@ describe('Routing', () => {
     await client.get('/greet?name=world').expect(200, 'hello world');
   });
 
+  it('throws when @server is used with invalid name', async () => {
+    const app = givenAnApplication();
+    const specOne = anOpenApiSpec()
+      .withOperationReturningString('get', '/greet', 'greet')
+      .withOperationReturningString('get', '/neat', 'neat')
+      .build();
+
+    @server('RustServer')
+    @api(specOne)
+    class MyController {}
+
+    app.controller(MyController);
+    try {
+      await app.start();
+      throw new Error('did not fail as expected');
+    } catch (e) {
+      expect(e.message).to.match(/invalid use of \@server/);
+    }
+  });
+
   describe('multiple servers', async () => {
     let app: Application;
     beforeEach(async () => {

--- a/packages/rest/test/unit/router/metadata.test.ts
+++ b/packages/rest/test/unit/router/metadata.test.ts
@@ -13,6 +13,7 @@ import {
   patch,
   del,
   param,
+  server,
 } from '../../..';
 import {expect} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
@@ -32,6 +33,40 @@ describe('Routing metadata', () => {
 
     const actualSpec = getControllerSpec(MyController);
     expect(actualSpec).to.eql(expectedSpec);
+  });
+
+  it('correctly scopes spec to specified server', () => {
+    const specOne = anOpenApiSpec()
+      .withOperationReturningString('get', '/greet', 'greet')
+      .build();
+
+    const specTwo = anOpenApiSpec()
+      .withOperationReturningString('get', '/feet', 'feet')
+      .build();
+
+    @server('foo')
+    @api(specOne)
+    class ControllerOne {
+      greet() {
+        return 'Hello world!';
+      }
+    }
+
+    @api(specTwo)
+    @server('bar')
+    class ControllerTwo {
+      feet() {
+        return '\|/ \|/';
+      }
+    }
+
+    const actualSpecOne = getControllerSpec(ControllerOne);
+    const actualSpecTwo = getControllerSpec(ControllerTwo);
+
+    // References are different
+    expect(actualSpecOne).to.not.equal(actualSpecTwo);
+    expect(actualSpecOne).to.eql(specOne);
+    expect(actualSpecTwo).to.eql(specTwo);
   });
 
   it('returns spec defined via @get decorator', () => {

--- a/packages/rest/test/unit/router/metadata.test.ts
+++ b/packages/rest/test/unit/router/metadata.test.ts
@@ -35,40 +35,6 @@ describe('Routing metadata', () => {
     expect(actualSpec).to.eql(expectedSpec);
   });
 
-  it('correctly scopes spec to specified server', () => {
-    const specOne = anOpenApiSpec()
-      .withOperationReturningString('get', '/greet', 'greet')
-      .build();
-
-    const specTwo = anOpenApiSpec()
-      .withOperationReturningString('get', '/feet', 'feet')
-      .build();
-
-    @servers(['foo'])
-    @api(specOne)
-    class ControllerOne {
-      greet() {
-        return 'Hello world!';
-      }
-    }
-
-    @api(specTwo)
-    @servers(['bar'])
-    class ControllerTwo {
-      feet() {
-        return '\|/ \|/';
-      }
-    }
-
-    const actualSpecOne = getControllerSpec(ControllerOne);
-    const actualSpecTwo = getControllerSpec(ControllerTwo);
-
-    // References are different
-    expect(actualSpecOne).to.not.equal(actualSpecTwo);
-    expect(actualSpecOne).to.eql(specOne);
-    expect(actualSpecTwo).to.eql(specTwo);
-  });
-
   it('returns spec defined via @get decorator', () => {
     const operationSpec = anOperationSpec()
       .withStringResponse()
@@ -388,5 +354,73 @@ describe('Routing metadata', () => {
       name: 'msg',
       in: 'query',
     });
+  });
+
+  it('correctly scopes spec to specified server', () => {
+    const specOne = anOpenApiSpec()
+      .withOperationReturningString('get', '/greet', 'greet')
+      .build();
+
+    const specTwo = anOpenApiSpec()
+      .withOperationReturningString('get', '/feet', 'feet')
+      .build();
+
+    @servers(['foo'])
+    @api(specOne)
+    class ControllerOne {
+      greet() {
+        return 'Hello world!';
+      }
+    }
+
+    @api(specTwo)
+    @servers(['bar'])
+    class ControllerTwo {
+      feet() {
+        return '\|/ \|/';
+      }
+    }
+
+    const actualSpecOne = getControllerSpec(ControllerOne);
+    const actualSpecTwo = getControllerSpec(ControllerTwo);
+
+    // References are different
+    expect(actualSpecOne).to.not.equal(actualSpecTwo);
+    expect(actualSpecOne).to.eql(specOne);
+    expect(actualSpecTwo).to.eql(specTwo);
+  });
+
+  it('correctly assigns controller endpoints to specific servers', () => {
+    @servers(['foo'])
+    class ControllerOne {
+      @get('/greet')
+      greet() {
+        return 'Hello world!';
+      }
+    }
+
+    @servers(['bar'])
+    class ControllerTwo {
+      @get('/feet')
+      feet() {
+        return '\|/ \|/';
+      }
+    }
+
+    const actualSpecOne = getControllerSpec(ControllerOne);
+    const actualSpecTwo = getControllerSpec(ControllerTwo);
+
+    expect(actualSpecOne).to.not.equal(actualSpecTwo);
+    expect(actualSpecOne.paths['/greet']['get']).to.have.property(
+      'x-operation-name',
+      'greet',
+    );
+    expect(actualSpecTwo.paths['/feet']['get']).to.have.property(
+      'x-operation-name',
+      'feet',
+    );
+    // The controller functions should be constrained to their individual specs.
+    expect(actualSpecOne.paths['/feet']).to.be.undefined();
+    expect(actualSpecTwo.paths['/greet']).to.be.undefined();
   });
 });

--- a/packages/rest/test/unit/router/metadata.test.ts
+++ b/packages/rest/test/unit/router/metadata.test.ts
@@ -13,7 +13,7 @@ import {
   patch,
   del,
   param,
-  server,
+  servers,
 } from '../../..';
 import {expect} from '@loopback/testlab';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
@@ -44,7 +44,7 @@ describe('Routing metadata', () => {
       .withOperationReturningString('get', '/feet', 'feet')
       .build();
 
-    @server('foo')
+    @servers(['foo'])
     @api(specOne)
     class ControllerOne {
       greet() {
@@ -53,7 +53,7 @@ describe('Routing metadata', () => {
     }
 
     @api(specTwo)
-    @server('bar')
+    @servers(['bar'])
     class ControllerTwo {
       feet() {
         return '\|/ \|/';


### PR DESCRIPTION
### Description

Calls to `@api` as well as specifications assembled via other
decorators may now be constrained to known server instances by
using the `@servers` decorator, along with an array of server names,
each of which corresponds to a server binding on the Application.

```ts

// This controller's routes are now scoped to the servers bound
// to `servers.someServer` and `servers.someOtherServer`.
@api(spec)
@servers(['someServer', 'someOtherServer'])
export class SomeController {
  // etc...
}
```

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

