### PR TITLE
feat(rest): allow basePath in RestServer configuration

### DIFF
--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -10,6 +10,7 @@ export namespace RestBindings {
   export const CONFIG = `${CoreBindings.APPLICATION_CONFIG}#rest`;
   export const HOST = 'rest.host';
   export const PORT = 'rest.port';
+  export const BASE_PATH = 'rest.basePath';
   export const HANDLER = 'rest.handler';
 
   export const API_SPEC = 'rest.apiSpec';

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -142,8 +142,12 @@ export class RestServer extends Context implements Server {
       // Set it to '' so that the http server will listen on all interfaces
       options.host = undefined;
     }
+    if (!options.basePath) {
+      options.basePath = '/';
+    }
     this.bind(RestBindings.PORT).to(options.port);
     this.bind(RestBindings.HOST).to(options.host);
+    this.bind(RestBindings.BASE_PATH).to(options.basePath);
     this.api(createEmptyApiSpec());
 
     this.sequence(options.sequence ? options.sequence : DefaultSequence);
@@ -595,6 +599,7 @@ export class RestServer extends Context implements Server {
 export interface RestServerConfig {
   host?: string;
   port?: number;
+  basePath?: string;
   apiExplorerUrl?: string;
   sequence?: Constructor<SequenceHandler>;
 }

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -15,6 +15,7 @@ import {
   InvokeMethod,
   RestBindings,
   RestComponent,
+  RestApplication,
 } from '../../..';
 
 describe('RestServer', () => {
@@ -97,6 +98,13 @@ describe('RestServer', () => {
       const server = await app.getServer(RestServer);
       expect(server.getSync(RestBindings.PORT)).to.equal(4000);
       expect(server.getSync(RestBindings.HOST)).to.equal('my-host');
+    });
+
+    it('uses default basePath of "/"', async () => {
+      const app = new RestApplication();
+      const server = await app.getServer(RestServer);
+      const basePath = await server.get(RestBindings.BASE_PATH);
+      expect(basePath).to.equal('/');
     });
   });
 


### PR DESCRIPTION
Part of #914 

Add the capability to set basePath as a part of your config.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
