### PR TITLE
fix(example-getting-started): remove juggler warning

### DIFF
--- a/packages/example-getting-started/src/controllers/todo.controller.ts
+++ b/packages/example-getting-started/src/controllers/todo.controller.ts
@@ -43,6 +43,12 @@ export class TodoController {
     @param.body('todo', TodoSchema)
     todo: Todo,
   ): Promise<boolean> {
+    // REST adapter does not coerce parameter values coming from string sources
+    // like path & query. As a workaround, we have to cast the value to a number
+    // ourselves.
+    // See https://github.com/strongloop/loopback-next/issues/750
+    id = +id;
+
     return await this.todoRepo.replaceById(id, todo);
   }
 
@@ -52,6 +58,12 @@ export class TodoController {
     @param.body('todo', TodoSchema)
     todo: Todo,
   ): Promise<boolean> {
+    // REST adapter does not coerce parameter values coming from string sources
+    // like path & query. As a workaround, we have to cast the value to a number
+    // ourselves.
+    // See https://github.com/strongloop/loopback-next/issues/750
+    id = +id;
+
     return await this.todoRepo.updateById(id, todo);
   }
 


### PR DESCRIPTION
Explicitly cast path parameter "id" from string to number because the REST transport does not implement parameter coercion yet. See https://github.com/strongloop/loopback-next/issues/750

This change removes the following warnings from `npm test` output:

    WARNING: id property cannot be changed from 3 to 3 for model:Todo
    in 'before save' operation hook

    WARNING: id property cannot be changed from 3 to 3 for model:Todo
    in 'loaded' operation hook

This pull request is an alternative to https://github.com/strongloop/loopback-next/pull/941.
 
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
