### PR TITLE
fix(rest): use context.get() to resolve current controller

### DIFF
--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -5,6 +5,7 @@
 
 import {BindingKey} from '@loopback/context';
 import {Application, ControllerClass} from './application';
+import {ControllerInstance} from '../../rest/src';
 
 /**
  * Namespace for core binding keys
@@ -53,4 +54,12 @@ export namespace CoreBindings {
    * request context
    */
   export const CONTROLLER_METHOD_META = 'controller.method.meta';
+
+  /**
+   * Binding key for the controller instance resolved in the current request
+   * context
+   */
+  export const CONTROLLER_CURRENT = BindingKey.create<ControllerInstance>(
+    'controller.current',
+  );
 }

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -5,7 +5,6 @@
 
 import {BindingKey} from '@loopback/context';
 import {Application, ControllerClass} from './application';
-import {ControllerInstance} from '../../rest/src';
 
 /**
  * Namespace for core binding keys
@@ -59,7 +58,5 @@ export namespace CoreBindings {
    * Binding key for the controller instance resolved in the current request
    * context
    */
-  export const CONTROLLER_CURRENT = BindingKey.create<ControllerInstance>(
-    'controller.current',
-  );
+  export const CONTROLLER_CURRENT = BindingKey.create('controller.current');
 }

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -34,10 +34,10 @@ export class HttpHandler {
     this.handleRequest = (req, res) => this._handleRequest(req, res);
   }
 
-  registerController(
-    controllerCtor: ControllerClass,
+  registerController<T>(
+    controllerCtor: ControllerClass<T>,
     spec: ControllerSpec,
-    controllerFactory?: ControllerFactory,
+    controllerFactory?: ControllerFactory<T>,
   ) {
     this._routes.registerController(controllerCtor, spec, controllerFactory);
   }

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -15,6 +15,7 @@ import {
   ResolvedRoute,
   RouteEntry,
   ControllerClass,
+  ControllerFactory,
 } from './router/routing-table';
 import {ParsedRequest} from './internal-types';
 
@@ -33,8 +34,12 @@ export class HttpHandler {
     this.handleRequest = (req, res) => this._handleRequest(req, res);
   }
 
-  registerController(name: ControllerClass, spec: ControllerSpec) {
-    this._routes.registerController(name, spec);
+  registerController(
+    controllerCtor: ControllerClass,
+    spec: ControllerSpec,
+    controllerFactory?: ControllerFactory,
+  ) {
+    this._routes.registerController(controllerCtor, spec, controllerFactory);
   }
 
   registerRoute(route: RouteEntry) {

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -35,11 +35,11 @@ export class HttpHandler {
   }
 
   registerController<T>(
-    controllerCtor: ControllerClass<T>,
     spec: ControllerSpec,
+    controllerCtor: ControllerClass<T>,
     controllerFactory?: ControllerFactory<T>,
   ) {
-    this._routes.registerController(controllerCtor, spec, controllerFactory);
+    this._routes.registerController(spec, controllerCtor, controllerFactory);
   }
 
   registerRoute(route: RouteEntry) {

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -14,6 +14,10 @@ export {
   ResolvedRoute,
   createResolvedRoute,
   parseRequestUrl,
+  ControllerClass,
+  ControllerInstance,
+  ControllerFactory,
+  createControllerFactory,
 } from './router/routing-table';
 
 export * from './providers';

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -17,7 +17,9 @@ export {
   ControllerClass,
   ControllerInstance,
   ControllerFactory,
-  createControllerFactory,
+  createControllerFactoryForBinding,
+  createControllerFactoryForClass,
+  createControllerFactoryForInstance,
 } from './router/routing-table';
 
 export * from './providers';

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -100,16 +100,16 @@ export class RestApplication extends Application implements HttpServerLike {
    * @param path URL path of the endpoint
    * @param spec The OpenAPI spec describing the endpoint (operation)
    * @param controllerCtor Controller constructor
-   * @param methodName The name of the controller method
    * @param controllerFactory A factory function to create controller instance
+   * @param methodName The name of the controller method
    */
   route<T>(
     verb: string,
     path: string,
     spec: OperationObject,
     controllerCtor: ControllerClass<T>,
+    controllerFactory: ControllerFactory<T>,
     methodName: string,
-    controllerFactory?: ControllerFactory<T>,
   ): Binding;
 
   /**
@@ -132,8 +132,8 @@ export class RestApplication extends Application implements HttpServerLike {
     path?: string,
     spec?: OperationObject,
     controllerCtor?: ControllerClass<T>,
-    methodName?: string,
     controllerFactory?: ControllerFactory<T>,
+    methodName?: string,
   ): Binding {
     const server = this.restServer;
     if (typeof routeOrVerb === 'object') {
@@ -144,8 +144,8 @@ export class RestApplication extends Application implements HttpServerLike {
         path!,
         spec!,
         controllerCtor!,
+        controllerFactory!,
         methodName!,
-        controllerFactory,
       );
     }
   }

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -10,7 +10,11 @@ import {Binding, Constructor} from '@loopback/context';
 import {format} from 'util';
 import {RestBindings} from './keys';
 import {RestServer, HttpRequestListener, HttpServerLike} from './rest.server';
-import {ControllerClass, RouteEntry} from './router/routing-table';
+import {
+  RouteEntry,
+  ControllerClass,
+  ControllerFactory,
+} from './router/routing-table';
 import {OperationObject, OpenApiSpec} from '@loopback/openapi-v3-types';
 
 export const ERR_NO_MULTI_SERVER = format(
@@ -97,6 +101,7 @@ export class RestApplication extends Application implements HttpServerLike {
    * @param spec The OpenAPI spec describing the endpoint (operation)
    * @param controller Controller constructor
    * @param methodName The name of the controller method
+   * @param factory A factory function to create controller instance
    */
   route(
     verb: string,
@@ -104,6 +109,7 @@ export class RestApplication extends Application implements HttpServerLike {
     spec: OperationObject,
     controller: ControllerClass,
     methodName: string,
+    factory?: ControllerFactory,
   ): Binding;
 
   /**
@@ -127,12 +133,20 @@ export class RestApplication extends Application implements HttpServerLike {
     spec?: OperationObject,
     controller?: ControllerClass,
     methodName?: string,
+    factory?: ControllerFactory,
   ): Binding {
     const server = this.restServer;
     if (typeof routeOrVerb === 'object') {
       return server.route(routeOrVerb);
     } else {
-      return server.route(routeOrVerb, path!, spec!, controller!, methodName!);
+      return server.route(
+        routeOrVerb,
+        path!,
+        spec!,
+        controller!,
+        methodName!,
+        factory,
+      );
     }
   }
 

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -99,17 +99,17 @@ export class RestApplication extends Application implements HttpServerLike {
    * @param verb HTTP verb of the endpoint
    * @param path URL path of the endpoint
    * @param spec The OpenAPI spec describing the endpoint (operation)
-   * @param controller Controller constructor
+   * @param controllerCtor Controller constructor
    * @param methodName The name of the controller method
-   * @param factory A factory function to create controller instance
+   * @param controllerFactory A factory function to create controller instance
    */
-  route(
+  route<T>(
     verb: string,
     path: string,
     spec: OperationObject,
-    controller: ControllerClass,
+    controllerCtor: ControllerClass<T>,
     methodName: string,
-    factory?: ControllerFactory,
+    controllerFactory?: ControllerFactory<T>,
   ): Binding;
 
   /**
@@ -127,13 +127,13 @@ export class RestApplication extends Application implements HttpServerLike {
    */
   route(route: RouteEntry): Binding;
 
-  route(
+  route<T>(
     routeOrVerb: RouteEntry | string,
     path?: string,
     spec?: OperationObject,
-    controller?: ControllerClass,
+    controllerCtor?: ControllerClass<T>,
     methodName?: string,
-    factory?: ControllerFactory,
+    controllerFactory?: ControllerFactory<T>,
   ): Binding {
     const server = this.restServer;
     if (typeof routeOrVerb === 'object') {
@@ -143,9 +143,9 @@ export class RestApplication extends Application implements HttpServerLike {
         routeOrVerb,
         path!,
         spec!,
-        controller!,
+        controllerCtor!,
         methodName!,
-        factory,
+        controllerFactory,
       );
     }
   }

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -10,10 +10,10 @@ import {
   Route,
   ControllerRoute,
   RouteEntry,
-  createControllerFactory,
   ControllerFactory,
   ControllerClass,
   ControllerInstance,
+  createControllerFactoryForBinding,
 } from './router/routing-table';
 import {ParsedRequest} from './internal-types';
 import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3-types';
@@ -246,8 +246,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
       if (apiSpec.components && apiSpec.components.schemas) {
         this._httpHandler.registerApiDefinitions(apiSpec.components.schemas);
       }
-      const controllerFactory = createControllerFactory(b.key);
-      this._httpHandler.registerController(ctor, apiSpec, controllerFactory);
+      const controllerFactory = createControllerFactoryForBinding(b.key);
+      this._httpHandler.registerController(apiSpec, ctor, controllerFactory);
     }
 
     for (const b of this.find('routes.*')) {
@@ -296,13 +296,12 @@ export class RestServer extends Context implements Server, HttpServerLike {
         );
       }
 
-      const controllerFactory = createControllerFactory(b.key);
+      const controllerFactory = createControllerFactoryForBinding(b.key);
       const route = new ControllerRoute(
         verb,
         path,
         spec,
         ctor,
-        undefined,
         controllerFactory,
       );
       this._httpHandler.registerRoute(route);
@@ -385,16 +384,16 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param path URL path of the endpoint
    * @param spec The OpenAPI spec describing the endpoint (operation)
    * @param controllerCtor Controller constructor
-   * @param methodName The name of the controller method
    * @param controllerFactory A factory function to create controller instance
+   * @param methodName The name of the controller method
    */
   route<I>(
     verb: string,
     path: string,
     spec: OperationObject,
     controllerCtor: ControllerClass<I>,
+    controllerFactory: ControllerFactory<I>,
     methodName: string,
-    controllerFactory?: ControllerFactory<I>,
   ): Binding;
 
   /**
@@ -417,8 +416,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
     path?: string,
     spec?: OperationObject,
     controllerCtor?: ControllerClass<I>,
-    methodName?: string,
     controllerFactory?: ControllerFactory<I>,
+    methodName?: string,
   ): Binding {
     if (typeof routeOrVerb === 'object') {
       const r = routeOrVerb;
@@ -459,8 +458,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
         path,
         spec,
         controllerCtor,
-        methodName,
         controllerFactory,
+        methodName,
       ),
     );
   }

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -13,6 +13,7 @@ import {
   createControllerFactory,
   ControllerFactory,
   ControllerClass,
+  ControllerInstance,
 } from './router/routing-table';
 import {ParsedRequest} from './internal-types';
 import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3-types';
@@ -362,7 +363,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * ```
    *
    */
-  controller(controllerCtor: ControllerClass): Binding {
+  controller(controllerCtor: ControllerClass<ControllerInstance>): Binding {
     return this.bind('controllers.' + controllerCtor.name).toClass(
       controllerCtor,
     );
@@ -383,17 +384,17 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param verb HTTP verb of the endpoint
    * @param path URL path of the endpoint
    * @param spec The OpenAPI spec describing the endpoint (operation)
-   * @param controller Controller constructor
+   * @param controllerCtor Controller constructor
    * @param methodName The name of the controller method
-   * @param factory A factory function to create controller instance
+   * @param controllerFactory A factory function to create controller instance
    */
-  route(
+  route<I>(
     verb: string,
     path: string,
     spec: OperationObject,
-    controller: ControllerClass,
+    controllerCtor: ControllerClass<I>,
     methodName: string,
-    factory?: ControllerFactory,
+    controllerFactory?: ControllerFactory<I>,
   ): Binding;
 
   /**
@@ -411,13 +412,13 @@ export class RestServer extends Context implements Server, HttpServerLike {
    */
   route(route: RouteEntry): Binding;
 
-  route(
+  route<I>(
     routeOrVerb: RouteEntry | string,
     path?: string,
     spec?: OperationObject,
-    controller?: ControllerClass,
+    controllerCtor?: ControllerClass<I>,
     methodName?: string,
-    controllerFactory?: ControllerFactory,
+    controllerFactory?: ControllerFactory<I>,
   ): Binding {
     if (typeof routeOrVerb === 'object') {
       const r = routeOrVerb;
@@ -440,7 +441,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
       });
     }
 
-    if (!controller) {
+    if (!controllerCtor) {
       throw new AssertionError({
         message: 'controller is required for a controller-based route',
       });
@@ -457,7 +458,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
         routeOrVerb,
         path,
         spec,
-        controller,
+        controllerCtor,
         methodName,
         controllerFactory,
       ),

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -16,6 +16,7 @@ import {
   ControllerClass,
   createControllerFactory,
   ControllerFactory,
+  ControllerInstance,
 } from '../../..';
 
 import {api, get, post, param, requestBody} from '@loopback/openapi-v3';
@@ -675,7 +676,8 @@ describe('Routing', () => {
         .withParameter({name: 'name', in: 'query', type: 'string'})
         .build();
 
-      const factory: ControllerFactory = ctx => new MySubController();
+      const factory: ControllerFactory<MyController> = ctx =>
+        new MySubController();
       app.route('get', '/greet', spec, MyController, 'greet', factory);
 
       await whenIMakeRequestTo(app)
@@ -714,7 +716,10 @@ describe('Routing', () => {
     return await app.getServer(RestServer);
   }
 
-  function givenControllerInApp(app: Application, controller: ControllerClass) {
+  function givenControllerInApp(
+    app: Application,
+    controller: ControllerClass<ControllerInstance>,
+  ) {
     app.controller(controller).inScope(BindingScope.CONTEXT);
   }
 

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -14,9 +14,9 @@ import {
   SequenceActions,
   HttpServerLike,
   ControllerClass,
-  createControllerFactory,
-  ControllerFactory,
   ControllerInstance,
+  createControllerFactoryForClass,
+  createControllerFactoryForInstance,
 } from '../../..';
 
 import {api, get, post, param, requestBody} from '@loopback/openapi-v3';
@@ -554,7 +554,14 @@ describe('Routing', () => {
       .withParameter({name: 'name', in: 'query', type: 'string'})
       .build();
 
-    server.route('get', '/greet', spec, MyController, 'greet');
+    server.route(
+      'get',
+      '/greet',
+      spec,
+      MyController,
+      createControllerFactoryForClass(MyController),
+      'greet',
+    );
 
     const client = whenIMakeRequestTo(server);
     await client.get('/greet?name=world').expect(200, 'hello world');
@@ -574,8 +581,8 @@ describe('Routing', () => {
       .withParameter({name: 'name', in: 'query', type: 'string'})
       .build();
 
-    const factory = createControllerFactory(MyController);
-    server.route('get', '/greet', spec, MyController, 'greet', factory);
+    const factory = createControllerFactoryForClass(MyController);
+    server.route('get', '/greet', spec, MyController, factory, 'greet');
 
     const client = whenIMakeRequestTo(server);
     await client.get('/greet?name=world').expect(200, 'hello world');
@@ -650,7 +657,8 @@ describe('Routing', () => {
         .withParameter({name: 'name', in: 'query', type: 'string'})
         .build();
 
-      app.route('get', '/greet', spec, MyController, 'greet');
+      const factory = createControllerFactoryForClass(MyController);
+      app.route('get', '/greet', spec, MyController, factory, 'greet');
 
       await whenIMakeRequestTo(app)
         .get('/greet?name=world')
@@ -676,9 +684,8 @@ describe('Routing', () => {
         .withParameter({name: 'name', in: 'query', type: 'string'})
         .build();
 
-      const factory: ControllerFactory<MyController> = ctx =>
-        new MySubController();
-      app.route('get', '/greet', spec, MyController, 'greet', factory);
+      const factory = createControllerFactoryForInstance(new MySubController());
+      app.route('get', '/greet', spec, MyController, factory, 'greet');
 
       await whenIMakeRequestTo(app)
         .get('/greet?name=world')

--- a/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
@@ -24,7 +24,10 @@ import {Application} from '@loopback/core';
 import {expect, Client, createClientForHandler} from '@loopback/testlab';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {inject, Context} from '@loopback/context';
-import {ControllerClass} from '../../../src/router/routing-table';
+import {
+  ControllerClass,
+  ControllerInstance,
+} from '../../../src/router/routing-table';
 
 const SequenceActions = RestBindings.SequenceActions;
 
@@ -209,7 +212,9 @@ describe('Sequence', () => {
     server = await app.getServer(RestServer);
   }
 
-  function givenControllerInServer(controller: ControllerClass) {
+  function givenControllerInServer(
+    controller: ControllerClass<ControllerInstance>,
+  ) {
     app.controller(controller);
   }
 

--- a/packages/rest/test/integration/http-handler.integration.ts
+++ b/packages/rest/test/integration/http-handler.integration.ts
@@ -454,7 +454,7 @@ describe('HttpHandler', () => {
     ctor: new (...args: any[]) => Object,
     spec: ControllerSpec,
   ) {
-    handler.registerController(ctor, spec);
+    handler.registerController(spec, ctor);
   }
 
   function givenClient() {

--- a/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -5,7 +5,12 @@
 
 import {expect, validateApiSpec} from '@loopback/testlab';
 import {Application} from '@loopback/core';
-import {RestServer, Route, RestComponent} from '../../..';
+import {
+  RestServer,
+  Route,
+  RestComponent,
+  createControllerFactoryForClass,
+} from '../../..';
 import {get, post, requestBody} from '@loopback/openapi-v3';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {model, property} from '@loopback/repository';
@@ -63,6 +68,7 @@ describe('RestServer.getApiSpec()', () => {
       '/greet.json',
       {responses: {}},
       MyController,
+      createControllerFactoryForClass(MyController),
       'greet',
     );
     expect(binding.key).to.eql('routes.get %2Fgreet%2Ejson');
@@ -88,7 +94,14 @@ describe('RestServer.getApiSpec()', () => {
       greet() {}
     }
 
-    server.route('get', '/greet', {responses: {}}, MyController, 'greet');
+    server.route(
+      'get',
+      '/greet',
+      {responses: {}},
+      MyController,
+      createControllerFactoryForClass(MyController),
+      'greet',
+    );
 
     const spec = server.getApiSpec();
     expect(spec.paths).to.eql({

--- a/packages/rest/test/unit/router/controller-factory.test.ts
+++ b/packages/rest/test/unit/router/controller-factory.test.ts
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {ControllerFactory, createControllerFactory} from '../../..';
+import {Context} from '@loopback/core';
+
+describe('createControllerFactory', () => {
+  let ctx: Context;
+
+  beforeEach(() => {
+    ctx = new Context();
+  });
+
+  it('creates a factory with binding key', async () => {
+    ctx.bind('controllers.my-controller').toClass(MyController);
+    const factory = createControllerFactory('controllers.my-controller');
+    const inst = await factory(ctx);
+    expect(inst).to.be.instanceof(MyController);
+  });
+
+  it('creates a factory with class', async () => {
+    const factory = createControllerFactory(MyController);
+    const inst = await factory(ctx);
+    expect(inst).to.be.instanceof(MyController);
+  });
+
+  it('creates a factory with an instance', async () => {
+    const factory = createControllerFactory(new MyController());
+    const inst = await factory(ctx);
+    expect(inst).to.be.instanceof(MyController);
+  });
+
+  class MyController {
+    greet() {
+      return 'Hello';
+    }
+  }
+});

--- a/packages/rest/test/unit/router/controller-factory.test.ts
+++ b/packages/rest/test/unit/router/controller-factory.test.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {ControllerFactory, createControllerFactory} from '../../..';
+import {createControllerFactory} from '../../..';
 import {Context} from '@loopback/core';
 
 describe('createControllerFactory', () => {
@@ -16,7 +16,9 @@ describe('createControllerFactory', () => {
 
   it('creates a factory with binding key', async () => {
     ctx.bind('controllers.my-controller').toClass(MyController);
-    const factory = createControllerFactory('controllers.my-controller');
+    const factory = createControllerFactory<MyController>(
+      'controllers.my-controller',
+    );
     const inst = await factory(ctx);
     expect(inst).to.be.instanceof(MyController);
   });

--- a/packages/rest/test/unit/router/controller-factory.test.ts
+++ b/packages/rest/test/unit/router/controller-factory.test.ts
@@ -4,7 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {createControllerFactory} from '../../..';
+import {
+  createControllerFactoryForBinding,
+  createControllerFactoryForClass,
+  createControllerFactoryForInstance,
+} from '../../..';
 import {Context} from '@loopback/core';
 
 describe('createControllerFactory', () => {
@@ -16,7 +20,7 @@ describe('createControllerFactory', () => {
 
   it('creates a factory with binding key', async () => {
     ctx.bind('controllers.my-controller').toClass(MyController);
-    const factory = createControllerFactory<MyController>(
+    const factory = createControllerFactoryForBinding<MyController>(
       'controllers.my-controller',
     );
     const inst = await factory(ctx);
@@ -24,13 +28,13 @@ describe('createControllerFactory', () => {
   });
 
   it('creates a factory with class', async () => {
-    const factory = createControllerFactory(MyController);
+    const factory = createControllerFactoryForClass(MyController);
     const inst = await factory(ctx);
     expect(inst).to.be.instanceof(MyController);
   });
 
   it('creates a factory with an instance', async () => {
-    const factory = createControllerFactory(new MyController());
+    const factory = createControllerFactoryForInstance(new MyController());
     const inst = await factory(ctx);
     expect(inst).to.be.instanceof(MyController);
   });

--- a/packages/rest/test/unit/router/controller-route.unit.ts
+++ b/packages/rest/test/unit/router/controller-route.unit.ts
@@ -28,7 +28,9 @@ describe('ControllerRoute', () => {
   it('honors a factory', () => {
     const spec = anOperationSpec().build();
 
-    const factory = createControllerFactory('controllers.my-controller');
+    const factory = createControllerFactory<MyController>(
+      'controllers.my-controller',
+    );
     const route = new MyRoute(
       'get',
       '/greet',
@@ -64,8 +66,8 @@ describe('ControllerRoute', () => {
     }
   }
 
-  class MyRoute extends ControllerRoute {
-    _controllerFactory: ControllerFactory;
+  class MyRoute extends ControllerRoute<MyController> {
+    _controllerFactory: ControllerFactory<MyController>;
     _controllerName: string;
   }
 });

--- a/packages/rest/test/unit/router/controller-route.unit.ts
+++ b/packages/rest/test/unit/router/controller-route.unit.ts
@@ -3,10 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ControllerRoute} from '../../..';
+import {
+  ControllerRoute,
+  createControllerFactoryForClass,
+  createControllerFactoryForBinding,
+} from '../../..';
 import {expect} from '@loopback/testlab';
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
-import {ControllerFactory, createControllerFactory} from '../../..';
+import {ControllerFactory} from '../../..';
 
 describe('ControllerRoute', () => {
   it('rejects routes with no methodName', () => {
@@ -20,7 +24,14 @@ describe('ControllerRoute', () => {
   it('creates a factory', () => {
     const spec = anOperationSpec().build();
 
-    const route = new MyRoute('get', '/greet', spec, MyController, 'greet');
+    const route = new MyRoute(
+      'get',
+      '/greet',
+      spec,
+      MyController,
+      myControllerFactory,
+      'greet',
+    );
 
     expect(route._controllerFactory).to.be.a.Function();
   });
@@ -28,7 +39,7 @@ describe('ControllerRoute', () => {
   it('honors a factory', () => {
     const spec = anOperationSpec().build();
 
-    const factory = createControllerFactory<MyController>(
+    const factory = createControllerFactoryForBinding<MyController>(
       'controllers.my-controller',
     );
     const route = new MyRoute(
@@ -36,8 +47,8 @@ describe('ControllerRoute', () => {
       '/greet',
       spec,
       MyController,
-      'greet',
       factory,
+      'greet',
     );
 
     expect(route._controllerFactory).to.be.exactly(factory);
@@ -46,7 +57,14 @@ describe('ControllerRoute', () => {
   it('infers controllerName from the class', () => {
     const spec = anOperationSpec().build();
 
-    const route = new MyRoute('get', '/greet', spec, MyController, 'greet');
+    const route = new MyRoute(
+      'get',
+      '/greet',
+      spec,
+      MyController,
+      myControllerFactory,
+      'greet',
+    );
 
     expect(route._controllerName).to.eql(MyController.name);
   });
@@ -55,7 +73,14 @@ describe('ControllerRoute', () => {
     const spec = anOperationSpec().build();
     spec['x-controller-name'] = 'my-controller';
 
-    const route = new MyRoute('get', '/greet', spec, MyController, 'greet');
+    const route = new MyRoute(
+      'get',
+      '/greet',
+      spec,
+      MyController,
+      myControllerFactory,
+      'greet',
+    );
 
     expect(route._controllerName).to.eql('my-controller');
   });
@@ -65,6 +90,8 @@ describe('ControllerRoute', () => {
       return 'Hello';
     }
   }
+
+  const myControllerFactory = createControllerFactoryForClass(MyController);
 
   class MyRoute extends ControllerRoute<MyController> {
     _controllerFactory: ControllerFactory<MyController>;

--- a/packages/rest/test/unit/router/routing-table.unit.ts
+++ b/packages/rest/test/unit/router/routing-table.unit.ts
@@ -40,7 +40,7 @@ describe('RoutingTable', () => {
     }
     const spec = getControllerSpec(TestController);
     const table = new RoutingTable();
-    table.registerController(TestController, spec);
+    table.registerController(spec, TestController);
     const paths = table.describeApiPaths();
     const params = paths['/greet']['get'].parameters;
     expect(params).to.have.property('length', 1);
@@ -59,7 +59,7 @@ describe('RoutingTable', () => {
     class TestController {}
 
     const table = new RoutingTable();
-    table.registerController(TestController, spec);
+    table.registerController(spec, TestController);
 
     const request = givenRequest({
       method: 'get',
@@ -90,7 +90,7 @@ describe('RoutingTable', () => {
     class TestController {}
 
     const table = new RoutingTable();
-    table.registerController(TestController, spec);
+    table.registerController(spec, TestController);
 
     const request = givenRequest({
       method: 'get',


### PR DESCRIPTION
The PR ensures the existing controller binding is used to resolve/invoke the controller method. It allows `scope` and configuration of a controller is honored. Please note `instantiateClass` always creates a new instance.

If a route is set up without binding the controller to a context (app), we now create a binding in the request context.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
