### PR TITLE
refactor(repository): model decorator accepts options without name

### DIFF
--- a/packages/repository/src/decorators/model.ts
+++ b/packages/repository/src/decorators/model.ts
@@ -27,12 +27,12 @@ type PropertyMap = MetadataMap<PropertyDefinition>;
  * @param definition
  * @returns {(target:any)}
  */
-export function model(definition?: ModelDefinitionSyntax) {
+export function model(definition?: Partial<ModelDefinitionSyntax>) {
   return function(target: Function & {definition?: ModelDefinition}) {
-    if (!definition) {
-      definition = {name: target.name};
-    }
-
+    definition = definition || {};
+    const def: ModelDefinitionSyntax = Object.assign(definition, {
+      name: definition.name || target.name,
+    });
     const decorator = ClassDecoratorFactory.createDecorator(
       MODEL_KEY,
       definition,
@@ -41,7 +41,7 @@ export function model(definition?: ModelDefinitionSyntax) {
     decorator(target);
 
     // Build "ModelDefinition" and store it on model constructor
-    const modelDef = new ModelDefinition(definition);
+    const modelDef = new ModelDefinition(def);
 
     const propertyMap: PropertyMap =
       MetadataInspector.getAllPropertyMetadata(

--- a/packages/repository/test/unit/decorator/model-and-relation.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.ts
@@ -36,6 +36,22 @@ describe('model decorator', () => {
     number: string;
   }
 
+  @model({
+    properties: {
+      id: {
+        type: 'number',
+        required: true,
+      },
+    },
+  })
+  class Receipt extends Entity {
+    id: number;
+    customerId: number;
+    orderId: number;
+    subtotal: number;
+    tax: number;
+  }
+
   @model()
   class Account extends Entity {
     id: string;
@@ -111,6 +127,29 @@ describe('model decorator', () => {
   it('adds model metadata', () => {
     const meta = MetadataInspector.getClassMetadata(MODEL_KEY, Order);
     expect(meta).to.eql({name: 'order'});
+  });
+
+  it('adds model metadata without name', () => {
+    const meta = MetadataInspector.getClassMetadata(MODEL_KEY, Receipt);
+    expect(meta).to.eql({
+      name: 'Receipt',
+      properties: {
+        id: {
+          type: 'number',
+          required: true,
+        },
+      },
+    });
+  });
+
+  it('adds model metadata with custom name', () => {
+    @model({name: 'foo'})
+    class Doohickey {
+      name: string;
+    }
+
+    const meta = MetadataInspector.getClassMetadata(MODEL_KEY, Doohickey);
+    expect(meta).to.eql({name: 'foo'});
   });
 
   it('adds property metadata', () => {


### PR DESCRIPTION
### Description
Allows the name to be optional for `@model` so that you can provide the other options for a ModelDefinition without having to provide redundant data (you can still provide it to override this behaviour)

```ts
@model({
  settings: { ... }
})
class Widget {
  // will return metadata of { name: 'Widget', settings: { ... } }
}
```
### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

