### PR TITLE
fix(example-getting-started): use RestApplication

### DIFF
--- a/packages/example-getting-started/package.json
+++ b/packages/example-getting-started/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.30",
     "@loopback/core": "^4.0.0-alpha.32",
+    "@loopback/openapi-spec": "^4.0.0-alpha.24",
     "@loopback/openapi-v2": "^4.0.0-alpha.9",
     "@loopback/repository": "^4.0.0-alpha.28",
     "@loopback/rest": "^4.0.0-alpha.24",

--- a/packages/example-getting-started/src/application.ts
+++ b/packages/example-getting-started/src/application.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, ApplicationConfig} from '@loopback/core';
-import {RestComponent} from '@loopback/rest';
+import {ApplicationConfig} from '@loopback/core';
+import {RestApplication} from '@loopback/rest';
 import {TodoController} from './controllers';
 import {TodoRepository} from './repositories';
 import {db} from './datasources/db.datasource';
@@ -18,7 +18,7 @@ import {
   RepositoryMixin,
 } from '@loopback/repository';
 /* tslint:enable:no-unused-imports */
-export class TodoApplication extends RepositoryMixin(Application) {
+export class TodoApplication extends RepositoryMixin(RestApplication) {
   constructor(options?: ApplicationConfig) {
     // TODO(bajtos) The comment below does not make sense to me.
     // Consumers of TodoApplication object should not be changing the shape
@@ -27,14 +27,6 @@ export class TodoApplication extends RepositoryMixin(Application) {
     // which database to connect to, etc.
     // See https://github.com/strongloop/loopback-next/issues/742
 
-    // Allow options to replace the defined components array, if desired.
-    options = Object.assign(
-      {},
-      {
-        components: [RestComponent],
-      },
-      options,
-    );
     super(options);
     this.setupRepositories();
     this.setupControllers();


### PR DESCRIPTION
- `application.ts` now extends `RestApplication` instead of `Application`
- also added missing imports (`@loopback/openapi-spec` for `todo.model.ts`)
- connected to #846 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
