### PR TITLE
fix(build): upgrade to strong-docs@1.7.1

### DIFF
--- a/packages/build/bin/generate-apidocs.js
+++ b/packages/build/bin/generate-apidocs.js
@@ -29,7 +29,23 @@ function run(argv, dryRun) {
     }
   }
 
-  return utils.runCLI('strong-docs/bin/cli', ['-o', 'api-docs'], dryRun);
+  const apidocsOpts = argv.slice(2);
+
+  const args = [];
+
+  if (!utils.isOptionSet(apidocsOpts, '--tstarget')) {
+    const target = utils.getCompilationTarget();
+    args.push('--tstarget', target);
+  }
+  if (!utils.isOptionSet(apidocsOpts, '--tsconfig')) {
+    const config = utils.getConfigFile('tsconfig.build.json', 'tsconfig.json');
+    args.push('--tsconfig', config);
+  }
+  if (!utils.isOptionSet(apidocsOpts, '--out', '-o')) {
+    args.push('-o', 'api-docs');
+  }
+  args.push(...apidocsOpts);
+  return utils.runCLI('strong-docs/bin/cli', args, dryRun);
 }
 
 module.exports = run;

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,7 @@
     "nyc": "^11.4.1",
     "prettier": "^1.10.2",
     "source-map-support": "^0.5.3",
-    "strong-docs": "^1.6.0",
+    "strong-docs": "^1.7.1",
     "tslint": "^5.9.1",
     "typescript": "^2.6.2"
   },

--- a/packages/build/test/integration/scripts.test.js
+++ b/packages/build/test/integration/scripts.test.js
@@ -185,6 +185,30 @@ describe('build', () => {
     });
   });
 
+  it('honors --tsconfig for apidocs', () => {
+    var run = require('../../bin/generate-apidocs');
+    var command = run(
+      ['node', 'bin/generate-apidocs', '--tsconfig', 'tsconfig.my.json'],
+      true
+    );
+    assert(
+      command.indexOf('--tsconfig tsconfig.my.json') !== -1,
+      '--tsconfig should be honored'
+    );
+  });
+
+  it('honors --tstarget for apidocs', () => {
+    var run = require('../../bin/generate-apidocs');
+    var command = run(
+      ['node', 'bin/generate-apidocs', '--tstarget', 'es2017'],
+      true
+    );
+    assert(
+      command.indexOf('--tstarget es2017') !== -1,
+      '--tstarget should be honored'
+    );
+  });
+
   it('runs tslint against ts files', done => {
     var run = require('../../bin/run-tslint');
     var childProcess = run(['node', 'bin/run-tslint']);


### PR DESCRIPTION
This change makes sure typedoc runs with the same configuration as tsc
and tslint do.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
