### PR TITLE
fix: ensure `npm run release` runs clean/build/test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",
-    "release": "lerna publish --cd-version=prerelease --preid=alpha",
+    "release": "npm run build:full && lerna publish --cd-version=prerelease --preid=alpha",
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
     "precoverage": "npm test",
     "coverage": "open coverage/index.html",
@@ -37,7 +37,8 @@
     "clean": "lerna run --loglevel=silent clean",
     "build": "lerna run --loglevel=silent build",
     "build:current": "lerna run --loglevel=silent build:current",
-    "pretest": "npm run build:current",
+    "build:full": "npm run clean && npm run build && npm run mocha && npm run lint",
+    "pretest": "npm run clean && npm run build:current",
     "test": "node packages/build/bin/run-nyc npm run mocha",
     "mocha": "node packages/build/bin/select-dist mocha --opts test/mocha.opts \"packages/*/DIST/test/**/*.js\" \"packages/cli/test\"",
     "posttest": "npm run lint"

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -13,7 +13,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "lb-clean loopback-context*.tgz dist dist6 package api-docs",
+    "clean": "lb-clean loopback-repository*.tgz dist dist6 package api-docs",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js' 'DIST/test/acceptance/**/*.js'",


### PR DESCRIPTION
### Description

Before this PR, `npm run release` does not trigger clean/build/test. As a result, there is possibility that some packages are not fully built/tested before being published.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

