### PR TITLE
fix: mark example-log-extension private to avoid npm publish

### DIFF
--- a/packages/example-log-extension/package.json
+++ b/packages/example-log-extension/package.json
@@ -2,6 +2,7 @@
   "name": "@loopback/example-log-extension",
   "version": "4.0.0-alpha.0",
   "description": "An example extension project for LoopBack 4",
+  "private": true,
   "main": "index.js",
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
Set `private` flag in package.json so that `lerna publish` won't push it to npm.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
