### PR TITLE
feat(context): formalize injection metadata as an interface

### DIFF
--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -21,7 +21,7 @@ export {Binding, BindingScope, BindingType} from './binding';
 
 export {Context} from './context';
 export {ResolutionSession} from './resolution-session';
-export {inject, Setter, Getter, Injection} from './inject';
+export {inject, Setter, Getter, Injection, InjectionMetadata} from './inject';
 export {Provider} from './provider';
 
 export {instantiateClass, invokeMethod} from './resolver';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -29,6 +29,25 @@ export interface ResolverFunction {
 }
 
 /**
+ * An object to provide metadata for `@inject`
+ */
+export interface InjectionMetadata {
+  /**
+   * Name of the decorator function, such as `@inject` or `@inject.setter`.
+   * It's usually set by the decorator implementation.
+   */
+  decorator?: string;
+  /**
+   * Control if the dependency is optional, default to false
+   */
+  optional?: boolean;
+  /**
+   * Other attributes
+   */
+  [attribute: string]: BoundValue;
+}
+
+/**
  * Descriptor for an injection point
  */
 export interface Injection {
@@ -39,7 +58,7 @@ export interface Injection {
     | number;
 
   bindingKey: string; // Binding key
-  metadata?: {[attribute: string]: BoundValue}; // Related metadata
+  metadata?: InjectionMetadata; // Related metadata
   resolve?: ResolverFunction; // A custom resolve function
 }
 
@@ -71,7 +90,7 @@ export interface Injection {
  */
 export function inject(
   bindingKey: string,
-  metadata?: Object,
+  metadata?: InjectionMetadata,
   resolve?: ResolverFunction,
 ) {
   metadata = Object.assign({decorator: '@inject'}, metadata);
@@ -162,7 +181,7 @@ export namespace inject {
    */
   export const getter = function injectGetter(
     bindingKey: string,
-    metadata?: Object,
+    metadata?: InjectionMetadata,
   ) {
     metadata = Object.assign({decorator: '@inject.getter'}, metadata);
     return inject(bindingKey, metadata, resolveAsGetter);
@@ -183,7 +202,7 @@ export namespace inject {
    */
   export const setter = function injectSetter(
     bindingKey: string,
-    metadata?: Object,
+    metadata?: InjectionMetadata,
   ) {
     metadata = Object.assign({decorator: '@inject.setter'}, metadata);
     return inject(bindingKey, metadata, resolveAsSetter);
@@ -205,7 +224,7 @@ export namespace inject {
    */
   export const tag = function injectTag(
     bindingTag: string | RegExp,
-    metadata?: Object,
+    metadata?: InjectionMetadata,
   ) {
     metadata = Object.assign(
       {decorator: '@inject.tag', tag: bindingTag},

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -166,7 +166,8 @@ export class ResolutionSession {
     return {
       targetName: name,
       bindingKey: injection.bindingKey,
-      metadata: injection.metadata,
+      // Cast to Object so that we don't have to expose InjectionMetadata
+      metadata: injection.metadata as Object,
     };
   }
 

--- a/packages/context/test/unit/resolver.test.ts
+++ b/packages/context/test/unit/resolver.test.ts
@@ -247,7 +247,7 @@ describe('constructor injection', () => {
     const context = new Context();
     let bindingPath = '';
     let resolutionPath = '';
-    let decorators: string[] = [];
+    let decorators: (string | undefined)[] = [];
 
     class ZClass {
       @inject(


### PR DESCRIPTION
This PR introduces `InjectionMetadata` interface to provide more type guidance for the metadata parameter of `@inject.*`.


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
