### PR TITLE
refactor: use top-level .gitignore & .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ npm-debug.log
 coverage
 .nyc_output
 api-docs
+packages/*/*.tgz
+packages/*/dist*
+packages/*/package
+packages/cli/test/sandbox

--- a/packages/authentication/.gitignore
+++ b/packages/authentication/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,0 @@
-coverage
-node_modules
-test/sandbox

--- a/packages/context/.gitignore
+++ b/packages/context/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/core/.travis.yml
+++ b/packages/core/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - "4"
-  - "6"
-  - "7"

--- a/packages/metadata/.gitignore
+++ b/packages/metadata/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/openapi-spec-builder/.gitignore
+++ b/packages/openapi-spec-builder/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/openapi-spec/.gitignore
+++ b/packages/openapi-spec/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/openapi-v2/.gitignore
+++ b/packages/openapi-v2/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/repository/.gitignore
+++ b/packages/repository/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/rest/.gitignore
+++ b/packages/rest/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package

--- a/packages/testlab/.gitignore
+++ b/packages/testlab/.gitignore
@@ -1,3 +1,0 @@
-*.tgz
-dist*
-package


### PR DESCRIPTION
Follow up based on a review comment here:
https://github.com/strongloop/loopback-next/pull/858#discussion_r161526236

This removes package level .gitignore and .travis.yml files in favour
of top-level files.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [n/a] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [n/a] Related API Documentation was updated
- [n/a] Affected artifact templates in `packages/cli` were updated
- [n/a] Affected example projects in `packages/example-*` were updated
