### PR TITLE
fix: export decorators for backward compatibility

### DIFF
--- a/packages/rest/index.ts
+++ b/packages/rest/index.ts
@@ -5,3 +5,4 @@
 
 // NOTE(bajtos) This file is used by VSCode/TypeScriptServer at dev time only
 export * from './src';
+export * from '@loopback/openapi-v2';

--- a/packages/rest/test/unit/backward-compatibility.test.ts
+++ b/packages/rest/test/unit/backward-compatibility.test.ts
@@ -1,0 +1,14 @@
+import {get} from '../..';
+
+describe('backward-compatibility', () => {
+  it('exports functions from @loopback/openapi-v2', async () => {
+    /* tslint:disable-next-line:no-unused-variable */
+    class Test {
+      // Make sure the decorators are exported
+      @get('/test')
+      async test() {
+        return '';
+      }
+    }
+  });
+});


### PR DESCRIPTION
- [x] related issue: https://github.com/strongloop/loopback/issues/3753

- [x] test cases