### PR TITLE
feat(repository): Make property parameter optional

### DIFF
--- a/packages/repository/src/decorators/model.ts
+++ b/packages/repository/src/decorators/model.ts
@@ -67,9 +67,9 @@ export function model(definition?: ModelDefinitionSyntax) {
  * @param definition
  * @returns {(target:any, key:string)}
  */
-export function property(definition: Partial<PropertyDefinition>) {
+export function property(definition?: Partial<PropertyDefinition>) {
   return PropertyDecoratorFactory.createDecorator(
     MODEL_PROPERTIES_KEY,
-    definition,
+    Object.assign({}, definition),
   );
 }

--- a/packages/repository/test/unit/decorator/model-and-relation.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.ts
@@ -67,6 +67,9 @@ describe('model decorator', () => {
     @belongsTo({target: 'Customer'})
     // TypeScript does not allow me to reference Customer here
     customer: ICustomer;
+
+    // Validates that property no longer requires a parameter
+    @property() isShipped: boolean;
   }
 
   @model()
@@ -112,6 +115,7 @@ describe('model decorator', () => {
       },
     });
     expect(meta.id).to.eql({type: 'string', id: true, generated: true});
+    expect(meta.isShipped).to.eql({type: Boolean});
   });
 
   it('adds embedsOne metadata', () => {


### PR DESCRIPTION
### Description
The `@property` decorator no longer requires a parameter.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)