### PR TITLE
docs(example-getting-started): use openapi-v2 decorators in readme

### DIFF
--- a/packages/example-getting-started/README.md
+++ b/packages/example-getting-started/README.md
@@ -286,7 +286,8 @@ incoming requests.
 
 #### src/controllers/todo.controller.ts
 ```ts
-import {post, param, get, put, patch, del, HttpErrors} from '@loopback/rest';
+import {post, param, get, put, patch, del} from '@loopback/openapi-v2';
+import {HttpErrors} from '@loopback/rest';
 import {TodoSchema, Todo} from '../models';
 import {repository} from '@loopback/repository';
 import {TodoRepository} from '../repositories/index';


### PR DESCRIPTION
connected to #729 

Porting over the same correction contained in https://github.com/strongloop/loopback.io/pull/601