### PR TITLE
feat(rest): app.route() and app.api()

### DIFF
--- a/packages/rest/src/rest-component.ts
+++ b/packages/rest/src/rest-component.ts
@@ -23,6 +23,8 @@ import {
   SendProvider,
 } from './providers';
 import {RestServer, RestServerConfig} from './rest-server';
+import {DefaultSequence} from '.';
+import {createEmptyApiSpec} from '@loopback/openapi-spec';
 
 export class RestComponent implements Component {
   providers: ProviderMap = {
@@ -45,7 +47,8 @@ export class RestComponent implements Component {
     @inject(CoreBindings.APPLICATION_INSTANCE) app: Application,
     @inject(RestBindings.CONFIG) config?: RestComponentConfig,
   ) {
-    if (!config) config = {};
+    app.bind(RestBindings.SEQUENCE).toClass(DefaultSequence);
+    app.bind(RestBindings.API_SPEC).to(createEmptyApiSpec());
   }
 }
 

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -9,11 +9,7 @@ import {safeDump} from 'js-yaml';
 import {Binding, Context, Constructor, inject} from '@loopback/context';
 import {Route, ControllerRoute, RouteEntry} from './router/routing-table';
 import {ParsedRequest} from './internal-types';
-import {
-  OpenApiSpec,
-  createEmptyApiSpec,
-  OperationObject,
-} from '@loopback/openapi-spec';
+import {OpenApiSpec, OperationObject} from '@loopback/openapi-spec';
 import {ServerRequest, ServerResponse, createServer} from 'http';
 import * as Http from 'http';
 import {Application, CoreBindings, Server} from '@loopback/core';
@@ -141,9 +137,10 @@ export class RestServer extends Context implements Server {
     }
     this.bind(RestBindings.PORT).to(options.port);
     this.bind(RestBindings.HOST).to(options.host);
-    this.api(createEmptyApiSpec());
 
-    this.sequence(options.sequence ? options.sequence : DefaultSequence);
+    if (options.sequence) {
+      this.sequence(options.sequence);
+    }
 
     this.handleHttp = (req: ServerRequest, res: ServerResponse) => {
       try {


### PR DESCRIPTION
Enhance `RestApplication` class to provide shortcuts for registering routes and configuring the master OpenAPI spec.

See #846 and #955.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `packages/example-*` were updated
