### PR TITLE
chore(cli): update templates to remove Node 6 remnants

### DIFF
--- a/packages/cli/generators/project/templates/.prettierignore
+++ b/packages/cli/generators/project/templates/.prettierignore
@@ -1,4 +1,3 @@
 dist
-dist6
 api-docs
 *.json

--- a/packages/cli/generators/project/templates/_.gitignore
+++ b/packages/cli/generators/project/templates/_.gitignore
@@ -62,5 +62,3 @@ api-docs/
 
 # Transpiled JavaScript files from Typescript
 dist/
-dist6/
-

--- a/packages/cli/generators/project/templates/tsconfig.json.ejs
+++ b/packages/cli/generators/project/templates/tsconfig.json.ejs
@@ -12,7 +12,7 @@
     "lib": ["es2017", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es2017",
     "sourceMap": true,
     "declaration": true
   },


### PR DESCRIPTION
Follow up from #996 and related to dropping Node 6 support. CLI template had references to `dist6` folders which are no longer generated.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
