### PR TITLE
[WIP] build: add experimental watch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ packages/*/*.tgz
 packages/*/dist*
 packages/*/package
 packages/cli/test/sandbox
+.build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 packages/*/dist
 packages/*/api-docs
 packages/cli/generators/*/templates
+.build
 *.json
 *.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 packages/*/dist
 packages/*/api-docs
 packages/cli/generators/*/templates
-package.json
-packages/*/package.json
+*.json
 *.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "**/.svn": true,
     "**/CVS": true,
     ".nyc_output": true,
+    ".build": true,
     "coverage": true,
     "packages/*/dist": true,
     "packages/*/api-docs": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,41 +1,44 @@
 {
   // See https://go.microsoft.com/fwlink/?LinkId=733558
   // for the documentation about the tasks.json format
-  "version": "0.1.0",
+  "version": "2.0.0",
   "tasks": [
     {
-      "taskName": "Install all dependencies",
+      "label": "Install all dependencies",
+      "group": "build",
       "command": "./node_modules/.bin/lerna",
-      "isShellCommand": true,
+      "type": "shell",
       "args": [
         "bootstrap"
       ]
     },
     {
-      "taskName": "Remove all dependencies",
+      "label": "Remove all dependencies",
+      "group": "build",
       "command": "./node_modules/.bin/lerna",
-      "isShellCommand": true,
+      "type": "shell",
       "args": [
         "clean",
         "--yes"
       ]
     },
     {
-      "taskName": "Run all tests",
+      "label": "Build and run and lint",
+      "group": "test",
       "command": "npm",
-      "isShellCommand": true,
+      "type": "shell",
       "args": [
         "run",
         "test",
         "-s"
       ],
-      "problemMatcher": ["$tsc", "$tslint5"],
-      "isTestCommand": true
+      "problemMatcher": ["$tsc", "$tslint5"]
     },
     {
-      "taskName": "Lint all packages",
+      "label": "Lint all packages",
+      "group": "test",
       "command": "npm",
-      "isShellCommand": true,
+      "type": "shell",
       "args": [
         "run",
         "lint"
@@ -102,9 +105,9 @@
       ]
     },
     {
-      "taskName": "Compile TypeScript sources",
-      "isBuildCommand": true,
-      "isShellCommand": true,
+      "label": "Compile TypeScript sources",
+      "group": "build",
+      "type": "shell",
       "command": "./node_modules/.bin/lerna",
       "args": [
         "run",
@@ -114,8 +117,9 @@
       "problemMatcher": "$tsc"
     },
     {
-      "taskName": "Clean all generated files",
-      "isShellCommand": true,
+      "label": "Clean all generated files",
+      "group": "build",
+      "type": "shell",
       "command": "npm",
       "args": [
         "run",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -125,6 +125,37 @@
         "run",
         "clean"
       ]
+    },
+    {
+      "label": "Watch and compile source files",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "command": "node",
+      "args": ["./bin/tsc-watch-monorepo"],
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "reveal": "silent",
+        "focus": false,
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "Run all tests",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "mocha", "-s"],
+      "presentation": {
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared"
+      }
     }
   ]
 }

--- a/bin/tsc-watch-monorepo.js
+++ b/bin/tsc-watch-monorepo.js
@@ -49,23 +49,29 @@ const tscChild = build.tsc([
 process.on('uncaughtException', onError);
 
 function copyFile(filePath, callback) {
-  debug('<update> %j', filePath);
-  const parts = filePath.split(/[\/\\]/g);
-  const pkg = parts.shift();
-  const localPath = parts.join('/');
-
-  const target = path.join(MONOREPO_DIR, 'packages', pkg, 'dist', localPath);
+  const source = path.join(BUILD_DIR, filePath);
+  const target = getTargetPath(filePath);
+  debug('update %j', target);
 
   mkdirp(path.dirname(target), err => {
     if (err) return callback(err);
 
-    fs.copyFile(path.join(BUILD_DIR, filePath), target, callback);
+    fs.copyFile(source, target, callback);
   });
 }
 
 function removeFile(filePath, callback) {
-  debug('<remove> %j', filePath);
-  fs.unlink(filePath, callback);
+  const target = getTargetPath(filePath);
+  debug('remove %j', target);
+  fs.unlink(target, callback);
+}
+
+function getTargetPath(filePath) {
+  const parts = filePath.split(/[\/\\]/g);
+  const packageName = parts.shift();
+  const localPath = parts.join('/');
+  const dist = build.utils.getDistribution();
+  return path.join(MONOREPO_DIR, 'packages', packageName, dist, localPath);
 }
 
 function onError(err) {

--- a/bin/tsc-watch-monorepo.js
+++ b/bin/tsc-watch-monorepo.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/authentication
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const build = require('../packages/build');
+const debug = require('debug')('build-watch');
+const chokidar = require('chokidar');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const path = require('path');
+
+const MONOREPO_DIR = path.resolve(__dirname, '..');
+const BUILD_DIR = path.resolve(MONOREPO_DIR, '.build');
+
+mkdirp.sync(BUILD_DIR);
+
+chokidar
+  .watch(BUILD_DIR, {
+    persistent: true,
+    cwd: BUILD_DIR,
+    awaitWriteFinish: true,
+  })
+  .on('add', path => copyFile(path, onError))
+  .on('change', path => copyFile(path, onError))
+  .on('unlink', path => removeFile(path, onError));
+
+const tscChild = build.tsc([
+  // disable emitting of `.d.ts` files to speed up compilation times
+  '--declaration',
+  'false',
+  // skip checking types in imported libraries (another speedup)
+  '--skipLibCheck',
+
+  // use the main monorepo-wide tsconfig
+  '--project',
+  path.resolve(__dirname, '..', 'tsconfig.json'),
+  // store the compiled output in a special directory we are watching
+  '--outDir',
+  BUILD_DIR,
+
+  // and finally, enable the watch mode
+  '--watch',
+]);
+
+process.on('uncaughtException', onError);
+
+function copyFile(filePath, callback) {
+  debug('<update> %j', filePath);
+  const parts = filePath.split(/[\/\\]/g);
+  const pkg = parts.shift();
+  const localPath = parts.join('/');
+
+  const target = path.join(MONOREPO_DIR, 'packages', pkg, 'dist', localPath);
+
+  mkdirp(path.dirname(target), err => {
+    if (err) return callback(err);
+
+    fs.copyFile(path.join(BUILD_DIR, filePath), target, callback);
+  });
+}
+
+function removeFile(filePath, callback) {
+  debug('<remove> %j', filePath);
+  fs.unlink(filePath, callback);
+}
+
+function onError(err) {
+  if (!err) return;
+
+  tscChild.kill();
+  console.error('Unhandled error', err);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
     "@commitlint/config-lerna-scopes": "^6.0.2",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.5.9",
+    "chokidar": "^2.0.1",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
-    "lerna": "^2.8.0"
+    "debug": "^3.1.0",
+    "lerna": "^2.8.0",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.6.2"
   },
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",
@@ -32,10 +36,11 @@
     "prettier:cli": "node packages/build/bin/run-prettier \"**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",
-    "clean": "lerna run clean --loglevel=silent --parallel",
+    "clean": "rimraf .build && lerna run clean --loglevel=silent --parallel",
     "clean:lerna": "lerna clean --yes --parallel --loglevel=silent",
     "build": "lerna run build --parallel --loglevel=silent",
     "build:full": "npm run clean:lerna && npm run bootstrap && npm run build && npm run mocha && npm run lint",
+    "build:watch": "node ./bin/tsc-watch-monorepo",
     "pretest": "npm run clean && npm run build",
     "test": "node packages/build/bin/run-nyc npm run mocha",
     "mocha": "node packages/build/bin/run-mocha \"packages/*/DIST/test/**/*.js\" \"packages/cli/test/*.js\"",

--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -17,14 +17,12 @@ Where <target> is either es2017 or es2015.
 
 'use strict';
 
-function run(argv, dryRun) {
+function run(compilerOpts, dryRun) {
   const utils = require('./utils');
   const path = require('path');
   const fs = require('fs');
 
   const packageDir = utils.getPackageDir();
-
-  const compilerOpts = argv.slice(2);
 
   const isTargetSet = utils.isOptionSet(compilerOpts, '--target');
   const isOutDirSet = utils.isOptionSet(compilerOpts, '--outDir');
@@ -118,4 +116,4 @@ function run(argv, dryRun) {
 }
 
 module.exports = run;
-if (require.main === module) run(process.argv);
+if (require.main === module) run(process.argv.slice(2));

--- a/packages/build/config/tsconfig.build.json
+++ b/packages/build/config/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "declaration": true
   },
   "include": [
     "src",

--- a/packages/build/config/tsconfig.build.json
+++ b/packages/build/config/tsconfig.build.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
-    "rootDir": ".",
-    "declaration": true
+    "rootDir": "."
   },
   "include": [
     "src",

--- a/packages/build/index.js
+++ b/packages/build/index.js
@@ -10,3 +10,4 @@ exports.prettier = require('./bin/run-prettier');
 exports.tslint = require('./bin/run-tslint');
 exports.nyc = require('./bin/run-nyc');
 exports.dist = require('./bin/select-dist');
+exports.utils = require('./bin/utils');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "./packages/build/config/tsconfig.common.json",
   "include": ["packages"],
-  "exclude": ["node_modules/**", "packages/*/node_modules/**", "**/*.d.ts"]
+  "exclude": [
+    "node_modules/**",
+    "packages/*/node_modules/**",
+    "**/*.d.ts",
+    "packages/*/test/sandbox/**",
+    "packages/cli/generators/*/templates/**"
+  ]
 }


### PR DESCRIPTION
**Let's make work in Lerna+Typescript monorepo fun again!**

In this pull request, I am introducing an experimental `tsc --watch` setup that works in a monorepo 🎉 

The problem: `tsc` does not respect the layout of our monorepo and writes compiled output to `{outDir}/{packageName}/{localPath}` instead of the desired `packages/{packageName}/dist/{localPath}`.

The solution: let `tsc` write the files to a hidden `.build` directory. Write a custom file watcher that picks any files changed by `tsc` in `.build` and copies them to their correct place in `packages` hierarchy.

In addition to this wrapper, this pull request also:

- Adds a new package script: `npm run build:watch`
- Add two new VSCode tasks and configure them as the default Build Task and Test Task respectively:
  - Watch and compile source files
  - Run all tests
- Configures prettier to ignore ALL json files (so that `.vscode/tasks.json` stays formatted as we like it)
- Upgrades VSCode tasks.json to version 2.0.0

Time to run `npm run build`: 21s
Time to finish the first compilation via `npm run build:current`: 4s
Time to recompile after changing a file: <1s
Time to run `npm run mocha` (for comparison): 7s

_I am fully aware of the fact that this work was not planned for February milestone. However, the current setup where the build takes so long leaves me unable to contribute any non-trivial code changes. I think the time needed to make this change happen (including reviews) will pay back very quickly._

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
