### PR TITLE
refactor(openapi-v2): use lb-clean instead of rm -rf to be OS agnostic

### DIFF
--- a/packages/openapi-v2/package.json
+++ b/packages/openapi-v2/package.json
@@ -18,7 +18,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
-    "clean": "rm -rf loopback-openapi-v2*.tgz dist* package",
+    "clean": "lb-clean loopback-openapi-v2*.tgz dist* package",
     "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-dist mocha --opts node_modules/@loopback/build/mocha.opts 'DIST/test/unit/**/*.js'",


### PR DESCRIPTION
All our packages use `lb-clean` except for `openapi-v2`. This makes it consistent with other packages. `rm -rf` doesn't work on Windows without certain utilities installed while `lb-clean` will work on all OS platforms since it uses `rimraf`. 

## Checklist

- [x] `npm test` passes on your machine
- [n/a] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [n/a] Related API Documentation was updated
- [n/a] Affected artifact templates in `packages/cli` were updated
- [n/a] Affected example projects in `packages/example-*` were updated
