### PR TITLE
test: run cli tests in top level npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
     "clean": "lerna run --loglevel=silent clean",
     "build": "lerna run --loglevel=silent build",
     "build:current": "lerna run --loglevel=silent build:current",
-    "pretest": "npm run build:current",
+    "pretest": "npm run build:current && npm run cli:link",
+    "cli:link": "cd packages/cli/generators/app && npm link && pwd && cd ../controller && npm link && pwd && cd ../extension && npm link && pwd && cd ../project && npm link && pwd && cd ../../.. && pwd",
     "test": "node packages/build/bin/run-nyc npm run mocha",
-    "mocha": "node packages/build/bin/select-dist mocha --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\"",
+    "mocha": "node packages/build/bin/select-dist mocha --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\" \"packages/cli/test\"",
     "posttest": "npm run lint"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "clean": "lerna run --loglevel=silent clean",
     "build": "lerna run --loglevel=silent build",
     "build:current": "lerna run --loglevel=silent build:current",
-    "pretest": "npm run build:current && npm run cli:link",
-    "cli:link": "cd packages/cli/generators/app && npm link && pwd && cd ../controller && npm link && pwd && cd ../extension && npm link && pwd && cd ../project && npm link && pwd && cd ../../.. && pwd",
+    "pretest": "npm run build:current",
     "test": "node packages/build/bin/run-nyc npm run mocha",
     "mocha": "node packages/build/bin/select-dist mocha --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\" \"packages/cli/test\"",
     "posttest": "npm run lint"

--- a/packages/cli/test/project.js
+++ b/packages/cli/test/project.js
@@ -9,6 +9,7 @@ const helpers = require('yeoman-test');
 const yeoman = require('yeoman-environment');
 const testUtils = require('./test-utils');
 const sinon = require('sinon');
+const path = require('path');
 
 module.exports = function(projGenerator, props, projectType) {
   return function() {
@@ -16,7 +17,7 @@ module.exports = function(projGenerator, props, projectType) {
       it('prints lb4', () => {
         const env = yeoman.createEnv();
         const name = projGenerator.substring(
-          projGenerator.lastIndexOf('/') + 1
+          projGenerator.lastIndexOf(path.sep) + 1
         );
         env.register(projGenerator, 'loopback4:' + name);
         const generator = env.create('loopback4:' + name);

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -6,11 +6,12 @@
 'use strict';
 
 const yeoman = require('yeoman-environment');
+const path = require('path');
 
 exports.testSetUpGen = function(genName, arg) {
   arg = arg || {};
   const env = yeoman.createEnv();
-  const name = genName.substring(genName.lastIndexOf('/') + 1);
+  const name = genName.substring(genName.lastIndexOf(path.sep) + 1);
   env.register(genName, 'loopback4:' + name);
   return env.create('loopback4:' + name, arg);
 };


### PR DESCRIPTION
### Description
CLI Tests aren't run as part of top level `npm test`. Test count before change was 609. After this change it is 694.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

