### PR TITLE
feat(rest): set controller name as the default tag

### DIFF
--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -273,6 +273,7 @@ export class ControllerRoute extends BaseRoute {
         {
           'x-controller-name': _controllerCtor.name,
           'x-operation-name': methodName,
+          tags: [_controllerCtor.name],
         },
         spec,
       ),

--- a/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
@@ -72,6 +72,27 @@ describe('RestServer.getApiSpec()', () => {
           responses: {},
           'x-controller-name': 'MyController',
           'x-operation-name': 'greet',
+          tags: ['MyController'],
+        },
+      },
+    });
+  });
+
+  it('honors tags in the operation spec', () => {
+    class MyController {
+      @get('/greet', {responses: {}, tags: ['MyTag']})
+      greet() {}
+    }
+    app.controller(MyController);
+
+    const spec = server.getApiSpec();
+    expect(spec.paths).to.eql({
+      '/greet': {
+        get: {
+          responses: {},
+          'x-controller-name': 'MyController',
+          'x-operation-name': 'greet',
+          tags: ['MyTag'],
         },
       },
     });
@@ -91,6 +112,7 @@ describe('RestServer.getApiSpec()', () => {
           responses: {},
           'x-controller-name': 'MyController',
           'x-operation-name': 'greet',
+          tags: ['MyController'],
         },
       },
     });


### PR DESCRIPTION
### Description

Swagger UI uses tags to group REST operations. This PR sets the controller
name as the default tag if not provided by the operation spec.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

