### PR TITLE
build(vscode): fix debugger setup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "args": [
         "--opts",
         "${workspaceRoot}/test/mocha.opts",
-        "packages/*/test/**/*.ts",
+        "packages/*/dist/test/**/*.js",
         "-t",
         "0"
       ]


### PR DESCRIPTION
Fix the path to source files passed to Mocha when debugging tests
in VisualStudio Code.

This is a follow-up for 0b49badd which removed ts-node from our project.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
