### PR TITLE
fix(rest): move @types/http-errors from dev-dep

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -26,6 +26,7 @@
     "@loopback/context": "^4.0.0-alpha.21",
     "@loopback/core": "^4.0.0-alpha.23",
     "@loopback/openapi-spec": "^4.0.0-alpha.16",
+    "@types/http-errors": "^1.6.1",
     "body": "^5.1.0",
     "debug": "^3.1.0",
     "http-errors": "^1.6.1",
@@ -38,7 +39,6 @@
     "@loopback/build": "^4.0.0-alpha.6",
     "@loopback/openapi-spec-builder": "^4.0.0-alpha.13",
     "@loopback/testlab": "^4.0.0-alpha.15",
-    "@types/http-errors": "^1.5.34",
     "@types/js-yaml": "^3.9.1",
     "@types/lodash": "^4.14.85"
   },


### PR DESCRIPTION
### Description

Move @types/http-errors from dev-dependency to dependency. Previously, project scaffolded by @loopback/cli would not compile when using @loopback/rest~11. On a side note, when the CLI is run on node 8.4 it installs rest@alpha.11, while node 8.7 installs rest@alpha.9. This may need to be looked into as well.