### PR TITLE
build: disable commit linter's footer-max-length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,7 +10,6 @@ module.exports = {
   ],
   rules: {
     'header-max-length': [2, 'always', 100],
-    'footer-max-length': [2, 'always', 100],
     'body-leading-blank': [2, 'always'],
     'footer-leading-blank': [0, 'always'],
   }


### PR DESCRIPTION
The setting controls the total length of the footer, not a maximum
allowed line length :(

See https://github.com/strongloop/loopback-next/pull/854 and https://travis-ci.org/strongloop/loopback-next/jobs/328017516#L1155

## Checklist

- n/a `npm test` passes on your machine
- n/a New tests added or existing tests modified to cover all changes
- n/a Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- n/a Related API Documentation was updated
- n/a Affected artifact templates in `packages/cli` were updated
- n/a Affected example projects in `packages/example-*` were updated
