### PR TITLE
fix(repository-json-schema): fix $ref typo

### DIFF
--- a/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param.test.ts
+++ b/packages/openapi-v2/test/unit/controller-spec/controller-decorators/param-decorators/param.test.ts
@@ -325,7 +325,7 @@ describe('Routing metadata for parameters', () => {
             type: 'string',
           },
           foo: {
-            $ref: '#definitions/Foo',
+            $ref: '#/definitions/Foo',
           },
         },
       });

--- a/packages/repository-json-schema/README.md
+++ b/packages/repository-json-schema/README.md
@@ -30,6 +30,7 @@ The value of `jsonSchema` will be:
 
 ```json
 {
+  "title": "MyModel",
   "properties": {
     "name": {
       "type": "string"

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -101,7 +101,7 @@ export function metaToJsonProperty(meta: PropertyDefinition): JsonDefinition {
   }
 
   const propDef = isComplexType(ctor)
-    ? {$ref: `#definitions/${ctor.name}`}
+    ? {$ref: `#/definitions/${ctor.name}`}
     : {type: ctor.name.toLowerCase()};
 
   if (meta.array) {

--- a/packages/repository-json-schema/test/integration/build-schema.test.ts
+++ b/packages/repository-json-schema/test/integration/build-schema.test.ts
@@ -139,7 +139,7 @@ describe('build-schema', () => {
           const jsonSchema = modelToJsonSchema(TestModel);
           expect(jsonSchema.properties).to.deepEqual({
             cusType: {
-              $ref: '#definitions/CustomType',
+              $ref: '#/definitions/CustomType',
             },
           });
           expect(jsonSchema).to.not.have.key('definitions');
@@ -159,7 +159,7 @@ describe('build-schema', () => {
           const jsonSchema = modelToJsonSchema(TestModel);
           expect(jsonSchema.properties).to.deepEqual({
             cusType: {
-              $ref: '#definitions/CustomType',
+              $ref: '#/definitions/CustomType',
             },
           });
           expect(jsonSchema.definitions).to.deepEqual({
@@ -195,7 +195,7 @@ describe('build-schema', () => {
           const schemaDefs = jsonSchema.definitions;
           expect(schemaProps).to.deepEqual({
             cusBar: {
-              $ref: '#definitions/CustomTypeBar',
+              $ref: '#/definitions/CustomTypeBar',
             },
           });
           expect(schemaDefs).to.deepEqual({
@@ -213,7 +213,7 @@ describe('build-schema', () => {
                 prop: {
                   type: 'array',
                   items: {
-                    $ref: '#definitions/CustomTypeFoo',
+                    $ref: '#/definitions/CustomTypeFoo',
                   },
                 },
               },
@@ -254,7 +254,7 @@ describe('build-schema', () => {
           cusArr: {
             type: 'array',
             items: {
-              $ref: '#definitions/CustomType',
+              $ref: '#/definitions/CustomType',
             },
           },
         });

--- a/packages/repository-json-schema/test/unit/build-schema.test.ts
+++ b/packages/repository-json-schema/test/unit/build-schema.test.ts
@@ -63,7 +63,7 @@ describe('build-schema', () => {
     it('converts complex types', () => {
       class CustomType {}
       expect(metaToJsonProperty({type: CustomType})).to.eql({
-        $ref: '#definitions/CustomType',
+        $ref: '#/definitions/CustomType',
       });
     });
 
@@ -78,7 +78,7 @@ describe('build-schema', () => {
       class CustomType {}
       expect(metaToJsonProperty({array: true, type: CustomType})).to.eql({
         type: 'array',
-        items: {$ref: '#definitions/CustomType'},
+        items: {$ref: '#/definitions/CustomType'},
       });
     });
   });


### PR DESCRIPTION
- previously, `$ref` key in JSON Schemas would be missing `/` between `#` and `definitions`. This PR fixes this

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
