### PR TITLE
fix(openapi-v3-types): change dev dependency

### DIFF
--- a/packages/openapi-v3-types/package.json
+++ b/packages/openapi-v3-types/package.json
@@ -9,7 +9,7 @@
     "openapi3-ts": "^0.7.0"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.13"
+    "@loopback/build": "^0.1.0"
   },
   "scripts": {
     "build": "lb-tsc es2017",


### PR DESCRIPTION
Update the dev dependency's version after we adopt the new version convention.