### PR TITLE
feat(repository): add datasource method on repository mixin

### DIFF
--- a/packages/example-getting-started/config/datasources.json
+++ b/packages/example-getting-started/config/datasources.json
@@ -1,5 +1,5 @@
 {
-  "name": "ds",
+  "name": "db",
   "connector": "memory",
   "file": "./data/db.json"
 }

--- a/packages/example-getting-started/src/application.ts
+++ b/packages/example-getting-started/src/application.ts
@@ -18,6 +18,7 @@ import {
   Repository,
   DataSourceConstructor,
   RepositoryMixin,
+  juggler,
 } from '@loopback/repository';
 /* tslint:enable:no-unused-variable */
 
@@ -38,10 +39,7 @@ export class TodoApplication extends BootMixin(
       this.options && this.options.datasource
         ? new DataSourceConstructor(this.options.datasource)
         : db;
-    // TODO(bajtos) use app.dataSource() from @loopback/repository mixin
-    // (app.dataSource() is not implemented there yet)
-    // See https://github.com/strongloop/loopback-next/issues/743
-    this.bind('datasource').to(datasource);
+    this.dataSource(datasource);
     this.repository(TodoRepository);
   }
 }

--- a/packages/example-getting-started/src/repositories/todo.repository.ts
+++ b/packages/example-getting-started/src/repositories/todo.repository.ts
@@ -11,7 +11,7 @@ export class TodoRepository extends DefaultCrudRepository<
   Todo,
   typeof Todo.prototype.id
 > {
-  constructor(@inject('datasource') protected datasource: DataSourceType) {
+  constructor(@inject('datasources.db') protected datasource: DataSourceType) {
     super(Todo, datasource);
   }
 }

--- a/packages/example-getting-started/test/acceptance/application.test.ts
+++ b/packages/example-getting-started/test/acceptance/application.test.ts
@@ -105,6 +105,7 @@ describe('Application', () => {
         port: 0,
       },
       datasource: {
+        name: 'db',
         connector: 'memory',
       },
     });

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@loopback/context": "^0.1.1",
-    "loopback-datasource-juggler": "^3.9.2"
+    "loopback-datasource-juggler": "^3.15.2"
   },
   "files": [
     "README.md",

--- a/packages/repository/src/repository-mixin.ts
+++ b/packages/repository/src/repository-mixin.ts
@@ -5,6 +5,7 @@
 
 import {Class} from './common-types';
 import {Repository} from './repository';
+import {juggler} from './loopback-datasource-juggler';
 
 // tslint:disable:no-any
 
@@ -55,6 +56,32 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
     repository(repo: Class<Repository<any>>) {
       const repoKey = `repositories.${repo.name}`;
       this.bind(repoKey).toClass(repo);
+    }
+
+    /**
+     * Add the dataSource to this application.
+     *
+     * @param dataSource The dataSource to add.
+     * @param name The binding name of the datasource; defaults to dataSource.name
+     *
+     * ```ts
+     *
+     * const ds: juggler.DataSource = new DataSourceConstructor({
+     *   name: 'db',
+     *   connector: 'memory',
+     * });
+     *
+     * app.dataSource(ds);
+     *
+     * // The datasource can be injected with
+     * constructor(@inject('datasources.db') protected datasource: DataSourceType) {
+     *
+     * }
+     * ```
+     */
+    dataSource(dataSource: juggler.DataSource, name?: string) {
+      const dataSourceKey = `datasources.${name || dataSource.name}`;
+      this.bind(dataSourceKey).to(dataSource);
     }
 
     /**

--- a/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
+++ b/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
@@ -111,3 +111,48 @@ describe('RepositoryMixin', () => {
     expect(componentInstance).to.be.instanceOf(component);
   }
 });
+
+describe('RepositoryMixin dataSource', () => {
+  it('mixes into the target class', () => {
+    const myApp = new AppWithRepoMixin();
+    expect(typeof myApp.dataSource).to.be.eql('function');
+  });
+
+  it('does not conflict with previous binding keys', () => {
+    const myApp = new AppWithRepoMixin();
+    const withoutDataSource = myApp.find('datasources.*');
+    expect(withoutDataSource).to.be.empty();
+  });
+
+  it('binds dataSource to a binding key using the dataSource name property', () => {
+    const myApp = new AppWithRepoMixin();
+    const fooDataSource: juggler.DataSource = new DataSourceConstructor({
+      name: 'foo',
+      connector: 'memory',
+    });
+    myApp.dataSource(fooDataSource);
+    expectDataSourceToBeBound(myApp, fooDataSource, 'foo');
+  });
+
+  it('binds dataSource to a binding key using the given name', () => {
+    const myApp = new AppWithRepoMixin();
+    const barDataSource: juggler.DataSource = new DataSourceConstructor({
+      connector: 'memory',
+    });
+    myApp.dataSource(barDataSource, 'bar');
+    expectDataSourceToBeBound(myApp, barDataSource, 'bar');
+  });
+
+  const expectDataSourceToBeBound = (
+    app: AppWithRepoMixin,
+    ds: juggler.DataSource,
+    name: string,
+  ) => {
+    expect(app.find('datasources.*').map(d => d.key)).to.containEql(
+      `datasources.${name}`,
+    );
+    expect(app.getSync(`datasources.${name}`)).to.be.eql(ds);
+  };
+
+  class AppWithRepoMixin extends RepositoryMixin(Application) {}
+});


### PR DESCRIPTION
The PR adds a new dataSource api to `RepositoryMixin` as described in https://github.com/strongloop/loopback-next/issues/743

### Check List
- [x] Add code to allow bindings
- [x] Write tests
- [x] Update examples accordingly (only `example-getting-started`)
- [x] Update TSDocs
