### PR TITLE
chore: revert "move tasks from prepare to prepublishOnly"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - npm run bootstrap
 
 script:
-  - npm test
+  - npm run test:ci
 
 after_success:
   - npm run coverage:ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - npm run test:ci
 
 build: off
 skip_branch_with_pr: true

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build:full": "npm run clean:lerna && npm run bootstrap && npm run build && npm run mocha && npm run lint",
     "pretest": "npm run clean && npm run build:current",
     "test": "node packages/build/bin/run-nyc npm run mocha",
+    "test:ci": "node packages/build/bin/run-nyc npm run mocha && npm run posttest",
     "mocha": "node packages/build/bin/run-mocha \"packages/*/DIST/test/**/*.js\" \"packages/cli/test/*.js\"",
     "posttest": "npm run lint"
   },

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -14,7 +14,7 @@
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-authentication*.tgz dist dist6 package api-docs",
     "integration": "lb-mocha \"DIST/test/integration/**/*.js\"",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/integration/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",

--- a/packages/cli/generators/project/templates/package.json
+++ b/packages/cli/generators/project/templates/package.json
@@ -43,7 +43,7 @@
 <% if (project.projectType === 'application') { -%>
     "start": "npm run build && node .",
 <% } -%>
-    "prepublishOnly": "npm run test"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -13,7 +13,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-context*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-core*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "integration": "lb-mocha \"DIST/test/integration/**/*.js\"",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/integration/**/*.js\" \"DIST/test/acceptance/**/*.js\"",

--- a/packages/example-getting-started/package.json
+++ b/packages/example-getting-started/package.json
@@ -15,7 +15,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean *example-getting-started*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",

--- a/packages/example-log-extension/package.json
+++ b/packages/example-log-extension/package.json
@@ -22,7 +22,7 @@
     "prettier:fix": "npm run prettier:cli -- --write",
     "tslint": "lb-tslint",
     "tslint:fix": "npm run tslint -- --fix",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "pretest": "npm run clean && npm run build:current",
     "test": "lb-dist mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "posttest": "npm run lint",

--- a/packages/example-rpc-server/package.json
+++ b/packages/example-rpc-server/package.json
@@ -28,7 +28,7 @@
     "test": "lb-dist mocha --opts node_modules/@loopback/build/mocha.opts DIST/test",
     "posttest": "npm run lint",
     "start": "npm run build && node .",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -13,7 +13,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-metadata*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -12,7 +12,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-openapi-spec*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"
   },
   "author": "IBM",

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -15,7 +15,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-openapi-spec*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "verify": "npm pack && tar xf loopback-openapi-spec*.tgz && tree package && npm run clean"
   },
   "author": "IBM",

--- a/packages/openapi-v2/package.json
+++ b/packages/openapi-v2/package.json
@@ -20,7 +20,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-openapi-v2*.tgz dist* package",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-openapi-v2*.tgz && tree package && npm run clean"

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -12,7 +12,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-json-schema*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/integration/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "verify": "npm pack && tar xf loopback-json-schema*.tgz && tree package && npm run clean"

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -14,7 +14,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-repository*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
     "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -13,7 +13,7 @@
     "build:dist6": "lb-tsc es2015",
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-rest*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build && npm run build:apidocs",
+    "prepare": "npm run build && npm run build:apidocs",
     "pretest": "npm run build:current",
     "integration": "lb-mocha \"DIST/test/integration/**/*.js\"",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/integration/**/*.js\" \"DIST/test/acceptance/**/*.js\"",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -11,7 +11,7 @@
     "build:dist": "lb-tsc es2017",
     "build:dist6": "lb-tsc es2015",
     "clean": "lb-clean loopback-testlab*.tgz dist dist6 package api-docs",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test\"",
     "verify": "npm pack && tar xf loopback-testlab*.tgz && tree package && npm run clean"


### PR DESCRIPTION
This reverts commit afac0cfd0e738dca4903be7b0f48631daa5fd1b2
(pull request #928) as an experimental attempt to fix our failing build.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
