### PR TITLE
Improve dependency injection/resolution

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -21,13 +21,15 @@
   "license": "MIT",
   "dependencies": {
     "@loopback/metadata": "^4.0.0-alpha.9",
-    "debug": "^3.1.0"
+    "debug": "^3.1.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "@loopback/build": "^4.0.0-alpha.13",
     "@loopback/testlab": "^4.0.0-alpha.23",
     "@types/bluebird": "^3.5.18",
     "@types/debug": "^0.0.30",
+    "@types/uuid": "^3.4.3",
     "bluebird": "^3.5.0"
   },
   "keywords": [

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -5,8 +5,8 @@
 
 import {Context} from './context';
 import {ResolutionSession} from './resolution-session';
-import {Constructor, instantiateClass} from './resolver';
-import {isPromise, BoundValue} from './value-promise';
+import {instantiateClass} from './resolver';
+import {Constructor, isPromise, BoundValue} from './value-promise';
 import {Provider} from './provider';
 
 import * as debugModule from 'debug';

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -270,10 +270,21 @@ export class Context {
    * binding is found, an error will be thrown.
    *
    * @param key Binding key
+   */
+  getBinding(key: string): Binding;
+
+  /**
+   * Look up a binding by key in the context and its ancestors. If no matching
+   * binding is found and `options.optional` is not set to true, an error will
+   * be thrown.
+   *
+   * @param key Binding key
    * @param options Options to control if the binding is optional. If
    * `options.optional` is set to true, the method will return `undefined`
    * instead of throwing an error if the binding key is not found.
    */
+  getBinding(key: string, options?: {optional?: boolean}): Binding | undefined;
+
   getBinding(key: string, options?: {optional?: boolean}): Binding | undefined {
     Binding.validateKey(key);
     const binding = this.registry.get(key);

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -68,6 +68,25 @@ export class Context {
   }
 
   /**
+   * Unbind a binding from the context. No parent contexts will be checked. If
+   * you need to unbind a binding owned by a parent context, use the code below:
+   * ```ts
+   * const ownerCtx = ctx.getOwnerContext(key);
+   * return ownerCtx != null && ownerCtx.unbind(key);
+   * ```
+   * @param key Binding key
+   * @returns true if the binding key is found and removed from this context
+   */
+  unbind(key: string): boolean {
+    Binding.validateKey(key);
+    const binding = this.registry.get(key);
+    if (binding == null) return false;
+    if (binding && binding.isLocked)
+      throw new Error(`Cannot unbind key "${key}" of a locked binding`);
+    return this.registry.delete(key);
+  }
+
+  /**
    * Check if a binding exists with the given key in the local context without
    * delegating to the parent context
    * @param key Binding key

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -7,7 +7,6 @@ import {Binding} from './binding';
 import {
   isPromise,
   BoundValue,
-  Constructor,
   ValueOrPromise,
   getDeepProperty,
 } from './value-promise';

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -3,16 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export {Binding, BindingScope, BindingType} from './binding';
+export * from '@loopback/metadata';
 
-export {Context} from './context';
-export {Constructor} from './resolver';
-export {ResolutionSession} from './resolution-session';
-export {inject, Setter, Getter} from './inject';
-export {Provider} from './provider';
 export {
   isPromise,
   BoundValue,
+  Constructor,
   ValueOrPromise,
   MapObject,
   resolveList,
@@ -21,12 +17,13 @@ export {
   getDeepProperty,
 } from './value-promise';
 
-// internals for testing
-export {instantiateClass, invokeMethod} from './resolver';
-export {
-  describeInjectedArguments,
-  describeInjectedProperties,
-  Injection,
-} from './inject';
+export {Binding, BindingScope, BindingType} from './binding';
 
-export * from '@loopback/metadata';
+export {Context} from './context';
+export {ResolutionSession} from './resolution-session';
+export {inject, Setter, Getter, Injection} from './inject';
+export {Provider} from './provider';
+
+export {instantiateClass, invokeMethod} from './resolver';
+// internals for testing
+export {describeInjectedArguments, describeInjectedProperties} from './inject';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -74,6 +74,7 @@ export function inject(
   metadata?: Object,
   resolve?: ResolverFunction,
 ) {
+  metadata = Object.assign({decorator: '@inject'}, metadata);
   return function markParameterOrPropertyAsInjected(
     target: Object,
     member: string | symbol,
@@ -163,6 +164,7 @@ export namespace inject {
     bindingKey: string,
     metadata?: Object,
   ) {
+    metadata = Object.assign({decorator: '@inject.getter'}, metadata);
     return inject(bindingKey, metadata, resolveAsGetter);
   };
 
@@ -183,12 +185,13 @@ export namespace inject {
     bindingKey: string,
     metadata?: Object,
   ) {
+    metadata = Object.assign({decorator: '@inject.setter'}, metadata);
     return inject(bindingKey, metadata, resolveAsSetter);
   };
 
   /**
-   * Inject an array of values by a tag
-   * @param bindingTag Tag name or regex
+   * Inject an array of values by a tag pattern string or regexp
+   *
    * @example
    * ```ts
    * class AuthenticationManager {
@@ -197,8 +200,17 @@ export namespace inject {
    *   ) { }
    * }
    * ```
+   * @param bindingTag Tag name or regex
+   * @param metadata Optional metadata to help the injection
    */
-  export const tag = function injectTag(bindingTag: string | RegExp) {
+  export const tag = function injectTag(
+    bindingTag: string | RegExp,
+    metadata?: Object,
+  ) {
+    metadata = Object.assign(
+      {decorator: '@inject.tag', tag: bindingTag},
+      metadata,
+    );
     return inject('', {tag: bindingTag}, resolveByTag);
   };
 }

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -197,7 +197,7 @@ export namespace inject {
    * class AuthenticationManager {
    *   constructor(
    *     @inject.tag('authentication.strategy') public strategies: Strategy[],
-   *   ) { }
+   *   ) {}
    * }
    * ```
    * @param bindingTag Tag name or regex
@@ -214,6 +214,16 @@ export namespace inject {
     return inject('', {tag: bindingTag}, resolveByTag);
   };
 
+  /**
+   * Inject the context object.
+   *
+   * @example
+   * ```ts
+   * class MyProvider {
+   *  constructor(@inject.context() private ctx: Context) {}
+   * }
+   * ```
+   */
   export const context = function injectContext() {
     return inject('', {decorator: '@inject.context'}, ctx => ctx);
   };
@@ -227,7 +237,10 @@ function resolveAsGetter(
   // We need to clone the session for the getter as it will be resolved later
   session = ResolutionSession.fork(session);
   return function getter() {
-    return ctx.get(injection.bindingKey, session);
+    return ctx.get(injection.bindingKey, {
+      session,
+      optional: injection.metadata && injection.metadata.optional,
+    });
   };
 }
 

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -211,7 +211,7 @@ export namespace inject {
       {decorator: '@inject.tag', tag: bindingTag},
       metadata,
     );
-    return inject('', {tag: bindingTag}, resolveByTag);
+    return inject('', metadata, resolveByTag);
   };
 
   /**

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -213,6 +213,10 @@ export namespace inject {
     );
     return inject('', {tag: bindingTag}, resolveByTag);
   };
+
+  export const context = function injectContext() {
+    return inject('', {decorator: '@inject.context'}, ctx => ctx);
+  };
 }
 
 function resolveAsGetter(

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -321,3 +321,20 @@ export class ResolutionSession {
     return this.stack.map(i => ResolutionSession.describe(i)).join(' --> ');
   }
 }
+
+/**
+ * Options for binding/dependency resolution
+ */
+export interface ResolutionOptions {
+  /**
+   * A session to track bindings and injections
+   */
+  session?: ResolutionSession;
+
+  /**
+   * A boolean flag to indicate if the dependency is optional. If it's set to
+   * `true` and the binding is not bound in a context, the resolution
+   * will return `undefined` instead of throwing an error.
+   */
+  optional?: boolean;
+}

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -228,11 +228,11 @@ export class ResolutionSession {
       debugSession('Enter binding:', binding.toJSON());
     }
     if (this.stack.find(i => i.type === 'binding' && i.value === binding)) {
-      throw new Error(
-        `Circular dependency detected on path '${this.getBindingPath()} --> ${
-          binding.key
-        }'`,
-      );
+      const msg =
+        `Circular dependency detected: ` +
+        `${this.getResolutionPath()} --> ${binding.key}`;
+      debugSession(msg);
+      throw new Error(msg);
     }
     this.stack.push({type: 'binding', value: binding});
     /* istanbul ignore if */

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -7,6 +7,7 @@ import {DecoratorFactory} from '@loopback/metadata';
 import {Context} from './context';
 import {
   BoundValue,
+  Constructor,
   ValueOrPromise,
   MapObject,
   isPromise,
@@ -26,13 +27,6 @@ import * as debugModule from 'debug';
 
 const debug = debugModule('loopback:context:resolver');
 const getTargetName = DecoratorFactory.getTargetName;
-
-/**
- * A class constructor accepting arbitrary arguments.
- */
-export type Constructor<T> =
-  // tslint:disable-next-line:no-any
-  new (...args: any[]) => T;
 
 /**
  * Create an instance of a class which constructor has arguments

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -134,6 +134,13 @@ function resolve<T>(
         return injection.resolve(ctx, injection, s);
       } else {
         // Default to resolve the value from the context by binding key
+        if (injection.metadata && injection.metadata.optional) {
+          // If the `optional` flag is set for the injection, the resolution
+          // will return `undefined` instead of throwing an error
+          if (!ctx.isBound(injection.bindingKey)) {
+            return undefined;
+          }
+        }
         return ctx.getValueOrPromise(injection.bindingKey, s);
       }
     },

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -128,14 +128,12 @@ function resolve<T>(
         return injection.resolve(ctx, injection, s);
       } else {
         // Default to resolve the value from the context by binding key
-        if (injection.metadata && injection.metadata.optional) {
+        return ctx.getValueOrPromise(injection.bindingKey, {
+          session: s,
           // If the `optional` flag is set for the injection, the resolution
           // will return `undefined` instead of throwing an error
-          if (!ctx.isBound(injection.bindingKey)) {
-            return undefined;
-          }
-        }
-        return ctx.getValueOrPromise(injection.bindingKey, s);
+          optional: injection.metadata && injection.metadata.optional,
+        });
       }
     },
     injection,

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -83,7 +83,11 @@ export function resolveMap<T, V>(
   let asyncResolvers: PromiseLike<void>[] | undefined = undefined;
 
   const setter = (key: string) => (val: V) => {
-    result[key] = val;
+    if (val !== undefined) {
+      // Only set the value if it's not undefined so that the default value
+      // for a key will be honored
+      result[key] = val;
+    }
   };
 
   for (const key in map) {
@@ -92,7 +96,11 @@ export function resolveMap<T, V>(
       if (!asyncResolvers) asyncResolvers = [];
       asyncResolvers.push(valueOrPromise.then(setter(key)));
     } else {
-      result[key] = valueOrPromise;
+      if (valueOrPromise !== undefined) {
+        // Only set the value if it's not undefined so that the default value
+        // for a key will be honored
+        result[key] = valueOrPromise;
+      }
     }
   }
 

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -8,6 +8,13 @@
  * utility methods to handle values and/or promises.
  */
 
+/**
+ * A class constructor accepting arbitrary arguments.
+ */
+export type Constructor<T> =
+  // tslint:disable-next-line:no-any
+  new (...args: any[]) => T;
+
 // tslint:disable-next-line:no-any
 export type BoundValue = any;
 

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -185,6 +185,15 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(resolved.config).to.equal('test-config');
   });
 
+  it('injects context with @inject.context', () => {
+    class Store {
+      constructor(@inject.context() public context: Context) {}
+    }
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.context).to.be.exactly(ctx);
+  });
+
   it('injects values by tag', () => {
     class Store {
       constructor(@inject.tag('store:location') public locations: string[]) {}

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -21,11 +21,17 @@ class TestContext extends Context {
 }
 
 describe('Context constructor', () => {
-  it('generates a unique name', () => {
+  it('generates uuid name if not provided', () => {
     const ctx = new Context();
     expect(ctx.name).to.match(
       /^[0-9A-F]{8}-[0-9A-F]{4}-[1][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
     );
+  });
+
+  it('generates unique names for different instances', () => {
+    const ctx1 = new Context();
+    const ctx2 = new Context();
+    expect(ctx1.name).to.not.eql(ctx2.name);
   });
 
   it('accepts a name', () => {
@@ -210,8 +216,12 @@ describe('Context', () => {
       expect(actual).to.equal(expected);
     });
 
-    it('reports an error when binding was not found', () => {
+    it('reports an error when binding is not found', () => {
       expect(() => ctx.getBinding('unknown-key')).to.throw(/unknown-key/);
+    });
+
+    it('returns undefined if an optional binding is not found', () => {
+      expect(ctx.getBinding('unknown-key', {optional: true})).to.be.undefined();
     });
 
     it('rejects a key containing property separator', () => {
@@ -227,6 +237,10 @@ describe('Context', () => {
       ctx.bind('foo').to('bar');
       const result = ctx.getSync('foo');
       expect(result).to.equal('bar');
+    });
+
+    it('returns undefined if an optional binding is not found', () => {
+      expect(ctx.getSync('unknown-key', {optional: true})).to.be.undefined();
     });
 
     it('returns the value with property separator', () => {
@@ -332,6 +346,10 @@ describe('Context', () => {
       expect(result).to.equal('bar');
     });
 
+    it('returns undefined if an optional binding is not found', async () => {
+      expect(await ctx.get('unknown-key', {optional: true})).to.be.undefined();
+    });
+
     it('returns the value with property separator', async () => {
       const SEP = Binding.PROPERTY_SEPARATOR;
       const val = {x: {y: 'Y'}};
@@ -408,6 +426,12 @@ describe('Context', () => {
       ctx.bind('key').to('value');
       const valueOrPromise = ctx.getValueOrPromise('key');
       expect(valueOrPromise).to.equal('value');
+    });
+
+    it('returns undefined if an optional binding is not found', () => {
+      expect(
+        ctx.getValueOrPromise('unknown-key', {optional: true}),
+      ).to.be.undefined();
     });
 
     it('returns promise for async values', async () => {

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -212,7 +212,7 @@ describe('Context', () => {
   describe('getBinding', () => {
     it('returns the binding object registered under the given key', () => {
       const expected = ctx.bind('foo');
-      const actual = ctx.getBinding('foo');
+      const actual: Binding = ctx.getBinding('foo');
       expect(actual).to.equal(expected);
     });
 
@@ -221,7 +221,8 @@ describe('Context', () => {
     });
 
     it('returns undefined if an optional binding is not found', () => {
-      expect(ctx.getBinding('unknown-key', {optional: true})).to.be.undefined();
+      const actual = ctx.getBinding('unknown-key', {optional: true});
+      expect(actual).to.be.undefined();
     });
 
     it('rejects a key containing property separator', () => {

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -6,6 +6,47 @@
 import {expect} from '@loopback/testlab';
 import {Context, Binding, BindingScope, BindingType, isPromise} from '../..';
 
+/**
+ * Create a subclass of context so that we can access parents and registry
+ * for assertions
+ */
+class TestContext extends Context {
+  get parent() {
+    return this._parent;
+  }
+  get bindingMap() {
+    const map = new Map(this.registry);
+    return map;
+  }
+}
+
+describe('Context constructor', () => {
+  it('generates a unique name', () => {
+    const ctx = new Context();
+    expect(ctx.name).to.match(
+      /^[0-9A-F]{8}-[0-9A-F]{4}-[1][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+    );
+  });
+
+  it('accepts a name', () => {
+    const ctx = new Context('my-context');
+    expect(ctx.name).to.eql('my-context');
+  });
+
+  it('accepts a parent context', () => {
+    const c1 = new Context('c1');
+    const ctx = new TestContext(c1);
+    expect(ctx.parent).to.eql(c1);
+  });
+
+  it('accepts a parent context and a name', () => {
+    const c1 = new Context('c1');
+    const ctx = new TestContext(c1, 'c2');
+    expect(ctx.name).to.eql('c2');
+    expect(ctx.parent).to.eql(c1);
+  });
+});
+
 describe('Context', () => {
   let ctx: Context;
   beforeEach('given a context', createContext);

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -116,6 +116,39 @@ describe('Context', () => {
     });
   });
 
+  describe('unbind', () => {
+    it('removes a binding', () => {
+      ctx.bind('foo');
+      const result = ctx.unbind('foo');
+      expect(result).to.be.true();
+      expect(ctx.contains('foo')).to.be.false();
+    });
+
+    it('returns false if the binding key does not exist', () => {
+      ctx.bind('foo');
+      const result = ctx.unbind('bar');
+      expect(result).to.be.false();
+    });
+
+    it('cannot unbind a locked binding', () => {
+      ctx
+        .bind('foo')
+        .to('a')
+        .lock();
+      expect(() => ctx.unbind('foo')).to.throw(
+        `Cannot unbind key "foo" of a locked binding`,
+      );
+    });
+
+    it('does not remove a binding from parent contexts', () => {
+      ctx.bind('foo');
+      const childCtx = new Context(ctx);
+      const result = childCtx.unbind('foo');
+      expect(result).to.be.false();
+      expect(ctx.contains('foo')).to.be.true();
+    });
+  });
+
   describe('find', () => {
     it('returns matching binding', () => {
       const b1 = ctx.bind('foo');

--- a/packages/context/test/unit/resolution-session.ts
+++ b/packages/context/test/unit/resolution-session.ts
@@ -1,0 +1,276 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {ResolutionSession, Binding, Injection, inject} from '../..';
+
+describe('ResolutionSession', () => {
+  class MyController {
+    constructor(@inject('b') private b: string) {}
+  }
+  function givenInjection(): Injection {
+    return {
+      target: MyController,
+      bindingKey: 'b',
+      methodDescriptorOrParameterIndex: 0,
+    };
+  }
+
+  let session: ResolutionSession;
+
+  beforeEach(() => (session = new ResolutionSession()));
+
+  it('tracks bindings', () => {
+    const binding = new Binding('a');
+    session.pushBinding(binding);
+    expect(session.currentBinding).to.be.exactly(binding);
+    expect(session.bindingStack).to.eql([binding]);
+    expect(session.popBinding()).to.be.exactly(binding);
+  });
+
+  it('tracks injections', () => {
+    const injection: Injection = givenInjection();
+    session.pushInjection(injection);
+    expect(session.currentInjection).to.be.exactly(injection);
+    expect(session.injectionStack).to.eql([injection]);
+    expect(session.popInjection()).to.be.exactly(injection);
+  });
+
+  it('popBinding() reports error if the top element is not a binding', () => {
+    const injection: Injection = givenInjection();
+    session.pushInjection(injection);
+    expect(session.currentBinding).to.be.undefined();
+    expect(() => session.popBinding()).to.throw(
+      /The top element must be a binding/,
+    );
+  });
+
+  it('popInjection() reports error if the top element is not an injection', () => {
+    const binding = new Binding('a');
+    session.pushBinding(binding);
+    expect(session.currentInjection).to.be.undefined();
+    expect(() => session.popInjection()).to.throw(
+      /The top element must be an injection/,
+    );
+  });
+
+  it('tracks mixed bindings and injections', () => {
+    const bindingA = new Binding('a');
+    session.pushBinding(bindingA);
+    const injection: Injection = givenInjection();
+    session.pushInjection(injection);
+    const bindingB = new Binding('b');
+    session.pushBinding(bindingB);
+
+    expect(session.currentBinding).to.be.exactly(bindingB);
+    expect(session.bindingStack).to.eql([bindingA, bindingB]);
+
+    expect(session.currentInjection).to.be.exactly(injection);
+    expect(session.injectionStack).to.eql([injection]);
+    expect(session.getBindingPath()).to.eql('a --> b');
+    expect(session.getInjectionPath()).to.eql('MyController.constructor[0]');
+    expect(session.getResolutionPath()).to.eql(
+      'a --> @MyController.constructor[0] --> b',
+    );
+
+    expect(session.popBinding()).to.be.exactly(bindingB);
+    expect(session.popInjection()).to.be.exactly(injection);
+    expect(session.popBinding()).to.be.exactly(bindingA);
+  });
+
+  describe('fork()', () => {
+    it('returns undefined if the current session does not exist', () => {
+      expect(ResolutionSession.fork(undefined)).to.be.undefined();
+    });
+
+    it('creates a new session with the same state as the current one', () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      session1.pushInjection(injection);
+      const bindingB = new Binding('b');
+      session1.pushBinding(bindingB);
+      const session2: ResolutionSession = ResolutionSession.fork(session1)!;
+      expect(session1).not.to.be.exactly(session2);
+      expect(session1.stack).not.to.be.exactly(session2.stack);
+      expect(session1.stack).to.be.eql(session2.stack);
+      const bindingC = new Binding('c');
+      session2.pushBinding(bindingC);
+      expect(session2.currentBinding).to.be.exactly(bindingC);
+      expect(session1.currentBinding).to.be.exactly(bindingB);
+    });
+  });
+
+  describe('runWithBinding()', () => {
+    it('allows current session to be undefined', () => {
+      const bindingA = new Binding('a');
+      const val = ResolutionSession.runWithBinding(() => 'ok', bindingA);
+      expect(val).to.eql('ok');
+    });
+
+    it('allows a promise to be returned', async () => {
+      const bindingA = new Binding('a');
+      const val = await ResolutionSession.runWithBinding(
+        () => Promise.resolve('ok'),
+        bindingA,
+      );
+      expect(val).to.eql('ok');
+    });
+
+    it('pushes/pops the binding atomically for a sync action', () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      session1.pushInjection(injection);
+      const bindingB = new Binding('b');
+      const val = ResolutionSession.runWithBinding(
+        () => 'ok',
+        bindingB,
+        session1,
+      );
+      expect(val).to.eql('ok');
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([injection]);
+    });
+
+    it('pushes/pops the binding atomically for a failed sync action', () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      session1.pushInjection(injection);
+      const bindingB = new Binding('b');
+      expect(() => {
+        ResolutionSession.runWithBinding(
+          () => {
+            throw new Error('bad');
+          },
+          bindingB,
+          session1,
+        );
+      }).to.throw('bad');
+
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([injection]);
+    });
+
+    it('pushes/pops the binding atomically for an async action', async () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      session1.pushInjection(injection);
+      const bindingB = new Binding('b');
+      const val = await ResolutionSession.runWithBinding(
+        () => Promise.resolve('ok'),
+        bindingB,
+        session1,
+      );
+      expect(val).to.eql('ok');
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([injection]);
+    });
+
+    it('pushes/pops the binding atomically for a failed action', async () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      session1.pushInjection(injection);
+      const bindingB = new Binding('b');
+      const val = ResolutionSession.runWithBinding(
+        () => Promise.reject(new Error('bad')),
+        bindingB,
+        session1,
+      );
+      await expect(val).to.rejectedWith('bad');
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([injection]);
+    });
+  });
+
+  describe('runWithInjection()', () => {
+    it('allows current session to be undefined', () => {
+      const injection = givenInjection();
+      const val = ResolutionSession.runWithInjection(() => 'ok', injection);
+      expect(val).to.eql('ok');
+    });
+
+    it('allows a promise to be returned', async () => {
+      const injection = givenInjection();
+      const val = await ResolutionSession.runWithInjection(
+        () => Promise.resolve('ok'),
+        injection,
+      );
+      expect(val).to.eql('ok');
+    });
+
+    it('pushes/pops the injection atomically for a sync action', () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      const val = ResolutionSession.runWithInjection(
+        () => 'ok',
+        injection,
+        session1,
+      );
+      expect(val).to.eql('ok');
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([]);
+    });
+
+    it('pushes/pops the injection atomically for a failed sync action', () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      expect(() => {
+        ResolutionSession.runWithInjection(
+          () => {
+            throw new Error('bad');
+          },
+          injection,
+          session1,
+        );
+      }).to.throw('bad');
+
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([]);
+    });
+
+    it('pushes/pops the injection atomically for an async action', async () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      const val = await ResolutionSession.runWithInjection(
+        () => Promise.resolve('ok'),
+        injection,
+        session1,
+      );
+      expect(val).to.eql('ok');
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([]);
+    });
+
+    it('pushes/pops the injection atomically for a failed async action', async () => {
+      const session1 = new ResolutionSession();
+      const bindingA = new Binding('a');
+      session1.pushBinding(bindingA);
+      const injection: Injection = givenInjection();
+      const val = ResolutionSession.runWithInjection(
+        () => Promise.reject(new Error('bad')),
+        injection,
+        session1,
+      );
+      await expect(val).to.rejectedWith('bad');
+      expect(session1.bindingStack).to.be.eql([bindingA]);
+      expect(session1.injectionStack).to.be.eql([]);
+    });
+  });
+});

--- a/packages/context/test/unit/resolution-session.ts
+++ b/packages/context/test/unit/resolution-session.ts
@@ -8,6 +8,7 @@ import {ResolutionSession, Binding, Injection, inject} from '../..';
 
 describe('ResolutionSession', () => {
   class MyController {
+    // tslint:disable-next-line:no-unused-variable
     constructor(@inject('b') private b: string) {}
   }
   function givenInjection(): Injection {

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -48,7 +48,7 @@ describe('constructor injection', () => {
   it('allows optional constructor injection', () => {
     class TestClass {
       constructor(
-        @inject('optional-bindng-key', {optional: true})
+        @inject('optional-binding-key', {optional: true})
         public fooBar: string | undefined,
       ) {}
     }

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -45,6 +45,40 @@ describe('constructor injection', () => {
     }).to.throw(/Cannot resolve injected arguments/);
   });
 
+  it('allows optional constructor injection', () => {
+    class TestClass {
+      constructor(
+        @inject('optional-bindng-key', {optional: true})
+        public fooBar: string | undefined,
+      ) {}
+    }
+
+    const test = instantiateClass(TestClass, ctx) as TestClass;
+    expect(test.fooBar).to.be.undefined();
+  });
+
+  it('allows optional constructor injection with default value', () => {
+    class TestClass {
+      constructor(
+        @inject('optional-binding-key', {optional: true})
+        public fooBar: string = 'fooBar',
+      ) {}
+    }
+
+    const test = instantiateClass(TestClass, ctx) as TestClass;
+    expect(test.fooBar).to.be.eql('fooBar');
+  });
+
+  it('allows optional property injection with default value', () => {
+    class TestClass {
+      @inject('optional-binding-key', {optional: true})
+      public fooBar: string = 'fooBar';
+    }
+
+    const test = instantiateClass(TestClass, ctx) as TestClass;
+    expect(test.fooBar).to.be.eql('fooBar');
+  });
+
   it('resolves constructor arguments with custom resolve function', () => {
     class TestClass {
       constructor(
@@ -213,6 +247,7 @@ describe('constructor injection', () => {
     const context = new Context();
     let bindingPath = '';
     let resolutionPath = '';
+    let decorators: string[] = [];
 
     class ZClass {
       @inject(
@@ -222,6 +257,7 @@ describe('constructor injection', () => {
         (c: Context, injection: Injection, session: ResolutionSession) => {
           bindingPath = session.getBindingPath();
           resolutionPath = session.getResolutionPath();
+          decorators = session.injectionStack.map(i => i.metadata!.decorator);
         },
       )
       myProp: string;
@@ -245,6 +281,7 @@ describe('constructor injection', () => {
       'x --> @XClass.constructor[0] --> y --> @YClass.constructor[0]' +
         ' --> z --> @ZClass.prototype.myProp',
     );
+    expect(decorators).to.eql(['@inject', '@inject.getter', '@inject']);
   });
 
   it('tracks path of injections', () => {

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -107,10 +107,12 @@ describe('constructor injection', () => {
     context.bind('x').toClass(XClass);
     context.bind('y').toClass(YClass);
     expect(() => context.getSync('x')).to.throw(
-      "Circular dependency detected on path 'x --> y --> x'",
+      'Circular dependency detected: x --> @XClass.prototype.y ' +
+        '--> y --> @YClass.prototype.x --> x',
     );
     expect(() => context.getSync('y')).to.throw(
-      "Circular dependency detected on path 'y --> x --> y'",
+      'Circular dependency detected: y --> @YClass.prototype.x ' +
+        '--> x --> @XClass.prototype.y --> y',
     );
   });
 
@@ -138,13 +140,16 @@ describe('constructor injection', () => {
     context.bind('y').toClass(YClass);
     context.bind('z').toClass(ZClass);
     expect(() => context.getSync('x')).to.throw(
-      "Circular dependency detected on path 'x --> y --> z --> x'",
+      'Circular dependency detected: x --> @XClass.constructor[0] --> y ' +
+        '--> @YClass.constructor[0] --> z --> @ZClass.constructor[0] --> x',
     );
     expect(() => context.getSync('y')).to.throw(
-      "Circular dependency detected on path 'y --> z --> x --> y'",
+      'Circular dependency detected: y --> @YClass.constructor[0] --> z ' +
+        '--> @ZClass.constructor[0] --> x --> @XClass.constructor[0] --> y',
     );
     expect(() => context.getSync('z')).to.throw(
-      "Circular dependency detected on path 'z --> x --> y --> z'",
+      'Circular dependency detected: z --> @ZClass.constructor[0] --> x ' +
+        '--> @XClass.constructor[0] --> y --> @YClass.constructor[0] --> z',
     );
   });
 

--- a/packages/context/test/unit/value-promise.test.ts
+++ b/packages/context/test/unit/value-promise.test.ts
@@ -146,12 +146,28 @@ describe('resolveMap', () => {
     expect(result).to.eql({a: 'X', b: 'Y'});
   });
 
+  it('does not set a key with value undefined', () => {
+    const source = {a: 'x', b: undefined};
+    const result = resolveMap(source, v => v && v.toUpperCase());
+    expect(result).to.not.have.property('b');
+    expect(result).to.eql({a: 'X'});
+  });
+
   it('resolves an object of promises', async () => {
     const source = {a: 'x', b: 'y'};
     const result = await resolveMap(source, v =>
       Promise.resolve(v.toUpperCase()),
     );
     expect(result).to.eql({a: 'X', b: 'Y'});
+  });
+
+  it('does not set a key with promise resolved to undefined', async () => {
+    const source = {a: 'x', b: undefined};
+    const result = await resolveMap(source, v =>
+      Promise.resolve(v && v.toUpperCase()),
+    );
+    expect(result).to.not.have.property('b');
+    expect(result).to.eql({a: 'X'});
   });
 
   it('resolves an object of promises or values', async () => {


### PR DESCRIPTION
This is a cherry-pick of non-controversial changes from #882.

The PR adds a few improvements to our IoC container as I polish
#872.

- Use full resolution path to report circular deps
- Make binding level cache context aware to better handle various scopes
- Add name to context instances to better identify each of them
- Add @inject.context() to express dependency of the current context
- Add decorator to injection metadata so that we can tell which decorator function is used
- Add optional to injection metadata to control if a binding should fail due to missing key
- Add unit tests for ResolutionSession

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
