### PR TITLE
chore: Use lb-clean script to clean the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,19 +11,15 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@commitlint/cli": "^4.3.0",
-    "@commitlint/config-angular": "^4.3.0",
-    "@commitlint/config-lerna-scopes": "^4.3.0",
+    "@commitlint/cli": "^5.2.5",
+    "@commitlint/config-angular": "^5.1.1",
+    "@commitlint/config-lerna-scopes": "^5.2.0",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.56",
-    "@types/request": "^2.0.7",
-    "@types/request-promise": "^4.1.39",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "lerna": "^2.5.1",
-    "mocha": "^4.0.0",
-    "request": "^2.83.0",
-    "request-promise": "^4.2.2"
+    "mocha": "^4.0.0"
   },
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -12,7 +12,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-authentication*.tgz dist* package",
+    "clean": "lb-clean loopback-authentication*.tgz dist dist6 package api-docs",
     "integration": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/integration/**/*.js'",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -12,7 +12,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-context*.tgz dist* package",
+    "clean": "lb-clean loopback-context*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js' 'DIST/test/acceptance/**/*.js'",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-core*.tgz dist* package",
+    "clean": "lb-clean loopback-core*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "integration": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/integration/**/*.js'",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -12,7 +12,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-metadata*.tgz dist* package",
+    "clean": "lb-clean loopback-metadata*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js' 'DIST/test/acceptance/**/*.js'",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -11,7 +11,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-openapi-spec*.tgz dist* package",
+    "clean": "lb-clean loopback-openapi-spec*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"
   },

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -14,7 +14,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-openapi-spec*.tgz dist* package",
+    "clean": "lb-clean loopback-openapi-spec*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"
   },

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -13,7 +13,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-context*.tgz dist* package",
+    "clean": "lb-clean loopback-context*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js' 'DIST/test/acceptance/**/*.js'",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -12,7 +12,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-rest*.tgz dist* package",
+    "clean": "lb-clean loopback-rest*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "integration": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/integration/**/*.js'",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -10,7 +10,7 @@
     "build:current": "lb-tsc",
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
-    "clean": "rm -rf loopback-testlab*.tgz dist* package",
+    "clean": "lb-clean loopback-testlab*.tgz dist dist6 package api-docs",
     "prepare": "npm run build",
     "pretest": "npm run build:current",
     "test": "lb-dist mocha --recursive DIST/test",


### PR DESCRIPTION
### Description

- Replace Unix `rm -rf` command with `lb-clean` which is a node.js script that runs on all supported platforms.

- Remove unused dependencies in `loopback-next/package.json`.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

