### PR TITLE
build(openapi-v2): fix the test script

### DIFF
--- a/packages/openapi-v2/package.json
+++ b/packages/openapi-v2/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf loopback-openapi-v2*.tgz dist* package",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
-    "unit": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js'",
+    "test": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js'",
     "verify": "npm pack && tar xf loopback-openapi-v2*.tgz && tree package && npm run clean"
   },
   "author": "IBM",


### PR DESCRIPTION
Rename "unit" to "test" in package.json, to ensure `npm test` executed from the package directory actually runs any tests.

This is a follow-up for recently landed #804 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- (n/a) New tests added or existing tests modified to cover all changes
- (n/a) Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)


  