### PR TITLE
build: use conventional commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   extends: [
-    '@commitlint/config-angular',
+    '@commitlint/config-conventional',
     '@commitlint/config-lerna-scopes'
   ],
   rules: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "^5.2.5",
-    "@commitlint/config-angular": "^5.1.1",
+    "@commitlint/config-conventional": "^6.0.2",
     "@commitlint/config-lerna-scopes": "^5.2.0",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.56",


### PR DESCRIPTION
Drop Angular config, which no longer supports "chore" type. Start using Conventional config, which was forked from the Angular config to preserve the "chore" type.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- (n/a) `npm test` passes on your machine
- (n/a) New tests added or existing tests modified to cover all changes
- (n/a) Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- (n/a) Related API Documentation was updated
- (n/a) Affected artifact templates in `packages/cli` were updated
- (n/a) Affected example projects in `packages/example-*` were updated
