### PR TITLE
feat(repository): add findOne function into legacy juggler bridge

### DIFF
--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -138,6 +138,17 @@ export class DefaultCrudRepository<T extends Entity, ID>
     return this.toEntities(models);
   }
 
+  async findOne(filter?: Filter, options?: Options): Promise<T> {
+    const models = await ensurePromise(this.modelClass.find(filter, options));
+    const modelsEntities = this.toEntities(models);
+    if (!modelsEntities || !modelsEntities[0]) {
+      return Promise.reject(
+        new Error(`no ${this.modelClass.name} found with filter "${filter}"`),
+      );
+    }
+    return modelsEntities[0];
+  }
+
   async findById(id: ID, filter?: Filter, options?: Options): Promise<T> {
     const model = await ensurePromise(
       this.modelClass.findById(id, filter, options),

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -139,14 +139,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
   }
 
   async findOne(filter?: Filter, options?: Options): Promise<T> {
-    const models = await ensurePromise(this.modelClass.find(filter, options));
-    const modelsEntities = this.toEntities(models);
-    if (!modelsEntities || !modelsEntities[0]) {
-      return Promise.reject(
-        new Error(`no ${this.modelClass.name} found with filter "${filter}"`),
-      );
-    }
-    return modelsEntities[0];
+    const model = await ensurePromise(this.modelClass.findOne(filter, options));
+    return this.toEntity(model);
   }
 
   async findById(id: ID, filter?: Filter, options?: Options): Promise<T> {

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -103,7 +103,7 @@ describe('DefaultCrudRepository', () => {
       {title: 't1', content: 'c1'},
       {title: 't1', content: 'c2'},
     ]);
-    const note = await repo.findOne({where: {title: 't1'}, order: 'content DESC'});
+    const note = await repo.findOne({where: {title: 't1'}, order: ['content DESC']});
     expect(note.title).to.eql('t1');
     expect(note.content).to.eql('c2');
   });

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -96,14 +96,17 @@ describe('DefaultCrudRepository', () => {
     const notes = await repo.find({where: {title: 't1'}});
     expect(notes.length).to.eql(1);
   });
-  
+
   it('implements Repository.findOne()', async () => {
     const repo = new DefaultCrudRepository(Note, ds);
     await repo.createAll([
       {title: 't1', content: 'c1'},
       {title: 't1', content: 'c2'},
     ]);
-    const note = await repo.findOne({where: {title: 't1'}, order: ['content DESC']});
+    const note = await repo.findOne({
+      where: {title: 't1'},
+      order: ['content DESC'],
+    });
     expect(note.title).to.eql('t1');
     expect(note.content).to.eql('c2');
   });

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -96,6 +96,16 @@ describe('DefaultCrudRepository', () => {
     const notes = await repo.find({where: {title: 't1'}});
     expect(notes.length).to.eql(1);
   });
+  
+  it('implements Repository.findOne()', async () => {
+    const repo = new DefaultCrudRepository(Note, ds);
+    await repo.createAll([
+      {title: 't1', content: 'c1'},
+      {title: 't1', content: 'c2'},
+    ]);
+    const notes = await repo.findOne({where: {title: 't1'}});
+    expect(notes.length).to.eql(1);
+  });
 
   it('implements Repository.delete()', async () => {
     const repo = new DefaultCrudRepository(Note, ds);

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -103,8 +103,9 @@ describe('DefaultCrudRepository', () => {
       {title: 't1', content: 'c1'},
       {title: 't1', content: 'c2'},
     ]);
-    const notes = await repo.findOne({where: {title: 't1'}});
-    expect(notes.length).to.eql(1);
+    const note = await repo.findOne({where: {title: 't1'}, order: 'content DESC'});
+    expect(note.title).to.eql('t1');
+    expect(note.content).to.eql('c2');
   });
 
   it('implements Repository.delete()', async () => {


### PR DESCRIPTION
Adding findOne function to reduce unnecessary coding in user project side.
  