### PR TITLE
fix: fix imports to use files owning the definitions

### DIFF
--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -4,7 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Constructor, Provider, BoundValue} from '@loopback/context';
-import {Server, Application, ControllerClass} from '.';
+import {Server} from './server';
+import {Application, ControllerClass} from './application';
 
 /**
  * A map of name/class pairs for binding providers

--- a/packages/repository/src/connector.ts
+++ b/packages/repository/src/connector.ts
@@ -10,7 +10,7 @@ import {
   Command,
   NamedParameters,
   PositionalParameters,
-} from '..';
+} from './common-types';
 
 /**
  * Common properties/operations for connectors

--- a/packages/repository/src/decorators/metadata.ts
+++ b/packages/repository/src/decorators/metadata.ts
@@ -1,6 +1,6 @@
 import {InspectionOptions, MetadataInspector} from '@loopback/context';
-import {MODEL_PROPERTIES_KEY, MODEL_WITH_PROPERTIES_KEY} from '../';
-import {ModelDefinition, PropertyDefinition} from '../../index';
+import {MODEL_PROPERTIES_KEY, MODEL_WITH_PROPERTIES_KEY} from './model';
+import {ModelDefinition, PropertyDefinition} from '../model';
 export class ModelMetadataHelper {
   /**
    * A utility function to simplify retrieving metadata from a target model and

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -19,7 +19,7 @@ import {
   Command,
   NamedParameters,
   PositionalParameters,
-} from '../index';
+} from './common-types';
 
 type DataSourceType = juggler.DataSource;
 export {DataSourceType};

--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -1,4 +1,4 @@
-import {AnyObject} from '..';
+import {AnyObject} from './common-types';
 import * as assert from 'assert';
 
 // Copyright IBM Corp. 2017. All Rights Reserved.

--- a/packages/repository/src/types/model.ts
+++ b/packages/repository/src/types/model.ts
@@ -3,7 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Model, Class} from '..';
+import {Class} from '../common-types';
+import {Model} from '../model';
 import {ObjectType} from './object';
 
 // tslint:disable:no-any

--- a/packages/repository/src/types/object.ts
+++ b/packages/repository/src/types/object.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import * as util from 'util';
-import {Class, AnyObject} from '..';
+import {Class, AnyObject} from '../common-types';
 import {Type} from './type';
 
 // tslint:disable:no-any

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {ServerRequest} from 'http';
-import {HttpErrors} from './';
+import * as HttpErrors from 'http-errors';
 import {OperationObject, ParameterObject} from '@loopback/openapi-spec';
 import {promisify} from '@loopback/core';
 import {

--- a/packages/rest/src/providers/log-error-provider.ts
+++ b/packages/rest/src/providers/log-error-provider.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Provider} from '@loopback/context';
-import {ServerRequest} from '../';
+import {ServerRequest} from 'http';
 import {LogError} from '../internal-types';
 
 export class LogErrorProvider implements Provider<LogError> {

--- a/packages/rest/src/rest-application.ts
+++ b/packages/rest/src/rest-application.ts
@@ -1,5 +1,6 @@
 import {Application, ApplicationConfig, Server} from '@loopback/core';
-import {RestComponent, SequenceHandler, SequenceFunction} from './index';
+import {RestComponent} from './rest-component';
+import {SequenceHandler, SequenceFunction} from './sequence';
 import {Binding, Constructor} from '@loopback/context';
 import {format} from 'util';
 import {RestBindings} from './keys';

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -7,7 +7,8 @@ import {AssertionError} from 'assert';
 const swagger2openapi = require('swagger2openapi');
 import {safeDump} from 'js-yaml';
 import {Binding, Context, Constructor, inject} from '@loopback/context';
-import {Route, ControllerRoute, RouteEntry, ParsedRequest} from '.';
+import {Route, ControllerRoute, RouteEntry} from './router/routing-table';
+import {ParsedRequest} from './internal-types';
 import {
   OpenApiSpec,
   createEmptyApiSpec,


### PR DESCRIPTION
Importing from the root index leads to circular resolution and cause
undefined artifacts. Since the root index re-export such artifacts, the
compilation is good but it fails at runtime. For example:

`/src/index.js --> src/decorators/metadata.js --> /src/index.js`

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
