### PR TITLE
feat(openapi-spec-builder): add withTags function to spec-builder

### DIFF
--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -162,4 +162,16 @@ export class OperationSpecBuilder extends BuilderBase<OperationObject> {
   withOperationName(name: string): this {
     return this.withExtension('x-operation-name', name);
   }
+
+  /**
+   * Describe tags associated with the operation
+   * @param tags
+   */
+  withTags(tags: string | string[]): this {
+    if (typeof tags === 'string') this._spec.tags = [tags];
+    else {
+      this._spec.tags = tags;
+    }
+    return this;
+  }
 }


### PR DESCRIPTION
### Description

Added a function to allow tags to be specified when building an OpenAPI's operation spec.
With the newest commit that assigns default tag to the swagger spec, this PR would allow an easier time writing acceptance tests.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

