### PR TITLE
[WIP] Improve composablity of Context with multiple delegates

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -5,13 +5,19 @@
 
 import {Binding, TagMap} from './binding';
 import {BindingKey, BindingAddress} from './binding-key';
-import {isPromiseLike, getDeepProperty, BoundValue} from './value-promise';
+import {map, takeUntil, reduce} from './iteratable';
+import {
+  isPromiseLike,
+  BoundValue,
+  Constructor,
+  ValueOrPromise,
+  getDeepProperty,
+} from './value-promise';
 import {ResolutionOptions, ResolutionSession} from './resolution-session';
 
 import {v1 as uuidv1} from 'uuid';
 
 import * as debugModule from 'debug';
-import {ValueOrPromise} from '.';
 const debug = debugModule('loopback:context');
 
 /**
@@ -22,19 +28,35 @@ export class Context {
    * Name of the context
    */
   readonly name: string;
+  /**
+   * Parent contexts to form a graph of contexts for binding resolution
+   */
+  protected readonly parents: Context[] = [];
+
+  /**
+   * Registry of bindings
+   */
   protected readonly registry: Map<string, Binding> = new Map();
-  protected _parent?: Context;
 
   /**
    * Create a new context
-   * @param _parent The optional parent context
+   * @param parents The optional parent contexts. If multiple parent contexts
+   * are provided, they will be used to resolve bindings following breadth first
+   * traversal.
+   * @name name The optional context name. If not present, a uuid is generated as
+   * the name.
    */
-  constructor(_parent?: Context | string, name?: string) {
-    if (typeof _parent === 'string') {
-      name = _parent;
-      _parent = undefined;
+  constructor(parents?: Context | Context[] | string, name?: string) {
+    if (typeof parents === 'string') {
+      // constructor(name)
+      name = parents;
+      parents = undefined;
     }
-    this._parent = _parent;
+    if (Array.isArray(parents)) {
+      this.parents.push(...parents);
+    } else if (parents) {
+      this.parents.push(parents);
+    }
     this.name = name || uuidv1();
   }
 
@@ -95,15 +117,71 @@ export class Context {
   }
 
   /**
+   * Iterate all contexts by breadth first traversal of the graph following
+   * `parents`. For example, with the following context graph:
+   * - reqCtx -> [serverCtx, connectorCtx]
+   * - serverCtx -> [appCtx]
+   * - connectorCtx -> [appCtx]
+   * `reqCtx.contexts()` returns an iterator of `[reqCtx, serverCtx,
+   * connectorCtx, appCtx]`.
+   */
+  protected *contexts(): IterableIterator<Context> {
+    const visited: Set<Context> = new Set();
+    const queue: Context[] = [];
+    // Enqueue the current context
+    queue.push(this);
+    while (queue.length) {
+      // Dequeue the head context
+      const c = queue.shift()!;
+      // Skip a context if it has been visited
+      if (visited.has(c)) continue;
+      visited.add(c);
+      yield c;
+      // Enqueue the parent contexts
+      queue.push(...c.parents);
+    }
+  }
+
+  /**
+   * Visit all contexts in the graph to resolve values following the context
+   * chain connected by `parents`.
+   *
+   * @param mapper A function to produce a result from the context object
+   * locally without consulting the parents
+   * @param predicator A function to control when the iteration stops
+   * @param reducer A function to reduce the previous result and current value
+   * into a new result
+   * @param initialValue The initial result
+   */
+  protected visitAllContexts<T, V>(
+    mapper: (ctx: Context) => T,
+    predicator: (value: T) => boolean,
+    reducer: (accumulator: V, currentValue: T) => V,
+    initialValue: V,
+  ): V {
+    return reduce(
+      // Iterate until the predicator returns `true`
+      takeUntil(
+        // Visit a context to produce a result locally
+        map(this.contexts(), mapper),
+        predicator,
+      ),
+      reducer,
+      initialValue,
+    );
+  }
+
+  /**
    * Check if a key is bound in the context or its ancestors
    * @param key Binding key
    */
   isBound<ValueType = BoundValue>(key: BindingAddress<ValueType>): boolean {
-    if (this.contains(key)) return true;
-    if (this._parent) {
-      return this._parent.isBound(key);
-    }
-    return false;
+    return this.visitAllContexts(
+      ctx => ctx.contains(key),
+      value => value === true,
+      (accumulator, currentValue) => currentValue,
+      false,
+    );
   }
 
   /**
@@ -113,11 +191,28 @@ export class Context {
   getOwnerContext<ValueType = BoundValue>(
     key: BindingAddress<ValueType>,
   ): Context | undefined {
-    if (this.contains(key)) return this;
-    if (this._parent) {
-      return this._parent.getOwnerContext(key);
-    }
-    return undefined;
+    return this.visitAllContexts<Context, Context | undefined>(
+      ctx => ctx,
+      value => value.contains(key),
+      (accumulator, currentValue) => currentValue,
+      undefined,
+    );
+  }
+
+  /**
+   * Compose this context with additional parent contexts. The newly created
+   * context will have this context and the provided parent contexts as its
+   * parents.
+   * @param parents Optional parent contexts to be added to the graph
+   * @param name Name of the newly composed context
+   */
+  composeWith(parents?: Context | Context[], name?: string): this {
+    // Construct a new instance with the same class of this instance
+    const ctor = this.constructor as Constructor<this>;
+    const copy = new ctor(parents, name);
+    // Add this context as the 1st parent for the new one
+    copy.parents.unshift(this);
+    return copy;
   }
 
   /**
@@ -163,7 +258,6 @@ export class Context {
       | RegExp
       | ((binding: Readonly<Binding<ValueType>>) => boolean),
   ): Readonly<Binding<ValueType>>[] {
-    let bindings: Readonly<Binding>[] = [];
     let filter: (binding: Readonly<Binding>) => boolean;
     if (!pattern) {
       filter = binding => true;
@@ -176,12 +270,21 @@ export class Context {
       filter = pattern;
     }
 
-    for (const b of this.registry.values()) {
-      if (filter(b)) bindings.push(b);
-    }
-
-    const parentBindings = this._parent && this._parent.find(filter);
-    return this._mergeWithParent(bindings, parentBindings);
+    const mapper = (ctx: Context) => {
+      const bindings: Readonly<Binding>[] = [];
+      ctx.registry.forEach(binding => {
+        const isMatch = filter(binding);
+        if (isMatch) bindings.push(binding);
+      });
+      return bindings;
+    };
+    return this.visitAllContexts<Readonly<Binding>[], Readonly<Binding>[]>(
+      mapper,
+      () => false,
+      (bindings, parentBindings) =>
+        this._mergeWithParent(bindings, parentBindings),
+      [],
+    );
   }
 
   /**
@@ -381,6 +484,9 @@ export class Context {
    * binding is found, an error will be thrown.
    *
    * @param key Binding key
+   * @param options Options to control if the binding is optional. If
+   * `options.optional` is set to true, the method will return `undefined`
+   * instead of throwing an error if the binding key is not found.
    */
   getBinding<ValueType = BoundValue>(
     key: BindingAddress<ValueType>,
@@ -401,21 +507,18 @@ export class Context {
     options?: {optional?: boolean},
   ): Binding<ValueType> | undefined;
 
-  getBinding<ValueType>(
-    key: BindingAddress<ValueType>,
-    options?: {optional?: boolean},
-  ): Binding<ValueType> | undefined {
-    key = BindingKey.validate(key);
-    const binding = this.registry.get(key);
-    if (binding) {
-      return binding;
-    }
-
-    if (this._parent) {
-      return this._parent.getBinding<ValueType>(key, options);
-    }
-
-    if (options && options.optional) return undefined;
+  getBinding(key: string, options?: {optional?: boolean}): Binding | undefined {
+    BindingKey.validate(key);
+    const result = this.visitAllContexts<
+      Binding | undefined,
+      Binding | undefined
+    >(
+      ctx => ctx.registry.get(key),
+      binding => binding != null,
+      (accumulator, currentValue) => currentValue,
+      undefined,
+    );
+    if ((options && options.optional) || result != null) return result;
     throw new Error(`The key ${key} was not bound to any value.`);
   }
 

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -34,28 +34,29 @@ export class Context {
   protected readonly parents: Context[] = [];
 
   /**
+   * Cached contexts for delegation
+   */
+  private contexts: Context[];
+
+  /**
    * Registry of bindings
    */
   protected readonly registry: Map<string, Binding> = new Map();
 
   /**
    * Create a new context
-   * @param parents The optional parent contexts. If multiple parent contexts
-   * are provided, they will be used to resolve bindings following breadth first
-   * traversal.
-   * @name name The optional context name. If not present, a uuid is generated as
-   * the name.
+   * @param parent The optional parent contexts.
+   * @name name The optional context name. If not present, a uuid is generated
+   * as the name.
    */
-  constructor(parents?: Context | Context[] | string, name?: string) {
-    if (typeof parents === 'string') {
+  constructor(parent?: Context | string, name?: string) {
+    if (typeof parent === 'string') {
       // constructor(name)
-      name = parents;
-      parents = undefined;
+      name = parent;
+      parent = undefined;
     }
-    if (Array.isArray(parents)) {
-      this.parents.push(...parents);
-    } else if (parents) {
-      this.parents.push(parents);
+    if (parent) {
+      this.parents.push(parent);
     }
     this.name = name || uuidv1();
   }
@@ -122,10 +123,12 @@ export class Context {
    * - reqCtx -> [serverCtx, connectorCtx]
    * - serverCtx -> [appCtx]
    * - connectorCtx -> [appCtx]
-   * `reqCtx.contexts()` returns an iterator of `[reqCtx, serverCtx,
+   * `reqCtx.getAllContexts()` returns an iterator of `[reqCtx, serverCtx,
    * connectorCtx, appCtx]`.
    */
-  protected *contexts(): IterableIterator<Context> {
+  protected getAllContexts(): Context[] {
+    if (this.contexts) return this.contexts;
+    this.contexts = [];
     const visited: Set<Context> = new Set();
     const queue: Context[] = [];
     // Enqueue the current context
@@ -136,10 +139,11 @@ export class Context {
       // Skip a context if it has been visited
       if (visited.has(c)) continue;
       visited.add(c);
-      yield c;
+      this.contexts.push(c);
       // Enqueue the parent contexts
       queue.push(...c.parents);
     }
+    return this.contexts;
   }
 
   /**
@@ -163,7 +167,7 @@ export class Context {
       // Iterate until the predicator returns `true`
       takeUntil(
         // Visit a context to produce a result locally
-        map(this.contexts(), mapper),
+        map(this.getAllContexts(), mapper),
         predicator,
       ),
       reducer,
@@ -206,12 +210,16 @@ export class Context {
    * @param parents Optional parent contexts to be added to the graph
    * @param name Name of the newly composed context
    */
-  composeWith(parents?: Context | Context[], name?: string): this {
+  composeWith(parents: Context | Context[], name?: string): this {
     // Construct a new instance with the same class of this instance
     const ctor = this.constructor as Constructor<this>;
-    const copy = new ctor(parents, name);
-    // Add this context as the 1st parent for the new one
-    copy.parents.unshift(this);
+    const copy = new ctor(this, name);
+
+    if (Array.isArray(parents)) {
+      copy.parents.push(...parents);
+    } else {
+      copy.parents.push(parents);
+    }
     return copy;
   }
 

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -260,6 +260,8 @@ export namespace inject {
    *  constructor(@inject.context() private ctx: Context) {}
    * }
    * ```
+   * @param bindingTag Tag name or regex
+   * @param metadata Optional metadata to help the injection
    */
   export const context = function injectContext() {
     return inject('', {decorator: '@inject.context'}, ctx => ctx);

--- a/packages/context/src/iteratable.ts
+++ b/packages/context/src/iteratable.ts
@@ -1,0 +1,92 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * Apply a mapping function to the given iterator to produce a new iterator
+ * with mapped values as its entries
+ *
+ * @param iterator An iterable object
+ * @param mapper A function maps an entry to a new value
+ */
+export function* map<T, V>(
+  iterator: Iterable<T>,
+  mapper: (item: T) => V,
+): Iterable<V> {
+  for (const item of iterator) {
+    yield mapper(item);
+  }
+}
+
+/**
+ * Take entries from the iterator to form a new one until the `predicator`
+ * function returns `true`. Please note the last entry that satisfies the
+ * condition is also included in the returned iterator.
+ *
+ * @param iterator An iterable object
+ * @param predicator A function to check if the iteration should be done
+ */
+export function* takeUntil<T>(
+  iterator: Iterable<T>,
+  predicator: (item: T) => boolean,
+): Iterable<T> {
+  for (const item of iterator) {
+    yield item; // Always take the item even filter returns true
+    if (predicator(item)) break;
+  }
+}
+
+/**
+ * Take entries from the iterator to form a new one while the `predicator`
+ * function returns `true`. Please note the last entry that satisfies the
+ * condition is also included in the returned iterator.
+ *
+ * @param iterator An iterable object
+ * @param predicator A function to check if the iteration should continue
+ */
+export function* takeWhile<T>(
+  iterator: Iterable<T>,
+  predicator: (item: T) => boolean,
+): Iterable<T> {
+  for (const item of iterator) {
+    if (predicator(item)) yield item;
+    else break;
+  }
+}
+
+/**
+ * Reduce the entries from the interator to be an aggregated value.
+ *
+ * @param iterator An iterable object
+ * @param reducer A function that reconciles the previous result with the
+ * current entry into a new result
+ * @param initialValue The initial value for the result
+ */
+export function reduce<T, V>(
+  iterator: Iterable<T>,
+  reducer: (accumulator: V, currentValue: T) => V,
+  initialValue: V,
+): V {
+  let accumulator = initialValue;
+  for (const item of iterator) {
+    accumulator = reducer(accumulator, item);
+  }
+  return accumulator;
+}
+
+/**
+ * Filter the given iterator to produce a new iterator with only entries
+ * satisfies the predicator
+ *
+ * @param iterator An iterable object
+ * @param predicator A function to check if an entry should be included
+ */
+export function* filter<T>(
+  iterator: Iterable<T>,
+  predicator: (item: T) => boolean,
+): Iterable<T> {
+  for (const item of iterator) {
+    if (predicator(item)) yield item;
+  }
+}

--- a/packages/context/test/acceptance/child-context.acceptance.ts
+++ b/packages/context/test/acceptance/child-context.acceptance.ts
@@ -55,7 +55,7 @@ describe('Context bindings - contexts with a single parent', () => {
   }
 });
 
-describe('Context bindings - contexts with multiple parents', () => {
+describe('Context bindings - contexts composed with other ones', () => {
   let appCtx: Context;
   let serverCtx: Context;
   let connectorCtx: Context;
@@ -152,6 +152,6 @@ describe('Context bindings - contexts with multiple parents', () => {
     appCtx = new Context(undefined, 'app'); // The root
     serverCtx = new Context(appCtx, 'server'); // server -> app
     connectorCtx = new Context(appCtx, 'connector'); // connector -> app
-    reqCtx = new Context([serverCtx, connectorCtx], 'req'); // req -> [server, connector]
+    reqCtx = new Context().composeWith([serverCtx, connectorCtx], 'req'); // req -> [server, connector]
   }
 });

--- a/packages/context/test/acceptance/child-context.acceptance.ts
+++ b/packages/context/test/acceptance/child-context.acceptance.ts
@@ -6,7 +6,7 @@
 import {expect} from '@loopback/testlab';
 import {Context} from '../..';
 
-describe('Context bindings - contexts inheritance', () => {
+describe('Context bindings - contexts with a single parent', () => {
   let parentCtx: Context;
   let childCtx: Context;
 
@@ -52,5 +52,106 @@ describe('Context bindings - contexts inheritance', () => {
   function createParentAndChildContext() {
     parentCtx = new Context();
     childCtx = new Context(parentCtx);
+  }
+});
+
+describe('Context bindings - contexts with multiple parents', () => {
+  let appCtx: Context;
+  let serverCtx: Context;
+  let connectorCtx: Context;
+  let reqCtx: Context;
+
+  beforeEach('given multiple parents and a child context', createContextGraph);
+
+  it('child inherits values bound in parent chain', () => {
+    appCtx.bind('foo').to('bar');
+    expect(reqCtx.getSync('foo')).to.equal('bar');
+  });
+
+  it('bindings are resolved in current context first', () => {
+    appCtx.bind('foo').to('app:bar');
+    serverCtx.bind('foo').to('server:bar');
+    connectorCtx.bind('foo').to('connector:bar');
+    reqCtx.bind('foo').to('req:bar');
+    // req
+    expect(reqCtx.getSync('foo')).to.equal('req:bar');
+  });
+
+  it('bindings are resolved by the order of parents', () => {
+    appCtx.bind('foo').to('app:bar');
+    serverCtx.bind('foo').to('server:bar');
+    connectorCtx.bind('foo').to('connector:bar');
+    // req -> server
+    expect(reqCtx.getSync('foo')).to.equal('server:bar');
+  });
+
+  it('bindings are resolved in first parent chain', () => {
+    appCtx.bind('foo').to('app:bar');
+    connectorCtx.bind('foo').to('connector:bar');
+    // req -> server -> connector -> app
+    expect(reqCtx.getSync('foo')).to.equal('connector:bar');
+  });
+
+  it('child changes are not propagated to parent', () => {
+    reqCtx.bind('foo').to('bar');
+    expect(() => serverCtx.getSync('foo')).to.throw(/not bound/);
+    expect(() => connectorCtx.getSync('foo')).to.throw(/not bound/);
+    expect(() => appCtx.getSync('foo')).to.throw(/not bound/);
+  });
+
+  it('includes parent bindings when searching via getBinding()', () => {
+    appCtx.bind('foo').to('app:foo');
+    appCtx.bind('bar').to('app:bar');
+    serverCtx.bind('foo').to('server:foo');
+    connectorCtx.bind('foo').to('connector:foo');
+    const binding = reqCtx.bind('foo').to('req:foo');
+
+    const found = reqCtx.getBinding('foo');
+    expect(found).to.be.exactly(binding);
+  });
+
+  it('includes parent bindings when searching via find()', () => {
+    appCtx.bind('foo').to('app:foo');
+    appCtx.bind('bar').to('app:bar');
+    serverCtx.bind('foo').to('server:foo');
+    serverCtx.bind('bar').to('server:bar');
+    connectorCtx.bind('foo').to('connector:foo');
+    reqCtx.bind('foo').to('req:foo');
+
+    const found = reqCtx.find().map(b => b.getValue(reqCtx));
+    expect(found).to.deepEqual(['req:foo', 'server:bar']);
+  });
+
+  it('includes parent bindings when searching via findByTag()', () => {
+    appCtx
+      .bind('foo')
+      .to('app:foo')
+      .tag('a-tag');
+    appCtx
+      .bind('bar')
+      .to('app:bar')
+      .tag('a-tag');
+    serverCtx
+      .bind('foo')
+      .to('server:foo')
+      .tag('a-tag');
+    connectorCtx
+      .bind('baz')
+      .to('connector:baz')
+      .tag('a-tag');
+    reqCtx
+      .bind('foo')
+      .to('req:foo')
+      .tag('a-tag');
+
+    const found = reqCtx.findByTag('a-tag').map(b => b.getValue(reqCtx));
+    expect(found).to.deepEqual(['req:foo', 'connector:baz', 'app:bar']);
+  });
+
+  function createContextGraph() {
+    appCtx = new Context(undefined, 'app'); // The root
+    serverCtx = new Context(appCtx, 'server'); // server -> app
+    connectorCtx = new Context(appCtx, 'connector'); // connector -> app
+    reqCtx = new Context([serverCtx, connectorCtx], 'req'); // req -> [server, connector]
   }
 });

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -18,8 +18,8 @@ import {
  * for assertions
  */
 class TestContext extends Context {
-  get parent() {
-    return this._parent;
+  get parentList() {
+    return this.parents;
   }
   get bindingMap() {
     const map = new Map(this.registry);
@@ -49,14 +49,21 @@ describe('Context constructor', () => {
   it('accepts a parent context', () => {
     const c1 = new Context('c1');
     const ctx = new TestContext(c1);
-    expect(ctx.parent).to.eql(c1);
+    expect(ctx.parentList).to.eql([c1]);
+  });
+
+  it('accepts multiple parent contexts', () => {
+    const c1 = new Context('c1');
+    const c2 = new Context('c2');
+    const ctx = new TestContext([c1, c2]);
+    expect(ctx.parentList).to.eql([c1, c2]);
   });
 
   it('accepts a parent context and a name', () => {
     const c1 = new Context('c1');
     const ctx = new TestContext(c1, 'c2');
     expect(ctx.name).to.eql('c2');
-    expect(ctx.parent).to.eql(c1);
+    expect(ctx.parentList).to.eql([c1]);
   });
 });
 
@@ -654,6 +661,27 @@ describe('Context', () => {
           type: BindingType.CONSTANT,
         },
       });
+    });
+  });
+
+  describe('composeWith()', () => {
+    it('creates a new context with additional parents', () => {
+      const c1 = new TestContext('c1');
+      c1.bind('a').to(1);
+      const c2 = new Context('c2');
+      const c3 = c1.composeWith(c2, 'c3');
+      expect(c3.name).to.be.eql('c3');
+      expect(c3.parentList).to.eql([c1, c2]);
+      expect(c3.bindingMap.size).to.eql(0);
+    });
+
+    it('adds additional parents', () => {
+      const c0 = new Context('c0'); // c0
+      const c1 = new TestContext(c0, 'c1'); // c1 -> c0
+      const c2 = new Context('c2'); // c2
+      const c3 = c1.composeWith(c2, 'c3');
+      expect(c3.name).to.be.eql('c3');
+      expect(c3.parentList).to.eql([c1, c2]);
     });
   });
 

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -52,13 +52,6 @@ describe('Context constructor', () => {
     expect(ctx.parentList).to.eql([c1]);
   });
 
-  it('accepts multiple parent contexts', () => {
-    const c1 = new Context('c1');
-    const c2 = new Context('c2');
-    const ctx = new TestContext([c1, c2]);
-    expect(ctx.parentList).to.eql([c1, c2]);
-  });
-
   it('accepts a parent context and a name', () => {
     const c1 = new Context('c1');
     const ctx = new TestContext(c1, 'c2');

--- a/packages/context/test/unit/iteratable.test.ts
+++ b/packages/context/test/unit/iteratable.test.ts
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+
+import {map, takeUntil, reduce, takeWhile, filter} from '../../src/iteratable';
+
+describe('Utilities for iteratable composition', () => {
+  let items: Iterable<number>;
+
+  beforeEach(givenIterable);
+
+  describe('map()', () => {
+    it('maps each entry of the iterator', () => {
+      const result = map(items, item => item * 2);
+      expect(Array.from(result)).to.eql([2, 4, 6]);
+    });
+  });
+
+  describe('filter()', () => {
+    it('filter each entry of the iterator', () => {
+      const result = filter(items, item => item % 2 === 1);
+      expect(Array.from(result)).to.eql([1, 3]);
+    });
+  });
+
+  describe('takeUntil()', () => {
+    it('takes entries until the predicator returns true', () => {
+      const result = takeUntil(items, item => item % 2 === 0);
+      expect(Array.from(result)).to.eql([1, 2]);
+    });
+
+    it('takes all entries if the predicator always return false', () => {
+      const result = takeUntil(items, item => false);
+      expect(Array.from(result)).to.eql([1, 2, 3]);
+    });
+  });
+
+  describe('takeWhile()', () => {
+    it('takes entries while the predicator returns true', () => {
+      const result = takeWhile(items, item => item <= 2);
+      expect(Array.from(result)).to.eql([1, 2]);
+    });
+
+    it('takes all entries if the predicator always return true', () => {
+      const result = takeWhile(items, item => true);
+      expect(Array.from(result)).to.eql([1, 2, 3]);
+    });
+  });
+
+  describe('reduce()', () => {
+    it('reduces entries of the iterator', () => {
+      const result = reduce(
+        items,
+        (accumulator, current) => accumulator + current,
+        0,
+      );
+      expect(result).to.eql(6);
+    });
+  });
+
+  function givenIterable() {
+    items = [1, 2, 3];
+  }
+});


### PR DESCRIPTION
The PR adds a few improvements to our IoC container as I polish 
https://github.com/strongloop/loopback-next/pull/872.

- Make binding level cache context aware to better handle various scopes
- Add name to context instances to better identify each of them
- Add `@inject.context()` to express dependency of the current context
- Add `decorator` to injection metadata so that we can tell which decorator function is used
- Add `optional` to injection metadata to control if a binding should fail due to missing key
- Add support of multiple parent contexts so that we can compose multiple contexts for resolution, such as requestCtx, serverCtx, connectorCtx, and appCtx.
- add unit tests for ResolutionSession

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
