### PR TITLE
[WIP] Add Binding.options and @inject.options for configuration per binding 

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -7,10 +7,10 @@ import {map, takeUntil, reduce} from './iteratable';
 import {Binding} from './binding';
 import {
   isPromise,
+  getDeepProperty,
   BoundValue,
   Constructor,
   ValueOrPromise,
-  getDeepProperty,
 } from './value-promise';
 import {ResolutionOptions, ResolutionSession} from './resolution-session';
 

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -242,6 +242,8 @@ export namespace inject {
    *  constructor(@inject.context() private ctx: Context) {}
    * }
    * ```
+   * @param bindingTag Tag name or regex
+   * @param metadata Optional metadata to help the injection
    */
   export const context = function injectContext() {
     return inject('', {decorator: '@inject.context'}, ctx => ctx);

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -10,7 +10,14 @@ import {
   PropertyDecoratorFactory,
   MetadataMap,
 } from '@loopback/metadata';
-import {BoundValue, ValueOrPromise, resolveList} from './value-promise';
+import {
+  BoundValue,
+  ValueOrPromise,
+  isPromise,
+  getDeepProperty,
+  resolveList,
+} from './value-promise';
+import {Binding} from './binding';
 import {Context} from './context';
 import {ResolutionSession} from './resolution-session';
 
@@ -248,6 +255,47 @@ export namespace inject {
   export const context = function injectContext() {
     return inject('', {decorator: '@inject.context'}, ctx => ctx);
   };
+
+  /**
+   * Inject an option from `options` of the parent binding. If no corresponding
+   * option value is present, `undefined` will be injected.
+   *
+   * @example
+   * ```ts
+   * class Store {
+   *   constructor(
+   *     @inject.options('x') public optionX: number,
+   *     @inject.options('y') public optionY: string,
+   *   ) { }
+   * }
+   *
+   * ctx.bind('store1').toClass(Store).withOptions({ x: 1, y: 'a' });
+   * ctx.bind('store2').toClass(Store).withOptions({ x: 2, y: 'b' });
+   *
+   *  const store1 = ctx.getSync('store1');
+   *  expect(store1.optionX).to.eql(1);
+   *  expect(store1.optionY).to.eql('a');
+
+   * const store2 = ctx.getSync('store2');
+   * expect(store2.optionX).to.eql(2);
+   * expect(store2.optionY).to.eql('b');
+   * ```
+   *
+   * @param optionPath Optional property path of the option. If is `''` or not
+   * present, the `options` object will be returned.
+   * @param metadata Optional metadata to help the injection
+   */
+  export const options = function injectOptions(
+    optionPath?: string,
+    metadata?: Object,
+  ) {
+    optionPath = optionPath || '';
+    metadata = Object.assign(
+      {optionPath, decorator: '@inject.options', optional: true},
+      metadata,
+    );
+    return inject('', metadata, resolveAsOptions);
+  };
 }
 
 function resolveAsGetter(
@@ -273,6 +321,106 @@ function resolveAsSetter(ctx: Context, injection: Injection) {
 }
 
 /**
+ * Try to resolve key/path from the binding key hierarchy
+ * For example, if the binding key is `servers.rest.server1`, we'll try the
+ * following entries:
+ * 1. servers.rest.server1:$options#host
+ * 2. servers.rest:$options#server1.host
+ * 3. servers.$options#rest.server1.host`
+ * 4. $options#servers.rest.server1.host
+ *
+ * @param ctx Context object
+ * @param key Binding key with namespaces as prefixes separated by `.`)
+ * @param path The property path
+ * @param session ResolutionSession
+ */
+function resolveOptionsByNamespaces(
+  ctx: Context,
+  key: string,
+  path: string,
+  session?: ResolutionSession,
+) {
+  let options;
+  while (true) {
+    const optionKeyAndPath = Binding.buildKeyWithPath(
+      key ? `${key}:$options` : '$options',
+      path,
+    );
+    options = ctx.getValueOrPromise(optionKeyAndPath, {
+      session,
+      optional: true,
+    });
+    // Found the corresponding options
+    if (options !== undefined) return options;
+
+    // We have tried all levels
+    if (!key) return undefined;
+
+    // Move last part of the key into the path
+    const index = key.lastIndexOf('.');
+    path = `${key.substring(index + 1)}.${path}`;
+    key = key.substring(0, index);
+  }
+}
+
+function resolveFromOptions(
+  options: Context,
+  path: string,
+  session?: ResolutionSession,
+) {
+  // Default to all options
+  const bindings = options.find(/.*/);
+  // Map array values to an object keyed by binding keys
+  const mapValues = (values: BoundValue[]) => {
+    const obj: {
+      [name: string]: BoundValue;
+    } = {};
+    let index = 0;
+    for (const v of values) {
+      obj[bindings[index].key] = v;
+      index++;
+    }
+    return getDeepProperty(obj, path);
+  };
+  const result = resolveBindings(options, bindings, session);
+  if (isPromise(result)) {
+    return result.then(mapValues);
+  } else {
+    return mapValues(result);
+  }
+}
+
+function resolveAsOptions(
+  ctx: Context,
+  injection: Injection,
+  session?: ResolutionSession,
+) {
+  if (!(session && session.currentBinding)) {
+    // No binding is available
+    return undefined;
+  }
+
+  const meta = injection.metadata || {};
+  const binding = session.currentBinding;
+  let options = binding.options;
+  const keyAndPath = Binding.parseKeyWithPath(meta.optionPath);
+  if (!options) {
+    /**
+     * No local options found, try to resolve it from the corresponding binding.
+     */
+    let key = binding.key;
+    let path = [keyAndPath.key, keyAndPath.path].join('.');
+    return resolveOptionsByNamespaces(ctx, key, path, session);
+  }
+
+  if (!keyAndPath.key) {
+    return resolveFromOptions(options, keyAndPath.path || '', session);
+  }
+
+  return options.getValueOrPromise(meta.optionPath, {session, optional: true});
+}
+
+/**
  * Return an array of injection objects for parameters
  * @param target The target class for constructor or static methods,
  * or the prototype for instance methods
@@ -291,6 +439,18 @@ export function describeInjectedArguments(
   return meta || [];
 }
 
+function resolveBindings(
+  ctx: Context,
+  bindings: Binding[],
+  session?: ResolutionSession,
+) {
+  return resolveList(bindings, b => {
+    // We need to clone the session so that resolution of multiple bindings
+    // can be tracked in parallel
+    return b.getValue(ctx, ResolutionSession.fork(session));
+  });
+}
+
 function resolveByTag(
   ctx: Context,
   injection: Injection,
@@ -298,12 +458,7 @@ function resolveByTag(
 ) {
   const tag: string | RegExp = injection.metadata!.tag;
   const bindings = ctx.findByTag(tag);
-
-  return resolveList(bindings, b => {
-    // We need to clone the session so that resolution of multiple bindings
-    // can be tracked in parallel
-    return b.getValue(ctx, ResolutionSession.fork(session));
-  });
+  return resolveBindings(ctx, bindings, session);
 }
 
 /**

--- a/packages/context/src/iteratable.ts
+++ b/packages/context/src/iteratable.ts
@@ -1,0 +1,92 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * Apply a mapping function to the given iterator to produce a new iterator
+ * with mapped values as its entries
+ *
+ * @param iterator An iterable object
+ * @param mapper A function maps an entry to a new value
+ */
+export function* map<T, V>(
+  iterator: Iterable<T>,
+  mapper: (item: T) => V,
+): Iterable<V> {
+  for (const item of iterator) {
+    yield mapper(item);
+  }
+}
+
+/**
+ * Take entries from the iterator to form a new one until the `predicator`
+ * function returns `true`. Please note the last entry that satisfies the
+ * condition is also included in the returned iterator.
+ *
+ * @param iterator An iterable object
+ * @param predicator A function to check if the iteration should be done
+ */
+export function* takeUntil<T>(
+  iterator: Iterable<T>,
+  predicator: (item: T) => boolean,
+): Iterable<T> {
+  for (const item of iterator) {
+    yield item; // Always take the item even filter returns true
+    if (predicator(item)) break;
+  }
+}
+
+/**
+ * Take entries from the iterator to form a new one while the `predicator`
+ * function returns `true`. Please note the last entry that satisfies the
+ * condition is also included in the returned iterator.
+ *
+ * @param iterator An iterable object
+ * @param predicator A function to check if the iteration should continue
+ */
+export function* takeWhile<T>(
+  iterator: Iterable<T>,
+  predicator: (item: T) => boolean,
+): Iterable<T> {
+  for (const item of iterator) {
+    if (predicator(item)) yield item;
+    else break;
+  }
+}
+
+/**
+ * Reduce the entries from the interator to be an aggregated value.
+ *
+ * @param iterator An iterable object
+ * @param reducer A function that reconciles the previous result with the
+ * current entry into a new result
+ * @param initialValue The initial value for the result
+ */
+export function reduce<T, V>(
+  iterator: Iterable<T>,
+  reducer: (accumulator: V, currentValue: T) => V,
+  initialValue: V,
+): V {
+  let accumulator = initialValue;
+  for (const item of iterator) {
+    accumulator = reducer(accumulator, item);
+  }
+  return accumulator;
+}
+
+/**
+ * Filter the given iterator to produce a new iterator with only entries
+ * satisfies the predicator
+ *
+ * @param iterator An iterable object
+ * @param predicator A function to check if an entry should be included
+ */
+export function* filter<T>(
+  iterator: Iterable<T>,
+  predicator: (item: T) => boolean,
+): Iterable<T> {
+  for (const item of iterator) {
+    if (predicator(item)) yield item;
+  }
+}

--- a/packages/context/test/acceptance/child-context.ts
+++ b/packages/context/test/acceptance/child-context.ts
@@ -55,7 +55,7 @@ describe('Context bindings - contexts with a single parent', () => {
   }
 });
 
-describe('Context bindings - contexts with multiple parents', () => {
+describe('Context bindings - contexts composed with other ones', () => {
   let appCtx: Context;
   let serverCtx: Context;
   let connectorCtx: Context;
@@ -152,6 +152,6 @@ describe('Context bindings - contexts with multiple parents', () => {
     appCtx = new Context(undefined, 'app'); // The root
     serverCtx = new Context(appCtx, 'server'); // server -> app
     connectorCtx = new Context(appCtx, 'connector'); // connector -> app
-    reqCtx = new Context([serverCtx, connectorCtx], 'req'); // req -> [server, connector]
+    reqCtx = new Context().composeWith([serverCtx, connectorCtx], 'req'); // req -> [server, connector]
   }
 });

--- a/packages/context/test/acceptance/child-context.ts
+++ b/packages/context/test/acceptance/child-context.ts
@@ -6,7 +6,7 @@
 import {expect} from '@loopback/testlab';
 import {Context} from '../..';
 
-describe('Context bindings - contexts inheritance', () => {
+describe('Context bindings - contexts with a single parent', () => {
   let parentCtx: Context;
   let childCtx: Context;
 
@@ -52,5 +52,106 @@ describe('Context bindings - contexts inheritance', () => {
   function createParentAndChildContext() {
     parentCtx = new Context();
     childCtx = new Context(parentCtx);
+  }
+});
+
+describe('Context bindings - contexts with multiple parents', () => {
+  let appCtx: Context;
+  let serverCtx: Context;
+  let connectorCtx: Context;
+  let reqCtx: Context;
+
+  beforeEach('given multiple parents and a child context', createContextGraph);
+
+  it('child inherits values bound in parent chain', () => {
+    appCtx.bind('foo').to('bar');
+    expect(reqCtx.getSync('foo')).to.equal('bar');
+  });
+
+  it('bindings are resolved in current context first', () => {
+    appCtx.bind('foo').to('app:bar');
+    serverCtx.bind('foo').to('server:bar');
+    connectorCtx.bind('foo').to('connector:bar');
+    reqCtx.bind('foo').to('req:bar');
+    // req
+    expect(reqCtx.getSync('foo')).to.equal('req:bar');
+  });
+
+  it('bindings are resolved by the order of parents', () => {
+    appCtx.bind('foo').to('app:bar');
+    serverCtx.bind('foo').to('server:bar');
+    connectorCtx.bind('foo').to('connector:bar');
+    // req -> server
+    expect(reqCtx.getSync('foo')).to.equal('server:bar');
+  });
+
+  it('bindings are resolved in first parent chain', () => {
+    appCtx.bind('foo').to('app:bar');
+    connectorCtx.bind('foo').to('connector:bar');
+    // req -> server -> connector -> app
+    expect(reqCtx.getSync('foo')).to.equal('connector:bar');
+  });
+
+  it('child changes are not propagated to parent', () => {
+    reqCtx.bind('foo').to('bar');
+    expect(() => serverCtx.getSync('foo')).to.throw(/not bound/);
+    expect(() => connectorCtx.getSync('foo')).to.throw(/not bound/);
+    expect(() => appCtx.getSync('foo')).to.throw(/not bound/);
+  });
+
+  it('includes parent bindings when searching via getBinding()', () => {
+    appCtx.bind('foo').to('app:foo');
+    appCtx.bind('bar').to('app:bar');
+    serverCtx.bind('foo').to('server:foo');
+    connectorCtx.bind('foo').to('connector:foo');
+    const binding = reqCtx.bind('foo').to('req:foo');
+
+    const found = reqCtx.getBinding('foo');
+    expect(found).to.be.exactly(binding);
+  });
+
+  it('includes parent bindings when searching via find()', () => {
+    appCtx.bind('foo').to('app:foo');
+    appCtx.bind('bar').to('app:bar');
+    serverCtx.bind('foo').to('server:foo');
+    serverCtx.bind('bar').to('server:bar');
+    connectorCtx.bind('foo').to('connector:foo');
+    reqCtx.bind('foo').to('req:foo');
+
+    const found = reqCtx.find().map(b => b.getValue(reqCtx));
+    expect(found).to.deepEqual(['req:foo', 'server:bar']);
+  });
+
+  it('includes parent bindings when searching via findByTag()', () => {
+    appCtx
+      .bind('foo')
+      .to('app:foo')
+      .tag('a-tag');
+    appCtx
+      .bind('bar')
+      .to('app:bar')
+      .tag('a-tag');
+    serverCtx
+      .bind('foo')
+      .to('server:foo')
+      .tag('a-tag');
+    connectorCtx
+      .bind('baz')
+      .to('connector:baz')
+      .tag('a-tag');
+    reqCtx
+      .bind('foo')
+      .to('req:foo')
+      .tag('a-tag');
+
+    const found = reqCtx.findByTag('a-tag').map(b => b.getValue(reqCtx));
+    expect(found).to.deepEqual(['req:foo', 'connector:baz', 'app:bar']);
+  });
+
+  function createContextGraph() {
+    appCtx = new Context(undefined, 'app'); // The root
+    serverCtx = new Context(appCtx, 'server'); // server -> app
+    connectorCtx = new Context(appCtx, 'connector'); // connector -> app
+    reqCtx = new Context([serverCtx, connectorCtx], 'req'); // req -> [server, connector]
   }
 });

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -12,6 +12,7 @@ import {
   Provider,
   Injection,
   ResolutionSession,
+  instantiateClass,
 } from '../..';
 
 const INFO_CONTROLLER = 'controllers.info';
@@ -315,6 +316,248 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       .toDynamicValue(() => Promise.reject(new Error('Bad')))
       .tag('store:location');
     await expect(ctx.get('store')).to.be.rejectedWith('Bad');
+  });
+
+  it('injects an option', () => {
+    class Store {
+      constructor(
+        @inject.options('x') public optionX: number,
+        @inject.options('y') public optionY: string,
+      ) {}
+    }
+
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions({x: 1, y: 'a'});
+    const store = ctx.getSync('store');
+    expect(store.optionX).to.eql(1);
+    expect(store.optionY).to.eql('a');
+  });
+
+  it('injects an option with promise value', async () => {
+    class Store {
+      constructor(@inject.options('x') public optionX: number) {}
+    }
+
+    const options = new Context();
+    options.bind('x').toDynamicValue(async () => 1);
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions(options);
+    const store = await ctx.get('store');
+    expect(store.optionX).to.eql(1);
+  });
+
+  it('injects an option with a binding provider', async () => {
+    class MyOptionProvider implements Provider<string> {
+      constructor(@inject('prefix') private prefix: string) {}
+      value() {
+        return this.prefix + 'my-option';
+      }
+    }
+
+    class Store {
+      constructor(@inject.options('myOption') public myOption: string) {}
+    }
+
+    ctx.bind('options.MyOptionProvider').toProvider(MyOptionProvider);
+
+    const options = new Context();
+    options.bind('myOption').toDynamicValue(() => {
+      return ctx.get('options.MyOptionProvider');
+    });
+    ctx.bind('prefix').to('hello-');
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions(options);
+
+    const store = await ctx.get('store');
+    expect(store.myOption).to.eql('hello-my-option');
+  });
+
+  it('injects an option with a rejected promise', async () => {
+    class Store {
+      constructor(@inject.options('x') public optionX: number) {}
+    }
+
+    const options = new Context();
+    options.bind('x').toDynamicValue(() => Promise.reject(Error('invalid')));
+
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions(options);
+
+    await expect(ctx.get('store')).to.be.rejectedWith('invalid');
+  });
+
+  it('injects an option when `options` is a context', async () => {
+    class Store {
+      constructor(@inject.options('x') public optionX: number) {}
+    }
+
+    const options = new Context();
+    options.bind('x').toDynamicValue(() => Promise.resolve(1));
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions(options);
+    const store = await ctx.get('store');
+    expect(store.optionX).to.eql(1);
+  });
+
+  it('injects an option.property when `options` is a context', async () => {
+    class Store {
+      constructor(@inject.options('x#y') public optionY: string) {}
+    }
+
+    const options = new Context();
+    options.bind('x').toDynamicValue(() => Promise.resolve({y: 'y'}));
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions(options);
+    const store = await ctx.get('store');
+    expect(store.optionY).to.eql('y');
+  });
+
+  it('injects an option with nested property', () => {
+    class Store {
+      constructor(@inject.options('x#y') public optionXY: string) {}
+    }
+
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions({x: {y: 'y'}});
+    const store = ctx.getSync('store');
+    expect(store.optionXY).to.eql('y');
+  });
+
+  it('injects options if the binding key is not present', () => {
+    class Store {
+      constructor(@inject.options() public options: object) {}
+    }
+
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions({x: 1, y: 'a'});
+    const store = ctx.getSync('store');
+    expect(store.options).to.eql({x: 1, y: 'a'});
+  });
+
+  it("injects options if the binding key is ''", () => {
+    class Store {
+      constructor(@inject.options('') public options: object) {}
+    }
+
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions({x: 1, y: 'a'});
+    const store = ctx.getSync('store');
+    expect(store.options).to.eql({x: 1, y: 'a'});
+  });
+
+  it('injects options if the binding key is a path', () => {
+    class Store {
+      constructor(@inject.options('#x') public optionX: number) {}
+    }
+
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions({x: 1, y: 'a'});
+    const store = ctx.getSync('store');
+    expect(store.optionX).to.eql(1);
+  });
+
+  it('injects undefined option if key not found', () => {
+    class Store {
+      constructor(
+        // tslint:disable-next-line:no-any
+        @inject.options('not-exist') public option: string | undefined,
+      ) {}
+    }
+
+    ctx
+      .bind('store')
+      .toClass(Store)
+      .withOptions({x: 1, y: 'a'});
+    const store = ctx.getSync('store');
+    expect(store.option).to.be.undefined();
+  });
+
+  it('injects an option based on the parent binding', async () => {
+    class Store {
+      constructor(
+        @inject.options('x') public optionX: number,
+        @inject.options('y') public optionY: string,
+      ) {}
+    }
+
+    ctx
+      .bind('store1')
+      .toClass(Store)
+      .withOptions({x: 1, y: 'a'});
+
+    ctx
+      .bind('store2')
+      .toClass(Store)
+      .withOptions({x: 2, y: 'b'});
+
+    const store1 = await ctx.get('store1');
+    expect(store1.optionX).to.eql(1);
+    expect(store1.optionY).to.eql('a');
+
+    const store2 = await ctx.get('store2');
+    expect(store2.optionX).to.eql(2);
+    expect(store2.optionY).to.eql('b');
+  });
+
+  it('injects undefined option if no binding is present', async () => {
+    class Store {
+      constructor(
+        // tslint:disable-next-line:no-any
+        @inject.options('x') public option: string | undefined,
+      ) {}
+    }
+
+    const store = await instantiateClass(Store, ctx);
+    expect(store.option).to.be.undefined();
+  });
+
+  it('injects options from options binding', () => {
+    class MyStore {
+      constructor(@inject.options('#x') public optionX: number) {}
+    }
+
+    ctx.bind('stores.MyStore:$options').to({x: 1, y: 'a'});
+    ctx.bind('stores.MyStore').toClass(MyStore);
+
+    const store = ctx.getSync('stores.MyStore');
+    expect(store.optionX).to.eql(1);
+  });
+
+  it('injects options from options binding by key namespaces', () => {
+    class MyStore {
+      constructor(
+        @inject.options('#x') public optionX: number,
+        @inject.options('y') public optionY: string,
+      ) {}
+    }
+
+    ctx.bind('stores:$options').to({MyStore: {y: 'a'}});
+    ctx.bind('stores.MyStore:$options').to({x: 1});
+    ctx.bind('stores.MyStore').toClass(MyStore);
+
+    const store = ctx.getSync('stores.MyStore');
+    expect(store.optionX).to.eql(1);
+    expect(store.optionY).to.eql('a');
   });
 
   function createContext() {

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -11,8 +11,8 @@ import {Context, Binding, BindingScope, BindingType, isPromise} from '../..';
  * for assertions
  */
 class TestContext extends Context {
-  get parent() {
-    return this._parent;
+  get parentList() {
+    return this.parents;
   }
   get bindingMap() {
     const map = new Map(this.registry);
@@ -42,14 +42,21 @@ describe('Context constructor', () => {
   it('accepts a parent context', () => {
     const c1 = new Context('c1');
     const ctx = new TestContext(c1);
-    expect(ctx.parent).to.eql(c1);
+    expect(ctx.parentList).to.eql([c1]);
+  });
+
+  it('accepts multiple parent contexts', () => {
+    const c1 = new Context('c1');
+    const c2 = new Context('c2');
+    const ctx = new TestContext([c1, c2]);
+    expect(ctx.parentList).to.eql([c1, c2]);
   });
 
   it('accepts a parent context and a name', () => {
     const c1 = new Context('c1');
     const ctx = new TestContext(c1, 'c2');
     expect(ctx.name).to.eql('c2');
-    expect(ctx.parent).to.eql(c1);
+    expect(ctx.parentList).to.eql([c1]);
   });
 });
 
@@ -567,6 +574,27 @@ describe('Context', () => {
           type: BindingType.CONSTANT,
         },
       });
+    });
+  });
+
+  describe('composeWith()', () => {
+    it('creates a new context with additional parents', () => {
+      const c1 = new TestContext('c1');
+      c1.bind('a').to(1);
+      const c2 = new Context('c2');
+      const c3 = c1.composeWith(c2, 'c3');
+      expect(c3.name).to.be.eql('c3');
+      expect(c3.parentList).to.eql([c1, c2]);
+      expect(c3.bindingMap.size).to.eql(0);
+    });
+
+    it('adds additional parents', () => {
+      const c0 = new Context('c0'); // c0
+      const c1 = new TestContext(c0, 'c1'); // c1 -> c0
+      const c2 = new Context('c2'); // c2
+      const c3 = c1.composeWith(c2, 'c3');
+      expect(c3.name).to.be.eql('c3');
+      expect(c3.parentList).to.eql([c1, c2]);
     });
   });
 

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -45,13 +45,6 @@ describe('Context constructor', () => {
     expect(ctx.parentList).to.eql([c1]);
   });
 
-  it('accepts multiple parent contexts', () => {
-    const c1 = new Context('c1');
-    const c2 = new Context('c2');
-    const ctx = new TestContext([c1, c2]);
-    expect(ctx.parentList).to.eql([c1, c2]);
-  });
-
   it('accepts a parent context and a name', () => {
     const c1 = new Context('c1');
     const ctx = new TestContext(c1, 'c2');

--- a/packages/context/test/unit/iteratable.test.ts
+++ b/packages/context/test/unit/iteratable.test.ts
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+
+import {map, takeUntil, reduce, takeWhile, filter} from '../../src/iteratable';
+
+describe('Utilities for iteratable composition', () => {
+  let items: Iterable<number>;
+
+  beforeEach(givenIterable);
+
+  describe('map()', () => {
+    it('maps each entry of the iterator', () => {
+      const result = map(items, item => item * 2);
+      expect(Array.from(result)).to.eql([2, 4, 6]);
+    });
+  });
+
+  describe('filter()', () => {
+    it('filter each entry of the iterator', () => {
+      const result = filter(items, item => item % 2 === 1);
+      expect(Array.from(result)).to.eql([1, 3]);
+    });
+  });
+
+  describe('takeUntil()', () => {
+    it('takes entries until the predicator returns true', () => {
+      const result = takeUntil(items, item => item % 2 === 0);
+      expect(Array.from(result)).to.eql([1, 2]);
+    });
+
+    it('takes all entries if the predicator always return false', () => {
+      const result = takeUntil(items, item => false);
+      expect(Array.from(result)).to.eql([1, 2, 3]);
+    });
+  });
+
+  describe('takeWhile()', () => {
+    it('takes entries while the predicator returns true', () => {
+      const result = takeWhile(items, item => item <= 2);
+      expect(Array.from(result)).to.eql([1, 2]);
+    });
+
+    it('takes all entries if the predicator always return true', () => {
+      const result = takeWhile(items, item => true);
+      expect(Array.from(result)).to.eql([1, 2, 3]);
+    });
+  });
+
+  describe('reduce()', () => {
+    it('reduces entries of the iterator', () => {
+      const result = reduce(
+        items,
+        (accumulator, current) => accumulator + current,
+        0,
+      );
+      expect(result).to.eql(6);
+    });
+  });
+
+  function givenIterable() {
+    items = [1, 2, 3];
+  }
+});

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -9,9 +9,9 @@ import {
   PathsObject,
 } from '@loopback/openapi-spec';
 import {
+  BindingScope,
   Context,
   Constructor,
-  instantiateClass,
   invokeMethod,
 } from '@loopback/context';
 import {ServerRequest} from 'http';
@@ -306,6 +306,10 @@ export class ControllerRoute extends BaseRoute {
 
   updateBindings(requestContext: Context) {
     const ctor = this._controllerCtor;
+    requestContext
+      .bind('controller.current')
+      .toClass(ctor)
+      .inScope(BindingScope.SINGLETON);
     requestContext.bind('controller.current.ctor').to(ctor);
     requestContext.bind('controller.current.operation').to(this._methodName);
   }
@@ -329,14 +333,10 @@ export class ControllerRoute extends BaseRoute {
     );
   }
 
-  private async _createControllerInstance(
+  private _createControllerInstance(
     requestContext: Context,
   ): Promise<ControllerInstance> {
-    const valueOrPromise = instantiateClass(
-      this._controllerCtor,
-      requestContext,
-    );
-    return (await Promise.resolve(valueOrPromise)) as ControllerInstance;
+    return requestContext.get('controller.current');
   }
 }
 


### PR DESCRIPTION
This is a spin-off from https://github.com/strongloop/loopback-next/pull/671. It has been reworked as follows:

1. Each binding can set `options` with `withOptions()`, which allows a plain object or an instance of `Context`. No promise is allowed directly.

2. Introduce a `@inject.options` to declare injections of binding options.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
