### PR TITLE
fix(rest): correctly re-export decorators at runtime

### DIFF
--- a/packages/rest/index.ts
+++ b/packages/rest/index.ts
@@ -5,4 +5,3 @@
 
 // NOTE(bajtos) This file is used by VSCode/TypeScriptServer at dev time only
 export * from './src';
-export * from '@loopback/openapi-v2';

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -35,3 +35,6 @@ export * from './rest-application';
 export * from './rest-component';
 export * from './rest-server';
 export * from './sequence';
+
+// Re-export decorators like @get for easier use
+export * from '@loopback/openapi-v2';

--- a/packages/rest/test/integration/rest-server.integration.ts
+++ b/packages/rest/test/integration/rest-server.integration.ts
@@ -155,8 +155,6 @@ paths:
       '/openapi.yaml',
     );
     expect(response.text).to.eql(`openapi: 3.0.0
-servers:
-  - url: /
 info:
   title: LoopBack Application
   version: 1.0.0
@@ -170,6 +168,8 @@ paths:
             '*/*':
               schema:
                 type: string
+servers:
+  - url: /
 `);
     expect(response.get('Access-Control-Allow-Origin')).to.equal('*');
     expect(response.get('Access-Control-Allow-Credentials')).to.equal('true');


### PR DESCRIPTION
Before this change, decorators from openapi-v2 were exported at compile time only.

This patch moves the re-export from `index.ts` to `src/index.tx` to fix this problem.

See https://github.com/strongloop/loopback-next/pull/883 for a discussion about how to prevent this kind of problems to resurface in the future.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
