### PR TITLE
feat(testlab): update sourceMappingURL when copying a JS file

### DIFF
--- a/packages/boot/test/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/test/acceptance/controller.booter.acceptance.ts
@@ -33,15 +33,8 @@ describe('controller booter acceptance tests', () => {
   async function getApp() {
     await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
     await sandbox.copyFile(
-      resolve(__dirname, '../fixtures/application.js.map'),
-    );
-    await sandbox.copyFile(
       resolve(__dirname, '../fixtures/multiple.artifact.js'),
       'controllers/multiple.controller.js',
-    );
-    await sandbox.copyFile(
-      resolve(__dirname, '../fixtures/multiple.artifact.js.map'),
-      'controllers/multiple.artifact.js.map',
     );
 
     const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;

--- a/packages/boot/test/integration/controller.booter.integration.ts
+++ b/packages/boot/test/integration/controller.booter.integration.ts
@@ -35,15 +35,8 @@ describe('controller booter integration tests', () => {
   async function getApp() {
     await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
     await sandbox.copyFile(
-      resolve(__dirname, '../fixtures/application.js.map'),
-    );
-    await sandbox.copyFile(
       resolve(__dirname, '../fixtures/multiple.artifact.js'),
       'controllers/multiple.controller.js',
-    );
-    await sandbox.copyFile(
-      resolve(__dirname, '../fixtures/multiple.artifact.js.map'),
-      'controllers/multiple.artifact.js.map',
     );
 
     const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;

--- a/packages/boot/test/integration/repository.booter.integration.ts
+++ b/packages/boot/test/integration/repository.booter.integration.ts
@@ -35,15 +35,8 @@ describe('repository booter integration tests', () => {
   async function getApp() {
     await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
     await sandbox.copyFile(
-      resolve(__dirname, '../fixtures/application.js.map'),
-    );
-    await sandbox.copyFile(
       resolve(__dirname, '../fixtures/multiple.artifact.js'),
       'repositories/multiple.repository.js',
-    );
-    await sandbox.copyFile(
-      resolve(__dirname, '../fixtures/multiple.artifact.js.map'),
-      'repositories/multiple.artifact.js.map',
     );
 
     const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;

--- a/packages/boot/test/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/test/unit/booters/booter-utils.unit.ts
@@ -46,15 +46,8 @@ describe('booter-utils unit tests', () => {
         resolve(__dirname, '../../fixtures/empty.artifact.js'),
       );
       await sandbox.copyFile(
-        resolve(__dirname, '../../fixtures/empty.artifact.js.map'),
-      );
-      await sandbox.copyFile(
         resolve(__dirname, '../../fixtures/multiple.artifact.js'),
         'nested/multiple.artifact.js',
-      );
-      await sandbox.copyFile(
-        resolve(__dirname, '../../fixtures/multiple.artifact.js.map'),
-        'nested/multiple.artifact.js.map',
       );
     }
   });
@@ -71,9 +64,6 @@ describe('booter-utils unit tests', () => {
       await sandbox.copyFile(
         resolve(__dirname, '../../fixtures/multiple.artifact.js'),
       );
-      await sandbox.copyFile(
-        resolve(__dirname, '../../fixtures/multiple.artifact.js.map'),
-      );
       const files = [resolve(SANDBOX_PATH, 'multiple.artifact.js')];
       const NUM_CLASSES = 2; // Number of classes in above file
 
@@ -86,9 +76,6 @@ describe('booter-utils unit tests', () => {
     it('returns an empty array given an empty file', async () => {
       await sandbox.copyFile(
         resolve(__dirname, '../../fixtures/empty.artifact.js'),
-      );
-      await sandbox.copyFile(
-        resolve(__dirname, '../../fixtures/empty.artifact.js.map'),
       );
       const files = [resolve(SANDBOX_PATH, 'empty.artifact.js')];
 

--- a/packages/testlab/test/fixtures/test.ts
+++ b/packages/testlab/test/fixtures/test.ts
@@ -1,0 +1,3 @@
+export function main(): string {
+  return 'Hello world';
+}


### PR DESCRIPTION
When a `.ts` compled `.js` file is copied and required, a warning / error is logged to console because the accompanying `.js.map` file cannot be resolved. This PR updates the sourceMappingURL in the copied file to point to the original `.js.map` file as an absolute path so it can be resolved (only if accompanying `.js.map` file exists).

Based on a review comment here: https://github.com/strongloop/loopback-next/pull/858#discussion_r164777386

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
