### PR TITLE
docs: update copyright notice years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2013,2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: loopback-next
 This project is licensed under the MIT License, full text below.
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: loopback-next
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  }
+  },
+  "copyright.owner": "IBM Corp."
 }

--- a/packages/authentication/LICENSE
+++ b/packages/authentication/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/authentication
 This project is licensed under the MIT License, full text below.
 

--- a/packages/authentication/index.d.ts
+++ b/packages/authentication/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/index.js
+++ b/packages/authentication/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/index.ts
+++ b/packages/authentication/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -21,6 +21,7 @@
     "verify": "npm pack && tar xf loopback-authentication*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.25",

--- a/packages/authentication/src/auth-component.ts
+++ b/packages/authentication/src/auth-component.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/decorators/authenticate.ts
+++ b/packages/authentication/src/decorators/authenticate.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: @loopback/authenticate
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/providers/auth-metadata.ts
+++ b/packages/authentication/src/providers/auth-metadata.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/providers/authenticate.ts
+++ b/packages/authentication/src/providers/authenticate.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/strategy-adapter.ts
+++ b/packages/authentication/src/strategy-adapter.ts
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 import {HttpErrors, ParsedRequest} from '@loopback/rest';
 import {Strategy} from 'passport';
 import {UserProfile} from './providers/authenticate';

--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/test/integration/smoke.ts
+++ b/packages/authentication/test/integration/smoke.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/test/unit/fixtures/mock-strategy.ts
+++ b/packages/authentication/test/unit/fixtures/mock-strategy.ts
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 import {Strategy, StrategyCreated, AuthenticateOptions} from 'passport';
 import {PassportRequest} from '../../..';
 

--- a/packages/authentication/test/unit/strategy-adapter.test.ts
+++ b/packages/authentication/test/unit/strategy-adapter.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/LICENSE
+++ b/packages/build/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/build
 This project is licensed under the MIT License, full text below.
 

--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/bin/generate-apidocs.js
+++ b/packages/build/bin/generate-apidocs.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 'use strict';
 
 function run(argv, dryRun) {

--- a/packages/build/bin/run-clean.js
+++ b/packages/build/bin/run-clean.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/bin/run-nyc.js
+++ b/packages/build/bin/run-nyc.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/bin/run-prettier.js
+++ b/packages/build/bin/run-prettier.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/bin/run-tslint.js
+++ b/packages/build/bin/run-tslint.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/bin/select-dist.js
+++ b/packages/build/bin/select-dist.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/bin/utils.js
+++ b/packages/build/bin/utils.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/index.js
+++ b/packages/build/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -10,6 +10,7 @@
     "node": ">=6"
   },
   "main": "index.js",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@types/mocha": "^2.2.43",

--- a/packages/build/test/fixtures/src/index.ts
+++ b/packages/build/test/fixtures/src/index.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/build
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /**
  * log decorator
  */

--- a/packages/build/test/integration/scripts.test.js
+++ b/packages/build/test/integration/scripts.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/build
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
-Node module: @loopback/openapi-v2
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Node module: @loopback/cli
 This project is licensed under the MIT License, full text below.
 
 --------

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/generators/app/templates/index.js
+++ b/packages/cli/generators/app/templates/index.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 const nodeMajorVersion = +process.versions.node.split('.')[0];
 const dist = nodeMajorVersion >= 7 ? './dist' : './dist6';
 

--- a/packages/cli/generators/app/templates/src/application.ts
+++ b/packages/cli/generators/app/templates/src/application.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Application, ApplicationConfig} from '@loopback/core';
 import {RestComponent, RestServer} from '@loopback/rest';
 import {PingController} from './controllers/ping.controller';

--- a/packages/cli/generators/app/templates/src/controllers/ping.controller.ts
+++ b/packages/cli/generators/app/templates/src/controllers/ping.controller.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {ServerRequest} from '@loopback/rest';
 import {get} from '@loopback/openapi-v2';
 import {inject} from '@loopback/context';

--- a/packages/cli/generators/app/templates/src/index.ts
+++ b/packages/cli/generators/app/templates/src/index.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {<%= project.applicationName %>} from './application';
 import {ApplicationConfig} from '@loopback/core';
 

--- a/packages/cli/generators/app/templates/src/sequence.ts
+++ b/packages/cli/generators/app/templates/src/sequence.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Context, inject} from '@loopback/context';
 import {
   FindRoute,

--- a/packages/cli/generators/app/templates/test/ping.controller.test.ts
+++ b/packages/cli/generators/app/templates/test/ping.controller.test.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {createClientForHandler, supertest} from '@loopback/testlab';
 import {RestServer} from '@loopback/rest';
 import {<%= project.applicationName %>} from '../';

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Filter, Where} from '@loopback/repository';
 import {post, param, get, put, patch, del} from '@loopback/openapi-v2';
 import {inject} from '@loopback/context';

--- a/packages/cli/generators/controller/templates/src/controllers/controller-template.ts
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-template.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // Uncomment these imports to begin using these cool features!
 
 // import {inject} from @loopback/context;

--- a/packages/cli/generators/extension/templates/index.js
+++ b/packages/cli/generators/extension/templates/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: <%= project.name %>
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/cli/generators/extension/templates/src/component.ts
+++ b/packages/cli/generators/extension/templates/src/component.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Component, ProviderMap} from '@loopback/core';
 
 export class <%= project.componentName %> implements Component {

--- a/packages/cli/generators/extension/templates/src/index.ts
+++ b/packages/cli/generators/extension/templates/src/index.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './component';

--- a/packages/cli/generators/project/templates/index.d.ts
+++ b/packages/cli/generators/project/templates/index.d.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './dist';

--- a/packages/cli/generators/project/templates/index.ts
+++ b/packages/cli/generators/project/templates/index.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // NOTE(bajtos) This file is used by TypeScript compiler to resolve imports
 // from "test" files against original TypeScript sources in "src" directory.
 // As a side effect, `tsc` also produces "dist/index.{js,d.ts,map} files

--- a/packages/cli/lib/artifact-generator.js
+++ b/packages/cli/lib/artifact-generator.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,5 +60,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next"
   },
+  "copyright.owner": "IBM Corp.",
   "license": "MIT"
 }

--- a/packages/cli/test/app.js
+++ b/packages/cli/test/app.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/test/controller.js
+++ b/packages/cli/test/controller.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/test/project.js
+++ b/packages/cli/test/project.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/cli/test/utils.js
+++ b/packages/cli/test/utils.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 require('mocha');
 const expect = require('@loopback/testlab').expect;
 const path = require('path');

--- a/packages/context/LICENSE
+++ b/packages/context/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/context
 This project is licensed under the MIT License, full text below.
 

--- a/packages/context/index.ts
+++ b/packages/context/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -20,6 +20,7 @@
     "verify": "npm pack && tar xf loopback-context*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@loopback/metadata": "^4.0.0-alpha.4",

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/src/is-promise.ts
+++ b/packages/context/src/is-promise.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/src/provider.ts
+++ b/packages/context/src/provider.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/child-context.ts
+++ b/packages/context/test/acceptance/child-context.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/creating-and-resolving-bindings.ts
+++ b/packages/context/test/acceptance/creating-and-resolving-bindings.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/finding-bindings.ts
+++ b/packages/context/test/acceptance/finding-bindings.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/locking-bindings.ts
+++ b/packages/context/test/acceptance/locking-bindings.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/method-level-bindings.ts
+++ b/packages/context/test/acceptance/method-level-bindings.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/tagged-bindings.ts
+++ b/packages/context/test/acceptance/tagged-bindings.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/acceptance/unlocking-bindings.ts
+++ b/packages/context/test/acceptance/unlocking-bindings.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/unit/inject.test.ts
+++ b/packages/context/test/unit/inject.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/unit/is-promise.test.ts
+++ b/packages/context/test/unit/is-promise.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/unit/provider.ts
+++ b/packages/context/test/unit/provider.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/context
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/core
 This project is licensed under the MIT License, full text below.
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "verify": "npm pack && tar xf loopback-core*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.25",

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/promisify.ts
+++ b/packages/core/src/promisify.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/test/acceptance/application.acceptance.ts
+++ b/packages/core/test/acceptance/application.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/test/unit/application.test.ts
+++ b/packages/core/test/unit/application.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/LICENSE
+++ b/packages/example-codehub/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/example-codehub
 This project is licensed under the MIT License, full text below.
 

--- a/packages/example-codehub/index.ts
+++ b/packages/example-codehub/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/package.json
+++ b/packages/example-codehub/package.json
@@ -13,6 +13,7 @@
     "unit": "mocha 'test/unit/**/*.ts'"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@loopback/core": "^4.0.0-alpha.27",

--- a/packages/example-codehub/src/codehub-application.ts
+++ b/packages/example-codehub/src/codehub-application.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/src/controllers/health-controller.api.ts
+++ b/packages/example-codehub/src/controllers/health-controller.api.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/src/controllers/health-controller.ts
+++ b/packages/example-codehub/src/controllers/health-controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/src/controllers/index.ts
+++ b/packages/example-codehub/src/controllers/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/src/controllers/user-controller.api.ts
+++ b/packages/example-codehub/src/controllers/user-controller.api.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/src/controllers/user-controller.ts
+++ b/packages/example-codehub/src/controllers/user-controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/src/main.ts
+++ b/packages/example-codehub/src/main.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/test/acceptance/health.test.ts
+++ b/packages/example-codehub/test/acceptance/health.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/test/acceptance/smoke.test.ts
+++ b/packages/example-codehub/test/acceptance/smoke.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/test/acceptance/user.test.ts
+++ b/packages/example-codehub/test/acceptance/user.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/test/integration/smoke.ts
+++ b/packages/example-codehub/test/integration/smoke.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/test/support/util.ts
+++ b/packages/example-codehub/test/support/util.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/example-codehub/test/unit/smoke.ts
+++ b/packages/example-codehub/test/unit/smoke.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/example-codehub
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/LICENSE
+++ b/packages/metadata/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/metadata
 This project is licensed under the MIT License, full text below.
 

--- a/packages/metadata/index.js
+++ b/packages/metadata/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/index.ts
+++ b/packages/metadata/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -20,6 +20,7 @@
     "verify": "npm pack && tar xf loopback-metadata*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "debug": "^3.1.0",

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/inspector.ts
+++ b/packages/metadata/src/inspector.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/test/unit/decorator-factory.test.ts
+++ b/packages/metadata/test/unit/decorator-factory.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/test/unit/inspector.test.ts
+++ b/packages/metadata/test/unit/inspector.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/test/unit/reflect.test.ts
+++ b/packages/metadata/test/unit/reflect.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-spec-builder/LICENSE
+++ b/packages/openapi-spec-builder/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/openapi-spec-builder
 This project is licensed under the MIT License, full text below.
 

--- a/packages/openapi-spec-builder/index.js
+++ b/packages/openapi-spec-builder/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: @loopback/testlab
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/openapi-spec-builder
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-spec-builder/index.ts
+++ b/packages/openapi-spec-builder/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/openapi-spec-builder
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -16,6 +16,7 @@
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "keywords": [
     "Swagger",

--- a/packages/openapi-spec-builder/src/index.ts
+++ b/packages/openapi-spec-builder/src/index.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/openapi-spec
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/openapi-spec-builder
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/openapi-spec-builder
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-spec/LICENSE
+++ b/packages/openapi-spec/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/openapi-spec
 This project is licensed under the MIT License, full text below.
 

--- a/packages/openapi-spec/index.d.ts
+++ b/packages/openapi-spec/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/openapi-spec
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-spec/index.js
+++ b/packages/openapi-spec/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/testlab
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/openapi-spec
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-spec/index.ts
+++ b/packages/openapi-spec/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/openapi-spec
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -19,6 +19,7 @@
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "keywords": [
     "Swagger",

--- a/packages/openapi-spec/src/index.ts
+++ b/packages/openapi-spec/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/openapi-spec
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-spec/src/openapi-spec-v2.ts
+++ b/packages/openapi-spec/src/openapi-spec-v2.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/openapi-spec
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v2/index.d.ts
+++ b/packages/openapi-v2/index.d.ts
@@ -1,5 +1,6 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: @loopback/openapi-spec
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 export * from './dist/src';

--- a/packages/openapi-v2/index.js
+++ b/packages/openapi-v2/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/testlab
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/index.ts
+++ b/packages/openapi-v2/index.ts
@@ -1,6 +1,7 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/openapi-spec
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 // NOTE(bajtos) This file is used by VSCode/TypeScriptServer at dev time only
 export * from './src';

--- a/packages/openapi-v2/package.json
+++ b/packages/openapi-v2/package.json
@@ -23,6 +23,7 @@
     "verify": "npm pack && tar xf loopback-openapi-v2*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "keywords": [
     "Swagger",

--- a/packages/openapi-v2/src/controller-spec.ts
+++ b/packages/openapi-v2/src/controller-spec.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/src/index.ts
+++ b/packages/openapi-v2/src/index.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './controller-spec';

--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators.test.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-body.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-body.test.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-form-data.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-form-data.test.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-header.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-header.test.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-path.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-path.test.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-query.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param-query.test.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param.test.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
-// Node module: @loopback/rest
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v2
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/repository/LICENSE
+++ b/packages/repository/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/repository
 This project is licensed under the MIT License, full text below.
 

--- a/packages/repository/index.ts
+++ b/packages/repository/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -21,6 +21,7 @@
     "verify": "npm pack && tar xf loopback-juggler*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "devDependencies": {
     "@loopback/build": "^4.0.0-alpha.8",

--- a/packages/repository/src/connector.ts
+++ b/packages/repository/src/connector.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/src/decorators/metadata.ts
+++ b/packages/repository/src/decorators/metadata.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {InspectionOptions, MetadataInspector} from '@loopback/context';
 import {MODEL_PROPERTIES_KEY, MODEL_WITH_PROPERTIES_KEY} from './model';
 import {ModelDefinition, PropertyDefinition} from '../model';

--- a/packages/repository/src/decorators/model.ts
+++ b/packages/repository/src/decorators/model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {AnyObject} from './common-types';
 import * as assert from 'assert';
 

--- a/packages/repository/src/types/model.ts
+++ b/packages/repository/src/types/model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/src/types/object.ts
+++ b/packages/repository/src/types/object.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/acceptance/thinking-in-loopback/models/product.model.ts
+++ b/packages/repository/test/acceptance/thinking-in-loopback/models/product.model.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: @loopback/loopback-next-hello-world
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/repository/test/acceptance/thinking-in-loopback/repositories/product.repository.ts
+++ b/packages/repository/test/acceptance/thinking-in-loopback/repositories/product.repository.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: @loopback/loopback-next-hello-world
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/repository/test/acceptance/thinking-in-loopback/thinking-in-loopback.acceptance.ts
+++ b/packages/repository/test/acceptance/thinking-in-loopback/thinking-in-loopback.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/decorator/metadata.ts
+++ b/packages/repository/test/unit/decorator/metadata.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {ModelMetadataHelper} from '../../../src';
 import {
   property,

--- a/packages/repository/test/unit/decorator/model-and-relation.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/decorator/repository-with-di.ts
+++ b/packages/repository/test/unit/decorator/repository-with-di.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/decorator/repository-with-value-provider.ts
+++ b/packages/repository/test/unit/decorator/repository-with-value-provider.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/decorator/repository.ts
+++ b/packages/repository/test/unit/decorator/repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/mixin/mixin.ts
+++ b/packages/repository/test/unit/mixin/mixin.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/model/model.ts
+++ b/packages/repository/test/unit/model/model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/query/query-builder.ts
+++ b/packages/repository/test/unit/query/query-builder.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
+++ b/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/repository/crud-repository.ts
+++ b/packages/repository/test/unit/repository/crud-repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
+++ b/packages/repository/test/unit/repository/legacy-juggler-bridge.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/repository/test/unit/type/type.ts
+++ b/packages/repository/test/unit/type/type.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/repository
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/LICENSE
+++ b/packages/rest/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/rest
 This project is licensed under the MIT License, full text below.
 

--- a/packages/rest/index.ts
+++ b/packages/rest/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -21,6 +21,7 @@
     "verify": "npm pack && tar xf loopback-rest*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.25",

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/src/providers/index.ts
+++ b/packages/rest/src/providers/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/src/providers/log-error-provider.ts
+++ b/packages/rest/src/providers/log-error-provider.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/src/rest-application.ts
+++ b/packages/rest/src/rest-application.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Application, ApplicationConfig, Server} from '@loopback/core';
 import {RestComponent} from './rest-component';
 import {SequenceHandler, SequenceFunction} from './sequence';

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/integration/http-handler.integration.ts
+++ b/packages/rest/test/integration/http-handler.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/integration/rest-server.integration.ts
+++ b/packages/rest/test/integration/rest-server.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/backward-compatibility.test.ts
+++ b/packages/rest/test/unit/backward-compatibility.test.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {get} from '../..';
 
 describe('backward-compatibility', () => {

--- a/packages/rest/test/unit/parser.test.ts
+++ b/packages/rest/test/unit/parser.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/rest-application/rest-application.test.ts
+++ b/packages/rest/test/unit/rest-application/rest-application.test.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {
   RestApplication,
   RestServer,

--- a/packages/rest/test/unit/rest-component.test.ts
+++ b/packages/rest/test/unit/rest-component.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/rest-server/rest-server.controller.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.controller.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/router/controller-route.test.ts
+++ b/packages/rest/test/unit/router/controller-route.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/router/reject.test.ts
+++ b/packages/rest/test/unit/router/reject.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/router/routing-table.test.ts
+++ b/packages/rest/test/unit/router/routing-table.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/rest/test/unit/writer.test.ts
+++ b/packages/rest/test/unit/writer.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/LICENSE
+++ b/packages/testlab/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
 Node module: @loopback/testlab
 This project is licensed under the MIT License, full text below.
 

--- a/packages/testlab/index.d.ts
+++ b/packages/testlab/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/testlab
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/index.js
+++ b/packages/testlab/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/testlab
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/index.ts
+++ b/packages/testlab/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/testlab
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -17,6 +17,7 @@
     "verify": "npm pack && tar xf loopback-testlab*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
+  "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@loopback/openapi-spec": "^4.0.0-alpha.19",

--- a/packages/testlab/should-as-function.d.ts
+++ b/packages/testlab/should-as-function.d.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 // Type definitions for should.js v8.1.1
 // Project: https://github.com/shouldjs/should.js
 // Definitions by: Alex Varju <https://github.com/varju/>, Maxime LUCE <https://github.com/SomaticIT/>

--- a/packages/testlab/src/client.ts
+++ b/packages/testlab/src/client.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/testlab
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/src/shot.ts
+++ b/packages/testlab/src/shot.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/testlab
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/src/testlab.ts
+++ b/packages/testlab/src/testlab.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/testlab
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/src/validate-api-spec.ts
+++ b/packages/testlab/src/validate-api-spec.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/testlab
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/testlab/test/testlab.smoke.ts
+++ b/packages/testlab/test/testlab.smoke.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import * as assert from 'assert';
 import * as testlab from '..';
 


### PR DESCRIPTION
Update copyright notice years to mention 2018, add missing LICENSE files where needed.

This is a follow-up for https://github.com/strongloop/loopback/pull/3746.

Unfortunately our `slt` tooling does not support monorepo layout yet, I had to update the licenses in multiple steps:

```
# update all files using "loopback-next" as the module name
slt copyright; SLT_OWNER="IBM Corp." slt license

# revert changes in individual packages
git checkout -- packages

# update per-package files using the right module name
for i in packages/*; do (cd $i; slt copyright; SLT_OWNER="IBM Corp." slt license); done
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- (n/a) New tests added or existing tests modified to cover all changes
- (n/a) Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- (n/a) Related API Documentation was updated
- (n/a) Affected artifact templates in `packages/cli` were updated
- (n/a) Affected example projects in `packages/example-*` were updated
