### PR TITLE
fix(cli): fix import for BootOptions (@loopback/boot)

### DIFF
--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -1,4 +1,4 @@
-import {Application, ApplicationConfig, BootOptions} from '@loopback/core';
+import {ApplicationConfig} from '@loopback/core';
 import {RestApplication, RestServer} from '@loopback/rest';
 import {MySequence} from './sequence';
 
@@ -18,14 +18,17 @@ export class <%= project.applicationName %> extends BootMixin(RestApplication) {
         dirs: ['controllers'],
         extensions: ['.controller.js'],
         nested: true,
-      }
-    }
+      },
+    };
   }
 
   async start() {
+    const server = await this.getServer(RestServer);
+    // Set up the custom sequence
+    server.sequence(MySequence);
+
     await super.start();
 
-    const server = await this.getServer(RestServer);
     const port = await server.get('rest.port');
     console.log(`Server is running at http://127.0.0.1:${port}`);
     console.log(`Try http://127.0.0.1:${port}/ping`);

--- a/packages/cli/generators/app/templates/src/sequence.ts.ejs
+++ b/packages/cli/generators/app/templates/src/sequence.ts.ejs
@@ -20,7 +20,7 @@ export class MySequence implements SequenceHandler {
     @inject(SequenceActions.PARSE_PARAMS) protected parseParams: ParseParams,
     @inject(SequenceActions.INVOKE_METHOD) protected invoke: InvokeMethod,
     @inject(SequenceActions.SEND) public send: Send,
-    @inject(SequenceActions.REJECT) public reject: Reject
+    @inject(SequenceActions.REJECT) public reject: Reject,
   ) {}
 
   async handle(req: ParsedRequest, res: ServerResponse) {

--- a/packages/cli/generators/app/templates/test/ping.controller.test.ts.ejs
+++ b/packages/cli/generators/app/templates/test/ping.controller.test.ts.ejs
@@ -12,6 +12,7 @@ describe('PingController', () => {
   before(givenARestServer);
 
   before(async () => {
+    await app.boot();
     await app.start();
   });
 


### PR DESCRIPTION
Newly scaffolded LB4 apps fail to start:

```
src/application.ts(1,41): error TS2305: Module '"/private/tmp/t1/node_modules/@loopback/core/index"' has no exported member 'BootOptions'.
```

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
