### PR TITLE
refactor: simplify app setup via RestApplication (part II)

### DIFF
--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -155,26 +155,27 @@ import {MyAuthStrategyProvider} from './providers/auth-strategy';
 import {MyController} from './controllers/my-controller';
 import {MySequence} from './sequence';
 
-class MyApp extends Application {
+class MyApp extends RestApplication {
   constructor() {
     super({
-      components: [AuthenticationComponent, RestComponent],
+      components: [AuthenticationComponent],
       rest: {
         sequence: MySequence
       },
       controllers: [MyController],
     });
 
+    this
+      .bind(AuthenticationBindings.STRATEGY)
+      .toProvider(MyAuthStrategyProvider);
+
     this.controller(MyController);
   }
 
   async start() {
-    const server = await this.getServer(RestServer);
-
-    server.bind(AuthenticationBindings.STRATEGY)
-    .toProvider(MyAuthStrategyProvider);
     await super.start();
 
+    const server = await this.getServer(RestServer);
     console.log(`REST server running on port: ${server.getSync('rest.port')}`);
   }
 }

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -145,29 +145,25 @@ export class MySequence implements SequenceHandler {
 Finally, put it all together in your application class:
 
 ```ts
-import {Application} from '@loopback/core';
 import {
   AuthenticationComponent,
   AuthenticationBindings,
 } from '@loopback/authentication';
-import {RestComponent, RestServer} from '@loopback/rest';
+import {RestApplication, RestServer} from '@loopback/rest';
 import {MyAuthStrategyProvider} from './providers/auth-strategy';
 import {MyController} from './controllers/my-controller';
 import {MySequence} from './sequence';
 
 class MyApp extends RestApplication {
   constructor() {
-    super({
-      components: [AuthenticationComponent],
-      rest: {
-        sequence: MySequence
-      },
-      controllers: [MyController],
-    });
+    super();
 
+    this.component(AuthenticationComponent);
     this
       .bind(AuthenticationBindings.STRATEGY)
       .toProvider(MyAuthStrategyProvider);
+
+    this.sequence(MySequence);
 
     this.controller(MyController);
   }

--- a/packages/cli/generators/app/templates/src/application.ts
+++ b/packages/cli/generators/app/templates/src/application.ts
@@ -4,32 +4,24 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Application, ApplicationConfig} from '@loopback/core';
-import {RestComponent, RestServer} from '@loopback/rest';
+import {RestApplication, RestServer} from '@loopback/rest';
 import {PingController} from './controllers/ping.controller';
 import {MySequence} from './sequence';
 
-export class <%= project.applicationName %> extends Application {
+export class <%= project.applicationName %> extends RestApplication {
   constructor(options?: ApplicationConfig) {
-    // Allow options to replace the defined components array, if desired.
-    options = Object.assign(
-      {},
-      {
-        components: [RestComponent],
-      },
-      options,
-    );
     super(options);
-    this.server(RestServer);
+    this.sequence(MySequence);
     this.setupControllers();
   }
 
   async start() {
+    await super.start();
+
     const server = await this.getServer(RestServer);
-    server.sequence(MySequence);
     const port = await server.get('rest.port');
     console.log(`Server is running at http://127.0.0.1:${port}`);
     console.log(`Try http://127.0.0.1:${port}/ping`);
-    return await super.start();
   }
 
   setupControllers() {

--- a/packages/cli/generators/app/templates/src/application.ts
+++ b/packages/cli/generators/app/templates/src/application.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, ApplicationConfig} from '@loopback/core';
+import {ApplicationConfig} from '@loopback/core';
 import {RestApplication, RestServer} from '@loopback/rest';
 import {PingController} from './controllers/ping.controller';
 import {MySequence} from './sequence';

--- a/packages/cli/test/app.js
+++ b/packages/cli/test/app.js
@@ -27,11 +27,10 @@ describe('app-generator specfic files', () => {
     assert.file('src/application.ts');
     assert.fileContent(
       'src/application.ts',
-      /class MyAppApplication extends Application/
+      /class MyAppApplication extends RestApplication/
     );
     assert.fileContent('src/application.ts', /constructor\(/);
     assert.fileContent('src/application.ts', /async start\(/);
-    assert.fileContent('src/application.ts', /RestComponent/);
 
     assert.file('src/index.ts');
     assert.fileContent('src/index.ts', /new MyAppApplication/);
@@ -48,7 +47,10 @@ describe('app-generator specfic files', () => {
       /@get\('\/ping'\)/
     );
     assert.fileContent('src/controllers/ping.controller.ts', /ping\(\)/);
-    assert.fileContent('src/controllers/ping.controller.ts', /\'\@loopback\/openapi\-v2\'/);
+    assert.fileContent(
+      'src/controllers/ping.controller.ts',
+      /\'\@loopback\/openapi\-v2\'/
+    );
 
     assert.file;
   });

--- a/packages/example-hello-world/src/application.ts
+++ b/packages/example-hello-world/src/application.ts
@@ -3,9 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// tslint:disable-next-line:no-unused-variable
-import {Application} from '@loopback/core';
-
 import {RestApplication, RestServer} from '@loopback/rest';
 
 export class HelloWorldApplication extends RestApplication {

--- a/packages/example-log-extension/README.md
+++ b/packages/example-log-extension/README.md
@@ -32,10 +32,10 @@ import {
 } from 'loopback4-example-log-extension';
 // Other imports ...
 
-class LogApp extends LogLevelMixin(Application) {
+class LogApp extends LogLevelMixin(RestApplication) {
   constructor() {
     super({
-      components: [RestComponent, LogComponent],
+      components: [LogComponent],
       logLevel: LOG_LEVEL.ERROR,
       controllers: [MyController]
     });

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -27,20 +27,17 @@ Here's a basic "Hello World" application using `@loopback/core` and
 
   ```ts
   import {Application} from '@loopback/core';
-  import {RestComponent, RestServer} from '@loopback/rest';
+  import {RestApplication, RestServer} from '@loopback/rest';
 
-  const app = new Application({
-    components: [
-      RestComponent,
-    ]
+  const app = new RestApplication();
+  app.handler((sequence, request, response) => {
+    sequence.send(response, 'hello world');
   });
 
   (async function start() {
-    const rest = await app.getServer(RestServer);
-    rest.handler((sequence, request, response) => {
-      sequence.send(response, 'hello world');
-    });
     await app.start();
+
+    const rest = await app.getServer(RestServer);
     console.log(`REST server running on port: ${rest.getSync('rest.port')}`);
   })();
   ```

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -26,7 +26,6 @@ Here's a basic "Hello World" application using `@loopback/core` and
 `@loopback/rest`:
 
   ```ts
-  import {Application} from '@loopback/core';
   import {RestApplication, RestServer} from '@loopback/rest';
 
   const app = new RestApplication();

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -26,6 +26,7 @@
     "@loopback/openapi-spec": "^4.0.0-alpha.25",
     "@loopback/openapi-v2": "^4.0.0-alpha.10",
     "@types/http-errors": "^1.6.1",
+    "@types/node": "^8.5.9",
     "body": "^5.1.0",
     "debug": "^3.1.0",
     "http-errors": "^1.6.1",


### PR DESCRIPTION
 - Move any REST-related setup from app.start() back to app constructor.
 - Update the project template to use RestApplication too
 - Update authentication README to use RestApplication

This is a follow-up for #955, a part of #846

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
