### PR TITLE
fix(cli): use prerelease versioning for templates

### DIFF
--- a/packages/cli/generators/project/templates/package.json
+++ b/packages/cli/generators/project/templates/package.json
@@ -58,22 +58,22 @@
     "dist6"
   ],
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.18",
+    "@loopback/context": ">=4.0.0-alpha.18",
     <% if (project.projectType === 'application') { -%>
-    "@loopback/core": "^4.0.0-alpha.20",
-    "@loopback/rest": "^4.0.0-alpha.7"
+    "@loopback/core": ">=4.0.0-alpha.20",
+    "@loopback/rest": ">=4.0.0-alpha.7"
     <% } else { -%>
-    "@loopback/core": "^4.0.0-alpha.20"
+    "@loopback/core": ">=4.0.0-alpha.20"
     <% } -%>
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.4",
+    "@loopback/build": ">=4.0.0-alpha.4",
     <% if (project.mocha) { -%>
-    "@loopback/testlab": "^4.0.0-alpha.13",
+    "@loopback/testlab": ">=4.0.0-alpha.13",
     "@types/mocha": "^2.2.43",
     "mocha": "^4.0.1"
     <% } else { -%>
-    "@loopback/testlab": "^4.0.0-alpha.13"
+    "@loopback/testlab": ">=4.0.0-alpha.13"
     <% } -%>
   }
 }

--- a/packages/cli/generators/project/templates/package.plain.json
+++ b/packages/cli/generators/project/templates/package.plain.json
@@ -57,12 +57,12 @@
     "dist"
   ],
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.18",
+    "@loopback/context": ">=4.0.0-alpha.18",
     <% if (project.projectType === 'application') { -%>
-    "@loopback/core": "^4.0.0-alpha.20",
-    "@loopback/rest": "^4.0.0-alpha.7"
+    "@loopback/core": ">=4.0.0-alpha.20",
+    "@loopback/rest": ">=4.0.0-alpha.7"
     <% } else { -%>
-    "@loopback/core": "^4.0.0-alpha.20"
+    "@loopback/core": ">=4.0.0-alpha.20"
     <% } -%>
   },
   "devDependencies": {
@@ -72,7 +72,7 @@
     <% if (project.tslint) { -%>
     "tslint": "^5.7.0",
     <% } -%>
-    "@loopback/testlab": "^4.0.0-alpha.13",
+    "@loopback/testlab": ">=4.0.0-alpha.13",
     <% if (project.mocha) { -%>
     "@types/mocha": "^2.2.43",
     "mocha": "^4.0.1",


### PR DESCRIPTION
### Description
The caret (`^`) doesn't work for prerelease packages, so now the templates will use `>` for determining which prerelease is "newer"/"newest".

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

