### PR TITLE
fix: fix build break and upgrade dependencies

### DIFF
--- a/packages/build/bin/run-prettier.js
+++ b/packages/build/bin/run-prettier.js
@@ -34,7 +34,7 @@ function run(argv, dryRun) {
   }
   args.push(...prettierOpts);
 
-  return utils.runCLI('prettier/bin/prettier', args, dryRun);
+  return utils.runCLI('prettier/bin-prettier', args, dryRun);
 }
 
 module.exports = run;

--- a/packages/build/config/tslint.common.json
+++ b/packages/build/config/tslint.common.json
@@ -22,7 +22,6 @@
     "no-unused-expression": true,
     "no-unused-variable": true,
     "no-var-keyword": true,
-    "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
-    "typeof-compare": true
+    "triple-equals": [true, "allow-null-check", "allow-undefined-check"]
   }
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -13,15 +13,15 @@
   "license": "MIT",
   "dependencies": {
     "@types/mocha": "^2.2.43",
-    "@types/node": "^8.0.50",
+    "@types/node": "^8.5.8",
     "cross-spawn": "^5.1.0",
     "debug": "^3.1.0",
     "mocha": "^4.0.0",
-    "nyc": "^11.3.0",
-    "prettier": "^1.8.1",
+    "nyc": "^11.4.1",
+    "prettier": "^1.10.2",
     "strong-docs": "^1.6.0",
-    "tslint": "^5.7.0",
-    "typescript": "^2.5.3"
+    "tslint": "^5.9.1",
+    "typescript": "^2.6.2"
   },
   "bin": {
     "lb-tsc": "./bin/compile-package.js",
@@ -43,6 +43,6 @@
     "posttest": "npm run lint"
   },
   "devDependencies": {
-    "fs-extra": "^4.0.2"
+    "fs-extra": "^5.0.0"
   }
 }


### PR DESCRIPTION
- fix build break by newer version of prettier (https://travis-ci.org/strongloop/loopback-next/jobs/327503885)
- upgrade tool dependencies

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
