### PR TITLE
Decouple application config from features (e.g. components)

### DIFF
--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -165,6 +165,7 @@ class MyApp extends RestApplication {
 
     this.sequence(MySequence);
 
+    this.components([AuthenticationComponent, RestComponent]);
     this.controller(MyController);
   }
 

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -165,7 +165,6 @@ class MyApp extends RestApplication {
 
     this.sequence(MySequence);
 
-    this.components([AuthenticationComponent, RestComponent]);
     this.controller(MyController);
   }
 

--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -89,9 +89,8 @@ describe('Basic Authentication', () => {
   }
 
   async function givenAServer() {
-    app = new Application({
-      components: [AuthenticationComponent, RestComponent],
-    });
+    app = new Application();
+    app.components([AuthenticationComponent, RestComponent]);
     server = await app.getServer(RestServer);
   }
 

--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -90,7 +90,8 @@ describe('Basic Authentication', () => {
 
   async function givenAServer() {
     app = new Application();
-    app.components([AuthenticationComponent, RestComponent]);
+    app.component(AuthenticationComponent);
+    app.component(RestComponent);
     server = await app.getServer(RestServer);
   }
 

--- a/packages/cli/generators/extension/templates/src/mixins/README.md
+++ b/packages/cli/generators/extension/templates/src/mixins/README.md
@@ -154,7 +154,6 @@ class LoggingComponent implements Component{
   loggers: [ColorLogger];
 }
 
-const app = new LoggingApplication({
-  components: [LoggingComponent] // Logger from MyComponent will be bound to loggers.ColorLogger
-});
+const app = new LoggingApplication();
+app.component(LoggingComponent); // Logger from MyComponent will be bound to loggers.ColorLogger
 ```

--- a/packages/cli/generators/extension/templates/src/providers/README.md
+++ b/packages/cli/generators/extension/templates/src/providers/README.md
@@ -16,18 +16,18 @@ The logger will log the URL, the parsed request parameters, and the result. The 
 
 TimerProvider is automatically bound to your Application's [Context](http://loopback.io/doc/en/lb4/Context.html) using the LogComponent which exports this provider with a binding key of `extension-starter.timer`. You can learn more about components in the [related resources section](#related-resources).
 
-This provider makes availble to your application a timer function which given a start time _(given as an array [seconds, nanoseconds])_ can give you a total time elapsed since the start in milliseconds. The timer can also start timing if no start time is given. This is used by LogComponent to allow a user to time a Sequence. 
+This provider makes availble to your application a timer function which given a start time _(given as an array [seconds, nanoseconds])_ can give you a total time elapsed since the start in milliseconds. The timer can also start timing if no start time is given. This is used by LogComponent to allow a user to time a Sequence.
 
 *NOTE:* _You can get the start time in the required format by using `this.logger.startTimer()`._
 
 You can provide your own implementation of the elapsed time function by binding it to the binding key (accessible via `ExtensionStarterBindings`) as follows:
 ```ts
 app.bind(ExtensionStarterBindings.TIMER).to(timerFn);
-``` 
+```
 
 ### LogProvider
 
-LogProvider can automatically be bound to your Application's Context using the LogComponent which exports the provider with a binding key of `extension-starter.actions.log`. 
+LogProvider can automatically be bound to your Application's Context using the LogComponent which exports the provider with a binding key of `extension-starter.actions.log`.
 
 The key can be accessed by importing `ExtensionStarterBindings` as follows:
 
@@ -38,7 +38,7 @@ import {ExtensionStarterBindings} from 'HelloExtensions';
 const key = ExtensionStarterBindings.LOG_ACTION;
 ```
 
-LogProvider gives us a seuqence action and a `startTimer` function. In order to use the sequence action, you must define your own sequence as shown below. 
+LogProvider gives us a seuqence action and a `startTimer` function. In order to use the sequence action, you must define your own sequence as shown below.
 
 **Example: Sequence**
 ```ts
@@ -85,9 +85,9 @@ Once a sequence has been written, we can just use that in our Application as fol
 **Example: Application**
 ```ts
 const app = new Application({
-  sequence: LogSequence,
-  components: [LogComponent]
+  sequence: LogSequence
 });
+app.component(LogComponent);
 
 // Now all requests handled by our sequence will be logged.
 ```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,7 +46,10 @@ const app = new Application({
     port: 3001,
   },
 });
-app.components([RestComponent, GrpcComponent]);
+app.components([
+  RestComponent, // REST Server
+  GrpcComponent, // GRPC Server
+  ]);
 
 (async function start() {
   // Let's retrieve the bound instances of our servers.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,10 +39,6 @@ import {RestComponent} from '@loopback/rest';
 import {GrpcComponent} from '@loopback/grpc';
 
 const app = new Application({
-  components: [
-    RestComponent, // REST Server
-    GrpcComponent, // GRPC Server
-  ],
   rest: {
     port: 3000,
   },
@@ -50,6 +46,7 @@ const app = new Application({
     port: 3001,
   },
 });
+app.components([RestComponent, GrpcComponent]);
 
 (async function start() {
   // Let's retrieve the bound instances of our servers.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,10 +46,8 @@ const app = new Application({
     port: 3001,
   },
 });
-app.components([
-  RestComponent, // REST Server
-  GrpcComponent, // GRPC Server
-  ]);
+app.component(RestComponent) // REST Server
+app.component(GrpcComponent) // GRPC Server
 
 (async function start() {
   // Let's retrieve the bound instances of our servers.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,9 +21,7 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.31",
-    "lodash": "^4.17.4",
-    "topo": "^3.0.0"
+    "@loopback/context": "^4.0.0-alpha.31"
   },
   "devDependencies": {
     "@loopback/build": "^4.0.0-alpha.13",

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -23,24 +23,6 @@ export class Application extends Context {
     this.bind(CoreBindings.APPLICATION_INSTANCE).to(this);
     // Make options available to other modules as well.
     this.bind(CoreBindings.APPLICATION_CONFIG).to(options);
-
-    if (options.components) {
-      for (const component of options.components) {
-        this.component(component);
-      }
-    }
-
-    if (options.servers) {
-      for (const name in options.servers) {
-        this.server(options.servers[name], name);
-      }
-    }
-
-    if (options.controllers) {
-      for (const ctor of options.controllers) {
-        this.controller(ctor);
-      }
-    }
   }
 
   /**
@@ -64,6 +46,10 @@ export class Application extends Context {
     return this.bind(`controllers.${name}`)
       .toClass(controllerCtor)
       .tag('controller');
+  }
+
+  controllers(ctors: ControllerClass[]): Binding[] {
+    return ctors.map(ctor => this.controller(ctor));
   }
 
   /**
@@ -212,26 +198,16 @@ export class Application extends Context {
     const instance = this.getSync(componentKey);
     mountComponent(this, instance);
   }
+
+  public components(ctors: Constructor<Component>[]) {
+    ctors.map(ctor => this.component(ctor));
+  }
 }
 
 /**
  * Configuration for application
  */
 export interface ApplicationConfig {
-  /**
-   * An array of component classes
-   */
-  components?: Array<Constructor<Component>>;
-  /**
-   * An array of controller classes
-   */
-  controllers?: Array<ControllerClass>;
-  /**
-   * A map of server name/class pairs
-   */
-  servers?: {
-    [name: string]: Constructor<Server>;
-  };
   /**
    * Other properties
    */

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -48,6 +48,26 @@ export class Application extends Context {
       .tag('controller');
   }
 
+  /**
+   * Bind an array of controllers to the Application's master
+   * context.
+   * Each controller added in this way will automatically be named based on
+   * the class constructor name with the "controllers." prefix.
+   *
+   * If you wish to control the binding keys for particular controller
+   * instances, use the app.controller function instead.
+   * ```ts
+   * app.controllers([
+   *  FooController,
+   *  BarController,
+   * ]);
+   * // Creates a binding for "controllers.FooController" and a binding for
+   * // "controllers.BarController";
+   * ```
+   *
+   * @param ctors Array of controller classes.
+   * @returns {Binding[]} An array of bindings for the registered controllers.
+   */
   controllers(ctors: ControllerClass[]): Binding[] {
     return ctors.map(ctor => this.controller(ctor));
   }
@@ -199,6 +219,25 @@ export class Application extends Context {
     mountComponent(this, instance);
   }
 
+  /**
+   * Add multiple components to this application and register their
+   * extensions.
+   *
+   * Each component added in this way will automatically be named based on the
+   * class constructor name with the "components." prefix.
+   *
+   * If you wish to control the binding keys for particular instances,
+   * use the app.component function instead.
+   * ```ts
+   * app.components([
+   *  RestComponent,
+   *  GRPCComponent,
+   * ]);
+   * // Creates a binding for "components.RestComponent" and a binding for
+   * // "components.GRPCComponent";
+   * ```
+   * @param ctors Array of components to add.
+   */
   public components(ctors: Constructor<Component>[]) {
     ctors.map(ctor => this.component(ctor));
   }

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -49,30 +49,6 @@ export class Application extends Context {
   }
 
   /**
-   * Bind an array of controllers to the Application's master
-   * context.
-   * Each controller added in this way will automatically be named based on
-   * the class constructor name with the "controllers." prefix.
-   *
-   * If you wish to control the binding keys for particular controller
-   * instances, use the app.controller function instead.
-   * ```ts
-   * app.controllers([
-   *  FooController,
-   *  BarController,
-   * ]);
-   * // Creates a binding for "controllers.FooController" and a binding for
-   * // "controllers.BarController";
-   * ```
-   *
-   * @param ctors Array of controller classes.
-   * @returns {Binding[]} An array of bindings for the registered controllers.
-   */
-  controllers(ctors: ControllerClass[]): Binding[] {
-    return ctors.map(ctor => this.controller(ctor));
-  }
-
-  /**
    * Bind a Server constructor to the Application's master context.
    * Each server constructor added in this way must provide a unique prefix
    * to prevent binding overlap.
@@ -217,29 +193,6 @@ export class Application extends Context {
     // Assuming components can be synchronously instantiated
     const instance = this.getSync(componentKey);
     mountComponent(this, instance);
-  }
-
-  /**
-   * Add multiple components to this application and register their
-   * extensions.
-   *
-   * Each component added in this way will automatically be named based on the
-   * class constructor name with the "components." prefix.
-   *
-   * If you wish to control the binding keys for particular instances,
-   * use the app.component function instead.
-   * ```ts
-   * app.components([
-   *  RestComponent,
-   *  GRPCComponent,
-   * ]);
-   * // Creates a binding for "components.RestComponent" and a binding for
-   * // "components.GRPCComponent";
-   * ```
-   * @param ctors Array of components to add.
-   */
-  public components(ctors: Constructor<Component>[]) {
-    ctors.map(ctor => this.component(ctor));
   }
 }
 

--- a/packages/core/test/acceptance/application.acceptance.ts
+++ b/packages/core/test/acceptance/application.acceptance.ts
@@ -12,9 +12,8 @@ describe('Bootstrapping the application', () => {
   context('with user-defined components', () => {
     it('binds all user-defined components to the application context', () => {
       class AuditComponent {}
-      const app = new Application({
-        components: [AuditComponent],
-      });
+      const app = new Application();
+      app.component(AuditComponent);
       const componentKeys = app.find('component.*').map(b => b.key);
       expect(componentKeys).to.containEql('components.AuditComponent');
 
@@ -32,27 +31,10 @@ describe('Bootstrapping the application', () => {
       class FooComponent {
         providers = {foo: FooProvider};
       }
-      const app = new Application({
-        components: [FooComponent],
-      });
+      const app = new Application();
+      app.component(FooComponent);
       const value = app.getSync('foo');
       expect(value).to.equal('bar');
-    });
-
-    it('registers controllers from constructor', () => {
-      class ProductController {}
-
-      const app = new Application({
-        controllers: [ProductController],
-      });
-
-      expect(app.find('controllers.*').map(b => b.key)).to.eql([
-        'controllers.ProductController',
-      ]);
-
-      expect(app.findByTag('controller').map(b => b.key)).to.eql([
-        'controllers.ProductController',
-      ]);
     });
 
     it('registers all controllers from components', async () => {
@@ -66,9 +48,8 @@ describe('Bootstrapping the application', () => {
         controllers: ControllerClass[] = [ProductController];
       }
 
-      const app = new Application({
-        components: [ProductComponent],
-      });
+      const app = new Application();
+      app.component(ProductComponent);
 
       expect(app.find('controllers.*').map(b => b.key)).to.eql([
         'controllers.ProductController',
@@ -111,9 +92,8 @@ describe('Bootstrapping the application', () => {
           };
         }
       }
-      const app = new Application({
-        components: [ConfigComponent, GreetingComponent],
-      });
+      const app = new Application();
+      app.components([ConfigComponent, GreetingComponent]);
 
       expect(app.getSync('greeting')).to.equal('Hi!');
     });

--- a/packages/core/test/acceptance/application.acceptance.ts
+++ b/packages/core/test/acceptance/application.acceptance.ts
@@ -93,7 +93,8 @@ describe('Bootstrapping the application', () => {
         }
       }
       const app = new Application();
-      app.components([ConfigComponent, GreetingComponent]);
+      app.component(ConfigComponent);
+      app.component(GreetingComponent);
 
       expect(app.getSync('greeting')).to.equal('Hi!');
     });

--- a/packages/core/test/acceptance/application.feature.md
+++ b/packages/core/test/acceptance/application.feature.md
@@ -2,14 +2,14 @@
 
 - In order to initialize my application
 - As an app developer
-- I want to register components and sequences when initalizing the application
+- I want to register components when initalizing the application
 - So that I can use them throughout the application lifecycle
 
 ## Scenario: Basic usage (config provided)
 
 - Given an importable `Application` class
 - When I create an application with user-defined configurations
-- Then the application should register the given components and sequences
+- Then the application should register the given components
 
 ```ts
 import {Application} from '@loopback/core';
@@ -17,11 +17,9 @@ import {Authentication} from '@loopback/authentication';
 import {Authorization} from '@loopback/authorization';
 import {Rejection} from '@loopback/rejection';
 
-const app = new Application({
-  components: [Todo, Authentication, Authorization, Rejection],
-  sequence: [TodoSequence]
-});
-
-// get metadata about the registered components
-console.log(app.find('sequence.*')); // [Bindings] should match the 1 sequence registered above
+const app = new Application();
+app.component(Todo);
+app.component(Authentication);
+app.component(Authorization);
+app.component(Rejection);
 ```

--- a/packages/core/test/unit/application.test.ts
+++ b/packages/core/test/unit/application.test.ts
@@ -109,13 +109,13 @@ describe('Application', () => {
 
     it('allows binding of multiple servers as an array', async () => {
       const app = new Application();
-      const bindings = app.servers([FakeServer, FakerServer]);
+      const bindings = app.servers([FakeServer, AnotherServer]);
       expect(Array.from(bindings[0].tags)).to.containEql('server');
       expect(Array.from(bindings[1].tags)).to.containEql('server');
       const fakeResult = await app.getServer(FakeServer);
       expect(fakeResult.constructor.name).to.equal(FakeServer.name);
-      const fakerResult = await app.getServer(FakerServer);
-      expect(fakerResult.constructor.name).to.equal(FakerServer.name);
+      const AnotherResult = await app.getServer(AnotherServer);
+      expect(AnotherResult.constructor.name).to.equal(AnotherServer.name);
     });
   });
 
@@ -138,4 +138,4 @@ class FakeServer extends Context implements Server {
   }
 }
 
-class FakerServer extends FakeServer {}
+class AnotherServer extends FakeServer {}

--- a/packages/example-getting-started/src/application.ts
+++ b/packages/example-getting-started/src/application.ts
@@ -20,13 +20,6 @@ import {
 /* tslint:enable:no-unused-variable */
 export class TodoApplication extends RepositoryMixin(RestApplication) {
   constructor(options?: ApplicationConfig) {
-    // TODO(bajtos) The comment below does not make sense to me.
-    // Consumers of TodoApplication object should not be changing the shape
-    // of the app (what components are mounted, etc.) The config object should
-    // be used only to configure what ports the app is listening on,
-    // which database to connect to, etc.
-    // See https://github.com/strongloop/loopback-next/issues/742
-
     super(options);
     this.setupRepositories();
     this.setupControllers();

--- a/packages/example-log-extension/README.md
+++ b/packages/example-log-extension/README.md
@@ -37,7 +37,7 @@ class LogApp extends LogLevelMixin(RestApplication) {
     super({
       logLevel: LOG_LEVEL.ERROR,
     });
-    this.components(LogComponent);
+    this.component(LogComponent);
     this.controller(MyController);
   };
 }

--- a/packages/example-log-extension/README.md
+++ b/packages/example-log-extension/README.md
@@ -37,8 +37,9 @@ class LogApp extends LogLevelMixin(RestApplication) {
     super({
       components: [LogComponent],
       logLevel: LOG_LEVEL.ERROR,
-      controllers: [MyController]
     });
+    this.components(LogComponent);
+    this.controller(MyController);
   };
 }
 

--- a/packages/example-log-extension/README.md
+++ b/packages/example-log-extension/README.md
@@ -35,7 +35,6 @@ import {
 class LogApp extends LogLevelMixin(RestApplication) {
   constructor() {
     super({
-      components: [LogComponent],
       logLevel: LOG_LEVEL.ERROR,
     });
     this.components(LogComponent);

--- a/packages/example-log-extension/test/acceptance/log.extension.acceptance.ts
+++ b/packages/example-log-extension/test/acceptance/log.extension.acceptance.ts
@@ -238,9 +238,8 @@ describe('log extension acceptance test', () => {
   }
 
   async function createApp() {
-    app = new LogApp({
-      components: [RestComponent, LogComponent],
-    });
+    app = new LogApp();
+    app.components([RestComponent, LogComponent]);
 
     app.bind(EXAMPLE_LOG_BINDINGS.TIMER).to(timer);
     server = await app.getServer(RestServer);

--- a/packages/example-log-extension/test/acceptance/log.extension.acceptance.ts
+++ b/packages/example-log-extension/test/acceptance/log.extension.acceptance.ts
@@ -3,9 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application} from '@loopback/core';
 import {
-  RestComponent,
+  RestApplication,
   RestServer,
   get,
   param,
@@ -46,7 +45,7 @@ describe('log extension acceptance test', () => {
   let server: RestServer;
   let spy: SinonSpy;
 
-  class LogApp extends LogLevelMixin(Application) {}
+  class LogApp extends LogLevelMixin(RestApplication) {}
 
   const debugMatch: string = chalk.white(
     'DEBUG: /debug :: MyController.debug() => debug called',
@@ -239,7 +238,7 @@ describe('log extension acceptance test', () => {
 
   async function createApp() {
     app = new LogApp();
-    app.components([RestComponent, LogComponent]);
+    app.component(LogComponent);
 
     app.bind(EXAMPLE_LOG_BINDINGS.TIMER).to(timer);
     server = await app.getServer(RestServer);

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -373,7 +373,7 @@ ctx.bind('repositories.noteRepo').toClass(MyNoteRepository);
 ```
 
 #### Using the Repository Mixin for Application
-A Repository Mixin is available for Application that provides convenience methods for binding and instantiating a repository class. Bound instances can be used anywhere in your application using Dependency Injection. An array set to the key `repositories` can be passed to the constructor or the `.repository(RepositoryClass)` function can be used. The mixin will also instantiate any repositories declared by a component in its constructor using the `repositories` key.
+A Repository Mixin is available for Application that provides convenience methods for binding and instantiating a repository class. Bound instances can be used anywhere in your application using Dependency Injection. The `.repository(RepositoryClass)` function can be used to bind a repository class to an Application. The mixin will also instantiate any repositories declared by a component in its constructor using the `repositories` key.
 
 Repositories will be bound to the key `repositories.RepositoryClass` where `RepositoryClass` is the name of the Repository class being bound.
 ```ts

--- a/packages/repository/src/repository-mixin.ts
+++ b/packages/repository/src/repository-mixin.ts
@@ -23,20 +23,6 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
     // A mixin class has to take in a type any[] argument!
     constructor(...args: any[]) {
       super(...args);
-      if (!this.options) this.options = {};
-
-      if (this.options.repositories) {
-        for (const repo of this.options.repositories) {
-          this.repository(repo);
-        }
-      }
-
-      if (this.options.components) {
-        // Super would have already mounted the component
-        for (const component of this.options.components) {
-          this.mountComponentRepository(component);
-        }
-      }
     }
 
     /**

--- a/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
+++ b/packages/repository/test/unit/repository-mixin/repository-mixin.test.ts
@@ -26,14 +26,6 @@ describe('RepositoryMixin', () => {
     expect(typeof myApp.repository).to.be.eql('function');
   });
 
-  it('binds repository from constructor', () => {
-    const myApp = new AppWithRepoMixin({
-      repositories: [NoteRepo],
-    });
-
-    expectNoteRepoToBeBound(myApp);
-  });
-
   it('binds repository from app.repository()', () => {
     const myApp = new AppWithRepoMixin();
 
@@ -45,19 +37,10 @@ describe('RepositoryMixin', () => {
   it('binds user defined component without repository', () => {
     class EmptyTestComponent {}
 
-    const myApp = new AppWithRepoMixin({
-      components: [EmptyTestComponent],
-    });
+    const myApp = new AppWithRepoMixin();
+    myApp.component(EmptyTestComponent);
 
     expectComponentToBeBound(myApp, EmptyTestComponent);
-  });
-
-  it('binds user defined component with repository in constructor', () => {
-    const myApp = new AppWithRepoMixin({
-      components: [TestComponent],
-    });
-
-    expectNoteRepoToBeBound(myApp);
   });
 
   it('binds user defined component with repository from .component()', () => {

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -47,13 +47,11 @@ Application options.
 
 ```ts
   const app = new Application({
-    components: [
-      RestComponent,
-    ],
     rest: {
       port: 3001
     }
   });
+  app.components(RestComponent);
 ```
 
 ### `rest` options

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -51,7 +51,7 @@ Application options.
       port: 3001
     }
   });
-  app.components(RestComponent);
+  app.component(RestComponent);
 ```
 
 ### `rest` options

--- a/packages/rest/src/rest-application.ts
+++ b/packages/rest/src/rest-application.ts
@@ -28,17 +28,8 @@ export const SequenceActions = RestBindings.SequenceActions;
 export class RestApplication extends Application {
   constructor(config?: ApplicationConfig) {
     const cfg = Object.assign({}, config);
-
-    // If the configuration provides an array of components, we want
-    // to preserve that collection, but also ensure that it contains
-    // RestComponent.
-    if (!cfg.components) {
-      cfg.components = [];
-    }
-    if (!cfg.components.includes(RestComponent)) {
-      cfg.components.push(RestComponent);
-    }
     super(cfg);
+    this.component(RestComponent);
   }
 
   server(server: Constructor<Server>, name?: string): Binding {

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -60,10 +60,7 @@ const OPENAPI_SPEC_MAPPING: {[key: string]: OpenApiSpecOptions} = {
  * A REST API server for use with Loopback.
  * Add this server to your application by importing the RestComponent.
  * ```ts
- * const app = new MyApplication({
- *   components: [RestComponent]
- * });
- * // OR
+ * const app = new MyApplication();
  * app.component(RestComponent);
  * ```
  *

--- a/packages/rest/test/acceptance/bootstrapping/rest.acceptance.ts
+++ b/packages/rest/test/acceptance/bootstrapping/rest.acceptance.ts
@@ -28,12 +28,12 @@ describe('Bootstrapping with RestComponent', () => {
     async function givenAppWithUserDefinedSequence() {
       class UserDefinedSequence extends DefaultSequence {}
       app = new Application({
-        components: [RestComponent],
         rest: {
           sequence: UserDefinedSequence,
           port: 0,
         },
       });
+      app.component(RestComponent);
       server = await app.getServer(RestServer);
     }
   });
@@ -42,11 +42,11 @@ describe('Bootstrapping with RestComponent', () => {
 describe('Starting the application', () => {
   it('starts an HTTP server (using RestServer)', async () => {
     const app = new Application({
-      components: [RestComponent],
       rest: {
         port: 0,
       },
     });
+    app.component(RestComponent);
     const server = await app.getServer(RestServer);
     server.handler(sequenceHandler);
     await startServerCheck(app);

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -490,9 +490,9 @@ describe('Routing', () => {
   /* ===== HELPERS ===== */
 
   function givenAnApplication() {
-    return new Application({
-      components: [RestComponent],
-    });
+    const app = new Application();
+    app.component(RestComponent);
+    return app;
   }
   async function givenAServer(app: Application) {
     return await app.getServer(RestServer);

--- a/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
@@ -185,9 +185,8 @@ describe('Sequence', () => {
   /* ===== HELPERS ===== */
 
   async function givenAnApplication() {
-    app = new Application({
-      components: [RestComponent],
-    });
+    app = new Application();
+    app.component(RestComponent);
     server = await app.getServer(RestServer);
   }
 

--- a/packages/rest/test/integration/rest-server.integration.ts
+++ b/packages/rest/test/integration/rest-server.integration.ts
@@ -184,9 +184,8 @@ servers:
   });
 
   it('exposes "GET /swagger-ui" endpoint', async () => {
-    const app = new Application({
-      components: [RestComponent],
-    });
+    const app = new Application();
+    app.component(RestComponent);
     const server = await app.getServer(RestServer);
     const greetSpec = {
       responses: {
@@ -216,9 +215,9 @@ servers:
 
   it('exposes "GET /swagger-ui" endpoint with apiExplorerUrl', async () => {
     const app = new Application({
-      components: [RestComponent],
       rest: {apiExplorerUrl: 'http://petstore.swagger.io'},
     });
+    app.component(RestComponent);
     const server = await app.getServer(RestServer);
     const greetSpec = {
       responses: {
@@ -247,9 +246,8 @@ servers:
   });
 
   async function givenAServer(options?: ApplicationConfig) {
-    if (!options) options = {};
-    options.components = [RestComponent];
     const app = new Application(options);
+    app.component(RestComponent);
     return await app.getServer(RestServer);
   }
 });

--- a/packages/rest/test/unit/rest-application/rest-application.test.ts
+++ b/packages/rest/test/unit/rest-application/rest-application.test.ts
@@ -37,30 +37,13 @@ describe('RestApplication', () => {
       );
     });
 
-    it('when attempting to bind servers via configuration', () => {
-      expect.throws(
-        () => {
-          // tslint:disable-next-line:no-unused-variable
-          const app = new RestApplication({
-            servers: {
-              foo: RestServer,
-              bar: RestServer,
-            },
-          });
-        },
-        Error,
-        ERR_NO_MULTI_SERVER,
-      );
-    });
-
     it('when attempting bind multiple servers via RestComponent', () => {
       class OtherRestComponent extends RestComponent {}
       expect.throws(
         () => {
           // tslint:disable-next-line:no-unused-variable
-          const app = new RestApplication({
-            components: [RestComponent, OtherRestComponent],
-          });
+          const app = new RestApplication();
+          app.components([RestComponent, OtherRestComponent]);
         },
         Error,
         ERR_NO_MULTI_SERVER,

--- a/packages/rest/test/unit/rest-application/rest-application.test.ts
+++ b/packages/rest/test/unit/rest-application/rest-application.test.ts
@@ -43,7 +43,8 @@ describe('RestApplication', () => {
         () => {
           // tslint:disable-next-line:no-unused-variable
           const app = new RestApplication();
-          app.components([RestComponent, OtherRestComponent]);
+          app.component(RestComponent);
+          app.component(OtherRestComponent);
         },
         Error,
         ERR_NO_MULTI_SERVER,

--- a/packages/rest/test/unit/rest-component.test.ts
+++ b/packages/rest/test/unit/rest-component.test.ts
@@ -20,9 +20,8 @@ const SequenceActions = RestBindings.SequenceActions;
 describe('RestComponent', () => {
   describe('Providers', () => {
     describe('Default implementations are bound', () => {
-      const app = new Application({
-        components: [RestComponent],
-      });
+      const app = new Application();
+      app.component(RestComponent);
 
       // Stub constructor requirements for some providers.
       app.bind(RestBindings.Http.CONTEXT).to(new Context());
@@ -40,9 +39,8 @@ describe('RestComponent', () => {
     });
     describe('LOG_ERROR', () => {
       it('matches expected argument signature', async () => {
-        const app = new Application({
-          components: [RestComponent],
-        });
+        const app = new Application();
+        app.component(RestComponent);
         const server = await app.getServer(RestServer);
         const logError = await server.get(SequenceActions.LOG_ERROR);
         expect(logError.length).to.equal(3); // (err, statusCode, request)
@@ -73,9 +71,8 @@ describe('RestComponent', () => {
           }
         }
 
-        const app = new Application({
-          components: [CustomRestComponent],
-        });
+        const app = new Application();
+        app.component(CustomRestComponent);
         const server = await app.getServer(RestServer);
         const logError = await server.get(SequenceActions.LOG_ERROR);
         logError(new Error('test-error'), 400, new ShotRequest({url: '/'}));

--- a/packages/rest/test/unit/rest-server/rest-server.controller.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.controller.test.ts
@@ -9,9 +9,8 @@ import {RestServer, RestComponent} from '../../..';
 
 describe('Application.controller()', () => {
   it('binds the controller to "controllers.*" namespace', async () => {
-    const app = new Application({
-      components: [RestComponent],
-    });
+    const app = new Application();
+    app.component(RestComponent);
     const server = await app.getServer(RestServer);
 
     class TestController {}

--- a/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
@@ -174,9 +174,8 @@ describe('RestServer.getApiSpec()', () => {
   });
 
   async function givenApplication() {
-    app = new Application({
-      components: [RestComponent],
-    });
+    app = new Application();
+    app.component(RestComponent);
     server = await app.getServer(RestServer);
   }
 });

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -64,17 +64,15 @@ describe('RestServer', () => {
 
   describe('configuration', () => {
     it('uses http port 3000 by default', async () => {
-      const app = new Application({
-        components: [RestComponent],
-      });
+      const app = new Application();
+      app.component(RestComponent);
       const server = await app.getServer(RestServer);
       expect(server.getSync(RestBindings.PORT)).to.equal(3000);
     });
 
     it('uses undefined http host by default', async () => {
-      const app = new Application({
-        components: [RestComponent],
-      });
+      const app = new Application();
+      app.component(RestComponent);
       const server = await app.getServer(RestServer);
       const host = await server.getSync(RestBindings.HOST);
       expect(host).to.be.undefined();
@@ -82,18 +80,18 @@ describe('RestServer', () => {
 
     it('can set port 0', async () => {
       const app = new Application({
-        components: [RestComponent],
         rest: {port: 0},
       });
+      app.component(RestComponent);
       const server = await app.getServer(RestServer);
       expect(server.getSync(RestBindings.PORT)).to.equal(0);
     });
 
     it('honors host/port', async () => {
       const app = new Application({
-        components: [RestComponent],
         rest: {port: 4000, host: 'my-host'},
       });
+      app.component(RestComponent);
       const server = await app.getServer(RestServer);
       expect(server.getSync(RestBindings.PORT)).to.equal(4000);
       expect(server.getSync(RestBindings.HOST)).to.equal('my-host');
@@ -101,9 +99,8 @@ describe('RestServer', () => {
   });
 
   async function givenRequestContext() {
-    const app = new Application({
-      components: [RestComponent],
-    });
+    const app = new Application();
+    app.component(RestComponent);
     const server = await app.getServer(RestServer);
     const requestContext = new Context(server);
     requestContext.bind(RestBindings.Http.CONTEXT).to(requestContext);


### PR DESCRIPTION
- Tweaked `ApplicationConfig` so that it can no longer be used to set up `components`, `controllers`, or servers
  - Components must now be registered through `app.component(MyComponent)`
  - Controllers and servers as well through `.controller()` and `.server()`
- ~Added in functions~ Overloaded existing functions to take in multiple components/controllers/servers
  - `component([My, List, Of, Components])`
  - `server([My, List, Of, Servers])`
  - `controller([My, List, Of, Controllers)`
- Also tweaked `RepositoryMixin` so that repositories can no longer be set up through the constructor
  - overloaded `repository` to also be able to take in an array of `Repository`ies
  - overloaded `component` to also be able to take in an array of `component`s
- First commit involves the code while the second commit involves READMEs
- connected to https://github.com/strongloop/loopback-next/issues/742
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
