### PR TITLE
fix(build): use `tslint.build.json` as the base

### DIFF
--- a/packages/cli/generators/project/templates/tslint.json
+++ b/packages/cli/generators/project/templates/tslint.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 <% if (project.loopbackBuild) { -%>
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
 <% } else { -%>
   // See https://palantir.github.io/tslint/rules/
   "rules": {

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -6,7 +6,7 @@
 import {Context} from './context';
 import {ResolutionSession} from './resolution-session';
 import {Constructor, instantiateClass} from './resolver';
-import {isPromise, BoundValue, ValueOrPromise} from './value-promise';
+import {isPromise, BoundValue} from './value-promise';
 import {Provider} from './provider';
 
 import * as debugModule from 'debug';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -10,12 +10,7 @@ import {
   PropertyDecoratorFactory,
   MetadataMap,
 } from '@loopback/metadata';
-import {
-  BoundValue,
-  ValueOrPromise,
-  isPromise,
-  resolveList,
-} from './value-promise';
+import {BoundValue, ValueOrPromise, resolveList} from './value-promise';
 import {Context} from './context';
 import {ResolutionSession} from './resolution-session';
 

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -5,12 +5,7 @@
 
 import {Binding} from './binding';
 import {Injection} from './inject';
-import {
-  isPromise,
-  ValueOrPromise,
-  BoundValue,
-  tryWithFinally,
-} from './value-promise';
+import {ValueOrPromise, BoundValue, tryWithFinally} from './value-promise';
 import * as debugModule from 'debug';
 import {DecoratorFactory} from '@loopback/metadata';
 

--- a/packages/context/test/unit/value-promise.test.ts
+++ b/packages/context/test/unit/value-promise.test.ts
@@ -4,14 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {
-  BoundValue,
-  ValueOrPromise,
-  resolveList,
-  resolveMap,
-  tryWithFinally,
-  getDeepProperty,
-} from '../..';
+import {resolveList, resolveMap, tryWithFinally, getDeepProperty} from '../..';
 
 describe('tryWithFinally', () => {
   it('performs final action for a fulfilled promise', async () => {

--- a/packages/example-getting-started/src/application.ts
+++ b/packages/example-getting-started/src/application.ts
@@ -8,7 +8,7 @@ import {RestApplication} from '@loopback/rest';
 import {TodoController} from './controllers';
 import {TodoRepository} from './repositories';
 import {db} from './datasources/db.datasource';
-/* tslint:disable:no-unused-imports */
+/* tslint:disable:no-unused-variable */
 // Class and Repository imports required to infer types in consuming code!
 // Do not remove them!
 import {
@@ -17,7 +17,7 @@ import {
   DataSourceConstructor,
   RepositoryMixin,
 } from '@loopback/repository';
-/* tslint:enable:no-unused-imports */
+/* tslint:enable:no-unused-variable */
 export class TodoApplication extends RepositoryMixin(RestApplication) {
   constructor(options?: ApplicationConfig) {
     // TODO(bajtos) The comment below does not make sense to me.

--- a/packages/example-getting-started/src/datasources/db.datasource.ts
+++ b/packages/example-getting-started/src/datasources/db.datasource.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 // The juggler reference must exist for consuming code to correctly infer
 // type info used in the "db" export (contained in DataSourceConstructor).
-/* tslint:disable-next-line:no-unused-imports */
+// tslint:disable-next-line:no-unused-variable
 import {juggler, DataSourceConstructor} from '@loopback/repository';
 
 const dsConfigPath = path.resolve(

--- a/packages/example-hello-world/src/application.ts
+++ b/packages/example-hello-world/src/application.ts
@@ -3,7 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+// tslint:disable-next-line:no-unused-variable
 import {Application} from '@loopback/core';
+
 import {RestApplication, RestServer} from '@loopback/rest';
 
 export class HelloWorldApplication extends RestApplication {

--- a/packages/openapi-v2/src/controller-spec.ts
+++ b/packages/openapi-v2/src/controller-spec.ts
@@ -22,7 +22,6 @@ import {
   ItemType,
   ItemsObject,
   DefinitionsObject,
-  MapObject,
 } from '@loopback/openapi-spec';
 
 import * as stream from 'stream';

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -145,7 +145,6 @@ export function modelToJsonSchema(ctor: Function): JsonDefinition {
     result.properties = result.properties || {};
     result.properties[p] = result.properties[p] || {};
 
-    const property = result.properties[p];
     const metaProperty = meta.properties[p];
     const metaType = metaProperty.type;
 

--- a/packages/testlab/src/test-sandbox.ts
+++ b/packages/testlab/src/test-sandbox.ts
@@ -3,10 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {tmpdir} from 'os';
-import {createHash} from 'crypto';
-import {resolve, join, parse} from 'path';
-import * as util from 'util';
+import {resolve, parse} from 'path';
 import {copy, ensureDirSync, emptyDir, remove, ensureDir} from 'fs-extra';
 
 /**

--- a/packages/testlab/test/integration/test-sandbox.integration.ts
+++ b/packages/testlab/test/integration/test-sandbox.integration.ts
@@ -5,8 +5,6 @@
 
 import {TestSandbox, expect} from '../..';
 import {resolve} from 'path';
-import {createHash} from 'crypto';
-import * as util from 'util';
 import {remove, pathExists, readFile} from 'fs-extra';
 
 describe('TestSandbox integration tests', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./packages/build/config/tslint.common.json"],
+  "extends": ["./packages/build/config/tslint.build.json"],
   "linterOptions": {
-    "exclude": ["./packages/cli/generators/*/templates/**/*"]
+    "exclude": [
+      "./packages/cli/generators/*/templates/**/*",
+      "./packages/cli/test/sandbox/**/*"
+    ]
   }
 }


### PR DESCRIPTION
This fixes a regression from https://github.com/strongloop/loopback-next/commit/15dd2dbd962882a63edb2227b2688dbdc961be80

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
