### PR TITLE
fix(context): fix optional param injection for methods

### DIFF
--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -184,7 +184,15 @@ export function resolveInjectedArguments(
   const injectedArgs = describeInjectedArguments(target, method);
   const extraArgs = nonInjectedArgs || [];
 
-  const argLength = DecoratorFactory.getNumberOfParameters(target, method);
+  let argLength = DecoratorFactory.getNumberOfParameters(target, method);
+  if (argLength < injectedArgs.length) {
+    /**
+     * `Function.prototype.length` excludes the rest parameter and only includes
+     * parameters before the first one with a default value. For example,
+     * `hello(@inject('name') name: string)` gives 0 for argLength
+     */
+    argLength = injectedArgs.length;
+  }
 
   let nonInjectedIndex = 0;
   return resolveList(new Array(argLength), (val, ix) => {

--- a/packages/context/test/acceptance/method-level-bindings.ts
+++ b/packages/context/test/acceptance/method-level-bindings.ts
@@ -15,7 +15,10 @@ class InfoController {
     return msg;
   }
 
-  hello(@inject('user') user: string): string {
+  hello(
+    @inject('user', {optional: true})
+    user: string = 'Mary',
+  ): string {
     const msg = `Hello ${user}`;
     debug(msg);
     return msg;
@@ -39,6 +42,15 @@ describe('Context bindings - Injecting dependencies of method', () => {
     // Invoke the `hello` method => Hello John
     const msg = await invokeMethod(instance, 'hello', ctx);
     expect(msg).to.eql('Hello John');
+  });
+
+  it('injects optional prototype method args', async () => {
+    ctx = new Context();
+    ctx.bind(INFO_CONTROLLER).toClass(InfoController);
+    const instance = await ctx.get(INFO_CONTROLLER);
+    // Invoke the `hello` method => Hello Mary
+    const msg = await invokeMethod(instance, 'hello', ctx);
+    expect(msg).to.eql('Hello Mary');
   });
 
   it('injects prototype method args with non-injected ones', async () => {

--- a/packages/rest/test/acceptance/bootstrapping/rest.acceptance.ts
+++ b/packages/rest/test/acceptance/bootstrapping/rest.acceptance.ts
@@ -20,9 +20,11 @@ describe('Bootstrapping with RestComponent', () => {
     let server: RestServer;
     before(givenAppWithUserDefinedSequence);
 
-    it('binds the `sequence` key to the user-defined sequence', async () => {
-      const binding = await server.get(RestBindings.SEQUENCE);
-      expect(binding.constructor.name).to.equal('UserDefinedSequence');
+    it('binds the `sequence` key to the user-defined sequence', () => {
+      // At this moment, the Sequence is not ready to be resolved
+      // as RestBindings.Http.CONTEXT is not bound
+      const binding = server.getBinding(RestBindings.SEQUENCE);
+      expect(binding.valueConstructor.name).to.equal('UserDefinedSequence');
     });
 
     async function givenAppWithUserDefinedSequence() {


### PR DESCRIPTION
The following function has length of 0 as the param has a default value:
```
hello(@inject('user', {optional: true}) user: string = 'Mary')
```

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length

Before this fix, the injected value for `user` is not used. The PR uses
decorations to help decide the real number of params.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
