### PR TITLE
chore: separate tslint config files for build and vscode

### DIFF
--- a/packages/cli/generators/project/templates/tslint.build.json
+++ b/packages/cli/generators/project/templates/tslint.build.json
@@ -1,17 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./tslint.json"],
-  // This configuration files enabled rules which require type checking
-  // and therefore cannot be run by Visual Studio Code TSLint extension
-  // See https://github.com/Microsoft/vscode-tslint/issues/70
-  "rules": {
-    // These rules find errors related to TypeScript features.
-
-    // These rules catch common errors in JS programming or otherwise
-    // confusing constructs that are prone to producing bugs.
-
-    "await-promise": true,
-    "no-floating-promises": true,
-    "no-void-expression": [true, "ignore-arrow-function-shorthand"]
-  }
+  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
 }

--- a/packages/cli/generators/project/templates/tslint.json
+++ b/packages/cli/generators/project/templates/tslint.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 <% if (project.loopbackBuild) { -%>
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
 <% } else { -%>
   // See https://palantir.github.io/tslint/rules/
   "rules": {

--- a/tslint.build.json
+++ b/tslint.build.json
@@ -1,20 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": [
-    "./tslint.json"
-  ],
-  // This configuration files enabled rules which require type checking
-  // and therefore cannot be run by Visual Studio Code TSLint extension
-  // See https://github.com/Microsoft/vscode-tslint/issues/70
-  "rules": {
-    // These rules find errors related to TypeScript features.
-
-
-    // These rules catch common errors in JS programming or otherwise
-    // confusing constructs that are prone to producing bugs.
-
-    "await-promise": true,
-    "no-floating-promises": true,
-    "no-void-expression": [true, "ignore-arrow-function-shorthand"]
+  "extends": ["./packages/build/config/tslint.build.json"],
+  "linterOptions": {
+    "exclude": [
+      "./packages/cli/generators/*/templates/**/*",
+      "./packages/cli/test/sandbox/**/*"
+    ]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./packages/build/config/tslint.build.json"],
+  "extends": ["./packages/build/config/tslint.common.json"],
   "linterOptions": {
     "exclude": [
       "./packages/cli/generators/*/templates/**/*",


### PR DESCRIPTION
This is a follow-up to https://github.com/strongloop/loopback-next/pull/964/.

Two config files are in place now:
- tslint.build.json for CLI build scripts
- tslint.json for vscode

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
