### PR TITLE
chore: Add `npm run release` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",
+    "release": "lerna publish --cd-version=prerelease --preid=alpha",
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
     "precoverage": "npm test",
     "coverage": "open coverage/index.html",


### PR DESCRIPTION
### Description

The command invokes `lerna` to tag and publish next prereleases for all packages:
```
lerna publish --cd-version=prerelease --preid=alpha
```

#### Related issues

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

