### PR TITLE
fix(example-getting-started): fix "extends" path to point to @loopback/build module

### DIFF
--- a/packages/example-getting-started/tsconfig.build.json
+++ b/packages/example-getting-started/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "../build/config/tsconfig.common.json",
+  "extends": "./node_modules/@loopback/build/config/tsconfig.common.json",
   "compilerOptions": {
     "rootDir": "."
   },


### PR DESCRIPTION
Without this, the build will break when the module is separately installed using `lb4 example`.

connected to #727 