### PR TITLE
refactor(rest): use named functions for sequence actions

### DIFF
--- a/packages/rest/src/providers/bind-element.ts
+++ b/packages/rest/src/providers/bind-element.ts
@@ -3,13 +3,18 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, Provider} from '@loopback/context';
+import {Context, inject, Provider, Binding} from '@loopback/context';
 import {BindElement} from '../internal-types';
 import {RestBindings} from '../keys';
 
 export class BindElementProvider implements Provider<BindElement> {
   constructor(@inject(RestBindings.Http.CONTEXT) protected context: Context) {}
+
   value(): BindElement {
-    return (key: string) => this.context.bind(key);
+    return key => this.action(key);
+  }
+
+  action(key: string): Binding {
+    return this.context.bind(key);
   }
 }

--- a/packages/rest/src/providers/find-route.ts
+++ b/packages/rest/src/providers/find-route.ts
@@ -7,6 +7,8 @@ import {Context, inject, Provider} from '@loopback/context';
 import {FindRoute} from '../internal-types';
 import {HttpHandler} from '../http-handler';
 import {RestBindings} from '../keys';
+import {ParsedRequest} from '../internal-types';
+import {ResolvedRoute} from '../router/routing-table';
 
 export class FindRouteProvider implements Provider<FindRoute> {
   constructor(
@@ -15,10 +17,12 @@ export class FindRouteProvider implements Provider<FindRoute> {
   ) {}
 
   value(): FindRoute {
-    return request => {
-      const found = this.handler.findRoute(request);
-      found.updateBindings(this.context);
-      return found;
-    };
+    return request => this.action(request);
+  }
+
+  action(request: ParsedRequest): ResolvedRoute {
+    const found = this.handler.findRoute(request);
+    found.updateBindings(this.context);
+    return found;
   }
 }

--- a/packages/rest/src/providers/get-from-context.ts
+++ b/packages/rest/src/providers/get-from-context.ts
@@ -3,14 +3,18 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, Provider} from '@loopback/context';
+import {Context, inject, Provider, BoundValue} from '@loopback/context';
 import {GetFromContext} from '../internal-types';
 import {RestBindings} from '../keys';
 
 export class GetFromContextProvider implements Provider<GetFromContext> {
   constructor(@inject(RestBindings.Http.CONTEXT) protected context: Context) {}
 
-  value() {
-    return (key: string) => this.context.get(key);
+  value(): GetFromContext {
+    return key => this.action(key);
+  }
+
+  action(key: string): Promise<BoundValue> {
+    return this.context.get(key);
   }
 }

--- a/packages/rest/src/providers/invoke-method.ts
+++ b/packages/rest/src/providers/invoke-method.ts
@@ -4,15 +4,18 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context, inject, Provider} from '@loopback/context';
-import {InvokeMethod} from '../internal-types';
+import {InvokeMethod, OperationArgs, OperationRetval} from '../internal-types';
 import {RestBindings} from '../keys';
+import {RouteEntry} from '../router/routing-table';
 
 export class InvokeMethodProvider implements Provider<InvokeMethod> {
   constructor(@inject(RestBindings.Http.CONTEXT) protected context: Context) {}
 
   value(): InvokeMethod {
-    return async (route, args) => {
-      return await route.invokeHandler(this.context, args);
-    };
+    return (route, args) => this.action(route, args);
+  }
+
+  action(route: RouteEntry, args: OperationArgs): Promise<OperationRetval> {
+    return route.invokeHandler(this.context, args);
   }
 }

--- a/packages/rest/src/providers/log-error-provider.ts
+++ b/packages/rest/src/providers/log-error-provider.ts
@@ -3,21 +3,26 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BoundValue, Provider} from '@loopback/context';
+import {Provider} from '@loopback/context';
 import {ServerRequest} from '../';
+import {LogError} from '../internal-types';
 
-export class LogErrorProvider implements Provider<BoundValue> {
-  value() {
-    return (err: Error, statusCode: number, req: ServerRequest) => {
-      if (statusCode >= 500) {
-        console.error(
-          'Unhandled error in %s %s: %s %s',
-          req.method,
-          req.url,
-          statusCode,
-          err.stack || err,
-        );
-      }
-    };
+export class LogErrorProvider implements Provider<LogError> {
+  value(): LogError {
+    return (err, statusCode, req) => this.action(err, statusCode, req);
+  }
+
+  action(err: Error, statusCode: number, req: ServerRequest) {
+    if (statusCode < 500) {
+      return;
+    }
+
+    console.error(
+      'Unhandled error in %s %s: %s %s',
+      req.method,
+      req.url,
+      statusCode,
+      err.stack || err,
+    );
   }
 }

--- a/packages/rest/src/providers/reject.ts
+++ b/packages/rest/src/providers/reject.ts
@@ -4,24 +4,26 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {LogError, Reject} from '../internal-types';
-import {inject} from '@loopback/context';
+import {inject, Provider} from '@loopback/context';
 import {ServerResponse, ServerRequest} from 'http';
 import {HttpError} from 'http-errors';
 import {writeErrorToResponse} from '../writer';
 import {RestBindings} from '../keys';
 
-export class RejectProvider {
+export class RejectProvider implements Provider<Reject> {
   constructor(
     @inject(RestBindings.SequenceActions.LOG_ERROR)
     protected logError: LogError,
   ) {}
 
   value(): Reject {
-    return (response: ServerResponse, request: ServerRequest, error: Error) => {
-      const err = <HttpError>error;
-      const statusCode = err.statusCode || err.status || 500;
-      writeErrorToResponse(response, err);
-      this.logError(error, statusCode, request);
-    };
+    return (response, request, error) => this.action(response, request, error);
+  }
+
+  action(response: ServerResponse, request: ServerRequest, error: Error) {
+    const err = <HttpError>error;
+    const statusCode = err.statusCode || err.status || 500;
+    writeErrorToResponse(response, err);
+    this.logError(error, statusCode, request);
   }
 }


### PR DESCRIPTION
Refactor sequence-action providers to use a named "action" method
to hold the actual action implementation, and change the anonymous
lambda (arrow) functions returned by "value" methods to delegate
to these new "action" methods.

This improves error stack traces in cases where the action fails.
Before this change, there would be no reference to the actual sequence
action that failed. After this change, the stack trace contains
an entry for "{Action}Provider.action" function.

This is a follow-up for my older comment https://github.com/strongloop/loopback4-example-log-extension/pull/3#discussion_r150567441:

> I was thinking about this pattern recently. When something wrong happens inside a sequence action implemented as an anonymous function, the stack trace will contain an empty function name that's rather unhelpful to diagnose the problem.

> I am proposing to move the meat of the sequence action into a named function in the provider class