### PR TITLE
build: use --hoist to speed up lerna bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
     "@commitlint/cli": "^5.2.5",
     "@commitlint/config-conventional": "^6.0.2",
     "@commitlint/config-lerna-scopes": "^5.2.0",
-    "@types/mocha": "^2.2.44",
-    "@types/node": "^8.0.56",
+    "@types/mocha": "^2.2.46",
+    "@types/node": "^8.5.8",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "lerna": "^2.5.1",
-    "mocha": "^4.0.0"
+    "mocha": "^5.0.0"
   },
   "scripts": {
-    "bootstrap": "npm i && lerna bootstrap",
+    "bootstrap": "npm i && lerna bootstrap --hoist",
     "release": "npm run build:full && lerna publish --cd-version=prerelease --preid=alpha",
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
     "precoverage": "npm test",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -13,11 +13,11 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@types/mocha": "^2.2.43",
+    "@types/mocha": "^2.2.46",
     "@types/node": "^8.5.8",
     "cross-spawn": "^5.1.0",
     "debug": "^3.1.0",
-    "mocha": "^4.0.0",
+    "mocha": "^5.0.0",
     "nyc": "^11.4.1",
     "prettier": "^1.10.2",
     "strong-docs": "^1.6.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,10 +29,10 @@
     "glob": "^7.1.2",
     "mem-fs": "^1.1.3",
     "mem-fs-editor": "^3.0.2",
-    "mocha": "^4.0.1",
+    "mocha": "^5.0.0",
     "nsp": "^3.1.0",
     "rimraf": "^2.6.2",
-    "sinon": "^4.1.2",
+    "sinon": "^4.1.5",
     "yeoman-assert": "^3.1.0",
     "yeoman-test": "^1.7.0"
   },

--- a/packages/example-getting-started/package.json
+++ b/packages/example-getting-started/package.json
@@ -33,7 +33,7 @@
     "@loopback/openapi-v2": "^4.0.0-alpha.4",
     "@loopback/repository": "^4.0.0-alpha.24",
     "@loopback/rest": "^4.0.0-alpha.19",
-    "@types/sinon": "^2.3.6",
+    "@types/sinon": "^2.3.7",
     "sinon": "^4.1.5"
   },
   "devDependencies": {
@@ -41,8 +41,8 @@
     "@loopback/testlab": "^4.0.0-alpha.19",
     "@types/mocha": "^2.2.46",
     "@types/node": "^8.5.8",
-    "mocha": "^4.1.0",
-    "typescript": "^2.5.2"
+    "mocha": "^5.0.0",
+    "typescript": "^2.6.2"
   },
   "keywords": [
     "loopback",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -42,7 +42,7 @@
     "@loopback/openapi-spec-builder": "^4.0.0-alpha.17",
     "@loopback/testlab": "^4.0.0-alpha.19",
     "@types/js-yaml": "^3.9.1",
-    "@types/lodash": "^4.14.85"
+    "@types/lodash": "^4.14.87"
   },
   "files": [
     "README.md",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -27,7 +27,7 @@
     "@types/swagger-parser": "^4.0.1",
     "shot": "^4.0.3",
     "should": "^13.1.3",
-    "sinon": "^4.1.2",
+    "sinon": "^4.1.5",
     "supertest": "^3.0.0",
     "swagger-parser": "^4.0.1"
   },


### PR DESCRIPTION
Since this requires upgrade of the version specifier used by common dependencies, I have upgraded Mocha to 5.0 along the way.

Fixes #881

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
