### PR TITLE
docs(example-getting-started): add links to tutorial paths

### DIFF
--- a/packages/example-getting-started/README.md
+++ b/packages/example-getting-started/README.md
@@ -1,6 +1,10 @@
 # @loopback/example-getting-started
 
 This is the basic tutorial for getting started with Loopback 4!
+[Click here](https://loopback.io/doc/en/lb4/Getting-started.html) to follow
+along, or jump to the
+[docs section](https://github.com/strongloop/loopback-next/tree/master/packages/example-getting-started/docs)
+and go through the pages in numbered order.
 
 ### Stuck?
 Check out our [Gitter channel](https://gitter.im/strongloop/loopback) and ask

--- a/packages/example-getting-started/README.md
+++ b/packages/example-getting-started/README.md
@@ -1,10 +1,9 @@
 # @loopback/example-getting-started
 
 This is the basic tutorial for getting started with Loopback 4!
-[Click here](https://loopback.io/doc/en/lb4/Getting-started.html) to follow
-along, or jump to the
-[docs section](https://github.com/strongloop/loopback-next/tree/master/packages/example-getting-started/docs)
-and go through the pages in numbered order.
+
+To get started, jump into the
+[Prerequisites and setup](docs/1-prerequisites-and-setup.html) section.
 
 ### Stuck?
 Check out our [Gitter channel](https://gitter.im/strongloop/loopback) and ask

--- a/packages/example-getting-started/README.md
+++ b/packages/example-getting-started/README.md
@@ -5,6 +5,17 @@ This is the basic tutorial for getting started with Loopback 4!
 To get started, jump into the
 [Prerequisites and setup](docs/1-prerequisites-and-setup.md) section.
 
+## Tutorial Steps
+
+1. [Prerequisites and setup](docs/1-prerequisites-and-setup.md)
+1. [Scaffolding your application](docs/2-scaffold-app.md)
+1. [Adding the legacy juggler](docs/3-add-legacy-juggler.md)
+1. [Add your Todo model](docs/4-todo-model.md)
+1. [Add a datasource](docs/5-datasource.md)
+1. [Add a repository](docs/6-repository.md)
+1. [Add a controller](docs/7-controller.md)
+1. [Putting it all together](docs/8-putting-it-together.md)
+
 ### Stuck?
 Check out our [Gitter channel](https://gitter.im/strongloop/loopback) and ask
 for help with this tutorial!

--- a/packages/example-getting-started/README.md
+++ b/packages/example-getting-started/README.md
@@ -3,7 +3,7 @@
 This is the basic tutorial for getting started with Loopback 4!
 
 To get started, jump into the
-[Prerequisites and setup](docs/1-prerequisites-and-setup.html) section.
+[Prerequisites and setup](docs/1-prerequisites-and-setup.md) section.
 
 ### Stuck?
 Check out our [Gitter channel](https://gitter.im/strongloop/loopback) and ask

--- a/packages/example-getting-started/docs/1-prerequisites-and-setup.md
+++ b/packages/example-getting-started/docs/1-prerequisites-and-setup.md
@@ -31,4 +31,4 @@ npm start
 
 ### Navigation
 
-Next step: [Scaffolding your application](2-scaffold-app.html)
+Next step: [Scaffolding your application](2-scaffold-app.md)

--- a/packages/example-getting-started/docs/1-prerequisites-and-setup.md
+++ b/packages/example-getting-started/docs/1-prerequisites-and-setup.md
@@ -28,3 +28,7 @@ cd loopback-example-getting-started && npm i
 ```
 npm start
 ```
+
+### Navigation
+
+Next step: [Scaffolding your application](2-scaffold-app.html)

--- a/packages/example-getting-started/docs/2-scaffold-app.md
+++ b/packages/example-getting-started/docs/2-scaffold-app.md
@@ -15,4 +15,5 @@ leave them all enabled.
 ### Navigation
 
 Previous step: [Prerequisites and setup](1-prerequisites-and-setup.md)
+
 Next step: [Adding the legacy juggler](3-add-legacy-juggler.md)

--- a/packages/example-getting-started/docs/2-scaffold-app.md
+++ b/packages/example-getting-started/docs/2-scaffold-app.md
@@ -14,5 +14,5 @@ leave them all enabled.
 
 ### Navigation
 
-Previous step: [Prerequisites and setup](1-prerequisites-and-setup.html)
-Next step: [Adding the legacy juggler](3-add-legacy-juggler.html)
+Previous step: [Prerequisites and setup](1-prerequisites-and-setup.md)
+Next step: [Adding the legacy juggler](3-add-legacy-juggler.md)

--- a/packages/example-getting-started/docs/2-scaffold-app.md
+++ b/packages/example-getting-started/docs/2-scaffold-app.md
@@ -11,3 +11,8 @@ not to enable certain project features (loopback's build, tslint, mocha, etc.),
 leave them all enabled.
 
 <!-- TODO: Add screenshot of terminal here to illustrate what we mean. -->
+
+### Navigation
+
+Previous step: [Prerequisites and setup](1-prerequisites-and-setup.html)
+Next step: [Adding the legacy juggler](3-add-legacy-juggler.html)

--- a/packages/example-getting-started/docs/3-add-legacy-juggler.md
+++ b/packages/example-getting-started/docs/3-add-legacy-juggler.md
@@ -1,4 +1,4 @@
-### Adding Legacy Juggler Capabilities
+### Adding the Legacy Juggler
 
 Jump into the directory for your new application. You'll see a folder structure
 similar to this:
@@ -52,3 +52,7 @@ export class TodoApplication extends RepositoryMixin(RestApplication) {
   }
 }
 ```
+### Navigation
+
+Previous step: [Scaffolding your application](2-scaffold-app.html)
+Next step: [Add your Todo model](4-todo-model.html)

--- a/packages/example-getting-started/docs/3-add-legacy-juggler.md
+++ b/packages/example-getting-started/docs/3-add-legacy-juggler.md
@@ -55,4 +55,5 @@ export class TodoApplication extends RepositoryMixin(RestApplication) {
 ### Navigation
 
 Previous step: [Scaffolding your application](2-scaffold-app.md)
+
 Next step: [Add your Todo model](4-todo-model.md)

--- a/packages/example-getting-started/docs/3-add-legacy-juggler.md
+++ b/packages/example-getting-started/docs/3-add-legacy-juggler.md
@@ -54,5 +54,5 @@ export class TodoApplication extends RepositoryMixin(RestApplication) {
 ```
 ### Navigation
 
-Previous step: [Scaffolding your application](2-scaffold-app.html)
-Next step: [Add your Todo model](4-todo-model.html)
+Previous step: [Scaffolding your application](2-scaffold-app.md)
+Next step: [Add your Todo model](4-todo-model.md)

--- a/packages/example-getting-started/docs/4-todo-model.md
+++ b/packages/example-getting-started/docs/4-todo-model.md
@@ -105,4 +105,5 @@ export const TodoSchema: SchemaObject = {
 ### Navigation
 
 Previous step: [Adding the Legacy Juggler](3-add-legacy-juggler.md)
+
 Next step: [Add a datasource](5-datasource.md)

--- a/packages/example-getting-started/docs/4-todo-model.md
+++ b/packages/example-getting-started/docs/4-todo-model.md
@@ -102,3 +102,7 @@ export const TodoSchema: SchemaObject = {
   required: ['title'],
 };
 ```
+### Navigation
+
+Previous step: [Adding the Legacy Juggler](3-add-legacy-juggler.html)
+Next step: [Add a datasource](5-datasource.html)

--- a/packages/example-getting-started/docs/4-todo-model.md
+++ b/packages/example-getting-started/docs/4-todo-model.md
@@ -104,5 +104,5 @@ export const TodoSchema: SchemaObject = {
 ```
 ### Navigation
 
-Previous step: [Adding the Legacy Juggler](3-add-legacy-juggler.html)
-Next step: [Add a datasource](5-datasource.html)
+Previous step: [Adding the Legacy Juggler](3-add-legacy-juggler.md)
+Next step: [Add a datasource](5-datasource.md)

--- a/packages/example-getting-started/docs/5-datasource.md
+++ b/packages/example-getting-started/docs/5-datasource.md
@@ -32,3 +32,8 @@ export const db = new DataSourceConstructor(config);
 
 This will give us a strongly-typed datasource export that we can work with to
 construct our TodoRepository definition.
+
+### Navigation
+
+Previous step: [Add your Todo model](4-todo-model.html)
+Next step: [Add a repository](6-repository.html)

--- a/packages/example-getting-started/docs/5-datasource.md
+++ b/packages/example-getting-started/docs/5-datasource.md
@@ -36,4 +36,5 @@ construct our TodoRepository definition.
 ### Navigation
 
 Previous step: [Add your Todo model](4-todo-model.md)
+
 Next step: [Add a repository](6-repository.md)

--- a/packages/example-getting-started/docs/5-datasource.md
+++ b/packages/example-getting-started/docs/5-datasource.md
@@ -35,5 +35,5 @@ construct our TodoRepository definition.
 
 ### Navigation
 
-Previous step: [Add your Todo model](4-todo-model.html)
-Next step: [Add a repository](6-repository.html)
+Previous step: [Add your Todo model](4-todo-model.md)
+Next step: [Add a repository](6-repository.md)

--- a/packages/example-getting-started/docs/6-repository.md
+++ b/packages/example-getting-started/docs/6-repository.md
@@ -26,3 +26,7 @@ export class TodoRepository extends DefaultCrudRepository<
   }
 }
 ```
+### Navigation
+
+Previous step: [Add a datasource](5-datasource.html)
+Next step: [Add a controller](7-controller.html)

--- a/packages/example-getting-started/docs/6-repository.md
+++ b/packages/example-getting-started/docs/6-repository.md
@@ -28,5 +28,5 @@ export class TodoRepository extends DefaultCrudRepository<
 ```
 ### Navigation
 
-Previous step: [Add a datasource](5-datasource.html)
-Next step: [Add a controller](7-controller.html)
+Previous step: [Add a datasource](5-datasource.md)
+Next step: [Add a controller](7-controller.md)

--- a/packages/example-getting-started/docs/6-repository.md
+++ b/packages/example-getting-started/docs/6-repository.md
@@ -29,4 +29,5 @@ export class TodoRepository extends DefaultCrudRepository<
 ### Navigation
 
 Previous step: [Add a datasource](5-datasource.md)
+
 Next step: [Add a controller](7-controller.md)

--- a/packages/example-getting-started/docs/7-controller.md
+++ b/packages/example-getting-started/docs/7-controller.md
@@ -66,5 +66,5 @@ export class TodoController {
 
 ### Navigation
 
-Previous step: [Add a repository](6-repository.html)
-Final step: [Putting it all together](8-putting-it-together.html)
+Previous step: [Add a repository](6-repository.md)
+Final step: [Putting it all together](8-putting-it-together.md)

--- a/packages/example-getting-started/docs/7-controller.md
+++ b/packages/example-getting-started/docs/7-controller.md
@@ -63,3 +63,8 @@ export class TodoController {
   }
 }
 ```
+
+### Navigation
+
+Previous step: [Add a repository](6-repository.html)
+Final step: [Putting it all together](8-putting-it-together.html)

--- a/packages/example-getting-started/docs/7-controller.md
+++ b/packages/example-getting-started/docs/7-controller.md
@@ -67,4 +67,5 @@ export class TodoController {
 ### Navigation
 
 Previous step: [Add a repository](6-repository.md)
+
 Final step: [Putting it all together](8-putting-it-together.md)

--- a/packages/example-getting-started/docs/8-putting-it-together.md
+++ b/packages/example-getting-started/docs/8-putting-it-together.md
@@ -55,7 +55,7 @@ Start the app (`npm start`) and then make some REST requests:
 
 ### Navigation
 
-Previous step: [Add a controller](7-controller.html)
+Previous step: [Add a controller](7-controller.md)
 
 ### More examples and tutorials
 

--- a/packages/example-getting-started/docs/8-putting-it-together.md
+++ b/packages/example-getting-started/docs/8-putting-it-together.md
@@ -52,3 +52,15 @@ Start the app (`npm start`) and then make some REST requests:
 - `POST /todo` with a body of `{ "title": "get the milk" }`
 - `GET /todo/1` and see if you get your Todo object back.
 - `PATCH /todo/1` with a body of `{ "desc": "need milk for cereal" }`
+
+### Navigation
+
+Previous step: [Add a controller](7-controller.html)
+
+### More examples and tutorials
+
+Eager to continue learning about LoopBack 4? Check out our
+[examples and tutorials](https://loopback.io/doc/en/lb4/Examples-and-tutorials.html)
+section to find examples for creating your own custom components, sequences and
+more!
+


### PR DESCRIPTION
The README now links back to the pathways for the tutorial, either on our docs site or in this
package.

connected to #729
continuation of #1001

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
