### PR TITLE
chore: switch to `0.x.y` for versioning before 4.0 GA

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git"
   },
-  "version": "4.0.0-alpha.1",
+  "version": "0.1.0",
   "engines": {
     "node": ">=8"
   },
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",
-    "release": "npm run build:full && lerna publish --cd-version=prerelease --preid=alpha",
+    "release": "npm run build:full && lerna publish",
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
     "precoverage": "npm test",
     "coverage": "open coverage/index.html",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/authentication",
-  "version": "4.0.0-alpha.33",
+  "version": "0.1.0",
   "description": "A LoopBack component for authentication support.",
   "engines": {
     "node": ">=8"
@@ -21,17 +21,17 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32",
-    "@loopback/core": "^4.0.0-alpha.34",
-    "@loopback/openapi-v2": "^4.0.0-alpha.11",
-    "@loopback/rest": "^4.0.0-alpha.26",
+    "@loopback/context": "^0.1.0",
+    "@loopback/core": "^0.1.0",
+    "@loopback/openapi-v2": "^0.1.0",
+    "@loopback/rest": "^0.1.0",
     "passport": "^0.4.0",
     "passport-strategy": "^1.0.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/openapi-spec-builder": "^4.0.0-alpha.22",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/openapi-spec-builder": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/passport": "^0.4.0",
     "@types/passport-http": "^0.3.3",
     "passport-http": "^0.3.0"

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/boot",
-  "version": "4.0.0-alpha.1",
+  "version": "0.1.0",
   "description": "A collection of Booters for LoopBack 4 Applications",
   "engines": {
     "node": ">=8"
@@ -26,18 +26,18 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.27",
-    "@loopback/core": "^4.0.0-alpha.29",
+    "@loopback/context": "^0.1.0",
+    "@loopback/core": "^0.1.0",
     "@types/debug": "0.0.30",
     "@types/glob": "^5.0.34",
     "debug": "^3.1.0",
     "glob": "^7.1.2"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.10",
-    "@loopback/openapi-v2": "^4.0.0-alpha.3",
-    "@loopback/rest": "^4.0.0-alpha.18",
-    "@loopback/testlab": "^4.0.0-alpha.20"
+    "@loopback/build": "^0.1.0",
+    "@loopback/openapi-v2": "^0.1.0",
+    "@loopback/rest": "^0.1.0",
+    "@loopback/testlab": "^0.1.0"
   },
   "files": [
     "README.md",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git"
   },
-  "version": "4.0.0-alpha.13",
+  "version": "0.1.0",
   "engines": {
     "node": ">=8"
   },

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -57,25 +57,25 @@
     "dist"
   ],
   "dependencies": {
-    "@loopback/boot": ">=4.0.0-alpha.1",
-    "@loopback/context": ">=4.0.0-alpha.18",
+    "@loopback/context": "^0.1.0",
+    "@loopback/boot": "^0.1.0",
 <% if (project.projectType === 'application') { -%>
-    "@loopback/core": ">=4.0.0-alpha.20",
-    "@loopback/rest": ">=4.0.0-alpha.7",
-    "@loopback/openapi-v2": ">=4.0.0-alpha.2"
+    "@loopback/core": "^0.1.0",
+    "@loopback/rest": "^0.1.0",
+    "@loopback/openapi-v2": "^0.1.0"
 <% } else { -%>
-    "@loopback/core": ">=4.0.0-alpha.20"
+    "@loopback/core": "^0.1.0"
 <% } -%>
   },
   "devDependencies": {
-    "@loopback/build": ">=4.0.0-alpha.4",
+    "@loopback/build": "^0.1.0",
 <% if (project.mocha) { -%>
-    "@loopback/testlab": ">=4.0.0-alpha.13",
+    "@loopback/testlab": "^0.1.0",
     "@types/mocha": "^2.2.43",
     "mocha": "^4.0.1",
     "source-map-support": "^0.5.2"
 <% } else { -%>
-    "@loopback/testlab": ">=4.0.0-alpha.13"
+    "@loopback/testlab": "^0.1.0"
 <% } -%>
   }
 }

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -57,14 +57,14 @@
     "dist"
   ],
   "dependencies": {
-    "@loopback/boot": ">=4.0.0-alpha.1",
-    "@loopback/context": ">=4.0.0-alpha.18",
+    "@loopback/context": "^0.1.0",
+    "@loopback/boot": "^0.1.0",
 <% if (project.projectType === 'application') { -%>
-    "@loopback/core": ">=4.0.0-alpha.20",
-    "@loopback/rest": ">=4.0.0-alpha.7",
-    "@loopback/openapi-v2": ">=4.0.0-alpha.2"
+    "@loopback/core": "^0.1.0",
+    "@loopback/rest": "^0.1.0",
+    "@loopback/openapi-v2": "^0.1.0"
 <% } else { -%>
-    "@loopback/core": ">=4.0.0-alpha.20"
+    "@loopback/core": "^0.1.0"
 <% } -%>
   },
   "devDependencies": {
@@ -74,7 +74,7 @@
 <% if (project.tslint) { -%>
     "tslint": "^5.7.0",
 <% } -%>
-    "@loopback/testlab": ">=4.0.0-alpha.13",
+    "@loopback/testlab": "^0.1.0",
 <% if (project.mocha) { -%>
     "@types/mocha": "^2.2.43",
     "mocha": "^4.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/cli",
-  "version": "4.0.0-alpha.23",
+  "version": "0.1.0",
   "description": "Yeoman generator for LoopBack 4",
   "homepage": "https://github.com/strongloop/loopback-next/tree/master/packages/cli",
   "author": {
@@ -24,8 +24,8 @@
     "yeoman-generator"
   ],
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "eslint-config-google": "^0.9.1",
     "glob": "^7.1.2",
     "mem-fs": "^1.1.3",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/context",
-  "version": "4.0.0-alpha.32",
+  "version": "0.1.0",
   "description": "LoopBack's container for Inversion of Control",
   "engines": {
     "node": ">=8"
@@ -20,13 +20,13 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/metadata": "^4.0.0-alpha.10",
+    "@loopback/metadata": "^0.1.0",
     "debug": "^3.1.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/bluebird": "^3.5.18",
     "@types/debug": "^0.0.30",
     "@types/uuid": "^3.4.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/core",
-  "version": "4.0.0-alpha.34",
+  "version": "0.1.0",
   "description": "",
   "engines": {
     "node": ">=8"
@@ -21,11 +21,11 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32"
+    "@loopback/context": "^0.1.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24"
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0"
   },
   "files": [
     "README.md",

--- a/packages/example-getting-started/package.json
+++ b/packages/example-getting-started/package.json
@@ -25,17 +25,17 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@loopback/boot": "^4.0.0-alpha.1",
-    "@loopback/context": "^4.0.0-alpha.32",
-    "@loopback/core": "^4.0.0-alpha.34",
-    "@loopback/openapi-spec": "^4.0.0-alpha.25",
-    "@loopback/openapi-v2": "^4.0.0-alpha.11",
-    "@loopback/repository": "^4.0.0-alpha.30",
-    "@loopback/rest": "^4.0.0-alpha.26"
+    "@loopback/boot": "^0.1.0",
+    "@loopback/context": "^0.1.0",
+    "@loopback/core": "^0.1.0",
+    "@loopback/openapi-spec": "^0.1.0",
+    "@loopback/openapi-v2": "^0.1.0",
+    "@loopback/repository": "^0.1.0",
+    "@loopback/rest": "^0.1.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/node": "^8.5.9",
     "source-map-support": "^0.5.2",
     "typescript": "^2.5.2"

--- a/packages/example-hello-world/package.json
+++ b/packages/example-hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/example-hello-world",
-  "version": "4.0.0-alpha.4",
+  "version": "0.1.0",
   "description": "A simple hello-world Application using LoopBack 4",
   "private": true,
   "main": "index.js",
@@ -22,11 +22,11 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@loopback/core": "^4.0.0-alpha.34",
-    "@loopback/rest": "^4.0.0-alpha.26"
+    "@loopback/core": "^0.1.0",
+    "@loopback/rest": "^0.1.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
+    "@loopback/build": "^0.1.0",
     "@types/node": "^8.5.9"
   },
   "keywords": [

--- a/packages/example-log-extension/package.json
+++ b/packages/example-log-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/example-log-extension",
-  "version": "4.0.0-alpha.7",
+  "version": "0.1.0",
   "description": "An example extension project for LoopBack 4",
   "private": true,
   "main": "index.js",
@@ -39,15 +39,15 @@
   },
   "homepage": "https://github.com/strongloop/loopback-next/tree/master/packages/example-log-extension",
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/debug": "0.0.30",
     "source-map-support": "^0.5.2"
   },
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32",
-    "@loopback/core": "^4.0.0-alpha.34",
-    "@loopback/rest": "^4.0.0-alpha.26",
+    "@loopback/context": "^0.1.0",
+    "@loopback/core": "^0.1.0",
+    "@loopback/rest": "^0.1.0",
     "chalk": "^2.3.0",
     "debug": "^3.1.0"
   }

--- a/packages/example-rpc-server/package.json
+++ b/packages/example-rpc-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/example-rpc-server",
-  "version": "4.0.0-alpha.5",
+  "version": "0.1.0",
   "description": "A basic RPC server using a made-up protocol.",
   "private": true,
   "keywords": [
@@ -40,8 +40,8 @@
     "dist"
   ],
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32",
-    "@loopback/core": "^4.0.0-alpha.34",
+    "@loopback/context": "^0.1.0",
+    "@loopback/core": "^0.1.0",
     "@types/express": "^4.0.39",
     "@types/node": "^8.0.51",
     "@types/p-event": "^1.3.0",
@@ -49,8 +49,8 @@
     "p-event": "^1.3.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "source-map-support": "^0.5.2"
   }
 }

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/metadata",
-  "version": "4.0.0-alpha.10",
+  "version": "0.1.0",
   "description": "LoopBack's metadata utilities for reflection and decoration",
   "engines": {
     "node": ">=8"
@@ -25,8 +25,8 @@
     "reflect-metadata": "^0.1.10"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/debug": "^0.0.30",
     "@types/lodash": "^4.14.96"
   },

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/openapi-spec-builder",
-  "version": "4.0.0-alpha.22",
+  "version": "0.1.0",
   "description": "Make it easy to create OpenAPI (Swagger) specification documents in your tests using the builder pattern.",
   "engines": {
     "node": ">=8"
@@ -23,10 +23,10 @@
     "Testing"
   ],
   "dependencies": {
-    "@loopback/openapi-spec": "^4.0.0-alpha.25"
+    "@loopback/openapi-spec": "^0.1.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13"
+    "@loopback/build": "^0.1.0"
   },
   "files": [
     "README.md",

--- a/packages/openapi-spec/package.json
+++ b/packages/openapi-spec/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@loopback/openapi-spec",
-  "version": "4.0.0-alpha.25",
+  "version": "0.1.0",
   "description": "TypeScript type definitions for OpenAPI Spec/Swagger documents.",
   "engines": {
     "node": ">=8"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13"
+    "@loopback/build": "^0.1.0"
   },
   "scripts": {
     "build": "lb-tsc es2017",

--- a/packages/openapi-v2/package.json
+++ b/packages/openapi-v2/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@loopback/openapi-v2",
-  "version": "4.0.0-alpha.11",
+  "version": "0.1.0",
   "description": "Processes openapi v2 related metadata",
   "engines": {
     "node": ">=8"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/openapi-spec-builder": "^4.0.0-alpha.22",
-    "@loopback/repository": "^4.0.0-alpha.30",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/openapi-spec-builder": "^0.1.0",
+    "@loopback/repository": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/debug": "0.0.30",
     "@types/lodash": "^4.14.96"
   },
@@ -46,9 +46,9 @@
     "url": "https://github.com/strongloop/loopback-next.git"
   },
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32",
-    "@loopback/openapi-spec": "^4.0.0-alpha.25",
-    "@loopback/repository-json-schema": "^4.0.0-alpha.8",
+    "@loopback/context": "^0.1.0",
+    "@loopback/openapi-spec": "^0.1.0",
+    "@loopback/repository-json-schema": "^0.1.0",
     "debug": "^3.1.0",
     "lodash": "^4.17.4"
   }

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/repository-json-schema",
-  "version": "4.0.0-alpha.8",
+  "version": "0.1.0",
   "description": "Converts TS classes into JSON Schemas using TypeScript's reflection API",
   "engines": {
     "node": ">=8"
@@ -25,14 +25,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32",
-    "@loopback/repository": "^4.0.0-alpha.30",
+    "@loopback/context": "^0.1.0",
+    "@loopback/repository": "^0.1.0",
     "lodash": "^4.17.4",
     "typescript-json-schema": "^0.20.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/lodash": "^4.14.96"
   },
   "files": [

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/repository",
-  "version": "4.0.0-alpha.30",
+  "version": "0.1.0",
   "description": "Repository based persistence for LoopBack 4",
   "engines": {
     "node": ">=8"
@@ -21,12 +21,12 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/core": "^4.0.0-alpha.34",
-    "@loopback/testlab": "^4.0.0-alpha.24"
+    "@loopback/build": "^0.1.0",
+    "@loopback/core": "^0.1.0",
+    "@loopback/testlab": "^0.1.0"
   },
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32",
+    "@loopback/context": "^0.1.0",
     "loopback-datasource-juggler": "^3.9.2"
   },
   "files": [

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/rest",
-  "version": "4.0.0-alpha.26",
+  "version": "0.1.0",
   "description": "",
   "engines": {
     "node": ">=8"
@@ -21,10 +21,10 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.32",
-    "@loopback/core": "^4.0.0-alpha.34",
-    "@loopback/openapi-spec": "^4.0.0-alpha.25",
-    "@loopback/openapi-v2": "^4.0.0-alpha.11",
+    "@loopback/context": "^0.1.0",
+    "@loopback/core": "^0.1.0",
+    "@loopback/openapi-spec": "^0.1.0",
+    "@loopback/openapi-v2": "^0.1.0",
     "@types/http-errors": "^1.6.1",
     "@types/node": "^8.5.9",
     "body": "^5.1.0",
@@ -36,10 +36,10 @@
     "swagger2openapi": "^2.10.7"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13",
-    "@loopback/openapi-spec-builder": "^4.0.0-alpha.22",
-    "@loopback/repository": "^4.0.0-alpha.30",
-    "@loopback/testlab": "^4.0.0-alpha.24",
+    "@loopback/build": "^0.1.0",
+    "@loopback/openapi-spec-builder": "^0.1.0",
+    "@loopback/repository": "^0.1.0",
+    "@loopback/testlab": "^0.1.0",
     "@types/debug": "0.0.30",
     "@types/js-yaml": "^3.9.1",
     "@types/lodash": "^4.14.96"

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/testlab",
-  "version": "4.0.0-alpha.24",
+  "version": "0.1.0",
   "description": "A collection of test utilities we use to write LoopBack tests.",
   "engines": {
     "node": ">=8"
@@ -17,7 +17,7 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/openapi-spec": "^4.0.0-alpha.25",
+    "@loopback/openapi-spec": "^0.1.0",
     "@types/fs-extra": "^5.0.0",
     "@types/shot": "^3.4.0",
     "@types/sinon": "^4.1.3",
@@ -31,7 +31,7 @@
     "swagger-parser": "^4.0.1"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13"
+    "@loopback/build": "^0.1.0"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
The current versioning `4.0.0-alpha-<x>` makes it difficult to release
breaking changes.

Fixes https://github.com/strongloop/loopback-next/issues/954

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
