### PR TITLE
add api-docs build step

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -34,7 +34,7 @@
     "lb-clean": "./bin/run-clean.js"
   },
   "scripts": {
-    "build:apidocs": "lb-apidocs",
+    "build:apidocs": "node bin/generate-apidocs",
     "lint": "npm run prettier:check",
     "lint:fix": "npm run prettier:fix",
     "prepare": "npm run build:apidocs",
@@ -45,9 +45,6 @@
     "mocha": "node bin/select-dist mocha --timeout 30000 --opts mocha.opts \"test/integration/*.js\"",
     "posttest": "npm run lint"
   },
-  "files": [
-    "api-docs"
-  ],
   "devDependencies": {
     "fs-extra": "^5.0.0"
   }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -34,8 +34,10 @@
     "lb-clean": "./bin/run-clean.js"
   },
   "scripts": {
+    "build:apidocs": "lb-apidocs",
     "lint": "npm run prettier:check",
     "lint:fix": "npm run prettier:fix",
+    "prepare": "npm run build:apidocs",
     "prettier:cli": "node bin/run-prettier \"bin/**/*.js\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",
@@ -43,6 +45,9 @@
     "mocha": "node bin/select-dist mocha --timeout 30000 --opts mocha.opts \"test/integration/*.js\"",
     "posttest": "npm run lint"
   },
+  "files": [
+    "api-docs"
+  ],
   "devDependencies": {
     "fs-extra": "^5.0.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,8 @@
   "files": [
     "bin",
     "lib",
-    "generators"
+    "generators",
+    "api-docs"
   ],
   "bin": {
     "lb4": "bin/cli.js"
@@ -53,6 +54,8 @@
     "yeoman-generator": "^2.0.1"
   },
   "scripts": {
+    "build:apidocs": "lb-apidocs",
+    "prepare": "npm run build:apidocs",
     "prepublishOnly": "nsp check",
     "test": "mocha test/**/*.js"
   },


### PR DESCRIPTION
Add the `build:apidocs` build step to our `@loopback/cli` and `@loopback/build` packages.
Blocks https://github.com/strongloop-internal/apidocs.strongloop.com/pull/81.

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
