### PR TITLE
fix(rest): Fix compilation error caused by @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@commitlint/config-angular": "^4.3.0",
     "@commitlint/config-lerna-scopes": "^4.3.0",
     "@types/mocha": "^2.2.44",
-    "@types/node": "^8.0.50",
+    "@types/node": "^8.0.56",
     "@types/request": "^2.0.7",
     "@types/request-promise": "^4.1.39",
     "coveralls": "^3.0.0",

--- a/packages/rest/src/internal-types.ts
+++ b/packages/rest/src/internal-types.ts
@@ -11,7 +11,7 @@ export interface ParsedRequest extends ServerRequest {
   // see http://expressjs.com/en/4x/api.html#req.path
   path: string;
   // see http://expressjs.com/en/4x/api.html#req.query
-  query: {[key: string]: string};
+  query: {[key: string]: string | string[]};
   // see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15808
   url: string;
   pathname: string;

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -45,7 +45,13 @@ export function parseRequestUrl(request: ServerRequest): ParsedRequest {
   const parsedRequest = request as ParsedRequest;
   const parsedUrl = url.parse(parsedRequest.url, true);
   parsedRequest.path = parsedUrl.pathname || '/';
-  parsedRequest.query = parsedUrl.query;
+  // parsedUrl.query cannot be a string as it is parsed with
+  // parseQueryString = true
+  if (parsedUrl.query != null && typeof parsedUrl.query !== 'string') {
+    parsedRequest.query = parsedUrl.query;
+  } else {
+    parsedRequest.query = {};
+  }
   return parsedRequest;
 }
 


### PR DESCRIPTION
@types/node@8.0.56 introduces a breaking change for URL and our build
fails due to imcompatible types

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

