### PR TITLE
feat(rest): Enable method dependency injection for controllers

### DIFF
--- a/packages/openapi-v2/src/controller-spec.ts
+++ b/packages/openapi-v2/src/controller-spec.ts
@@ -160,7 +160,19 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
         throw new Error('More than one body parameters found: ' + bodyParams);
       }
       params = DecoratorFactory.cloneDeep(params);
-      operationSpec.parameters = params;
+      /**
+       * If a controller method uses dependency injection, the parameters
+       * might be sparsed. For example,
+       * ```ts
+       * class MyController {
+       *   greet(
+       *     @inject('prefix') prefix: string,
+       *     @param.query.string('name) name: string) {
+       *      return `${prefix}`, ${name}`;
+       *   }
+       * ```
+       */
+      operationSpec.parameters = params.filter(p => p != null);
     }
     operationSpec['x-operation-name'] = op;
 

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -8,7 +8,12 @@ import {
   ParameterObject,
   PathsObject,
 } from '@loopback/openapi-spec';
-import {Context, Constructor, instantiateClass} from '@loopback/context';
+import {
+  Context,
+  Constructor,
+  instantiateClass,
+  invokeMethod,
+} from '@loopback/context';
 import {ServerRequest} from 'http';
 import * as HttpErrors from 'http-errors';
 
@@ -315,7 +320,13 @@ export class ControllerRoute extends BaseRoute {
         `Controller method not found: ${this.describe()}`,
       );
     }
-    return await controller[this._methodName](...args);
+    // Invoke the method with dependency injection
+    return await invokeMethod(
+      controller,
+      this._methodName,
+      requestContext,
+      args,
+    );
   }
 
   private async _createControllerInstance(

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -119,6 +119,47 @@ describe('Routing', () => {
     );
   });
 
+  it('allows controllers to use method DI with mixed params', async () => {
+    class MyController {
+      @get('/greet')
+      greet(
+        @param.query.string('name') name: string,
+        @inject('hello.prefix') prefix: string,
+      ) {
+        return `${prefix} ${name}`;
+      }
+    }
+    const app = givenAnApplication();
+    app.bind('hello.prefix').to('Hello');
+    const server = await givenAServer(app);
+    givenControllerInApp(app, MyController);
+    return (
+      whenIMakeRequestTo(server)
+        .get('/greet?name=world')
+        // Then I get the result `hello world` from the `Method`
+        .expect('Hello world')
+    );
+  });
+
+  it('allows controllers to use method DI without rest params', async () => {
+    class MyController {
+      @get('/greet')
+      greet(@inject('hello.prefix') prefix: string) {
+        return `${prefix} world`;
+      }
+    }
+    const app = givenAnApplication();
+    app.bind('hello.prefix').to('Hello');
+    const server = await givenAServer(app);
+    givenControllerInApp(app, MyController);
+    return (
+      whenIMakeRequestTo(server)
+        .get('/greet')
+        // Then I get the result `hello world` from the `Method`
+        .expect('Hello world')
+    );
+  });
+
   it('injects controller constructor arguments', async () => {
     const app = givenAnApplication();
     const server = await givenAServer(app);

--- a/packages/rest/test/unit/router/routing-table.test.ts
+++ b/packages/rest/test/unit/router/routing-table.test.ts
@@ -43,9 +43,8 @@ describe('RoutingTable', () => {
     table.registerController(TestController, spec);
     const paths = table.describeApiPaths();
     const params = paths['/greet']['get'].parameters;
-    expect(params).to.have.property('length', 2);
-    expect(params[0]).to.be.undefined();
-    expect(params[1]).to.have.properties({
+    expect(params).to.have.property('length', 1);
+    expect(params[0]).to.have.properties({
       name: 'message',
       in: 'query',
       type: 'string',


### PR DESCRIPTION
This PR allows controller methods to use dependency injection.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
