### PR TITLE
ci: skip re-build again in pretest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ git:
 before_script:
   - npm run bootstrap
 
+script:
+  - npm run test:ci
+
 after_success:
   - npm run coverage:ci
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - npm run test:ci
 
 build: off
 skip_branch_with_pr: true

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "build:full": "npm run clean:full && npm run bootstrap && npm run build && npm run mocha && npm run lint",
     "pretest": "npm run clean && npm run build:current",
     "test": "node packages/build/bin/run-nyc npm run mocha",
-    "mocha": "node packages/build/bin/run-mocha \"packages/*/DIST/test/**/*.js\" \"packages/cli/test/*.js\"",
+    "test:ci": "node packages/build/bin/run-nyc npm run mocha && npm run posttest",
+    "mocha": "node packages/build/bin/select-dist mocha --opts packages/build/mocha.ts.opts \"packages/*/DIST/test/**/*.js\" \"packages/cli/test/*.js\"",
     "posttest": "npm run lint"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pretest": "npm run clean && npm run build:current",
     "test": "node packages/build/bin/run-nyc npm run mocha",
     "test:ci": "node packages/build/bin/run-nyc npm run mocha && npm run posttest",
-    "mocha": "node packages/build/bin/select-dist mocha --opts packages/build/mocha.ts.opts \"packages/*/DIST/test/**/*.js\" \"packages/cli/test/*.js\"",
+    "mocha": "node packages/build/bin/run-mocha \"packages/*/DIST/test/**/*.js\" \"packages/cli/test/*.js\"",
     "posttest": "npm run lint"
   },
   "config": {

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -6,7 +6,7 @@
     "node": ">=6"
   },
   "scripts": {
-    "build": "npm run build:dist",
+    "build": "npm run build:dist && npm run build:dist6",
     "build:current": "lb-tsc",
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",


### PR DESCRIPTION
current test script run pretest which cleans and rebuilds the project. This isn't needed on CI as
it's a clean build every time.

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
