### PR TITLE
feat: add findOne function into legacy juggler bridge

### DIFF
--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -138,6 +138,11 @@ export class DefaultCrudRepository<T extends Entity, ID>
     return this.toEntities(models);
   }
 
+  async findOne(filter?: Filter, options?: Options): Promise<T> {
+    const model = await ensurePromise(this.modelClass.findOne(filter, options));
+    return this.toEntity(model);
+  }
+
   async findById(id: ID, filter?: Filter, options?: Options): Promise<T> {
     const model = await ensurePromise(
       this.modelClass.findById(id, filter, options),

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -97,6 +97,20 @@ describe('DefaultCrudRepository', () => {
     expect(notes.length).to.eql(1);
   });
 
+  it('implements Repository.findOne()', async () => {
+    const repo = new DefaultCrudRepository(Note, ds);
+    await repo.createAll([
+      {title: 't1', content: 'c1'},
+      {title: 't1', content: 'c2'},
+    ]);
+    const note = await repo.findOne({
+      where: {title: 't1'},
+      order: ['content DESC'],
+    });
+    expect(note.title).to.eql('t1');
+    expect(note.content).to.eql('c2');
+  });
+
   it('implements Repository.delete()', async () => {
     const repo = new DefaultCrudRepository(Note, ds);
     const note = await repo.create({title: 't3', content: 'c3'});


### PR DESCRIPTION
Recreate PR from https://github.com/strongloop/loopback-next/pull/839

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
