### PR TITLE
[WIP] feat(context): a better/simpler way for binding configuration and @inject.config

### DIFF
--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -104,8 +104,19 @@ export class BindingKey<ValueType> {
     );
   }
 
-  static CONFIG_KEY = '$config';
-  static buildKeyForConfig(key?: string) {
-    return key ? `${key}:${BindingKey.CONFIG_KEY}` : BindingKey.CONFIG_KEY;
+  static CONFIG_NAMESPACE = '$config';
+  /**
+   * Build a binding key for the configuration of the given binding and env.
+   * The format is `$config.<env>:<key>`
+   *
+   * @param key The binding key that accepts the configuration
+   * @param env The environment such as `dev`, `test`, and `prod`
+   */
+  static buildKeyForConfig(key: string = '', env: string = '') {
+    const namespace = env
+      ? `${BindingKey.CONFIG_NAMESPACE}.${env}`
+      : BindingKey.CONFIG_NAMESPACE;
+    const bindingKey = key ? `${namespace}${key}` : BindingKey.CONFIG_NAMESPACE;
+    return bindingKey;
   }
 }

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -112,7 +112,7 @@ export class BindingKey<ValueType> {
    * @param key The binding key that accepts the configuration
    * @param env The environment such as `dev`, `test`, and `prod`
    */
-  static buildKeyForConfig(key: string = '', env: string = '') {
+  static buildKeyForConfig<T>(key: BindingAddress<T> = '', env: string = '') {
     const namespace = env
       ? `${BindingKey.CONFIG_NAMESPACE}.${env}`
       : BindingKey.CONFIG_NAMESPACE;

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -103,4 +103,9 @@ export class BindingKey<ValueType> {
       keyWithPath.substr(index + 1),
     );
   }
+
+  static OPTIONS_KEY = '$options';
+  static buildKeyForOptions(key?: string) {
+    return key ? `${key}:${BindingKey.OPTIONS_KEY}` : BindingKey.OPTIONS_KEY;
+  }
 }

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -104,8 +104,8 @@ export class BindingKey<ValueType> {
     );
   }
 
-  static OPTIONS_KEY = '$options';
-  static buildKeyForOptions(key?: string) {
-    return key ? `${key}:${BindingKey.OPTIONS_KEY}` : BindingKey.OPTIONS_KEY;
+  static CONFIG_KEY = '$config';
+  static buildKeyForConfig(key?: string) {
+    return key ? `${key}:${BindingKey.CONFIG_KEY}` : BindingKey.CONFIG_KEY;
   }
 }

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -238,6 +238,9 @@ export class Binding<T = BoundValue> {
     );
   }
 
+  /**
+   * Lock the binding so that it cannot be rebound
+   */
   lock(): this {
     this.isLocked = true;
     return this;
@@ -291,6 +294,10 @@ export class Binding<T = BoundValue> {
     return Object.keys(this.tagMap);
   }
 
+  /**
+   * Set the binding scope
+   * @param scope Binding scope
+   */
   inScope(scope: BindingScope): this {
     this.scope = scope;
     return this;
@@ -418,11 +425,17 @@ export class Binding<T = BoundValue> {
     return this;
   }
 
+  /**
+   * Unlock the binding
+   */
   unlock(): this {
     this.isLocked = false;
     return this;
   }
 
+  /**
+   * Convert to a plain JSON object
+   */
   toJSON(): Object {
     // tslint:disable-next-line:no-any
     const json: {[name: string]: any} = {

--- a/packages/context/src/config.ts
+++ b/packages/context/src/config.ts
@@ -1,0 +1,157 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as debugModule from 'debug';
+import {BindingAddress, BindingKey} from './binding-key';
+import {Context} from './context';
+import {ResolutionOptions} from './resolution-session';
+import {
+  BoundValue,
+  ValueOrPromise,
+  resolveUntil,
+  transformValueOrPromise,
+} from './value-promise';
+
+const debug = debugModule('loopback:context:config');
+
+/**
+ * Interface for configuration resolver
+ */
+export interface ConfigurationResolver {
+  /**
+   * Resolve the configuration value for a given binding key and config property
+   * path
+   * @param key Binding key
+   * @param configPath Config property path
+   * @param resolutionOptions Resolution options
+   */
+  getConfigAsValueOrPromise<ConfigValueType>(
+    key: BindingAddress<BoundValue>,
+    configPath?: string,
+    resolutionOptions?: ResolutionOptions,
+  ): ValueOrPromise<ConfigValueType | undefined>;
+}
+
+/**
+ * Resolver for configurations of bindings
+ */
+export class DefaultConfigurationResolver implements ConfigurationResolver {
+  constructor(public readonly context: Context) {}
+
+  /**
+   * Resolve config from the binding key hierarchy using namespaces
+   * separated by `.`
+   *
+   * For example, if the binding key is `servers.rest.server1`, we'll try the
+   * following entries:
+   * 1. servers.rest.server1:$config#host (namespace: server1)
+   * 2. servers.rest:$config#server1.host (namespace: rest)
+   * 3. servers.$config#rest.server1.host` (namespace: server)
+   * 4. $config#servers.rest.server1.host (namespace: '' - root)
+   *
+   * @param key Binding key with namespaces separated by `.`
+   * @param configPath Property path for the option. For example, `x.y`
+   * requests for `config.x.y`. If not set, the `config` object will be
+   * returned.
+   * @param resolutionOptions Options for the resolution.
+   * - localConfigOnly: if set to `true`, no parent namespaces will be checked
+   * - optional: if not set or set to `true`, `undefined` will be returned if
+   * no corresponding value is found. Otherwise, an error will be thrown.
+   */
+  getConfigAsValueOrPromise<ConfigValueType>(
+    key: BindingAddress<BoundValue>,
+    configPath?: string,
+    resolutionOptions?: ResolutionOptions,
+  ): ValueOrPromise<ConfigValueType | undefined> {
+    const env = resolutionOptions && resolutionOptions.environment;
+    configPath = configPath || '';
+    const configKey = BindingKey.create<ConfigValueType>(
+      BindingKey.buildKeyForConfig(key, env),
+      configPath,
+    );
+
+    const localConfigOnly =
+      resolutionOptions && resolutionOptions.localConfigOnly;
+
+    /**
+     * Set up possible keys to resolve the config value
+     */
+    key = key.toString();
+    const keys = [];
+    while (true) {
+      const configKeyAndPath = BindingKey.create<ConfigValueType>(
+        BindingKey.buildKeyForConfig(key, env),
+        configPath,
+      );
+      keys.push(configKeyAndPath);
+      if (env) {
+        // The `environment` is set, let's try the non env specific binding too
+        keys.push(
+          BindingKey.create<ConfigValueType>(
+            BindingKey.buildKeyForConfig(key),
+            configPath,
+          ),
+        );
+      }
+      if (!key || localConfigOnly) {
+        // No more keys
+        break;
+      }
+      // Shift last part of the key into the path as we'll try the parent
+      // namespace in the next iteration
+      const index = key.lastIndexOf('.');
+      configPath = configPath
+        ? `${key.substring(index + 1)}.${configPath}`
+        : `${key.substring(index + 1)}`;
+      key = key.substring(0, index);
+    }
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Configuration keyWithPaths: %j', keys);
+    }
+
+    const resolveConfig = (keyWithPath: string) => {
+      // Set `optional` to `true` to resolve config locally
+      const options = Object.assign(
+        {}, // Make sure resolutionOptions is copied
+        resolutionOptions,
+        {optional: true}, // Force optional to be true
+      );
+      return this.context.getValueOrPromise<ConfigValueType>(
+        keyWithPath,
+        options,
+      );
+    };
+
+    const evaluateConfig = (keyWithPath: string, val: ConfigValueType) => {
+      /* istanbul ignore if */
+      if (debug.enabled) {
+        debug('Configuration keyWithPath: %s => value: %j', keyWithPath, val);
+      }
+      // Found the corresponding config
+      if (val !== undefined) return true;
+
+      if (localConfigOnly) {
+        return true;
+      }
+      return false;
+    };
+
+    const required = resolutionOptions && resolutionOptions.optional === false;
+    const valueOrPromise = resolveUntil<
+      BindingAddress<ConfigValueType>,
+      ConfigValueType
+    >(keys[Symbol.iterator](), resolveConfig, evaluateConfig);
+    return transformValueOrPromise<
+      ConfigValueType | undefined,
+      ConfigValueType | undefined
+    >(valueOrPromise, val => {
+      if (val === undefined && required) {
+        throw Error(`Configuration '${configKey}' cannot be resolved`);
+      }
+      return val;
+    });
+  }
+}

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -105,11 +105,11 @@ export class Context {
    * - optional: if not set or set to `true`, `undefined` will be returned if
    * no corresponding value is found. Otherwise, an error will be thrown.
    */
-  getConfigAsValueOrPromise(
+  getConfigAsValueOrPromise<T>(
     key: string,
     configPath?: string,
     resolutionOptions?: ResolutionOptions,
-  ): ValueOrPromise<BoundValue> {
+  ): ValueOrPromise<T | undefined> {
     configPath = configPath || '';
     const configKeyAndPath = BindingKey.create(
       BindingKey.buildKeyForConfig(key),
@@ -180,12 +180,12 @@ export class Context {
    * @param resolutionOptions Options for the resolution. If `localOnly` is
    * set to true, no parent namespaces will be looked up.
    */
-  async getConfig(
+  async getConfig<T>(
     key: string,
     configPath?: string,
     resolutionOptions?: ResolutionOptions,
-  ): Promise<BoundValue> {
-    return await this.getConfigAsValueOrPromise(
+  ): Promise<T | undefined> {
+    return await this.getConfigAsValueOrPromise<T>(
       key,
       configPath,
       resolutionOptions,
@@ -210,12 +210,12 @@ export class Context {
    * @param resolutionOptions Options for the resolution. If `localOnly` is
    * set to true, no parent namespaces will be looked up.
    */
-  getConfigSync(
+  getConfigSync<T>(
     key: string,
     configPath?: string,
     resolutionOptions?: ResolutionOptions,
-  ): BoundValue {
-    const valueOrPromise = this.getConfigAsValueOrPromise(
+  ): T | undefined {
+    const valueOrPromise = this.getConfigAsValueOrPromise<T>(
       key,
       configPath,
       resolutionOptions,

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -5,13 +5,18 @@
 
 import {Binding, TagMap} from './binding';
 import {BindingKey, BindingAddress} from './binding-key';
-import {isPromiseLike, getDeepProperty, BoundValue} from './value-promise';
+import {
+  isPromiseLike,
+  getDeepProperty,
+  ValueOrPromise,
+  BoundValue,
+} from './value-promise';
 import {ResolutionOptions, ResolutionSession} from './resolution-session';
 
 import {v1 as uuidv1} from 'uuid';
 
 import * as debugModule from 'debug';
-import {ValueOrPromise} from '.';
+
 const debug = debugModule('loopback:context');
 
 /**
@@ -63,6 +68,157 @@ export class Context {
     const binding = new Binding<ValueType>(key);
     this.registry.set(key, binding);
     return binding;
+  }
+
+  /**
+   * Creates a corresponding binding for `options` (configuration) of the
+   * target in the context bound by the key.
+   *
+   * For example, `ctx.bindOptions('controllers.MyController', {x: 1})` will
+   * create binding `controllers.MyController:$options` with `{x: 1}`.
+   *
+   * @param key The key for the binding that accepts the options
+   * @param options Options object
+   */
+  bindOptions(key: string, options?: BoundValue): Binding {
+    const keyForOptions = BindingKey.buildKeyForOptions(key);
+    const bindingForOptions = this.bind(keyForOptions);
+    if (options != null) {
+      bindingForOptions.to(options).tag(`options:${key}`);
+    }
+    return bindingForOptions;
+  }
+
+  /**
+   * Resolve options from the binding key hierarchy using namespaces
+   * separated by `.`
+   *
+   * For example, if the binding key is `servers.rest.server1`, we'll try the
+   * following entries:
+   * 1. servers.rest.server1:$options#host (namespace: server1)
+   * 2. servers.rest:$options#server1.host (namespace: rest)
+   * 3. servers.$options#rest.server1.host` (namespace: server)
+   * 4. $options#servers.rest.server1.host (namespace: '' - root)
+   *
+   * @param key Binding key with namespaces separated by `.`
+   * @param optionPath Property path for the option. For example, `x.y`
+   * requests for `options.x.y`. If not set, the `options` object will be
+   * returned.
+   * @param resolutionOptions Options for the resolution. If `localOnly` is
+   * set to true, no parent namespaces will be looked up.
+   */
+  getOptionsAsValueOrPromise(
+    key: string,
+    optionPath?: string,
+    resolutionOptions?: ResolutionOptions & {localOnly?: boolean},
+  ): ValueOrPromise<BoundValue> {
+    optionPath = optionPath || '';
+    const optionKeyAndPath = BindingKey.create(
+      BindingKey.buildKeyForOptions(key),
+      optionPath || '',
+    );
+    let valueOrPromise = this.getValueOrPromise(
+      optionKeyAndPath,
+      resolutionOptions,
+    );
+
+    const checkResult = (val: BoundValue) => {
+      // Found the corresponding options
+      if (val !== undefined) return val;
+
+      // We have tried all levels
+      if (!key) return undefined;
+
+      if (resolutionOptions && resolutionOptions.localOnly) {
+        // Local only, not trying parent namespaces
+        return undefined;
+      }
+
+      // Shift last part of the key into the path as we'll try the parent
+      // namespace in the next iteration
+      const index = key.lastIndexOf('.');
+      optionPath = `${key.substring(index + 1)}.${optionPath}`;
+      key = key.substring(0, index);
+      // Continue to try the parent namespace
+      return this.getOptionsAsValueOrPromise(
+        key,
+        optionPath,
+        resolutionOptions,
+      );
+    };
+
+    if (isPromiseLike(valueOrPromise)) {
+      return valueOrPromise.then(checkResult);
+    } else {
+      return checkResult(valueOrPromise);
+    }
+  }
+
+  /**
+   * Resolve options from the binding key hierarchy using namespaces
+   * separated by `.`
+   *
+   * For example, if the binding key is `servers.rest.server1`, we'll try the
+   * following entries:
+   * 1. servers.rest.server1:$options#host (namespace: server1)
+   * 2. servers.rest:$options#server1.host (namespace: rest)
+   * 3. servers.$options#rest.server1.host` (namespace: server)
+   * 4. $options#servers.rest.server1.host (namespace: '' - root)
+   *
+   * @param key Binding key with namespaces separated by `.`
+   * @param optionPath Property path for the option. For example, `x.y`
+   * requests for `options.x.y`. If not set, the `options` object will be
+   * returned.
+   * @param resolutionOptions Options for the resolution. If `localOnly` is
+   * set to true, no parent namespaces will be looked up.
+   */
+  async getOptions(
+    key: string,
+    optionPath?: string,
+    resolutionOptions?: ResolutionOptions & {localOnly?: boolean},
+  ): Promise<BoundValue> {
+    return await this.getOptionsAsValueOrPromise(
+      key,
+      optionPath,
+      resolutionOptions,
+    );
+  }
+
+  /**
+   * Resolve options synchronously from the binding key hierarchy using
+   * namespaces separated by `.`
+   *
+   * For example, if the binding key is `servers.rest.server1`, we'll try the
+   * following entries:
+   * 1. servers.rest.server1:$options#host (namespace: server1)
+   * 2. servers.rest:$options#server1.host (namespace: rest)
+   * 3. servers.$options#rest.server1.host` (namespace: server)
+   * 4. $options#servers.rest.server1.host (namespace: '' - root)
+   *
+   * @param key Binding key with namespaces separated by `.`
+   * @param optionPath Property path for the option. For example, `x.y`
+   * requests for `options.x.y`. If not set, the `options` object will be
+   * returned.
+   * @param resolutionOptions Options for the resolution. If `localOnly` is
+   * set to true, no parent namespaces will be looked up.
+   */
+  getOptionsSync(
+    key: string,
+    optionPath?: string,
+    resolutionOptions?: ResolutionOptions & {localOnly?: boolean},
+  ): BoundValue {
+    const valueOrPromise = this.getOptionsAsValueOrPromise(
+      key,
+      optionPath,
+      resolutionOptions,
+    );
+    if (isPromiseLike(valueOrPromise)) {
+      throw new Error(
+        `Cannot get options[${optionPath ||
+          ''}] for ${key} synchronously: the value is a promise`,
+      );
+    }
+    return valueOrPromise;
   }
 
   /**

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -24,7 +24,14 @@ export {Binding, BindingScope, BindingType, TagMap} from './binding';
 export {Context} from './context';
 export {BindingKey, BindingAddress} from './binding-key';
 export {ResolutionSession} from './resolution-session';
-export {inject, Setter, Getter, Injection, InjectionMetadata} from './inject';
+export {
+  inject,
+  Setter,
+  Getter,
+  Injection,
+  InjectionMetadata,
+  ENVIRONMENT_KEY,
+} from './inject';
 export {Provider} from './provider';
 
 export {instantiateClass, invokeMethod} from './resolver';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -75,6 +75,12 @@ export interface Injection<ValueType = BoundValue> {
 }
 
 /**
+ * A special binding key for the execution environment, typically set
+ * by `NODE_ENV` environment variable
+ */
+export const ENVIRONMENT_KEY = '$environment';
+
+/**
  * A decorator to annotate method arguments for automatic injection
  * by LoopBack IoC container.
  *
@@ -353,10 +359,15 @@ function resolveFromConfig(
   const meta = injection.metadata || {};
   const binding = session.currentBinding;
 
+  const env =
+    ctx.getSync<string>(ENVIRONMENT_KEY, {optional: true}) ||
+    process.env.NODE_ENV;
+
   return ctx.getConfigAsValueOrPromise(binding.key, meta.configPath, {
     session,
     optional: meta.optional,
     localConfigOnly: meta.localConfigOnly,
+    environment: env,
   });
 }
 

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -342,4 +342,20 @@ export interface ResolutionOptions {
    * will return `undefined` instead of throwing an error.
    */
   optional?: boolean;
+
+  /**
+   * A boolean flag to control if the resolution only looks up properties from
+   * the local configuration of the target binding itself. If not set to `true`,
+   * all namespaces of a binding key will be checked.
+   *
+   * For example, if the binding key is `servers.rest.server1`, we'll try the
+   * following entries:
+   * 1. servers.rest.server1:$config#host (namespace: server1)
+   * 2. servers.rest:$config#server1.host (namespace: rest)
+   * 3. servers.$config#rest.server1.host` (namespace: server)
+   * 4. $config#servers.rest.server1.host (namespace: '' - root)
+   *
+   * The default value is `false`.
+   */
+  localConfigOnly?: boolean;
 }

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -358,4 +358,9 @@ export interface ResolutionOptions {
    * The default value is `false`.
    */
   localConfigOnly?: boolean;
+
+  /**
+   * Environment for resolution, such as `dev`, `test`, `staging`, and `prod`
+   */
+  environment?: string;
 }

--- a/packages/context/test/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/test/acceptance/class-level-bindings.acceptance.ts
@@ -318,27 +318,27 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     await expect(ctx.get('store')).to.be.rejectedWith('Bad');
   });
 
-  it('injects an option', () => {
+  it('injects a config property', () => {
     class Store {
       constructor(
-        @inject.options('x') public optionX: number,
-        @inject.options('y') public optionY: string,
+        @inject.config('x') public optionX: number,
+        @inject.config('y') public optionY: string,
       ) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
     expect(store.optionY).to.eql('a');
   });
 
-  it('injects an option with promise value', async () => {
+  it('injects a config property with promise value', async () => {
     class Store {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
-    ctx.bindOptions('store').toDynamicValue(async () => {
+    ctx.configure('store').toDynamicValue(async () => {
       return {x: 1};
     });
     ctx.bind('store').toClass(Store);
@@ -346,8 +346,8 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.optionX).to.eql(1);
   });
 
-  it('injects an option with a binding provider', async () => {
-    class MyOptionsProvider implements Provider<{}> {
+  it('injects a config property with a binding provider', async () => {
+    class MyConfigProvider implements Provider<{}> {
       constructor(@inject('prefix') private prefix: string) {}
       value() {
         return {
@@ -357,11 +357,11 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     }
 
     class Store {
-      constructor(@inject.options('myOption') public myOption: string) {}
+      constructor(@inject.config('myOption') public myOption: string) {}
     }
 
-    ctx.bind('options.MyOptionProvider').toProvider(MyOptionsProvider);
-    ctx.bindOptions('store').toProvider(MyOptionsProvider);
+    ctx.bind('config').toProvider(MyConfigProvider);
+    ctx.configure('store').toProvider(MyConfigProvider);
     ctx.bind('prefix').to('hello-');
     ctx.bind('store').toClass(Store);
 
@@ -369,13 +369,13 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.myOption).to.eql('hello-my-option');
   });
 
-  it('injects an option with a rejected promise', async () => {
+  it('injects a config property with a rejected promise', async () => {
     class Store {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
     ctx
-      .bindOptions('store')
+      .configure('store')
       .toDynamicValue(() => Promise.reject(Error('invalid')));
 
     ctx.bind('store').toClass(Store);
@@ -383,45 +383,45 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     await expect(ctx.get('store')).to.be.rejectedWith('invalid');
   });
 
-  it('injects an option with nested property', () => {
+  it('injects a config property with nested property', () => {
     class Store {
-      constructor(@inject.options('x.y') public optionXY: string) {}
+      constructor(@inject.config('x.y') public optionXY: string) {}
     }
 
-    ctx.bindOptions('store', {x: {y: 'y'}});
+    ctx.configure('store').to({x: {y: 'y'}});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.optionXY).to.eql('y');
   });
 
-  it('injects options if the binding key is not present', () => {
+  it('injects config if the binding key is not present', () => {
     class Store {
-      constructor(@inject.options() public options: object) {}
+      constructor(@inject.config() public config: object) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
-    expect(store.options).to.eql({x: 1, y: 'a'});
+    expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
-  it("injects options if the binding key is ''", () => {
+  it("injects config if the binding key is ''", () => {
     class Store {
-      constructor(@inject.options('') public options: object) {}
+      constructor(@inject.config('') public config: object) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
-    expect(store.options).to.eql({x: 1, y: 'a'});
+    expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
-  it('injects options if the binding key is a path', () => {
+  it('injects config if the binding key is a path', () => {
     class Store {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
@@ -431,26 +431,26 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     class Store {
       constructor(
         // tslint:disable-next-line:no-any
-        @inject.options('not-exist') public option: string | undefined,
+        @inject.config('not-exist') public option: string | undefined,
       ) {}
     }
 
-    ctx.bindOptions('store', {x: 1, y: 'a'});
+    ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
     const store = ctx.getSync('store');
     expect(store.option).to.be.undefined();
   });
 
-  it('injects an option based on the parent binding', async () => {
+  it('injects a config property based on the parent binding', async () => {
     class Store {
       constructor(
-        @inject.options('x') public optionX: number,
-        @inject.options('y') public optionY: string,
+        @inject.config('x') public optionX: number,
+        @inject.config('y') public optionY: string,
       ) {}
     }
 
-    ctx.bindOptions('store1', {x: 1, y: 'a'});
-    ctx.bindOptions('store2', {x: 2, y: 'b'});
+    ctx.configure('store1').to({x: 1, y: 'a'});
+    ctx.configure('store2').to({x: 2, y: 'b'});
 
     ctx.bind('store1').toClass(Store);
     ctx.bind('store2').toClass(Store);
@@ -464,40 +464,40 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store2.optionY).to.eql('b');
   });
 
-  it('injects undefined option if no binding is present', async () => {
+  it('injects undefined config if no binding is present', async () => {
     class Store {
       constructor(
         // tslint:disable-next-line:no-any
-        @inject.options('x') public option: string | undefined,
+        @inject.config('x') public config: string | undefined,
       ) {}
     }
 
     const store = await instantiateClass(Store, ctx);
-    expect(store.option).to.be.undefined();
+    expect(store.config).to.be.undefined();
   });
 
-  it('injects options from options binding', () => {
+  it('injects config from config binding', () => {
     class MyStore {
-      constructor(@inject.options('x') public optionX: number) {}
+      constructor(@inject.config('x') public optionX: number) {}
     }
 
-    ctx.bind('stores.MyStore:$options').to({x: 1, y: 'a'});
+    ctx.configure('stores.MyStore').to({x: 1, y: 'a'});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
     const store = ctx.getSync('stores.MyStore');
     expect(store.optionX).to.eql(1);
   });
 
-  it('injects options from options binding by key namespaces', () => {
+  it('injects config from config binding by key namespaces', () => {
     class MyStore {
       constructor(
-        @inject.options('x') public optionX: number,
-        @inject.options('y') public optionY: string,
+        @inject.config('x') public optionX: number,
+        @inject.config('y') public optionY: string,
       ) {}
     }
 
-    ctx.bind('stores:$options').to({MyStore: {y: 'a'}});
-    ctx.bind('stores.MyStore:$options').to({x: 1});
+    ctx.configure('stores').to({MyStore: {y: 'a'}});
+    ctx.configure('stores.MyStore').to({x: 1});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
     const store = ctx.getSync('stores.MyStore');

--- a/packages/context/test/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/test/acceptance/class-level-bindings.acceptance.ts
@@ -328,7 +328,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
     expect(store.optionY).to.eql('a');
   });
@@ -342,7 +342,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       return {x: 1};
     });
     ctx.bind('store').toClass(Store);
-    const store = await ctx.get('store');
+    const store = await ctx.get<Store>('store');
     expect(store.optionX).to.eql(1);
   });
 
@@ -365,7 +365,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.bind('prefix').to('hello-');
     ctx.bind('store').toClass(Store);
 
-    const store = await ctx.get('store');
+    const store = await ctx.get<Store>('store');
     expect(store.myOption).to.eql('hello-my-option');
   });
 
@@ -390,7 +390,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: {y: 'y'}});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.optionXY).to.eql('y');
   });
 
@@ -401,7 +401,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
@@ -412,7 +412,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.config).to.eql({x: 1, y: 'a'});
   });
 
@@ -423,7 +423,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.optionX).to.eql(1);
   });
 
@@ -437,7 +437,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
     ctx.configure('store').to({x: 1, y: 'a'});
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store: Store = ctx.getSync('store');
     expect(store.option).to.be.undefined();
   });
 
@@ -455,11 +455,11 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.bind('store1').toClass(Store);
     ctx.bind('store2').toClass(Store);
 
-    const store1 = await ctx.get('store1');
+    const store1 = await ctx.get<Store>('store1');
     expect(store1.optionX).to.eql(1);
     expect(store1.optionY).to.eql('a');
 
-    const store2 = await ctx.get('store2');
+    const store2 = await ctx.get<Store>('store2');
     expect(store2.optionX).to.eql(2);
     expect(store2.optionY).to.eql('b');
   });
@@ -484,7 +484,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.configure('stores.MyStore').to({x: 1, y: 'a'});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
-    const store = ctx.getSync('stores.MyStore');
+    const store: MyStore = ctx.getSync('stores.MyStore');
     expect(store.optionX).to.eql(1);
   });
 
@@ -500,7 +500,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.configure('stores.MyStore').to({x: 1});
     ctx.bind('stores.MyStore').toClass(MyStore);
 
-    const store = ctx.getSync('stores.MyStore');
+    const store: MyStore = ctx.getSync('stores.MyStore');
     expect(store.optionX).to.eql(1);
     expect(store.optionY).to.eql('a');
   });

--- a/packages/context/test/acceptance/config.feature.md
+++ b/packages/context/test/acceptance/config.feature.md
@@ -1,0 +1,147 @@
+# Feature: Context bindings - injecting configuration for bound artifacts
+
+- In order to receive configuration for a given binding
+- As a developer
+- I want to set up configuration for a binding key
+- So that configuration can be injected by the IoC framework
+
+# Scenario: configure an artifact before it's bound
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+// Bind configuration
+ctx.bind('servers.rest.server1:$config').to({port: 3000});
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Scenario: configure an artifact with a dynamic source
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration factory of `{port: 3000}` to `servers.rest.server1:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+// Bind configuration
+ctx.bind('servers.rest.server1:$config')
+  .toDynamicValue(() => Promise.resolve({port: 3000}));
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Scenario: configure values at parent level(s)
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration object `{server1: {port: 3000}}` to `servers.rest:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+// Bind configuration
+ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Scenario: configure values for different envs
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+`config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@inject.config()`
+- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config.test`
+- And I bind a configuration object `{port: 4000}` to `servers.rest.server1.:$config.dev`
+- And bind the rest server to `servers.rest.server1`
+- And bind the env `'dev'` to `env`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 4000}`
+
+
+```ts
+class RestServer {
+   constructor(@inject.config() public config: RestServerConfig) {}
+ }
+
+const ctx = new Context();
+
+ctx.bind('env').to('dev');
+
+// Bind configuration
+ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
+ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 4000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Notes
+
+This document only captures the expected behavior at context binding level. It
+establishes conventions to configure and resolve binding.
+
+Sources of configuration can be one or more files, databases, distributed
+registries, or services. How such sources are discovered and loaded is out of
+scope.
+
+See the following modules as candidates for configuration management facilities:
+
+- https://github.com/lorenwest/node-config
+- https://github.com/mozilla/node-convict

--- a/packages/context/test/acceptance/config.feature.md
+++ b/packages/context/test/acceptance/config.feature.md
@@ -11,7 +11,7 @@
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config`
+- When I bind a configuration object `{port: 3000}` to `$config:servers.rest.server1`
 - And bind the rest server to `servers.rest.server1`
 - And resolve the binding for `servers.rest.server1`
 - Then I get a new instance of `RestServer`
@@ -25,7 +25,7 @@ class RestServer {
 const ctx = new Context();
 
 // Bind configuration
-ctx.bind('servers.rest.server1:$config').to({port: 3000});
+ctx.configure('servers.rest.server1').to({port: 3000});
 
 // Bind RestServer
 ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -41,7 +41,7 @@ const server1 = await ctx.get('servers.rest.server1');
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration factory of `{port: 3000}` to `servers.rest.server1:$config`
+- When I bind a configuration factory of `{port: 3000}` to `$config:servers.rest.server1`
 - And bind the rest server to `servers.rest.server1`
 - And resolve the binding for `servers.rest.server1`
 - Then I get a new instance of `RestServer`
@@ -55,7 +55,7 @@ class RestServer {
 const ctx = new Context();
 
 // Bind configuration
-ctx.bind('servers.rest.server1:$config')
+ctx.configure('servers.rest.server1')
   .toDynamicValue(() => Promise.resolve({port: 3000}));
 
 // Bind RestServer
@@ -72,7 +72,7 @@ const server1 = await ctx.get('servers.rest.server1');
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration object `{server1: {port: 3000}}` to `servers.rest:$config`
+- When I bind a configuration object `{server1: {port: 3000}}` to `$config:servers.rest`
 - And bind the rest server to `servers.rest.server1`
 - And resolve the binding for `servers.rest.server1`
 - Then I get a new instance of `RestServer`
@@ -86,7 +86,7 @@ class RestServer {
 const ctx = new Context();
 
 // Bind configuration
-ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+ctx.configure('servers.rest).to({server1: {port: 3000}});
 
 // Bind RestServer
 ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -102,8 +102,8 @@ const server1 = await ctx.get('servers.rest.server1');
 - Given a class RestServer with a constructor accepting a single argument
 `config: RestServerConfig`
 - Given `RestServer` ctor argument is decorated with `@inject.config()`
-- When I bind a configuration object `{port: 3000}` to `servers.rest.server1:$config.test`
-- And I bind a configuration object `{port: 4000}` to `servers.rest.server1.:$config.dev`
+- When I bind a configuration object `{port: 3000}` to `$config.test:servers.rest.server1`
+- And I bind a configuration object `{port: 4000}` to `$config.dev:servers.rest.server1`
 - And bind the rest server to `servers.rest.server1`
 - And bind the env `'dev'` to `env`
 - And resolve the binding for `servers.rest.server1`
@@ -118,11 +118,11 @@ class RestServer {
 
 const ctx = new Context();
 
-ctx.bind('env').to('dev');
+ctx.bind('$environment').to('dev');
 
 // Bind configuration
-ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
-ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+ctx.configure('servers.rest.server1', 'dev').to({port: 4000});
+ctx.bind('servers.rest.server1', 'test').to({port: 3000});
 
 // Bind RestServer
 ctx.bind('servers.rest.server1').toClass(RestServer);

--- a/packages/context/test/acceptance/config.ts
+++ b/packages/context/test/acceptance/config.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, inject} from '../..';
+import {Context, inject, ENVIRONMENT_KEY} from '../..';
 
 interface RestServerConfig {
   host?: string;
@@ -15,12 +15,19 @@ class RestServer {
   constructor(@inject.config() public config: RestServerConfig) {}
 }
 
+class RestServer2 {
+  constructor(
+    @inject.config('host') public host?: string,
+    @inject.config('port') public port?: number,
+  ) {}
+}
+
 describe('Context bindings - injecting configuration for bound artifacts', () => {
   it('binds configuration independent of binding', async () => {
     const ctx = new Context();
 
     // Bind configuration
-    ctx.bind('servers.rest.server1:$config').to({port: 3000});
+    ctx.configure('servers.rest.server1').to({port: 3000});
 
     // Bind RestServer
     ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -37,7 +44,7 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
 
     // Bind configuration
     ctx
-      .bind('servers.rest.server1:$config')
+      .configure('servers.rest.server1')
       .toDynamicValue(() => Promise.resolve({port: 3000}));
 
     // Bind RestServer
@@ -53,7 +60,7 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
     const ctx = new Context();
 
     // Bind configuration
-    ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+    ctx.configure('servers.rest').to({server1: {port: 3000}});
 
     // Bind RestServer
     ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -64,12 +71,13 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
     expect(server1.config).to.eql({port: 3000});
   });
 
-  it.skip('binds configuration for environments', async () => {
+  it('binds configuration for environments', async () => {
     const ctx = new Context();
 
+    ctx.bind('$environment').to('test');
     // Bind configuration
-    ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
-    ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+    ctx.configure('servers.rest.server1', 'dev').to({port: 4000});
+    ctx.configure('servers.rest.server1', 'test').to({port: 3000});
 
     // Bind RestServer
     ctx.bind('servers.rest.server1').toClass(RestServer);
@@ -79,5 +87,25 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
     const server1 = await ctx.get<RestServer>('servers.rest.server1');
 
     expect(server1.config).to.eql({port: 3000});
+  });
+
+  it('binds configuration for environments with defaults', async () => {
+    const ctx = new Context();
+
+    ctx.bind(ENVIRONMENT_KEY).to('dev');
+    // Bind configuration
+    ctx.configure('servers.rest.server1', 'dev').to({port: 4000});
+    ctx.configure('servers.rest.server1', 'test').to({port: 3000});
+    ctx.configure('servers.rest.server1').to({host: 'localhost'});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer2);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer2>('servers.rest.server1');
+
+    expect(server1.host).to.eql('localhost');
+    expect(server1.port).to.eql(4000);
   });
 });

--- a/packages/context/test/acceptance/config.ts
+++ b/packages/context/test/acceptance/config.ts
@@ -1,0 +1,83 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Context, inject} from '../..';
+
+interface RestServerConfig {
+  host?: string;
+  port?: number;
+}
+
+class RestServer {
+  constructor(@inject.config() public config: RestServerConfig) {}
+}
+
+describe('Context bindings - injecting configuration for bound artifacts', () => {
+  it('binds configuration independent of binding', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx.bind('servers.rest.server1:$config').to({port: 3000});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+
+    expect(server1.config).to.eql({port: 3000});
+  });
+
+  it('configure an artifact with a dynamic source', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx
+      .bind('servers.rest.server1:$config')
+      .toDynamicValue(() => Promise.resolve({port: 3000}));
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+    expect(server1.config).to.eql({port: 3000});
+  });
+
+  it('configure values at parent level(s)', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx.bind('servers.rest:$config').to({server1: {port: 3000}});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+    expect(server1.config).to.eql({port: 3000});
+  });
+
+  it.skip('binds configuration for environments', async () => {
+    const ctx = new Context();
+
+    // Bind configuration
+    ctx.bind('servers.rest.server1:$config.dev').to({port: 4000});
+    ctx.bind('servers.rest.server1:$config.test').to({port: 3000});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+
+    expect(server1.config).to.eql({port: 3000});
+  });
+});

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -318,6 +318,53 @@ describe('Context', () => {
     });
   });
 
+  describe('bindOptions()', () => {
+    it('binds options for a binding before it is bound', () => {
+      const bindingForOptions = ctx.bindOptions('foo', {x: 1});
+      expect(bindingForOptions.key).to.equal(Binding.buildKeyForOptions('foo'));
+    });
+
+    it('binds options for a binding after it is bound', () => {
+      ctx.bind('foo').to('bar');
+      const bindingForOptions = ctx.bindOptions('foo').to({x: 1});
+      expect(bindingForOptions.key).to.equal(Binding.buildKeyForOptions('foo'));
+    });
+  });
+
+  describe('getOptions()', () => {
+    it('gets options for a binding', async () => {
+      ctx.bindOptions('foo').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getOptions('foo')).to.eql({x: 1});
+    });
+
+    it('gets local options for a binding', async () => {
+      ctx
+        .bindOptions('foo')
+        .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
+      ctx.bindOptions('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getOptions('foo.a', 'x', {localOnly: true})).to.eql(1);
+      expect(
+        await ctx.getOptions('foo.a', 'y', {localOnly: true}),
+      ).to.be.undefined();
+    });
+
+    it('gets parent options for a binding', async () => {
+      ctx
+        .bindOptions('foo')
+        .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
+      ctx.bindOptions('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getOptions('foo.a', 'x')).to.eql(1);
+      expect(await ctx.getOptions('foo.a', 'y')).to.eql(0);
+    });
+  });
+
+  describe('getOptionsSync()', () => {
+    it('gets options for a binding', () => {
+      ctx.bindOptions('foo').to({x: 1});
+      expect(ctx.getOptionsSync('foo')).to.eql({x: 1});
+    });
+  });
+
   describe('getSync', () => {
     it('returns the value immediately when the binding is sync', () => {
       ctx.bind('foo').to('bar');

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -325,7 +325,7 @@ describe('Context', () => {
       expect(bindingForConfig.key).to.equal(
         BindingKey.buildKeyForConfig('foo'),
       );
-      expect(bindingForConfig.tags.has('config:foo')).to.be.true();
+      expect(bindingForConfig.tagMap).to.eql({config: 'foo'});
     });
 
     it('configures options for a binding after it is bound', () => {
@@ -334,7 +334,7 @@ describe('Context', () => {
       expect(bindingForConfig.key).to.equal(
         BindingKey.buildKeyForConfig('foo'),
       );
-      expect(bindingForConfig.tags.has('config:foo')).to.be.true();
+      expect(bindingForConfig.tagMap).to.eql({config: 'foo'});
     });
   });
 

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -11,6 +11,7 @@ import {
   BindingType,
   isPromiseLike,
   BindingKey,
+  BoundValue,
 } from '../..';
 
 /**
@@ -321,14 +322,18 @@ describe('Context', () => {
   describe('configure()', () => {
     it('configures options for a binding before it is bound', () => {
       const bindingForConfig = ctx.configure('foo').to({x: 1});
-      expect(bindingForConfig.key).to.equal(Binding.buildKeyForConfig('foo'));
+      expect(bindingForConfig.key).to.equal(
+        BindingKey.buildKeyForConfig('foo'),
+      );
       expect(bindingForConfig.tags.has('config:foo')).to.be.true();
     });
 
     it('configures options for a binding after it is bound', () => {
       ctx.bind('foo').to('bar');
       const bindingForConfig = ctx.configure('foo').to({x: 1});
-      expect(bindingForConfig.key).to.equal(Binding.buildKeyForConfig('foo'));
+      expect(bindingForConfig.key).to.equal(
+        BindingKey.buildKeyForConfig('foo'),
+      );
       expect(bindingForConfig.tags.has('config:foo')).to.be.true();
     });
   });
@@ -344,11 +349,11 @@ describe('Context', () => {
         .configure('foo')
         .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
       ctx.configure('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
-      expect(await ctx.getConfig('foo.a', 'x', {localConfigOnly: true})).to.eql(
-        1,
-      );
       expect(
-        await ctx.getConfig('foo.a', 'y', {localConfigOnly: true}),
+        await ctx.getConfig<number>('foo.a', 'x', {localConfigOnly: true}),
+      ).to.eql(1);
+      expect(
+        await ctx.getConfig<number>('foo.a', 'y', {localConfigOnly: true}),
       ).to.be.undefined();
     });
 
@@ -357,21 +362,21 @@ describe('Context', () => {
         .configure('foo')
         .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
       ctx.configure('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
-      expect(await ctx.getConfig('foo.a', 'x')).to.eql(1);
-      expect(await ctx.getConfig('foo.a', 'y')).to.eql(0);
+      expect(await ctx.getConfig<number>('foo.a', 'x')).to.eql(1);
+      expect(await ctx.getConfig<number>('foo.a', 'y')).to.eql(0);
     });
 
     it('defaults optional to true for config resolution', async () => {
       ctx.configure('servers').to({rest: {port: 80}});
       // `servers.rest` does not exist yet
-      let server1port = await ctx.getConfig('servers.rest', 'port');
+      let server1port = await ctx.getConfig<number>('servers.rest', 'port');
       // The port is resolved at `servers` level
       expect(server1port).to.eql(80);
 
       // Now add `servers.rest`
       ctx.configure('servers.rest').to({port: 3000});
-      const servers = await ctx.getConfig('servers');
-      server1port = await ctx.getConfig('servers.rest', 'port');
+      const servers: BoundValue = await ctx.getConfig('servers');
+      server1port = await ctx.getConfig<number>('servers.rest', 'port');
       // We don't add magic to merge `servers.rest` level into `servers`
       expect(servers.rest.port).to.equal(80);
       expect(server1port).to.eql(3000);
@@ -380,7 +385,7 @@ describe('Context', () => {
     it('throws error if a required config cannot be resolved', async () => {
       ctx.configure('servers').to({rest: {port: 80}});
       // `servers.rest` does not exist yet
-      let server1port = await ctx.getConfig('servers.rest', 'port', {
+      let server1port = await ctx.getConfig<number>('servers.rest', 'port', {
         optional: false,
       });
       // The port is resolved at `servers` level

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -410,6 +410,13 @@ describe('Context', () => {
       ctx.configure('foo').to({x: 1});
       expect(ctx.getConfigSync('foo')).to.eql({x: 1});
     });
+
+    it('throws a helpful error when the config is async', () => {
+      ctx.configure('foo').toDynamicValue(() => Promise.resolve('bar'));
+      expect(() => ctx.getConfigSync('foo')).to.throw(
+        /Cannot get config\[\] for foo synchronously: the value is a promise/,
+      );
+    });
   });
 
   describe('getSync', () => {
@@ -516,6 +523,21 @@ describe('Context', () => {
       expect(result).to.equal(2);
       result = childCtx.getSync('foo');
       expect(result).to.equal(1);
+    });
+  });
+
+  describe('getOwnerContext', () => {
+    it('returns owner context', () => {
+      ctx.bind('foo').to('bar');
+      expect(ctx.getOwnerContext('foo')).to.equal(ctx);
+    });
+
+    it('returns owner context with parent', () => {
+      ctx.bind('foo').to('bar');
+      const childCtx = new Context(ctx, 'child');
+      childCtx.bind('xyz').to('abc');
+      expect(childCtx.getOwnerContext('foo')).to.equal(ctx);
+      expect(childCtx.getOwnerContext('xyz')).to.equal(childCtx);
     });
   });
 

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -318,50 +318,92 @@ describe('Context', () => {
     });
   });
 
-  describe('bindOptions()', () => {
-    it('binds options for a binding before it is bound', () => {
-      const bindingForOptions = ctx.bindOptions('foo', {x: 1});
-      expect(bindingForOptions.key).to.equal(Binding.buildKeyForOptions('foo'));
+  describe('configure()', () => {
+    it('configures options for a binding before it is bound', () => {
+      const bindingForConfig = ctx.configure('foo').to({x: 1});
+      expect(bindingForConfig.key).to.equal(Binding.buildKeyForConfig('foo'));
+      expect(bindingForConfig.tags.has('config:foo')).to.be.true();
     });
 
-    it('binds options for a binding after it is bound', () => {
+    it('configures options for a binding after it is bound', () => {
       ctx.bind('foo').to('bar');
-      const bindingForOptions = ctx.bindOptions('foo').to({x: 1});
-      expect(bindingForOptions.key).to.equal(Binding.buildKeyForOptions('foo'));
+      const bindingForConfig = ctx.configure('foo').to({x: 1});
+      expect(bindingForConfig.key).to.equal(Binding.buildKeyForConfig('foo'));
+      expect(bindingForConfig.tags.has('config:foo')).to.be.true();
     });
   });
 
-  describe('getOptions()', () => {
-    it('gets options for a binding', async () => {
-      ctx.bindOptions('foo').toDynamicValue(() => Promise.resolve({x: 1}));
-      expect(await ctx.getOptions('foo')).to.eql({x: 1});
+  describe('getConfig()', () => {
+    it('gets config for a binding', async () => {
+      ctx.configure('foo').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getConfig('foo')).to.eql({x: 1});
     });
 
-    it('gets local options for a binding', async () => {
+    it('gets local config for a binding', async () => {
       ctx
-        .bindOptions('foo')
+        .configure('foo')
         .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
-      ctx.bindOptions('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
-      expect(await ctx.getOptions('foo.a', 'x', {localOnly: true})).to.eql(1);
+      ctx.configure('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getConfig('foo.a', 'x', {localConfigOnly: true})).to.eql(
+        1,
+      );
       expect(
-        await ctx.getOptions('foo.a', 'y', {localOnly: true}),
+        await ctx.getConfig('foo.a', 'y', {localConfigOnly: true}),
       ).to.be.undefined();
     });
 
-    it('gets parent options for a binding', async () => {
+    it('gets parent config for a binding', async () => {
       ctx
-        .bindOptions('foo')
+        .configure('foo')
         .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
-      ctx.bindOptions('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
-      expect(await ctx.getOptions('foo.a', 'x')).to.eql(1);
-      expect(await ctx.getOptions('foo.a', 'y')).to.eql(0);
+      ctx.configure('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getConfig('foo.a', 'x')).to.eql(1);
+      expect(await ctx.getConfig('foo.a', 'y')).to.eql(0);
+    });
+
+    it('defaults optional to true for config resolution', async () => {
+      ctx.configure('servers').to({rest: {port: 80}});
+      // `servers.rest` does not exist yet
+      let server1port = await ctx.getConfig('servers.rest', 'port');
+      // The port is resolved at `servers` level
+      expect(server1port).to.eql(80);
+
+      // Now add `servers.rest`
+      ctx.configure('servers.rest').to({port: 3000});
+      const servers = await ctx.getConfig('servers');
+      server1port = await ctx.getConfig('servers.rest', 'port');
+      // We don't add magic to merge `servers.rest` level into `servers`
+      expect(servers.rest.port).to.equal(80);
+      expect(server1port).to.eql(3000);
+    });
+
+    it('throws error if a required config cannot be resolved', async () => {
+      ctx.configure('servers').to({rest: {port: 80}});
+      // `servers.rest` does not exist yet
+      let server1port = await ctx.getConfig('servers.rest', 'port', {
+        optional: false,
+      });
+      // The port is resolved at `servers` level
+      expect(server1port).to.eql(80);
+
+      expect(
+        ctx.getConfig('servers.rest', 'host', {
+          optional: false,
+        }),
+      )
+        .to.be.rejectedWith(
+          `Configuration 'servers.rest#host' cannot be resolved`,
+        )
+        .catch(e => {
+          // Sink the error to avoid UnhandledPromiseRejectionWarning
+        });
     });
   });
 
-  describe('getOptionsSync()', () => {
-    it('gets options for a binding', () => {
-      ctx.bindOptions('foo').to({x: 1});
-      expect(ctx.getOptionsSync('foo')).to.eql({x: 1});
+  describe('getConfigSync()', () => {
+    it('gets config for a binding', () => {
+      ctx.configure('foo').to({x: 1});
+      expect(ctx.getConfigSync('foo')).to.eql({x: 1});
     });
   });
 


### PR DESCRIPTION
This PR provides a simpler and better way (IMO) over https://github.com/strongloop/loopback-next/pull/872.

1. Add `context.configure()` to configure bindings
2. Add `context.getConfig()` to look up config for a binding
3. Add `@injection.config()` to receive injection of config

Key design:

1. `configuration` for each binding is now another binding, for example: `servers.rest.server1 --> $config:servers.rest.server1`. The previous design uses `binding.options`, which doesn't allow us to bind configuration before the binding itself is created.

2. Allow hierarchical resolution following the key namespaces. 
  For example, if the binding key is `servers.rest.server1`, we'll try the following entries:
   - `servers.rest.server1:$config#host` (namespace: server1)
   - `servers.rest:$config#server1.host` (namespace: rest)
   - `servers.$config#rest.server1.host` (namespace: server)
   - `$config#servers.rest.server1.host` (namespace: '' - root)
 
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
