### PR TITLE
fix(example-getting-started): use sinon from testlab

### DIFF
--- a/packages/example-getting-started/package.json
+++ b/packages/example-getting-started/package.json
@@ -30,9 +30,7 @@
     "@loopback/openapi-spec": "^4.0.0-alpha.25",
     "@loopback/openapi-v2": "^4.0.0-alpha.10",
     "@loopback/repository": "^4.0.0-alpha.29",
-    "@loopback/rest": "^4.0.0-alpha.25",
-    "@types/sinon": "^4.1.3",
-    "sinon": "^4.1.5"
+    "@loopback/rest": "^4.0.0-alpha.25"
   },
   "devDependencies": {
     "@loopback/build": "^4.0.0-alpha.13",

--- a/packages/example-getting-started/test/unit/controllers/todo.controller.test.ts
+++ b/packages/example-getting-started/test/unit/controllers/todo.controller.test.ts
@@ -1,7 +1,6 @@
-import {expect} from '@loopback/testlab';
+import {expect, sinon} from '@loopback/testlab';
 import {TodoController} from '../../../src/controllers';
 import {TodoRepository} from '../../../src/repositories';
-import * as sinon from 'sinon';
 import {Todo} from '../../../src/models/index';
 import {givenTodo} from '../../helpers';
 


### PR DESCRIPTION
Rework example-getting-started to use sinon from @loopback/testlab
instead of importing it directly.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
