### PR TITLE
docs(testlab): fix README

### DIFF
--- a/packages/testlab/README.md
+++ b/packages/testlab/README.md
@@ -4,7 +4,7 @@ A collection of test utilities we use to write LoopBack tests.
 
 ## Overview
 
-Test utilities to help writing loopback-next tests:
+Test utilities to help writing LoopBack 4 tests:
 - `expect` - behavior-driven development (BDD) style assertions
 - `sinon`
    - test spies: functions recording arguments and other information for all of their calls
@@ -73,7 +73,7 @@ For more info about `supertest`, please refer to [supertest](https://www.npmjs.c
 
 ## Contributions
 
-- [Guidelines](https://github.com/strongloop/loopback-next/wiki/Contributing##guidelines)
+- [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/DEVELOPING.md)
 - [Join the team](https://github.com/strongloop/loopback-next/issues/110)
 
 ## Tests


### PR DESCRIPTION
Minor fixes in packages\testlab README:
- loopback-next -> LoopBack 4
- Contributing link is currently pointing to a wiki page which links to DEVELOPING.md.  Change it to reference DEVELOPING.md directly. 

Related to: #988 