### PR TITLE
docs(example-getting-started): remove file extensions from links

### DIFF
--- a/packages/example-getting-started/README.md
+++ b/packages/example-getting-started/README.md
@@ -3,18 +3,18 @@
 This is the basic tutorial for getting started with Loopback 4!
 
 To get started, jump into the
-[Prerequisites and setup](docs/1-prerequisites-and-setup.md) section.
+[Prerequisites and setup](docs/1-prerequisites-and-setup) section.
 
 ## Tutorial Steps
 
-1. [Prerequisites and setup](docs/1-prerequisites-and-setup.md)
-1. [Scaffolding your application](docs/2-scaffold-app.md)
-1. [Adding the legacy juggler](docs/3-add-legacy-juggler.md)
-1. [Add your Todo model](docs/4-todo-model.md)
-1. [Add a datasource](docs/5-datasource.md)
-1. [Add a repository](docs/6-repository.md)
-1. [Add a controller](docs/7-controller.md)
-1. [Putting it all together](docs/8-putting-it-together.md)
+1. [Prerequisites and setup](docs/1-prerequisites-and-setup)
+1. [Scaffolding your application](docs/2-scaffold-app)
+1. [Adding the legacy juggler](docs/3-add-legacy-juggler)
+1. [Add your Todo model](docs/4-todo-model)
+1. [Add a datasource](docs/5-datasource)
+1. [Add a repository](docs/6-repository)
+1. [Add a controller](docs/7-controller)
+1. [Putting it all together](docs/8-putting-it-together)
 
 ### Stuck?
 Check out our [Gitter channel](https://gitter.im/strongloop/loopback) and ask

--- a/packages/example-getting-started/docs/1-prerequisites-and-setup.md
+++ b/packages/example-getting-started/docs/1-prerequisites-and-setup.md
@@ -31,4 +31,4 @@ npm start
 
 ### Navigation
 
-Next step: [Scaffolding your application](2-scaffold-app.md)
+Next step: [Scaffolding your application](2-scaffold-app)

--- a/packages/example-getting-started/docs/2-scaffold-app.md
+++ b/packages/example-getting-started/docs/2-scaffold-app.md
@@ -14,6 +14,6 @@ leave them all enabled.
 
 ### Navigation
 
-Previous step: [Prerequisites and setup](1-prerequisites-and-setup.md)
+Previous step: [Prerequisites and setup](1-prerequisites-and-setup)
 
-Next step: [Adding the legacy juggler](3-add-legacy-juggler.md)
+Next step: [Adding the legacy juggler](3-add-legacy-juggler)

--- a/packages/example-getting-started/docs/3-add-legacy-juggler.md
+++ b/packages/example-getting-started/docs/3-add-legacy-juggler.md
@@ -54,6 +54,6 @@ export class TodoApplication extends RepositoryMixin(RestApplication) {
 ```
 ### Navigation
 
-Previous step: [Scaffolding your application](2-scaffold-app.md)
+Previous step: [Scaffolding your application](2-scaffold-app)
 
-Next step: [Add your Todo model](4-todo-model.md)
+Next step: [Add your Todo model](4-todo-model)

--- a/packages/example-getting-started/docs/4-todo-model.md
+++ b/packages/example-getting-started/docs/4-todo-model.md
@@ -104,6 +104,6 @@ export const TodoSchema: SchemaObject = {
 ```
 ### Navigation
 
-Previous step: [Adding the Legacy Juggler](3-add-legacy-juggler.md)
+Previous step: [Adding the Legacy Juggler](3-add-legacy-juggler)
 
-Next step: [Add a datasource](5-datasource.md)
+Next step: [Add a datasource](5-datasource)

--- a/packages/example-getting-started/docs/5-datasource.md
+++ b/packages/example-getting-started/docs/5-datasource.md
@@ -35,6 +35,6 @@ construct our TodoRepository definition.
 
 ### Navigation
 
-Previous step: [Add your Todo model](4-todo-model.md)
+Previous step: [Add your Todo model](4-todo-model)
 
-Next step: [Add a repository](6-repository.md)
+Next step: [Add a repository](6-repository)

--- a/packages/example-getting-started/docs/6-repository.md
+++ b/packages/example-getting-started/docs/6-repository.md
@@ -28,6 +28,6 @@ export class TodoRepository extends DefaultCrudRepository<
 ```
 ### Navigation
 
-Previous step: [Add a datasource](5-datasource.md)
+Previous step: [Add a datasource](5-datasource)
 
-Next step: [Add a controller](7-controller.md)
+Next step: [Add a controller](7-controller)

--- a/packages/example-getting-started/docs/7-controller.md
+++ b/packages/example-getting-started/docs/7-controller.md
@@ -66,6 +66,6 @@ export class TodoController {
 
 ### Navigation
 
-Previous step: [Add a repository](6-repository.md)
+Previous step: [Add a repository](6-repository)
 
-Final step: [Putting it all together](8-putting-it-together.md)
+Final step: [Putting it all together](8-putting-it-together)

--- a/packages/example-getting-started/docs/8-putting-it-together.md
+++ b/packages/example-getting-started/docs/8-putting-it-together.md
@@ -55,7 +55,7 @@ Start the app (`npm start`) and then make some REST requests:
 
 ### Navigation
 
-Previous step: [Add a controller](7-controller.md)
+Previous step: [Add a controller](7-controller)
 
 ### More examples and tutorials
 


### PR DESCRIPTION
Making the filetypes of the links ambiguous will allow the translated HTML to cross-link correctly.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
