### PR TITLE
fix(example-rpc-server): mocha opts, mark as private

### DIFF
--- a/packages/example-rpc-server/package.json
+++ b/packages/example-rpc-server/package.json
@@ -2,6 +2,7 @@
   "name": "@loopback/example-rpc-server",
   "version": "4.0.0-alpha.0",
   "description": "A basic RPC server using a made-up protocol.",
+  "private": true,
   "keywords": [
     "loopback-application",
     "loopback"

--- a/packages/example-rpc-server/package.json
+++ b/packages/example-rpc-server/package.json
@@ -24,7 +24,7 @@
     "tslint": "lb-tslint",
     "tslint:fix": "npm run tslint -- --fix",
     "pretest": "npm run clean && npm run build:current",
-    "test": "lb-dist mocha --opts node_modules/@loopback/build/mocha.ts.opts DIST/test",
+    "test": "lb-dist mocha --opts node_modules/@loopback/build/mocha.opts DIST/test",
     "posttest": "npm run lint",
     "start": "npm run build && node .",
     "prepare": "npm run build"


### PR DESCRIPTION
Use the new "mocha.opts" instead of no-longer-available "mocha.ts.opts".

This is a follow-up for recently-landed #917, see also https://github.com/strongloop/loopback-next/issues/836

cc @kjdelisle @virkt25 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
