### PR TITLE
[WIP] feat(context): Allow components to expose a list of bindings

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -383,7 +383,7 @@ export class Binding<T = BoundValue> {
    *
    * @param provider The value provider to use.
    */
-  public toProvider(providerClass: Constructor<Provider<T>>): this {
+  toProvider(providerClass: Constructor<Provider<T>>): this {
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Bind %s to provider %s', this.key, providerClass.name);
@@ -435,5 +435,15 @@ export class Binding<T = BoundValue> {
       json.type = this.type;
     }
     return json;
+  }
+
+  /**
+   * A static method to create a binding so that we can do
+   * `Binding.bind('foo').to('bar');` as `new Binding('foo').to('bar')` is not
+   * easy to read.
+   * @param key Binding key
+   */
+  static bind(key: string): Binding {
+    return new Binding(key);
   }
 }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -42,16 +42,26 @@ export class Context {
    * Create a binding with the given key in the context. If a locked binding
    * already exists with the same key, an error will be thrown.
    *
-   * @param key Binding key
+   * @param keyOrBinding Binding key or a binding
    */
   bind<ValueType = BoundValue>(
-    key: BindingAddress<ValueType>,
+    keyOrBinding: BindingAddress<ValueType> | Binding,
   ): Binding<ValueType> {
+    let key: string;
+    let binding: Binding<ValueType>;
+    if (keyOrBinding instanceof Binding) {
+      key = keyOrBinding.key;
+      binding = keyOrBinding;
+    } else {
+      key = keyOrBinding.toString();
+      binding = new Binding<ValueType>(key);
+    }
+
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Adding binding: %s', key);
     }
-    key = BindingKey.validate(key);
+
     const keyExists = this.registry.has(key);
     if (keyExists) {
       const existingBinding = this.registry.get(key);
@@ -59,8 +69,6 @@ export class Context {
       if (bindingIsLocked)
         throw new Error(`Cannot rebind key "${key}" to a locked binding`);
     }
-
-    const binding = new Binding<ValueType>(key);
     this.registry.set(key, binding);
     return binding;
   }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -42,21 +42,23 @@ export class Context {
    * Create a binding with the given key in the context. If a locked binding
    * already exists with the same key, an error will be thrown.
    *
-   * @param keyOrBinding Binding key or a binding
+   * @param key Binding key
    */
   bind<ValueType = BoundValue>(
-    keyOrBinding: BindingAddress<ValueType> | Binding,
+    key: BindingAddress<ValueType>,
   ): Binding<ValueType> {
-    let key: string;
-    let binding: Binding<ValueType>;
-    if (keyOrBinding instanceof Binding) {
-      key = keyOrBinding.key;
-      binding = keyOrBinding;
-    } else {
-      key = keyOrBinding.toString();
-      binding = new Binding<ValueType>(key);
-    }
+    const binding = new Binding<ValueType>(key.toString());
+    this.add(binding);
+    return binding;
+  }
 
+  /**
+   * Add a binding to the context. If a locked binding already exists with the
+   * same key, an error will be thrown.
+   * @param binding The configured binding to be added
+   */
+  add<ValueType = BoundValue>(binding: Binding<ValueType>): this {
+    const key = binding.key;
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Adding binding: %s', key);
@@ -70,7 +72,7 @@ export class Context {
         throw new Error(`Cannot rebind key "${key}" to a locked binding`);
     }
     this.registry.set(key, binding);
-    return binding;
+    return this;
   }
 
   /**

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -71,13 +71,6 @@ describe('Context', () => {
       expect(result).to.be.true();
     });
 
-    it('accepts a binding', () => {
-      const binding = new Binding('foo').to('bar');
-      expect(ctx.bind(binding)).to.be.exactly(binding);
-      const result = ctx.contains('foo');
-      expect(result).to.be.true();
-    });
-
     it('returns a binding', () => {
       const binding = ctx.bind('foo');
       expect(binding).to.be.instanceOf(Binding);
@@ -86,6 +79,30 @@ describe('Context', () => {
     it('rejects a key containing property separator', () => {
       const key = 'a' + BindingKey.PROPERTY_SEPARATOR + 'b';
       expect(() => ctx.bind(key)).to.throw(/Binding key .* cannot contain/);
+    });
+
+    it('rejects rebinding of a locked key', () => {
+      ctx.bind('foo').lock();
+      expect(() => ctx.bind('foo')).to.throw(
+        'Cannot rebind key "foo" to a locked binding',
+      );
+    });
+  });
+
+  describe('add', () => {
+    it('accepts a binding', () => {
+      const binding = new Binding('foo').to('bar');
+      ctx.add(binding);
+      expect(ctx.getBinding(binding.key)).to.be.exactly(binding);
+      const result = ctx.contains('foo');
+      expect(result).to.be.true();
+    });
+
+    it('rejects rebinding of a locked key', () => {
+      ctx.bind('foo').lock();
+      expect(() => ctx.add(new Binding('foo'))).to.throw(
+        'Cannot rebind key "foo" to a locked binding',
+      );
     });
   });
 

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -71,6 +71,13 @@ describe('Context', () => {
       expect(result).to.be.true();
     });
 
+    it('accepts a binding', () => {
+      const binding = new Binding('foo').to('bar');
+      expect(ctx.bind(binding)).to.be.exactly(binding);
+      const result = ctx.contains('foo');
+      expect(result).to.be.true();
+    });
+
     it('returns a binding', () => {
       const binding = ctx.bind('foo');
       expect(binding).to.be.instanceOf(Binding);

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -166,7 +166,7 @@ export class Application extends Context {
    * Add a component to this application and register extensions such as
    * controllers, providers, and servers from the component.
    *
-   * @param componentCtor The component class to add.
+   * @param componentClassOrInstance The component class or instance to add.
    * @param {string=} name Optional component name, default to the class name
    *
    * ```ts
@@ -183,16 +183,32 @@ export class Application extends Context {
    * app.component(ProductComponent);
    * ```
    */
-  public component(componentCtor: Constructor<Component>, name?: string) {
-    name = name || componentCtor.name;
-    const componentKey = `components.${name}`;
-    this.bind(componentKey)
-      .toClass(componentCtor)
-      .inScope(BindingScope.SINGLETON)
-      .tag('component');
-    // Assuming components can be synchronously instantiated
-    const instance = this.getSync<Component>(componentKey);
+  public component(
+    componentClassOrInstance: Constructor<Component> | Component,
+    name?: string,
+  ) {
+    let binding: Binding;
+    let instance: Component;
+    if (typeof componentClassOrInstance === 'function') {
+      name = name || componentClassOrInstance.name;
+      const componentKey = `components.${name}`;
+      binding = this.bind(componentKey)
+        .toClass(componentClassOrInstance)
+        .inScope(BindingScope.SINGLETON)
+        .tag('component');
+      // Assuming components can be synchronously instantiated
+      instance = this.getSync<Component>(componentKey);
+    } else {
+      name = name || componentClassOrInstance.name;
+      instance = componentClassOrInstance;
+      const componentKey = `components.${name}`;
+      binding = this.bind(componentKey)
+        .to(componentClassOrInstance)
+        .inScope(BindingScope.SINGLETON)
+        .tag('component');
+    }
     mountComponent(this, instance);
+    return binding;
   }
 }
 

--- a/packages/core/test/unit/application.unit.ts
+++ b/packages/core/test/unit/application.unit.ts
@@ -4,8 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Application, Server, Component} from '../../index';
-import {Context, Constructor} from '@loopback/context';
+import {Application, Server, Component, CoreBindings} from '../..';
+import {
+  Context,
+  Constructor,
+  Binding,
+  Provider,
+  inject,
+} from '@loopback/context';
 
 describe('Application', () => {
   describe('controller binding', () => {
@@ -35,9 +41,26 @@ describe('Application', () => {
 
   describe('component binding', () => {
     let app: Application;
+    const binding = new Binding('foo');
     class MyController {}
+    class MyClass {}
+    class MyProvider implements Provider<string> {
+      value() {
+        return 'my-str';
+      }
+    }
     class MyComponent implements Component {
       controllers = [MyController];
+      bindings = [binding];
+      classes = {'my-class': MyClass};
+      providers = {'my-provider': MyProvider};
+    }
+
+    class MyComponentWithDI implements Component {
+      constructor(@inject(CoreBindings.APPLICATION_INSTANCE) ctx: Context) {
+        // Porgramatically bind to the context
+        ctx.bind('foo').to('bar');
+      }
     }
 
     beforeEach(givenApp);
@@ -54,6 +77,32 @@ describe('Application', () => {
       expect(findKeysByTag(app, 'component')).to.containEql(
         'components.my-component',
       );
+    });
+
+    it('binds bindings from a component', () => {
+      app.component(MyComponent);
+      expect(app.contains('controllers.MyController')).to.be.true();
+      expect(app.getBinding('foo')).to.be.exactly(binding);
+    });
+
+    it('binds classes from a component', () => {
+      app.component(MyComponent);
+      expect(app.contains('my-class')).to.be.true();
+      expect(app.getBinding('my-class').valueConstructor).to.be.exactly(
+        MyClass,
+      );
+    });
+
+    it('binds providers from a component', () => {
+      app.component(MyComponent);
+      expect(app.contains('my-provider')).to.be.true();
+      expect(app.getSync('my-provider')).to.be.eql('my-str');
+    });
+
+    it('binds from a component constructor', () => {
+      app.component(MyComponentWithDI);
+      expect(app.contains('foo')).to.be.true();
+      expect(app.getSync('foo')).to.be.eql('bar');
     });
 
     function givenApp() {

--- a/packages/core/test/unit/application.unit.ts
+++ b/packages/core/test/unit/application.unit.ts
@@ -56,6 +56,11 @@ describe('Application', () => {
       providers = {'my-provider': MyProvider};
     }
 
+    const aComponent: Component = {
+      controllers: [MyController],
+      name: 'AnotherComponent',
+    };
+
     class MyComponentWithDI implements Component {
       constructor(@inject(CoreBindings.APPLICATION_INSTANCE) ctx: Context) {
         // Porgramatically bind to the context
@@ -65,10 +70,24 @@ describe('Application', () => {
 
     beforeEach(givenApp);
 
-    it('binds a component', () => {
+    it('binds a component by class', () => {
       app.component(MyComponent);
       expect(findKeysByTag(app, 'component')).to.containEql(
         'components.MyComponent',
+      );
+    });
+
+    it('binds a component by instance with a custom name', () => {
+      app.component(aComponent, 'YourComponent');
+      expect(findKeysByTag(app, 'component')).to.containEql(
+        'components.YourComponent',
+      );
+    });
+
+    it('binds a component by instance', () => {
+      app.component(aComponent);
+      expect(findKeysByTag(app, 'component')).to.containEql(
+        'components.AnotherComponent',
       );
     });
 


### PR DESCRIPTION
The PR adds a few APIs:

- Context.bind(Binding) - bind an binding to the current context.
- Component.classes and Component.bindings - allow a component to declare an array of bindings or a map of classes.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
