### PR TITLE
feat(cli): store config in custom file

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -6,6 +6,7 @@
 'use strict';
 const BaseGenerator = require('./base-generator');
 const utils = require('./utils');
+const pkg = require('../package.json');
 
 module.exports = class ProjectGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.
@@ -208,10 +209,23 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     if (!this.projectInfo.mocha) {
       this.fs.delete(this.destinationPath('test/mocha.opts'));
     }
+
+    this.writeConfig();
   }
 
   install() {
     if (this.shouldExit()) return false;
     this.npmInstall(null, {}, {cwd: this.destinationRoot()});
+  }
+
+  /**
+   * Write the default config for a generated project
+   */
+  writeConfig() {
+    return this.config.defaults({
+      cliVersion: pkg.version,
+      lbVersion: '4.0.0',
+      type: this.projectInfo.projectType,
+    });
   }
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",
     "regenerate": "^1.3.3",
+    "semver": "^5.4.1",
     "unicode-10.0.0": "^0.7.4",
     "validate-npm-package-name": "^3.0.0",
     "yeoman-generator": "^2.0.1"

--- a/packages/cli/test/controller.js
+++ b/packages/cli/test/controller.js
@@ -24,7 +24,7 @@ describe('controller-generator extending BaseGenerator', baseTests);
 describe('generator-loopback4:controller', tests);
 
 describe('lb4 controller', () => {
-  it('does not run without package.json', () => {
+  it('does not run without .yo-rc.json', () => {
     helpers
       .run(generator)
       .withPrompts(withInputProps)
@@ -32,16 +32,18 @@ describe('lb4 controller', () => {
         assert.noFile(withInputName);
       });
   });
-  it('does not run without the loopback keyword', () => {
+  it('does not run without the correct lbVersion', () => {
     let tmpDir;
     helpers
       .run(generator)
       .inTmpDir(dir => {
         tmpDir = dir;
         fs.writeFileSync(
-          path.join(tmpDir, 'package.json'),
+          path.join(tmpDir, '.yo-rc.json'),
           JSON.stringify({
-            keywords: ['foobar'],
+            '@loopback/cli': {
+              lbVersion: '4.0.0',
+            },
           })
         );
       })
@@ -59,9 +61,11 @@ describe('lb4 controller', () => {
         .inTmpDir(dir => {
           tmpDir = dir;
           fs.writeFileSync(
-            path.join(tmpDir, 'package.json'),
+            path.join(tmpDir, '.yo-rc.json'),
             JSON.stringify({
-              keywords: ['loopback'],
+              '@loopback/cli': {
+                lbVersion: '4.0.0',
+              },
             })
           );
         })
@@ -84,9 +88,11 @@ describe('lb4 controller', () => {
         .inTmpDir(dir => {
           tmpDir = dir;
           fs.writeFileSync(
-            path.join(tmpDir, 'package.json'),
+            path.join(tmpDir, '.yo-rc.json'),
             JSON.stringify({
-              keywords: ['loopback'],
+              '@loopback/cli': {
+                lbVersion: '4.0.0',
+              },
             })
           );
         })


### PR DESCRIPTION
This creates a file called `.loopback` that allows us to store project config for future reference. Can store stuff like CLI Version, type of project, orm's being used, etc. 

Storage API is used for reading / writing to config. Any class extending `BaseGenerator` will have access to `.loopback` config.  

connect to #759 