### PR TITLE
fix: use parameter level decorators for openapi params

### DIFF
--- a/packages/example-getting-started/src/controllers/todo.controller.ts
+++ b/packages/example-getting-started/src/controllers/todo.controller.ts
@@ -12,8 +12,10 @@ export class TodoController {
     @repository(TodoRepository.name) protected todoRepo: TodoRepository,
   ) {}
   @post('/todo')
-  @param.body('todo', TodoSchema)
-  async createTodo(todo: Todo) {
+  async createTodo(
+    @param.body('todo', TodoSchema)
+    todo: Todo,
+  ) {
     // TODO(bajtos) This should be handled by the framework
     // See https://github.com/strongloop/loopback-next/issues/118
     if (!todo.title) {
@@ -23,9 +25,10 @@ export class TodoController {
   }
 
   @get('/todo/{id}')
-  @param.path.number('id')
-  @param.query.boolean('items')
-  async findTodoById(id: number, items?: boolean): Promise<Todo> {
+  async findTodoById(
+    @param.path.number('id') id: number,
+    @param.query.boolean('items') items?: boolean,
+  ): Promise<Todo> {
     return await this.todoRepo.findById(id);
   }
 
@@ -35,22 +38,25 @@ export class TodoController {
   }
 
   @put('/todo/{id}')
-  @param.path.number('id')
-  @param.body('todo', TodoSchema)
-  async replaceTodo(id: number, todo: Todo): Promise<boolean> {
+  async replaceTodo(
+    @param.path.number('id') id: number,
+    @param.body('todo', TodoSchema)
+    todo: Todo,
+  ): Promise<boolean> {
     return await this.todoRepo.replaceById(id, todo);
   }
 
   @patch('/todo/{id}')
-  @param.path.number('id')
-  @param.body('todo', TodoSchema)
-  async updateTodo(id: number, todo: Todo): Promise<boolean> {
+  async updateTodo(
+    @param.path.number('id') id: number,
+    @param.body('todo', TodoSchema)
+    todo: Todo,
+  ): Promise<boolean> {
     return await this.todoRepo.updateById(id, todo);
   }
 
   @del('/todo/{id}')
-  @param.path.number('id')
-  async deleteTodo(id: number): Promise<boolean> {
+  async deleteTodo(@param.path.number('id') id: number): Promise<boolean> {
     return await this.todoRepo.deleteById(id);
   }
 }

--- a/packages/example-getting-started/test/acceptance/application.test.ts
+++ b/packages/example-getting-started/test/acceptance/application.test.ts
@@ -1,9 +1,9 @@
 import {createClientForHandler, expect, supertest} from '@loopback/testlab';
 import {RestServer} from '@loopback/rest';
 import {TodoApplication} from '../../src/application';
-import {TodoRepository} from '../../src/repositories/index';
+import {TodoRepository} from '../../src/repositories/';
 import {givenTodo} from '../helpers';
-import {Todo} from '../../src/models/index';
+import {Todo} from '../../src/models/';
 
 describe('Application', () => {
   let app: TodoApplication;

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -284,12 +284,14 @@ export class DecoratorFactory<
         Reflector.getMetadata(this.key, target),
       );
       meta = this.mergeWithInherited(meta, target, member, descriptorOrIndex);
+      /* istanbul ignore if  */
       if (debug.enabled) {
         debug('%s: %j', targetName, meta);
       }
       Reflector.defineMetadata(this.key, meta, target);
     } else {
       meta = this.mergeWithOwn(meta, target, member, descriptorOrIndex);
+      /* istanbul ignore if  */
       if (debug.enabled) {
         debug('%s: %j', targetName, meta);
       }

--- a/packages/metadata/test/unit/decorator-factory.test.ts
+++ b/packages/metadata/test/unit/decorator-factory.test.ts
@@ -123,6 +123,38 @@ describe('ClassDecoratorFactory', () => {
   });
 });
 
+describe('ClassDecoratorFactory for primitive types', () => {
+  /**
+   * Define `@classDecorator(spec)`
+   * @param spec
+   */
+  function classDecorator(spec: number): ClassDecorator {
+    return ClassDecoratorFactory.createDecorator('test', spec);
+  }
+
+  const xSpec = 1;
+  @classDecorator(xSpec)
+  class BaseController {}
+
+  @classDecorator(2)
+  class SubController extends BaseController {}
+
+  it('applies metadata to a class', () => {
+    const meta = Reflector.getOwnMetadata('test', BaseController);
+    expect(meta).to.equal(xSpec);
+  });
+
+  it('merges with base class metadata', () => {
+    const meta = Reflector.getOwnMetadata('test', SubController);
+    expect(meta).to.equal(2);
+  });
+
+  it('does not mutate base class metadata', () => {
+    const meta = Reflector.getOwnMetadata('test', BaseController);
+    expect(meta).to.equal(1);
+  });
+});
+
 describe('ClassDecoratorFactory with create', () => {
   interface MySpec {
     x?: number;


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
