### PR TITLE
feat(context): export function to concat the binding key and path

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -113,6 +113,16 @@ export class Binding {
   }
 
   /**
+   * Build a binding key from a key and a path
+   * @param key The key
+   * @param path The path
+   *
+   */
+  static buildKeyWithPath(key: string, path: string) {
+    return `${key}${Binding.PROPERTY_SEPARATOR}${path}`;
+  }
+
+  /**
    * Parse a string containing both the binding key and the path to the deeply
    * nested property to retrieve.
    *

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -54,6 +54,24 @@ describe('Binding', () => {
     });
   });
 
+  describe('key', () => {
+    it('build key with path', () => {
+      expect(Binding.buildKeyWithPath('foo', 'bar')).to.equal('foo#bar');
+    });
+    it('parse key without path', () => {
+      expect(Binding.parseKeyWithPath('foo')).to.eql({
+        key: 'foo',
+        path: undefined,
+      });
+    });
+    it('parse key with path', () => {
+      expect(Binding.parseKeyWithPath('foo#bar')).to.eql({
+        key: 'foo',
+        path: 'bar',
+      });
+    });
+  });
+
   describe('inScope', () => {
     it('defaults the transient binding scope', () => {
       expect(binding.scope).to.equal(BindingScope.TRANSIENT);


### PR DESCRIPTION
## Description

The current rest config key `RestBinding.CONFIG` in `packages/rest/keys.ts` is defined as `${CoreBindings.APPLICATION_CONFIG}#rest`.

It is safer to use an exported function from `context/binding` where both the concatenation and split are implemented.

The new key is `export const CONFIG = Binding.concatKeyAndPath (CoreBindings.APPLICATION_CONFIG, rest)`