### PR TITLE
Track dependency resolution

### DIFF
--- a/packages/context/docs.json
+++ b/packages/context/docs.json
@@ -8,6 +8,7 @@
         "src/is-promise.ts",
         "src/provider.ts",
         "src/reflect.ts",
+        "src/resolution-session.ts",
         "src/resolver.ts"
     ],
     "codeSectionDepth": 4,

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -22,12 +22,14 @@
   "author": "IBM",
   "license": "MIT",
   "dependencies": {
-    "@loopback/metadata": "^4.0.0-alpha.4"
+    "@loopback/metadata": "^4.0.0-alpha.4",
+    "debug": "^3.1.0"
   },
   "devDependencies": {
     "@loopback/build": "^4.0.0-alpha.8",
     "@loopback/testlab": "^4.0.0-alpha.18",
     "@types/bluebird": "^3.5.18",
+    "@types/debug": "0.0.30",
     "bluebird": "^3.5.0"
   },
   "keywords": [

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from './context';
-import {Constructor, instantiateClass} from './resolver';
+import {Constructor, instantiateClass, ResolutionSession} from './resolver';
 import {isPromise} from './is-promise';
 import {Provider} from './provider';
 
@@ -147,7 +147,10 @@ export class Binding {
   public type: BindingType;
 
   private _cache: BoundValue;
-  private _getValue: (ctx?: Context) => BoundValue | Promise<BoundValue>;
+  private _getValue: (
+    ctx?: Context,
+    session?: ResolutionSession,
+  ) => BoundValue | Promise<BoundValue>;
 
   // For bindings bound via toClass, this property contains the constructor
   // function
@@ -224,8 +227,14 @@ export class Binding {
    *   doSomething(result);
    * }
    * ```
+   *
+   * @param ctx Context for the resolution
+   * @param session Optional session for binding and dependency resolution
    */
-  getValue(ctx: Context): BoundValue | Promise<BoundValue> {
+  getValue(
+    ctx: Context,
+    session?: ResolutionSession,
+  ): BoundValue | Promise<BoundValue> {
     // First check cached value for non-transient
     if (this._cache !== undefined) {
       if (this.scope === BindingScope.SINGLETON) {
@@ -237,7 +246,22 @@ export class Binding {
       }
     }
     if (this._getValue) {
-      const result = this._getValue(ctx);
+      const resolutionSession = ResolutionSession.enterBinding(this, session);
+      const result = this._getValue(ctx, resolutionSession);
+      if (isPromise(result)) {
+        if (result instanceof Promise) {
+          result.catch(err => {
+            resolutionSession.exit();
+            return Promise.reject(err);
+          });
+        }
+        result.then(val => {
+          resolutionSession.exit();
+          return val;
+        });
+      } else {
+        resolutionSession.exit();
+      }
       return this._cacheValue(ctx, result);
     }
     return Promise.reject(
@@ -347,10 +371,11 @@ export class Binding {
    */
   public toProvider<T>(providerClass: Constructor<Provider<T>>): this {
     this.type = BindingType.PROVIDER;
-    this._getValue = ctx => {
+    this._getValue = (ctx, session) => {
       const providerOrPromise = instantiateClass<Provider<T>>(
         providerClass,
         ctx!,
+        session,
       );
       if (isPromise(providerOrPromise)) {
         return providerOrPromise.then(p => p.value());
@@ -370,7 +395,7 @@ export class Binding {
    */
   toClass<T>(ctor: Constructor<T>): this {
     this.type = BindingType.CLASS;
-    this._getValue = ctx => instantiateClass(ctor, ctx!);
+    this._getValue = (ctx, session) => instantiateClass(ctor, ctx!, session);
     this.valueConstructor = ctor;
     return this;
   }

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -259,22 +259,22 @@ export class Binding {
       try {
         result = this._getValue(ctx, resolutionSession);
       } catch (e) {
-        resolutionSession.exit();
+        resolutionSession.popBinding();
         throw e;
       }
       if (isPromise(result)) {
         result = result.then(
           (val: BoundValue) => {
-            resolutionSession.exit();
+            resolutionSession.popBinding();
             return val;
           },
           err => {
-            resolutionSession.exit();
+            resolutionSession.popBinding();
             throw err;
           },
         );
       } else {
-        resolutionSession.exit();
+        resolutionSession.popBinding();
       }
       return this._cacheValue(ctx, result);
     }

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -8,6 +8,9 @@ import {Constructor, instantiateClass, ResolutionSession} from './resolver';
 import {isPromise} from './is-promise';
 import {Provider} from './provider';
 
+import * as debugModule from 'debug';
+const debug = debugModule('loopback:context:binding');
+
 // tslint:disable-next-line:no-any
 export type BoundValue = any;
 
@@ -235,6 +238,10 @@ export class Binding {
     ctx: Context,
     session?: ResolutionSession,
   ): BoundValue | Promise<BoundValue> {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Get value for binding %s', this.key);
+    }
     // First check cached value for non-transient
     if (this._cache !== undefined) {
       if (this.scope === BindingScope.SINGLETON) {
@@ -324,6 +331,10 @@ export class Binding {
           'via ".toDynamicValue()" instead.',
       );
     }
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Bind %s to constant:', this.key, value);
+    }
     this.type = BindingType.CONSTANT;
     this._getValue = () => value;
     return this;
@@ -348,6 +359,10 @@ export class Binding {
    * ```
    */
   toDynamicValue(factoryFn: () => BoundValue | Promise<BoundValue>): this {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Bind %s to dynamic value:', this.key, factoryFn);
+    }
     this.type = BindingType.DYNAMIC_VALUE;
     this._getValue = ctx => factoryFn();
     return this;
@@ -370,6 +385,10 @@ export class Binding {
    * @param provider The value provider to use.
    */
   public toProvider<T>(providerClass: Constructor<Provider<T>>): this {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Bind %s to provider %s', this.key, providerClass.name);
+    }
     this.type = BindingType.PROVIDER;
     this._getValue = (ctx, session) => {
       const providerOrPromise = instantiateClass<Provider<T>>(
@@ -394,6 +413,10 @@ export class Binding {
    *   we can resolve them from the context.
    */
   toClass<T>(ctor: Constructor<T>): this {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Bind %s to class %s', this.key, ctor.name);
+    }
     this.type = BindingType.CLASS;
     this._getValue = (ctx, session) => instantiateClass(ctor, ctx!, session);
     this.valueConstructor = ctor;

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -254,28 +254,11 @@ export class Binding {
       }
     }
     if (this._getValue) {
-      const resolutionSession = ResolutionSession.enterBinding(this, session);
-      let result: ValueOrPromise<BoundValue>;
-      try {
-        result = this._getValue(ctx, resolutionSession);
-      } catch (e) {
-        resolutionSession.popBinding();
-        throw e;
-      }
-      if (isPromise(result)) {
-        result = result.then(
-          (val: BoundValue) => {
-            resolutionSession.popBinding();
-            return val;
-          },
-          err => {
-            resolutionSession.popBinding();
-            throw err;
-          },
-        );
-      } else {
-        resolutionSession.popBinding();
-      }
+      let result = ResolutionSession.runWithBinding(
+        s => this._getValue(ctx, s),
+        this,
+        session,
+      );
       return this._cacheValue(ctx, result);
     }
     return Promise.reject(

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -254,15 +254,18 @@ export class Binding {
     }
     if (this._getValue) {
       const resolutionSession = ResolutionSession.enterBinding(this, session);
-      const result = this._getValue(ctx, resolutionSession);
+      let result: ValueOrPromise<BoundValue> = this._getValue(
+        ctx,
+        resolutionSession,
+      );
       if (isPromise(result)) {
         if (result instanceof Promise) {
-          result.catch(err => {
+          result = result.catch(err => {
             resolutionSession.exit();
-            return Promise.reject(err);
+            throw err;
           });
         }
-        result.then(val => {
+        result = result.then((val: BoundValue) => {
           resolutionSession.exit();
           return val;
         });

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -5,6 +5,7 @@
 
 import {Binding, BoundValue, ValueOrPromise} from './binding';
 import {isPromise} from './is-promise';
+import {ResolutionSession} from './resolver';
 
 /**
  * Context provides an implementation of Inversion of Control (IoC) container
@@ -143,9 +144,9 @@ export class Context {
    *   (deeply) nested property to retrieve.
    * @returns A promise of the bound value.
    */
-  get(key: string): Promise<BoundValue> {
+  get(key: string, session?: ResolutionSession): Promise<BoundValue> {
     try {
-      return Promise.resolve(this.getValueOrPromise(key));
+      return Promise.resolve(this.getValueOrPromise(key, session));
     } catch (err) {
       return Promise.reject(err);
     }
@@ -173,8 +174,8 @@ export class Context {
    *   (deeply) nested property to retrieve.
    * @returns A promise of the bound value.
    */
-  getSync(key: string): BoundValue {
-    const valueOrPromise = this.getValueOrPromise(key);
+  getSync(key: string, session?: ResolutionSession): BoundValue {
+    const valueOrPromise = this.getValueOrPromise(key, session);
 
     if (isPromise(valueOrPromise)) {
       throw new Error(
@@ -227,13 +228,17 @@ export class Context {
    *
    * @param keyWithPath The binding key, optionally suffixed with a path to the
    *   (deeply) nested property to retrieve.
+   * @param session An object to keep states of the resolution
    * @returns The bound value or a promise of the bound value, depending
    *   on how the binding was configured.
    * @internal
    */
-  getValueOrPromise(keyWithPath: string): ValueOrPromise<BoundValue> {
+  getValueOrPromise(
+    keyWithPath: string,
+    session?: ResolutionSession,
+  ): ValueOrPromise<BoundValue> {
     const {key, path} = Binding.parseKeyWithPath(keyWithPath);
-    const boundValue = this.getBinding(key).getValue(this);
+    const boundValue = this.getBinding(key).getValue(this, session);
     if (path === undefined || path === '') {
       return boundValue;
     }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -7,6 +7,9 @@ import {Binding, BoundValue, ValueOrPromise} from './binding';
 import {isPromise} from './is-promise';
 import {ResolutionSession} from './resolver';
 
+import * as debugModule from 'debug';
+const debug = debugModule('loopback:context');
+
 /**
  * Context provides an implementation of Inversion of Control (IoC) container
  */
@@ -28,6 +31,10 @@ export class Context {
    * @param key Binding key
    */
   bind(key: string): Binding {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Adding binding: %s', key);
+    }
     Binding.validateKey(key);
     const keyExists = this.registry.has(key);
     if (keyExists) {
@@ -145,6 +152,10 @@ export class Context {
    * @returns A promise of the bound value.
    */
   get(key: string, session?: ResolutionSession): Promise<BoundValue> {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Resolving binding: %s', key);
+    }
     try {
       return Promise.resolve(this.getValueOrPromise(key, session));
     } catch (err) {
@@ -175,6 +186,10 @@ export class Context {
    * @returns A promise of the bound value.
    */
   getSync(key: string, session?: ResolutionSession): BoundValue {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Resolving binding synchronously: %s', key);
+    }
     const valueOrPromise = this.getValueOrPromise(key, session);
 
     if (isPromise(valueOrPromise)) {

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -5,7 +5,7 @@
 
 import {Binding, BoundValue, ValueOrPromise} from './binding';
 import {isPromise} from './is-promise';
-import {ResolutionSession} from './resolver';
+import {ResolutionSession} from './resolution-session';
 
 import * as debugModule from 'debug';
 const debug = debugModule('loopback:context');

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -12,7 +12,8 @@ export {
 } from './binding';
 
 export {Context} from './context';
-export {Constructor, ResolutionSession} from './resolver';
+export {Constructor} from './resolver';
+export {ResolutionSession} from './resolution-session';
 export {inject, Setter, Getter} from './inject';
 export {Provider} from './provider';
 export {isPromise} from './is-promise';

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -12,7 +12,7 @@ export {
 } from './binding';
 
 export {Context} from './context';
-export {Constructor} from './resolver';
+export {Constructor, ResolutionSession} from './resolver';
 export {inject, Setter, Getter} from './inject';
 export {Provider} from './provider';
 export {isPromise} from './is-promise';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -12,7 +12,6 @@ import {
 } from '@loopback/metadata';
 import {BoundValue, ValueOrPromise} from './binding';
 import {Context} from './context';
-import {isPromise} from './is-promise';
 import {ResolutionSession} from './resolver';
 
 const PARAMETERS_KEY = 'inject:parameters';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -12,7 +12,7 @@ import {
 } from '@loopback/metadata';
 import {BoundValue, ValueOrPromise} from './binding';
 import {Context} from './context';
-import {ResolutionSession} from './resolver';
+import {ResolutionSession} from './resolution-session';
 
 const PARAMETERS_KEY = 'inject:parameters';
 const PROPERTIES_KEY = 'inject:properties';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -193,7 +193,7 @@ function resolveAsGetter(
   session?: ResolutionSession,
 ) {
   // We need to clone the session for the getter as it will be resolved later
-  if (session != null) session = session.clone();
+  session = ResolutionSession.fork(session);
   return function getter() {
     return ctx.get(injection.bindingKey, session);
   };

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -188,10 +188,15 @@ export namespace inject {
   };
 }
 
-function resolveAsGetter(ctx: Context, injection: Injection) {
-  // No resolution session should be propagated into the getter
+function resolveAsGetter(
+  ctx: Context,
+  injection: Injection,
+  session?: ResolutionSession,
+) {
+  // We need to clone the session for the getter as it will be resolved later
+  if (session != null) session = session.clone();
   return function getter() {
-    return ctx.get(injection.bindingKey);
+    return ctx.get(injection.bindingKey, session);
   };
 }
 

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -11,6 +11,8 @@ import {
 } from '@loopback/metadata';
 import {BoundValue, ValueOrPromise} from './binding';
 import {Context} from './context';
+import {isPromise} from './is-promise';
+import {ResolutionSession} from './resolver';
 
 const PARAMETERS_KEY = 'inject:parameters';
 const PROPERTIES_KEY = 'inject:properties';
@@ -19,7 +21,11 @@ const PROPERTIES_KEY = 'inject:properties';
  * A function to provide resolution of injected values
  */
 export interface ResolverFunction {
-  (ctx: Context, injection: Injection): ValueOrPromise<BoundValue>;
+  (
+    ctx: Context,
+    injection: Injection,
+    session?: ResolutionSession,
+  ): ValueOrPromise<BoundValue>;
 }
 
 /**
@@ -168,12 +174,14 @@ export namespace inject {
 }
 
 function resolveAsGetter(ctx: Context, injection: Injection) {
+  // No resolution session should be propagated into the getter
   return function getter() {
     return ctx.get(injection.bindingKey);
   };
 }
 
 function resolveAsSetter(ctx: Context, injection: Injection) {
+  // No resolution session should be propagated into the setter
   return function setter(value: BoundValue) {
     ctx.bind(injection.bindingKey).to(value);
   };

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -21,6 +21,9 @@ export class ResolutionSession {
    */
   readonly bindings: Binding[] = [];
 
+  /**
+   * A stack of injections for the current resolution session.
+   */
   readonly injections: Injection[] = [];
 
   /**
@@ -44,7 +47,7 @@ export class ResolutionSession {
     session?: ResolutionSession,
   ): ResolutionSession {
     session = session || new ResolutionSession();
-    session.enter(binding);
+    session.pushBinding(binding);
     return session;
   }
 
@@ -58,10 +61,14 @@ export class ResolutionSession {
     session?: ResolutionSession,
   ): ResolutionSession {
     session = session || new ResolutionSession();
-    session.enterInjection(injection);
+    session.pushInjection(injection);
     return session;
   }
 
+  /**
+   * Describe the injection for debugging purpose
+   * @param injection
+   */
   static describeInjection(injection?: Injection) {
     /* istanbul ignore if */
     if (injection == null) return injection;
@@ -81,7 +88,7 @@ export class ResolutionSession {
    * Push the injection onto the session
    * @param injection Injection
    */
-  enterInjection(injection: Injection) {
+  pushInjection(injection: Injection) {
     /* istanbul ignore if */
     if (debugSession.enabled) {
       debugSession(
@@ -99,7 +106,7 @@ export class ResolutionSession {
   /**
    * Pop the last injection
    */
-  exitInjection() {
+  popInjection() {
     const injection = this.injections.pop();
     /* istanbul ignore if */
     if (debugSession.enabled) {
@@ -130,7 +137,7 @@ export class ResolutionSession {
    * Enter the resolution of the given binding. If
    * @param binding Binding
    */
-  enter(binding: Binding) {
+  pushBinding(binding: Binding) {
     /* istanbul ignore if */
     if (debugSession.enabled) {
       debugSession('Enter binding:', binding.toJSON());
@@ -152,7 +159,7 @@ export class ResolutionSession {
   /**
    * Exit the resolution of a binding
    */
-  exit() {
+  popBinding() {
     const binding = this.bindings.pop();
     /* istanbul ignore if */
     if (debugSession.enabled) {

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -1,0 +1,180 @@
+// Copyright IBM Corp. 2013, 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Binding} from './binding';
+import {Injection} from './inject';
+import * as debugModule from 'debug';
+import {DecoratorFactory} from '@loopback/metadata';
+
+const debugSession = debugModule('loopback:context:resolver:session');
+const getTargetName = DecoratorFactory.getTargetName;
+/**
+ * Object to keep states for a session to resolve bindings and their
+ * dependencies within a context
+ */
+export class ResolutionSession {
+  /**
+   * A stack of bindings for the current resolution session. It's used to track
+   * the path of dependency resolution and detect circular dependencies.
+   */
+  readonly bindings: Binding[] = [];
+
+  readonly injections: Injection[] = [];
+
+  /**
+   * Take a snapshot of the ResolutionSession so that we can pass it to
+   * `@inject.getter` without interferring with the current session
+   */
+  clone() {
+    const copy = new ResolutionSession();
+    copy.bindings.push(...this.bindings);
+    copy.injections.push(...this.injections);
+    return copy;
+  }
+
+  /**
+   * Start to resolve a binding within the session
+   * @param binding Binding
+   * @param session Resolution session
+   */
+  static enterBinding(
+    binding: Binding,
+    session?: ResolutionSession,
+  ): ResolutionSession {
+    session = session || new ResolutionSession();
+    session.enter(binding);
+    return session;
+  }
+
+  /**
+   * Push an injection into the session
+   * @param injection Injection
+   * @param session Resolution session
+   */
+  static enterInjection(
+    injection: Injection,
+    session?: ResolutionSession,
+  ): ResolutionSession {
+    session = session || new ResolutionSession();
+    session.enterInjection(injection);
+    return session;
+  }
+
+  static describeInjection(injection?: Injection) {
+    /* istanbul ignore if */
+    if (injection == null) return injection;
+    const name = getTargetName(
+      injection.target,
+      injection.member,
+      injection.methodDescriptorOrParameterIndex,
+    );
+    return {
+      targetName: name,
+      bindingKey: injection.bindingKey,
+      metadata: injection.metadata,
+    };
+  }
+
+  /**
+   * Push the injection onto the session
+   * @param injection Injection
+   */
+  enterInjection(injection: Injection) {
+    /* istanbul ignore if */
+    if (debugSession.enabled) {
+      debugSession(
+        'Enter injection:',
+        ResolutionSession.describeInjection(injection),
+      );
+    }
+    this.injections.push(injection);
+    /* istanbul ignore if */
+    if (debugSession.enabled) {
+      debugSession('Injection path:', this.getInjectionPath());
+    }
+  }
+
+  /**
+   * Pop the last injection
+   */
+  exitInjection() {
+    const injection = this.injections.pop();
+    /* istanbul ignore if */
+    if (debugSession.enabled) {
+      debugSession(
+        'Exit injection:',
+        ResolutionSession.describeInjection(injection),
+      );
+      debugSession('Injection path:', this.getInjectionPath() || '<empty>');
+    }
+    return injection;
+  }
+
+  /**
+   * Getter for the current injection
+   */
+  get currentInjection() {
+    return this.injections[this.injections.length - 1];
+  }
+
+  /**
+   * Getter for the current binding
+   */
+  get currentBinding() {
+    return this.bindings[this.bindings.length - 1];
+  }
+
+  /**
+   * Enter the resolution of the given binding. If
+   * @param binding Binding
+   */
+  enter(binding: Binding) {
+    /* istanbul ignore if */
+    if (debugSession.enabled) {
+      debugSession('Enter binding:', binding.toJSON());
+    }
+    if (this.bindings.indexOf(binding) !== -1) {
+      throw new Error(
+        `Circular dependency detected on path '${this.getBindingPath()} --> ${
+          binding.key
+        }'`,
+      );
+    }
+    this.bindings.push(binding);
+    /* istanbul ignore if */
+    if (debugSession.enabled) {
+      debugSession('Binding path:', this.getBindingPath());
+    }
+  }
+
+  /**
+   * Exit the resolution of a binding
+   */
+  exit() {
+    const binding = this.bindings.pop();
+    /* istanbul ignore if */
+    if (debugSession.enabled) {
+      debugSession('Exit binding:', binding && binding.toJSON());
+      debugSession('Binding path:', this.getBindingPath() || '<empty>');
+    }
+    return binding;
+  }
+
+  /**
+   * Get the binding path as `bindingA --> bindingB --> bindingC`.
+   */
+  getBindingPath() {
+    return this.bindings.map(b => b.key).join(' --> ');
+  }
+
+  /**
+   * Get the injection path as `injectionA->injectionB->injectionC`.
+   */
+  getInjectionPath() {
+    return this.injections
+      .map(i => ResolutionSession.describeInjection(i)!.targetName)
+      .join(' --> ');
+  }
+}

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -307,7 +307,7 @@ function resolve<T>(
       })
       .catch(e => {
         session!.exitInjection();
-        return Promise.reject(e);
+        throw e;
       });
   } else {
     session.exitInjection();

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -40,6 +40,17 @@ export class ResolutionSession {
   readonly injections: Injection[] = [];
 
   /**
+   * Take a snapshot of the ResolutionSession so that we can pass it to
+   * `@inject.getter` without interferring with the current session
+   */
+  clone() {
+    const copy = new ResolutionSession();
+    copy.bindings.push(...this.bindings);
+    copy.injections.push(...this.injections);
+    return copy;
+  }
+
+  /**
    * Start to resolve a binding within the session
    * @param binding Binding
    * @param session Resolution session

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -53,7 +53,6 @@ export function instantiateClass<T>(
       debug('Non-injected arguments:', nonInjectedArgs);
     }
   }
-  session = session || new ResolutionSession();
   const argsOrPromise = resolveInjectedArguments(ctor, '', ctx, session);
   const propertiesOrPromise = resolveInjectedProperties(ctor, ctx, session);
   let inst: T | Promise<T>;
@@ -201,7 +200,12 @@ export function resolveInjectedArguments(
       }
     }
 
-    const valueOrPromise = resolve(ctx, injection, session);
+    // Clone the session so that multiple arguments can be resolved in parallel
+    const valueOrPromise = resolve(
+      ctx,
+      injection,
+      ResolutionSession.fork(session),
+    );
     if (isPromise(valueOrPromise)) {
       if (!asyncResolvers) asyncResolvers = [];
       asyncResolvers.push(
@@ -314,7 +318,12 @@ export function resolveInjectedProperties(
       );
     }
 
-    const valueOrPromise = resolve(ctx, injection, session);
+    // Clone the session so that multiple properties can be resolved in parallel
+    const valueOrPromise = resolve(
+      ctx,
+      injection,
+      ResolutionSession.fork(session),
+    );
     if (isPromise(valueOrPromise)) {
       if (!asyncResolvers) asyncResolvers = [];
       asyncResolvers.push(valueOrPromise.then(propertyResolver(p)));

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -142,9 +142,9 @@ export class ResolutionSession {
     }
     if (this.bindings.indexOf(binding) !== -1) {
       throw new Error(
-        `Circular dependency detected for '${
+        `Circular dependency detected on path '${this.getBindingPath()} --> ${
           binding.key
-        }' on path '${this.getBindingPath()}'`,
+        }'`,
       );
     }
     this.bindings.push(binding);

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -133,22 +133,22 @@ function resolve<T>(
       resolved = ctx.getValueOrPromise(injection.bindingKey, session);
     }
   } catch (e) {
-    session.exit();
+    session.popBinding();
     throw e;
   }
   if (isPromise(resolved)) {
     resolved = resolved.then(
       r => {
-        session!.exitInjection();
+        session!.popInjection();
         return r;
       },
       e => {
-        session!.exitInjection();
+        session!.popInjection();
         throw e;
       },
     );
   } else {
-    session.exitInjection();
+    session.popInjection();
   }
   return resolved;
 }

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -111,9 +111,14 @@ describe('Binding', () => {
     });
 
     it('rejects rejected promise values', () => {
-      expect(() => binding.to(Promise.reject('error'))).to.throw(
+      const p = Promise.reject('error');
+      expect(() => binding.to(p)).to.throw(
         /Promise instances are not allowed.*toDynamicValue/,
       );
+      // Catch the rejected promise to avoid
+      // (node:60994) UnhandledPromiseRejectionWarning: Unhandled promise
+      // rejection (rejection id: 1): error
+      p.catch(e => {});
     });
   });
 

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -88,6 +88,73 @@ describe('constructor injection', () => {
     const t = instantiateClass(TestClass, ctx) as TestClass;
     expect(t.fooBar).to.eql('FOO:BAR');
   });
+
+  it('reports circular dependencies of two bindings', () => {
+    const context = new Context();
+
+    // Declare two interfaces so that they can be used for typing
+    interface XInterface {}
+    interface YInterface {}
+
+    class XClass implements XInterface {
+      constructor(@inject('y') public y: YInterface) {}
+    }
+
+    class YClass implements YInterface {
+      constructor(@inject('x') public x: XInterface) {}
+    }
+
+    context.bind('x').toClass(XClass);
+    context.bind('y').toClass(YClass);
+    expect(() => context.getSync('x')).to.throw(/Circular dependency/);
+    expect(() => context.getSync('y')).to.throw(/Circular dependency/);
+  });
+
+  it('reports circular dependencies of three bindings', () => {
+    const context = new Context();
+
+    // Declare interfaces so that they can be used for typing
+    interface XInterface {}
+    interface YInterface {}
+    interface ZInterface {}
+
+    class XClass {
+      constructor(@inject('y') public y: YInterface) {}
+    }
+
+    class YClass {
+      constructor(@inject('z') public z: ZInterface) {}
+    }
+
+    class ZClass {
+      constructor(@inject('x') public x: XInterface) {}
+    }
+
+    context.bind('x').toClass(XClass);
+    context.bind('y').toClass(YClass);
+    context.bind('z').toClass(ZClass);
+    expect(() => context.getSync('x')).to.throw(/Circular dependency/);
+    expect(() => context.getSync('y')).to.throw(/Circular dependency/);
+    expect(() => context.getSync('z')).to.throw(/Circular dependency/);
+  });
+
+  it('will not report circular dependencies if two bindings', () => {
+    const context = new Context();
+    class XClass {}
+
+    class YClass {
+      constructor(
+        @inject('x') public a: XClass,
+        @inject('x') public b: XClass,
+      ) {}
+    }
+
+    context.bind('x').toClass(XClass);
+    context.bind('y').toClass(YClass);
+    const y: YClass = context.getSync('y');
+    expect(y.a).to.be.instanceof(XClass);
+    expect(y.b).to.be.instanceof(XClass);
+  });
 });
 
 describe('async constructor injection', () => {
@@ -188,6 +255,24 @@ describe('property injection', () => {
 
     const t = instantiateClass(TestClass, ctx) as TestClass;
     expect(t.fooBar).to.eql('FOO:BAR');
+  });
+
+  it('reports circular dependencies of two bindings', () => {
+    const context = new Context();
+    class XClass {
+      // tslint:disable-next-line:no-any
+      @inject('y') public y: any;
+    }
+
+    class YClass {
+      // tslint:disable-next-line:no-any
+      @inject('x') public x: any;
+    }
+
+    context.bind('x').toClass(XClass);
+    context.bind('y').toClass(YClass);
+    expect(() => context.getSync('x')).to.throw(/Circular dependency/);
+    expect(() => context.getSync('y')).to.throw(/Circular dependency/);
   });
 });
 

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -185,7 +185,7 @@ describe('constructor injection', () => {
     context.bind('y').toClass(YClass);
     context.bind('z').toClass(ZClass);
     context.getSync('x');
-    expect(bindingPath).to.eql('x->y->z');
+    expect(bindingPath).to.eql('x --> y --> z');
   });
 
   it('tracks path of injections', () => {
@@ -217,7 +217,7 @@ describe('constructor injection', () => {
     context.bind('z').toClass(ZClass);
     context.getSync('x');
     expect(injectionPath).to.eql(
-      'XClass.constructor[0]->YClass.constructor[0]->ZClass.prototype.myProp',
+      'XClass.constructor[0] --> YClass.constructor[0] --> ZClass.prototype.myProp',
     );
   });
 });

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -10,7 +10,6 @@ import {
   instantiateClass,
   invokeMethod,
   Injection,
-  Constructor,
   Getter,
   ResolutionSession,
 } from '../..';

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -459,6 +459,53 @@ describe('async constructor & sync property injection', () => {
   });
 });
 
+describe('async constructor injection with errors', () => {
+  let ctx: Context;
+
+  before(function() {
+    ctx = new Context();
+    ctx.bind('foo').toDynamicValue(
+      () =>
+        new Promise((resolve, reject) => {
+          setImmediate(() => {
+            reject(new Error('foo: error'));
+          });
+        }),
+    );
+  });
+
+  it('resolves properties and constructor arguments', async () => {
+    class TestClass {
+      constructor(@inject('foo') public foo: string) {}
+    }
+
+    await expect(instantiateClass(TestClass, ctx)).to.be.rejectedWith(
+      'foo: error',
+    );
+  });
+});
+
+describe('async property injection with errors', () => {
+  let ctx: Context;
+
+  before(function() {
+    ctx = new Context();
+    ctx.bind('bar').toDynamicValue(async () => {
+      throw new Error('bar: error');
+    });
+  });
+
+  it('resolves properties and constructor arguments', async () => {
+    class TestClass {
+      @inject('bar') bar: string;
+    }
+
+    await expect(instantiateClass(TestClass, ctx)).to.be.rejectedWith(
+      'bar: error',
+    );
+  });
+});
+
 describe('sync constructor & async property injection', () => {
   let ctx: Context;
 

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -148,7 +148,8 @@ describe('constructor injection', () => {
     );
   });
 
-  it('will not report circular dependencies if two bindings', () => {
+  // tslint:disable-next-line:max-line-length
+  it('will not report circular dependencies if a binding is injected twice', () => {
     const context = new Context();
     class XClass {}
 

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -170,6 +170,7 @@ describe('constructor injection', () => {
   it('tracks path of bindings', () => {
     const context = new Context();
     let bindingPath = '';
+    let resolutionPath = '';
 
     class ZClass {
       @inject(
@@ -178,6 +179,7 @@ describe('constructor injection', () => {
         // Set up a custom resolve() to access information from the session
         (c: Context, injection: Injection, session: ResolutionSession) => {
           bindingPath = session.getBindingPath();
+          resolutionPath = session.getResolutionPath();
         },
       )
       myProp: string;
@@ -196,11 +198,16 @@ describe('constructor injection', () => {
     context.bind('z').toClass(ZClass);
     context.getSync('x');
     expect(bindingPath).to.eql('x --> y --> z');
+    expect(resolutionPath).to.eql(
+      'x --> @XClass.constructor[0] --> y --> @YClass.constructor[0]' +
+        ' --> z --> @ZClass.prototype.myProp',
+    );
   });
 
   it('tracks path of bindings for @inject.getter', async () => {
     const context = new Context();
     let bindingPath = '';
+    let resolutionPath = '';
 
     class ZClass {
       @inject(
@@ -209,6 +216,7 @@ describe('constructor injection', () => {
         // Set up a custom resolve() to access information from the session
         (c: Context, injection: Injection, session: ResolutionSession) => {
           bindingPath = session.getBindingPath();
+          resolutionPath = session.getResolutionPath();
         },
       )
       myProp: string;
@@ -228,6 +236,10 @@ describe('constructor injection', () => {
     const x: XClass = context.getSync('x');
     await x.y.z();
     expect(bindingPath).to.eql('x --> y --> z');
+    expect(resolutionPath).to.eql(
+      'x --> @XClass.constructor[0] --> y --> @YClass.constructor[0]' +
+        ' --> z --> @ZClass.prototype.myProp',
+    );
   });
 
   it('tracks path of injections', () => {

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -146,18 +146,18 @@ export class DecoratorFactory<
     let name =
       target instanceof Function
         ? target.name
-        : target.constructor.name + '.prototype';
+        : `${target.constructor.name}.prototype`;
     if (member == null && descriptorOrIndex == null) {
-      return 'class ' + name;
+      return `class ${name}`;
     }
     if (member == null) member = 'constructor';
     if (typeof descriptorOrIndex === 'number') {
       // Parameter
-      name = name + '.' + member.toString() + '[' + descriptorOrIndex + ']';
+      name = `${name}.${member}[${descriptorOrIndex}]`;
     } else if (descriptorOrIndex != null) {
-      name = name + '.' + member.toString() + '()';
+      name = `${name}.${member}()`;
     } else {
-      name = name + '.' + member.toString();
+      name = `${name}.${member}`;
     }
     return name;
   }
@@ -627,7 +627,7 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
     );
     // Fetch the cached parameter index
     let index = Reflector.getOwnMetadata(
-      this.key + ':index',
+      `${this.key}:index`,
       target,
       methodName,
     );
@@ -667,7 +667,7 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
     }
     // Cache the index to help us position the next parameter
     Reflector.defineMetadata(
-      this.key + ':index',
+      `${this.key}:index`,
       index - 1,
       target,
       methodName,
@@ -691,7 +691,7 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
     ownMetadata[methodName!] = params;
     // Cache the index to help us position the next parameter
     Reflector.defineMetadata(
-      this.key + ':index',
+      `${this.key}:index`,
       index - 1,
       target,
       methodName,

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -621,7 +621,10 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
     methodName?: string | symbol,
     methodDescriptor?: TypedPropertyDescriptor<any> | number,
   ) {
-    const numOfParams = this.getNumberOfParameters(target, methodName);
+    const numOfParams = DecoratorFactory.getNumberOfParameters(
+      target,
+      methodName,
+    );
     // Fetch the cached parameter index
     let index = Reflector.getOwnMetadata(
       this.key + ':index',
@@ -632,7 +635,11 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
     if (index == null) index = numOfParams - 1;
     if (index < 0) {
       // Excessive decorations than the number of parameters detected
-      const method = this.getTargetName(target, methodName, methodDescriptor);
+      const method = DecoratorFactory.getTargetName(
+        target,
+        methodName,
+        methodDescriptor,
+      );
       throw new Error(
         `The decorator is used more than ${numOfParams} time(s) on ${method}`,
       );

--- a/packages/metadata/test/unit/decorator-factory.test.ts
+++ b/packages/metadata/test/unit/decorator-factory.test.ts
@@ -691,7 +691,7 @@ describe('MethodParameterDecoratorFactory with invalid decorations', () => {
         myMethod(a: string, b: number) {}
       }
     }).to.throw(
-      /The decorator is used more than 2 time\(s\) on method MyController\.prototype\.myMethod/,
+      /The decorator is used more than 2 time\(s\) on MyController\.prototype\.myMethod\(\)/,
     );
   });
 });

--- a/packages/metadata/test/unit/decorator-factory.test.ts
+++ b/packages/metadata/test/unit/decorator-factory.test.ts
@@ -329,7 +329,7 @@ describe('PropertyDecoratorFactory', () => {
         myProp: string;
       }
     }).to.throw(
-      /Decorator cannot be applied more than once on property MyController\.prototype\.myProp/,
+      /Decorator cannot be applied more than once on MyController\.prototype\.myProp/,
     );
   });
 });
@@ -377,7 +377,7 @@ describe('PropertyDecoratorFactory for static properties', () => {
         static myProp: string;
       }
     }).to.throw(
-      /Decorator cannot be applied more than once on property MyController\.myProp/,
+      /Decorator cannot be applied more than once on MyController\.myProp/,
     );
   });
 });
@@ -425,7 +425,7 @@ describe('MethodDecoratorFactory', () => {
         myMethod() {}
       }
     }).to.throw(
-      /Decorator cannot be applied more than once on method MyController\.prototype\.myMethod/,
+      /Decorator cannot be applied more than once on MyController\.prototype\.myMethod\(\)/,
     );
   });
 });
@@ -473,7 +473,7 @@ describe('MethodDecoratorFactory for static methods', () => {
         static myMethod() {}
       }
     }).to.throw(
-      /Decorator cannot be applied more than once on method MyController\.myMethod/,
+      /Decorator cannot be applied more than once on MyController\.myMethod\(\)/,
     );
   });
 });
@@ -530,7 +530,7 @@ describe('ParameterDecoratorFactory', () => {
         ) {}
       }
     }).to.throw(
-      /Decorator cannot be applied more than once on parameter MyController\.prototype\.myMethod\[0\]/,
+      /Decorator cannot be applied more than once on MyController\.prototype\.myMethod\[0\]/,
     );
   });
 });
@@ -631,7 +631,7 @@ describe('ParameterDecoratorFactory for a static method', () => {
         ) {}
       }
     }).to.throw(
-      /Decorator cannot be applied more than once on parameter MyController\.myMethod\[0\]/,
+      /Decorator cannot be applied more than once on MyController\.myMethod\[0\]/,
     );
   });
 });


### PR DESCRIPTION
Add ability to track dependency resolution and detect circular dependencies. This is a spin-off from https://github.com/strongloop/loopback-next/pull/671.

See #535

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
