### PR TITLE
feat(context): allow context.find by a filter function

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -143,18 +143,20 @@ export class Context {
    * - `*` matches zero or more characters except `.` and `:`
    * - `?` matches exactly one character except `.` and `:`
    */
-  find(pattern?: string | RegExp): Binding[];
+  find(pattern?: string | RegExp): Readonly<Binding>[];
 
   /**
    * Find bindings using a filter function
    * @param filter A function to test on the binding. It returns `true` to
    * include the binding or `false` to exclude the binding.
    */
-  find(filter: (binding: Binding) => boolean): Binding[];
+  find(filter: (binding: Readonly<Binding>) => boolean): Readonly<Binding>[];
 
-  find(pattern?: string | RegExp | ((binding: Binding) => boolean)): Binding[] {
-    let bindings: Binding[] = [];
-    let filter: (binding: Binding) => boolean;
+  find(
+    pattern?: string | RegExp | ((binding: Binding) => boolean),
+  ): Readonly<Binding>[] {
+    let bindings: Readonly<Binding>[] = [];
+    let filter: (binding: Readonly<Binding>) => boolean;
     if (!pattern) {
       filter = binding => true;
     } else if (typeof pattern === 'string') {
@@ -182,13 +184,16 @@ export class Context {
    * - `*` matches zero or more characters except `.` and `:`
    * - `?` matches exactly one character except `.` and `:`
    */
-  findByTag(pattern: string | RegExp): Binding[] {
+  findByTag(pattern: string | RegExp): Readonly<Binding>[] {
     const regexp =
       typeof pattern === 'string' ? this.wildcardToRegExp(pattern) : pattern;
     return this.find(b => Array.from(b.tags).some(t => regexp.test(t)));
   }
 
-  protected _mergeWithParent(childList: Binding[], parentList?: Binding[]) {
+  protected _mergeWithParent(
+    childList: Readonly<Binding>[],
+    parentList?: Readonly<Binding>[],
+  ) {
     if (!parentList) return childList;
     const additions = parentList.filter(parentBinding => {
       // children bindings take precedence

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -23,7 +23,7 @@ const PROPERTIES_KEY = 'inject:properties';
 export interface ResolverFunction {
   (
     ctx: Context,
-    injection: Injection,
+    injection: Readonly<Injection>,
     session?: ResolutionSession,
   ): ValueOrPromise<BoundValue>;
 }
@@ -250,7 +250,7 @@ export namespace inject {
 
 function resolveAsGetter(
   ctx: Context,
-  injection: Injection,
+  injection: Readonly<Injection>,
   session?: ResolutionSession,
 ) {
   // We need to clone the session for the getter as it will be resolved later
@@ -279,9 +279,9 @@ function resolveAsSetter(ctx: Context, injection: Injection) {
 export function describeInjectedArguments(
   target: Object,
   method?: string | symbol,
-): Injection[] {
+): Readonly<Injection>[] {
   method = method || '';
-  const meta = MetadataInspector.getAllParameterMetadata<Injection>(
+  const meta = MetadataInspector.getAllParameterMetadata<Readonly<Injection>>(
     PARAMETERS_KEY,
     target,
     method,
@@ -291,7 +291,7 @@ export function describeInjectedArguments(
 
 function resolveByTag(
   ctx: Context,
-  injection: Injection,
+  injection: Readonly<Injection>,
   session?: ResolutionSession,
 ) {
   const tag: string | RegExp = injection.metadata!.tag;
@@ -311,9 +311,9 @@ function resolveByTag(
  */
 export function describeInjectedProperties(
   target: Object,
-): MetadataMap<Injection> {
+): MetadataMap<Readonly<Injection>> {
   const metadata =
-    MetadataInspector.getAllPropertyMetadata<Injection>(
+    MetadataInspector.getAllPropertyMetadata<Readonly<Injection>>(
       PROPERTIES_KEY,
       target,
     ) || {};

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -24,7 +24,7 @@ export type ResolutionAction = (
  */
 export interface BindingElement {
   type: 'binding';
-  value: Binding;
+  value: Readonly<Binding>;
 }
 
 /**
@@ -32,7 +32,7 @@ export interface BindingElement {
  */
 export interface InjectionElement {
   type: 'injection';
-  value: Injection;
+  value: Readonly<Injection>;
 }
 
 /**
@@ -90,7 +90,7 @@ export class ResolutionSession {
    * @param session The current resolution session
    */
   private static enterBinding(
-    binding: Binding,
+    binding: Readonly<Binding>,
     session?: ResolutionSession,
   ): ResolutionSession {
     session = session || new ResolutionSession();
@@ -106,7 +106,7 @@ export class ResolutionSession {
    */
   static runWithBinding(
     action: ResolutionAction,
-    binding: Binding,
+    binding: Readonly<Binding>,
     session?: ResolutionSession,
   ) {
     const resolutionSession = ResolutionSession.enterBinding(binding, session);
@@ -122,7 +122,7 @@ export class ResolutionSession {
    * @param session The current resolution session
    */
   private static enterInjection(
-    injection: Injection,
+    injection: Readonly<Injection>,
     session?: ResolutionSession,
   ): ResolutionSession {
     session = session || new ResolutionSession();
@@ -138,7 +138,7 @@ export class ResolutionSession {
    */
   static runWithInjection(
     action: ResolutionAction,
-    injection: Injection,
+    injection: Readonly<Injection>,
     session?: ResolutionSession,
   ) {
     const resolutionSession = ResolutionSession.enterInjection(
@@ -155,7 +155,7 @@ export class ResolutionSession {
    * Describe the injection for debugging purpose
    * @param injection Injection object
    */
-  static describeInjection(injection?: Injection) {
+  static describeInjection(injection?: Readonly<Injection>) {
     /* istanbul ignore if */
     if (injection == null) return undefined;
     const name = getTargetName(
@@ -175,7 +175,7 @@ export class ResolutionSession {
    * Push the injection onto the session
    * @param injection Injection The current injection
    */
-  pushInjection(injection: Injection) {
+  pushInjection(injection: Readonly<Injection>) {
     /* istanbul ignore if */
     if (debugSession.enabled) {
       debugSession(
@@ -214,7 +214,7 @@ export class ResolutionSession {
   /**
    * Getter for the current injection
    */
-  get currentInjection(): Injection | undefined {
+  get currentInjection(): Readonly<Injection> | undefined {
     for (let i = this.stack.length - 1; i >= 0; i--) {
       const element = this.stack[i];
       if (isInjection(element)) return element.value;
@@ -225,7 +225,7 @@ export class ResolutionSession {
   /**
    * Getter for the current binding
    */
-  get currentBinding(): Binding | undefined {
+  get currentBinding(): Readonly<Binding> | undefined {
     for (let i = this.stack.length - 1; i >= 0; i--) {
       const element = this.stack[i];
       if (isBinding(element)) return element.value;
@@ -237,7 +237,7 @@ export class ResolutionSession {
    * Enter the resolution of the given binding. If
    * @param binding Binding
    */
-  pushBinding(binding: Binding) {
+  pushBinding(binding: Readonly<Binding>) {
     /* istanbul ignore if */
     if (debugSession.enabled) {
       debugSession('Enter binding:', binding.toJSON());
@@ -260,7 +260,7 @@ export class ResolutionSession {
   /**
    * Exit the resolution of a binding
    */
-  popBinding() {
+  popBinding(): Readonly<Binding> {
     const top = this.stack.pop();
     if (!isBinding(top)) {
       throw new Error('The top element must be a binding');
@@ -277,14 +277,14 @@ export class ResolutionSession {
   /**
    * Getter for bindings on the stack
    */
-  get bindingStack(): Binding[] {
+  get bindingStack(): Readonly<Binding>[] {
     return this.stack.filter(isBinding).map(e => e.value);
   }
 
   /**
    * Getter for injections on the stack
    */
-  get injectionStack(): Injection[] {
+  get injectionStack(): Readonly<Injection>[] {
     return this.stack.filter(isInjection).map(e => e.value);
   }
 

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -111,7 +111,7 @@ export function instantiateClass<T>(
  */
 function resolve<T>(
   ctx: Context,
-  injection: Injection,
+  injection: Readonly<Injection>,
   session?: ResolutionSession,
 ): ValueOrPromise<T> {
   /* istanbul ignore if */

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -202,7 +202,7 @@ describe('Context', () => {
     });
 
     it('escapes reserved chars for regexp', () => {
-      const b1 = ctx.bind('foo');
+      ctx.bind('foo');
       const b2 = ctx.bind('foo+bar');
       const b3 = ctx.bind('foo|baz');
       let result = ctx.find('fo+');

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -173,6 +173,46 @@ describe('Context', () => {
       expect(result).to.be.eql([b2, b3]);
     });
 
+    it('returns matching binding with * respecting key separators', () => {
+      const b1 = ctx.bind('foo');
+      const b2 = ctx.bind('foo.bar');
+      const b3 = ctx.bind('foo:bar');
+      let result = ctx.find('*');
+      expect(result).to.be.eql([b1]);
+      result = ctx.find('*.*');
+      expect(result).to.be.eql([b2]);
+      result = ctx.find('*:ba*');
+      expect(result).to.be.eql([b3]);
+    });
+
+    it('returns matching binding with ? respecting separators', () => {
+      const b1 = ctx.bind('foo');
+      const b2 = ctx.bind('foo.bar');
+      const b3 = ctx.bind('foo:bar');
+      let result = ctx.find('???');
+      expect(result).to.be.eql([b1]);
+      result = ctx.find('???.???');
+      expect(result).to.be.eql([b2]);
+      result = ctx.find('???:???');
+      expect(result).to.be.eql([b3]);
+      result = ctx.find('?');
+      expect(result).to.be.eql([]);
+      result = ctx.find('???????');
+      expect(result).to.be.eql([]);
+    });
+
+    it('escapes reserved chars for regexp', () => {
+      const b1 = ctx.bind('foo');
+      const b2 = ctx.bind('foo+bar');
+      const b3 = ctx.bind('foo|baz');
+      let result = ctx.find('fo+');
+      expect(result).to.be.eql([]);
+      result = ctx.find('foo+bar');
+      expect(result).to.be.eql([b2]);
+      result = ctx.find('foo|baz');
+      expect(result).to.be.eql([b3]);
+    });
+
     it('returns matching binding with regexp', () => {
       const b1 = ctx.bind('foo');
       const b2 = ctx.bind('bar');
@@ -180,6 +220,22 @@ describe('Context', () => {
       let result = ctx.find(/\w+/);
       expect(result).to.be.eql([b1, b2, b3]);
       result = ctx.find(/ba/);
+      expect(result).to.be.eql([b2, b3]);
+    });
+
+    it('returns matching binding with filter', () => {
+      const b1 = ctx.bind('foo').inScope(BindingScope.SINGLETON);
+      const b2 = ctx.bind('bar').tag('b');
+      const b3 = ctx.bind('baz').tag('b');
+      let result = ctx.find(() => true);
+      expect(result).to.be.eql([b1, b2, b3]);
+      result = ctx.find(() => false);
+      expect(result).to.be.eql([]);
+      result = ctx.find(binding => binding.key.startsWith('ba'));
+      expect(result).to.be.eql([b2, b3]);
+      result = ctx.find(binding => binding.scope === BindingScope.SINGLETON);
+      expect(result).to.be.eql([b1]);
+      result = ctx.find(binding => binding.tags.has('b'));
       expect(result).to.be.eql([b2, b3]);
     });
   });

--- a/packages/core/test/acceptance/application.acceptance.ts
+++ b/packages/core/test/acceptance/application.acceptance.ts
@@ -14,7 +14,7 @@ describe('Bootstrapping the application', () => {
       class AuditComponent {}
       const app = new Application();
       app.component(AuditComponent);
-      const componentKeys = app.find('component.*').map(b => b.key);
+      const componentKeys = app.find('components.*').map(b => b.key);
       expect(componentKeys).to.containEql('components.AuditComponent');
 
       const componentInstance = app.getSync('components.AuditComponent');

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -382,7 +382,11 @@ export class RestServer extends Context implements Server {
   ): Binding {
     if (typeof routeOrVerb === 'object') {
       const r = routeOrVerb;
-      return this.bind(`routes.${r.verb} ${r.path}`).to(r);
+      // Encode the path to escape special chars
+      const encodedPath = encodeURIComponent(r.path).replace(/\./g, '%2E');
+      return this.bind(`routes.${r.verb} ${encodedPath}`)
+        .to(r)
+        .tag('route');
     }
 
     if (!path) {

--- a/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.open-api-spec.test.ts
@@ -46,6 +46,31 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
+  it('binds a route via app.route(route)', () => {
+    function greet() {}
+    const binding = server.route(
+      new Route('get', '/greet', {responses: {}}, greet),
+    );
+    expect(binding.key).to.eql('routes.get %2Fgreet');
+    expect(binding.tags.has('route')).to.be.true();
+  });
+
+  it('binds a route via app.route(..., Controller, method)', () => {
+    class MyController {
+      greet() {}
+    }
+
+    const binding = server.route(
+      'get',
+      '/greet.json',
+      {responses: {}},
+      MyController,
+      'greet',
+    );
+    expect(binding.key).to.eql('routes.get %2Fgreet%2Ejson');
+    expect(binding.tags.has('route')).to.be.true();
+  });
+
   it('returns routes registered via app.route(route)', () => {
     function greet() {}
     server.route(new Route('get', '/greet', {responses: {}}, greet));


### PR DESCRIPTION
Sometimes we need to find bindings using multiple conditions, such as
multiple tags or the bound class. The filter function gives us the
maximum flexibility.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
