### PR TITLE
Fix tslint-related configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
   "files.trimTrailingWhitespace": true,
 
   "tslint.ignoreDefinitionFiles": true,
+  "tslint.nodePath": "./packages/build/node_modules",
   "typescript.tsdk": "./packages/build/node_modules/typescript/lib"
 }

--- a/packages/build/config/tslint.build.json
+++ b/packages/build/config/tslint.build.json
@@ -9,12 +9,12 @@
   "rules": {
     // These rules find errors related to TypeScript features.
 
-
     // These rules catch common errors in JS programming or otherwise
     // confusing constructs that are prone to producing bugs.
 
     "await-promise": true,
     "no-floating-promises": true,
+    "no-unused-variable": true,
     "no-void-expression": [true, "ignore-arrow-function-shorthand"]
   }
 }

--- a/packages/build/config/tslint.common.json
+++ b/packages/build/config/tslint.common.json
@@ -20,7 +20,6 @@
     "no-shadowed-variable": true,
     "no-string-throw": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-var-keyword": true,
     "triple-equals": [true, "allow-null-check", "allow-undefined-check"]
   }


### PR DESCRIPTION
 - Fix tslint integration with VS Code
 - Move the configuration of "no-unused-variables"
from tsling.common.json to tslint.build.json to avoid warnings printed
to VS Code console

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- (n/a) New tests added or existing tests modified to cover all changes
- (n/a) Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- (n/a) Related API Documentation was updated
- (n/a) Affected artifact templates in `packages/cli` were updated
- (n/a) Affected example projects in `packages/example-*` were updated
