### PR TITLE
feat(core): add sugar function for model binding

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -67,6 +67,27 @@ export class Application extends Context {
   }
 
   /**
+   * Register a model class with this application.
+   *
+   * @param modelCtor {Function} The model class
+   * (constructor function).
+   * @return {Binding} The newly created binding, you can use the reference to
+   * further modify the binding, e.g. lock the value to prevent further
+   * modifications.
+   *
+   * ```ts
+   * class MyModel {
+   * }
+   * app.model(MyModel).lock();
+   * ```
+   */
+  model(modelCtor: Constructor<{}>): Binding {
+    return this.bind(`models.${modelCtor.name}`)
+      .toClass(modelCtor)
+      .tag('model');
+  }
+
+  /**
    * Bind a Server constructor to the Application's master context.
    * Each server constructor added in this way must provide a unique prefix
    * to prevent binding overlap.

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -54,6 +54,12 @@ export function mountComponent(app: Application, component: Component) {
     }
   }
 
+  if (component.models) {
+    for (const modelCtor of component.models) {
+      app.model(modelCtor);
+    }
+  }
+
   if (component.providers) {
     for (const providerKey in component.providers) {
       app.bind(providerKey).toProvider(component.providers[providerKey]);

--- a/packages/core/test/acceptance/application.acceptance.ts
+++ b/packages/core/test/acceptance/application.acceptance.ts
@@ -75,6 +75,22 @@ describe('Bootstrapping the application', () => {
       ]);
     });
 
+    it('registers all models from components', async () => {
+      class ProductModel {}
+
+      class ProductComponent {
+        models = [ProductModel];
+      }
+
+      const app = new Application({
+        components: [ProductComponent],
+      });
+
+      expect(app.find('models.*').map(b => b.key)).to.eql([
+        'models.ProductModel',
+      ]);
+    });
+
     it('injects component dependencies', () => {
       class ConfigComponent {
         providers = {

--- a/packages/core/test/unit/application.test.ts
+++ b/packages/core/test/unit/application.test.ts
@@ -33,6 +33,24 @@ describe('Application', () => {
     }
   });
 
+  describe('model binding', () => {
+    let app: Application;
+    class MyModel {}
+
+    beforeEach(givenApp);
+
+    it('binds a model', () => {
+      const binding = app.model(MyModel);
+      expect(Array.from(binding.tags)).to.containEql('model');
+      expect(binding.key).to.equal('models.MyModel');
+      expect(findKeysByTag(app, 'model')).to.containEql(binding.key);
+    });
+
+    function givenApp() {
+      app = new Application();
+    }
+  });
+
   describe('component binding', () => {
     let app: Application;
     class MyController {}


### PR DESCRIPTION
### Description

Adding in sugar function for `ctx.bind('model.modelName').toClass(modelCtor).tag('model')`. This is done as a part of https://github.com/strongloop/loopback-next/issues/786 and #441. In order for metadata for the models to be accessed, users require access to the names of the models, which in turn can be provided by using these bindings.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)


  