### PR TITLE
ci: add osx to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
   - "6"
   - "8"
 
+os:
+  - linux
+  - osx
+
 git:
   depth: 300
 
@@ -24,8 +28,8 @@ jobs:
       before_script: skip
       script: /bin/bash ./bin/lint-commits.sh
       after_success: skip
-      node_js:
-        - "8"
+      os:
+        - linux
 
 branches:
   only:


### PR DESCRIPTION
This PR looks to add osx to our travis build matrix. It gives us more platform coverage, but is also used as a way to fix build issue arising from #948. 


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
