### PR TITLE
fix: remove typedoc/node_modules/.bin from local typescript dep

### DIFF
--- a/packages/build/bin/generate-apidocs.js
+++ b/packages/build/bin/generate-apidocs.js
@@ -8,7 +8,7 @@
 
 function run(argv, dryRun) {
   const utils = require('./utils');
-  const fs = require('fs');
+  const fs = require('fs-extra');
   const path = require('path');
   var tsPath;
   try {
@@ -22,6 +22,8 @@ function run(argv, dryRun) {
     // typescript version for our projects
     try {
       fs.renameSync(tsPath, tsPath + '.bak');
+      // Clean up the symbolic links (tsc & tsserver)
+      fs.removeSync(path.join(tsPath, '../.bin'));
     } catch (e) {
       // Ignore the error
     }

--- a/packages/build/test/integration/scripts.test.js
+++ b/packages/build/test/integration/scripts.test.js
@@ -170,6 +170,17 @@ describe('build', () => {
         fs.existsSync(path.join(projectDir, 'api-docs')),
         'api-docs should have been created'
       );
+      var typedocDir = require.resolve('typedoc/package.json');
+      assert(
+        !fs.existsSync(path.join(typedocDir, '../node_modules/typescript')),
+        'typedoc local dependency of typescript should have been renamed'
+      );
+      assert(
+        !fs.existsSync(
+          path.join(typedocDir, '../node_modules/.bin'),
+          'typedoc local scripts from typescript should have been removed'
+        )
+      );
       done();
     });
   });


### PR DESCRIPTION
The generate-apidocs script has a workaround to remove local dependency
of TypeScript from typedoc module so that our version of TS will be used.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
