### PR TITLE
feat(context): add @inject.tag to allow injection by a tag

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -29,7 +29,7 @@
     "@loopback/build": "^4.0.0-alpha.8",
     "@loopback/testlab": "^4.0.0-alpha.18",
     "@types/bluebird": "^3.5.18",
-    "@types/debug": "0.0.30",
+    "@types/debug": "^0.0.30",
     "bluebird": "^3.5.0"
   },
   "keywords": [

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -174,7 +174,7 @@ export class ResolutionSession {
    */
   static describeInjection(injection?: Injection) {
     /* istanbul ignore if */
-    if (injection == null) return injection;
+    if (injection == null) return undefined;
     const name = getTargetName(
       injection.target,
       injection.member,

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -5,12 +5,15 @@
 
 import {expect} from '@loopback/testlab';
 import {Context, inject, Setter, Getter} from '../..';
+import {Provider} from '../../src/provider';
+import {Injection} from '../../src/inject';
+import {ResolutionSession} from '../../src/resolution-session';
 
 const INFO_CONTROLLER = 'controllers.info';
 
 describe('Context bindings - Injecting dependencies of classes', () => {
   let ctx: Context;
-  before('given a context', createContext);
+  beforeEach('given a context', createContext);
 
   it('injects constructor args', async () => {
     ctx.bind('application.name').to('CodeHub');
@@ -175,6 +178,129 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     const resolved = await ctx.get('component');
     expect(resolved.config).to.equal('test-config');
+  });
+
+  it('injects values by tag', () => {
+    class Store {
+      constructor(@inject.tag('store:location') public locations: string[]) {}
+    }
+
+    ctx.bind('store').toClass(Store);
+    ctx
+      .bind('store.locations.sf')
+      .to('San Francisco')
+      .tag('store:location');
+    ctx
+      .bind('store.locations.sj')
+      .to('San Jose')
+      .tag('store:location');
+    const store: Store = ctx.getSync('store');
+    expect(store.locations).to.eql(['San Francisco', 'San Jose']);
+  });
+
+  it('injects values by tag regex', () => {
+    class Store {
+      constructor(
+        @inject.tag(/.+:location:sj/)
+        public locations: string[],
+      ) {}
+    }
+
+    ctx.bind('store').toClass(Store);
+    ctx
+      .bind('store.locations.sf')
+      .to('San Francisco')
+      .tag('store:location:sf');
+    ctx
+      .bind('store.locations.sj')
+      .to('San Jose')
+      .tag('store:location:sj');
+    const store: Store = ctx.getSync('store');
+    expect(store.locations).to.eql(['San Jose']);
+  });
+
+  it('injects empty values by tag if not found', () => {
+    class Store {
+      constructor(@inject.tag('store:location') public locations: string[]) {}
+    }
+
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.locations).to.eql([]);
+  });
+
+  it('injects values by tag asynchronously', async () => {
+    class Store {
+      constructor(@inject.tag('store:location') public locations: string[]) {}
+    }
+
+    ctx.bind('store').toClass(Store);
+    ctx
+      .bind('store.locations.sf')
+      .to('San Francisco')
+      .tag('store:location');
+    ctx
+      .bind('store.locations.sj')
+      .toDynamicValue(async () => 'San Jose')
+      .tag('store:location');
+    const store: Store = await ctx.get('store');
+    expect(store.locations).to.eql(['San Francisco', 'San Jose']);
+  });
+
+  it('injects values by tag asynchronously', async () => {
+    class Store {
+      constructor(@inject.tag('store:location') public locations: string[]) {}
+    }
+
+    let resolutionPath;
+    class LocationProvider implements Provider<string> {
+      @inject(
+        'location',
+        {},
+        // Set up a custom resolve() to access information from the session
+        (c: Context, injection: Injection, session: ResolutionSession) => {
+          resolutionPath = session.getResolutionPath();
+          return 'San Jose';
+        },
+      )
+      location: string;
+      value() {
+        return this.location;
+      }
+    }
+
+    ctx.bind('store').toClass(Store);
+    ctx
+      .bind('store.locations.sf')
+      .to('San Francisco')
+      .tag('store:location');
+    ctx
+      .bind('store.locations.sj')
+      .toProvider(LocationProvider)
+      .tag('store:location');
+    const store: Store = await ctx.get('store');
+    expect(store.locations).to.eql(['San Francisco', 'San Jose']);
+    expect(resolutionPath).to.eql(
+      'store --> @Store.constructor[0] --> store.locations.sj --> ' +
+        '@LocationProvider.prototype.location',
+    );
+  });
+
+  it('reports error when @inject.tag rejects a promise', async () => {
+    class Store {
+      constructor(@inject.tag('store:location') public locations: string[]) {}
+    }
+
+    ctx.bind('store').toClass(Store);
+    ctx
+      .bind('store.locations.sf')
+      .to('San Francisco')
+      .tag('store:location');
+    ctx
+      .bind('store.locations.sj')
+      .toDynamicValue(() => Promise.reject(new Error('Bad')))
+      .tag('store:location');
+    await expect(ctx.get('store')).to.be.rejectedWith('Bad');
   });
 
   function createContext() {

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@loopback/build": "^4.0.0-alpha.8",
     "@loopback/testlab": "^4.0.0-alpha.18",
-    "@types/debug": "0.0.30",
+    "@types/debug": "^0.0.30",
     "@types/lodash": "^4.14.87"
   },
   "keywords": [


### PR DESCRIPTION
Add `@inject.tag` decorator to allow injection of an array of bound values by a tag.

This DI can be used with the extension point/extension pattern so that the extension point can receive injection all extensions.

This is a spin-off from #671. The PR will be enhanced with ResolutionSession once https://github.com/strongloop/loopback-next/pull/852 is landed.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
