### PR TITLE
style: use lambda function to reset sandbox

### DIFF
--- a/packages/boot/test/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/test/acceptance/controller.booter.acceptance.ts
@@ -13,7 +13,7 @@ describe('controller booter acceptance tests', () => {
   const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
   const sandbox = new TestSandbox(SANDBOX_PATH);
 
-  beforeEach(resetSandbox);
+  beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
   afterEach(stopApp);
@@ -54,9 +54,5 @@ describe('controller booter acceptance tests', () => {
     } catch (err) {
       console.log(`Stopping the app threw an error: ${err}`);
     }
-  }
-
-  async function resetSandbox() {
-    await sandbox.reset();
   }
 });

--- a/packages/boot/test/integration/controller.booter.integration.ts
+++ b/packages/boot/test/integration/controller.booter.integration.ts
@@ -17,7 +17,7 @@ describe('controller booter integration tests', () => {
 
   let app: BooterApp;
 
-  beforeEach(async () => await sandbox.reset());
+  beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
   it('boots controllers when app.boot() is called', async () => {

--- a/packages/boot/test/integration/repository.booter.integration.ts
+++ b/packages/boot/test/integration/repository.booter.integration.ts
@@ -17,7 +17,7 @@ describe('repository booter integration tests', () => {
 
   let app: BooterApp;
 
-  beforeEach(() => sandbox.reset());
+  beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
   it('boots repositories when app.boot() is called', async () => {

--- a/packages/boot/test/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/test/unit/booters/booter-utils.unit.ts
@@ -11,7 +11,7 @@ describe('booter-utils unit tests', () => {
   const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');
   const sandbox = new TestSandbox(SANDBOX_PATH);
 
-  beforeEach(resetSandbox);
+  beforeEach('reset sandbox', () => sandbox.reset());
 
   describe('discoverFiles()', () => {
     beforeEach(setupSandbox);
@@ -102,8 +102,4 @@ describe('booter-utils unit tests', () => {
       expect(() => loadClassesFromFiles(files)).to.throw(/Cannot find module/);
     });
   });
-
-  async function resetSandbox() {
-    await sandbox.reset();
-  }
 });

--- a/packages/boot/test/unit/booters/controller.booter.unit.ts
+++ b/packages/boot/test/unit/booters/controller.booter.unit.ts
@@ -17,7 +17,7 @@ describe('controller booter unit tests', () => {
 
   let app: Application;
 
-  beforeEach(resetSandbox);
+  beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
   it(`constructor uses ControllerDefaults for 'options' if none are given`, () => {
@@ -61,9 +61,5 @@ describe('controller booter unit tests', () => {
 
   function getApp() {
     app = new Application();
-  }
-
-  async function resetSandbox() {
-    await sandbox.reset();
   }
 });

--- a/packages/boot/test/unit/booters/repository.booter.unit.ts
+++ b/packages/boot/test/unit/booters/repository.booter.unit.ts
@@ -21,7 +21,7 @@ describe('repository booter unit tests', () => {
   let app: RepoApp;
   let stub: sinon.SinonStub;
 
-  beforeEach(() => sandbox.reset());
+  beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
   beforeEach(createStub);
   afterEach(restoreStub);

--- a/packages/cli/test/clone-example.test.js
+++ b/packages/cli/test/clone-example.test.js
@@ -18,12 +18,12 @@ const readFile = promisify(fs.readFile);
 
 const VALID_EXAMPLE = 'getting-started';
 const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-let sandbox;
+const sandbox = new TestSandbox(SANDBOX_PATH);
 
 describe('cloneExampleFromGitHub (SLOW)', function() {
   this.timeout(20000);
-  before(createSandbox);
-  beforeEach(resetSandbox);
+
+  beforeEach('reset sandbox', () => sandbox.reset());
 
   it('extracts project files', async () => {
     const outDir = await cloneExampleFromGitHub(VALID_EXAMPLE, SANDBOX_PATH);
@@ -55,12 +55,4 @@ describe('cloneExampleFromGitHub (SLOW)', function() {
       name: `@loopback/example-${VALID_EXAMPLE}`,
     });
   });
-
-  function createSandbox() {
-    sandbox = new TestSandbox(SANDBOX_PATH);
-  }
-
-  function resetSandbox() {
-    sandbox.reset();
-  }
 });


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

I'm using this style for the repository booter #1030 and think it's cleaner and makes code easier to read and understand as the `resetSandbox` function was just one line. Didn't want to add this to the same PR since it's unrelated files so making a new PR to keep style consistent. 


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
