### PR TITLE
fix(cli) Add back the test for cloneExampleFromGitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ api-docs
 packages/*/*.tgz
 packages/*/dist*
 packages/*/package
-packages/cli/test/sandbox
+.sandbox

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,8 @@
     ".nyc_output": true,
     "coverage": true,
     "packages/*/dist": true,
-    "packages/*/api-docs": true
+    "packages/*/api-docs": true,
+    "**/.sandbox": true
   },
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,

--- a/packages/cli/test/clone-example.test.js
+++ b/packages/cli/test/clone-example.test.js
@@ -14,6 +14,8 @@ const TestSandbox = require('@loopback/testlab').TestSandbox;
 const glob = promisify(require('glob'));
 const path = require('path');
 
+const readFile = promisify(fs.readFile);
+
 const VALID_EXAMPLE = 'getting-started';
 const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 let sandbox;
@@ -48,7 +50,7 @@ describe('cloneExampleFromGitHub (SLOW)', function() {
       'src/index.ts',
     ]);
 
-    const packageJson = JSON.parse(fs.readFileSync(`${outDir}/package.json`));
+    const packageJson = JSON.parse(await readFile(`${outDir}/package.json`));
     expect(packageJson).to.have.properties({
       name: `@loopback/example-${VALID_EXAMPLE}`,
     });


### PR DESCRIPTION
Relax the assertions performed by the test to allow changes reorganizing files around.

Rework the test to async/await style, now that we no longer support Node.js 6.x

Change the sandbox directory from "test/sandbox" to ".sandbox" to prevent interference with code scanning "test" for test files to run.

This is a follow-up for #1003 which disabled this problematic test.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
