### PR TITLE
fix(metadata): fix method-level parameter decorators

### DIFF
--- a/packages/metadata/README.md
+++ b/packages/metadata/README.md
@@ -204,6 +204,17 @@ strongly discouraged for a few reasons:
 
 We recommend that `ParameterDecorator` be used instead.
 
+## Decorator options
+
+An object of type `DecoratorOptions` can be passed in to create decorator
+functions. There are two flags for the options:
+
+- allowInheritance: Controls if inherited metadata will be honored. Default to `true`.
+- cloneInputSpec: Controls if the value of `spec` argument will be cloned.
+Sometimes we use shared spec for the decoration, but the decorator function
+might need to mutate the object. Cloning the input spec makes it safe to use
+the same spec (`template`) to decorate different members. Default to `true`.
+
 ## Customize inheritance of metadata
 
 By default, the decorator factories allow inheritance with the following rules:

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -310,6 +310,14 @@ export class DecoratorFactory<
     return _.cloneDeepWith(val, v => {
       // Do not clone functions
       if (typeof v === 'function') return v;
+      if (
+        v &&
+        typeof v.constructor === 'function' &&
+        v.constructor.prototype === v
+      ) {
+        // Do not clone class prototype
+        return v;
+      }
       return undefined;
     });
   }

--- a/packages/metadata/test/unit/decorator-factory.test.ts
+++ b/packages/metadata/test/unit/decorator-factory.test.ts
@@ -14,6 +14,65 @@ import {
   Reflector,
 } from '../..';
 
+describe('DecoratorFactory.cloneDeep', () => {
+  it('keeps functions/classes', () => {
+    class MyController {}
+    const val = {
+      target: MyController,
+      fn: function() {},
+      spec: {x: 1},
+    };
+    const copy = DecoratorFactory.cloneDeep(val);
+    expect(copy.target).to.be.exactly(val.target);
+    expect(copy.fn).to.be.exactly(val.fn);
+    expect(copy.spec).to.not.exactly(val.spec);
+    expect(copy).to.be.eql(val);
+  });
+
+  it('keeps class prototypes', () => {
+    class MyController {}
+    const val = {
+      target: MyController.prototype,
+      spec: {x: 1},
+    };
+    const copy = DecoratorFactory.cloneDeep(val);
+    expect(copy.target).to.be.exactly(val.target);
+    expect(copy.spec).to.not.exactly(val.spec);
+    expect(copy).to.be.eql(val);
+  });
+
+  it('clones class instances', () => {
+    class MyController {
+      constructor(public x: string) {}
+    }
+    const val = {
+      target: new MyController('A'),
+    };
+    const copy = DecoratorFactory.cloneDeep(val);
+    expect(copy.target).to.not.exactly(val.target);
+    expect(copy).to.be.eql(val);
+    expect(copy.target).to.be.instanceof(MyController);
+  });
+
+  it('clones dates', () => {
+    const val = {
+      d: new Date(),
+    };
+    const copy = DecoratorFactory.cloneDeep(val);
+    expect(copy.d).to.not.exactly(val.d);
+    expect(copy).to.be.eql(val);
+  });
+
+  it('clones regexp', () => {
+    const val = {
+      re: /Ab/,
+    };
+    const copy = DecoratorFactory.cloneDeep(val);
+    expect(copy.re).to.not.exactly(val.re);
+    expect(copy).to.be.eql(val);
+  });
+});
+
 describe('ClassDecoratorFactory', () => {
   /**
    * Define `@classDecorator(spec)`


### PR DESCRIPTION
### Description

The PR fixes how method level parameter decorations are processed to make sure the order
of decorations match the number of parameters of the target method. It also uses a cache to 
track the parameter index.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

