### PR TITLE
feat(context): add type as a generic parameter to `ctx.get()` and friends

### DIFF
--- a/packages/authentication/test/unit/authenticate-action.test.ts
+++ b/packages/authentication/test/unit/authenticate-action.test.ts
@@ -60,10 +60,10 @@ describe('AuthenticationProvider', () => {
           .bind(AuthenticationBindings.AUTH_ACTION)
           .toProvider(AuthenticationProvider);
         const request = <ParsedRequest>{};
-        const authenticate = await context.get(
+        const authenticate = await context.get<AuthenticateFn>(
           AuthenticationBindings.AUTH_ACTION,
         );
-        const user: UserProfile = await authenticate(request);
+        const user: UserProfile | undefined = await authenticate(request);
         expect(user).to.be.equal(mockUser);
       });
 
@@ -73,7 +73,7 @@ describe('AuthenticationProvider', () => {
         context
           .bind(AuthenticationBindings.AUTH_ACTION)
           .toProvider(AuthenticationProvider);
-        const authenticate = await context.get(
+        const authenticate = await context.get<AuthenticateFn>(
           AuthenticationBindings.AUTH_ACTION,
         );
         const request = <ParsedRequest>{};
@@ -92,7 +92,7 @@ describe('AuthenticationProvider', () => {
         context
           .bind(AuthenticationBindings.AUTH_ACTION)
           .toProvider(AuthenticationProvider);
-        const authenticate = await context.get(
+        const authenticate = await context.get<AuthenticateFn>(
           AuthenticationBindings.AUTH_ACTION,
         );
         const request = <ParsedRequest>{};

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -109,7 +109,10 @@ export class Bootstrapper {
 
     // Resolve Booter Instances
     const booterInsts = await resolveList(filteredBindings, binding =>
-      bootCtx.get(binding.key),
+      // We cannot use Booter interface here because "filter.booters"
+      // allows arbitrary string values, not only the phases defined
+      // by Booter interface
+      bootCtx.get<{[phase: string]: () => Promise<void>}>(binding.key),
     );
 
     // Run phases of booters

--- a/packages/build/config/tslint.build.json
+++ b/packages/build/config/tslint.build.json
@@ -12,7 +12,10 @@
     // These rules catch common errors in JS programming or otherwise
     // confusing constructs that are prone to producing bugs.
 
-    "await-promise": true,
+    // User-land promises like Bluebird implement "PromiseLike" (not "Promise")
+    // interface only. The string "PromiseLike" bellow is needed to
+    // tell tslint that it's ok to `await` such promises.
+    "await-promise": [true, "PromiseLike"],
     "no-floating-promises": true,
     "no-unused-variable": true,
     "no-void-expression": [true, "ignore-arrow-function-shorthand"]

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -8,7 +8,7 @@ import {ResolutionSession} from './resolution-session';
 import {instantiateClass} from './resolver';
 import {
   Constructor,
-  isPromise,
+  isPromiseLike,
   BoundValue,
   ValueOrPromise,
 } from './value-promise';
@@ -176,7 +176,7 @@ export class Binding {
   ): ValueOrPromise<BoundValue> {
     // Initialize the cache as a weakmap keyed by context
     if (!this._cache) this._cache = new WeakMap<Context, BoundValue>();
-    if (isPromise(result)) {
+    if (isPromiseLike(result)) {
       if (this.scope === BindingScope.SINGLETON) {
         // Cache the value at owning context level
         result = result.then(val => {
@@ -294,7 +294,7 @@ export class Binding {
    * ```
    */
   to(value: BoundValue): this {
-    if (isPromise(value)) {
+    if (isPromiseLike(value)) {
       // Promises are a construct primarily intended for flow control:
       // In an algorithm with steps 1 and 2, we want to wait for the outcome
       // of step 1 before starting step 2.
@@ -380,7 +380,7 @@ export class Binding {
         ctx!,
         session,
       );
-      if (isPromise(providerOrPromise)) {
+      if (isPromiseLike(providerOrPromise)) {
         return providerOrPromise.then(p => p.value());
       } else {
         return providerOrPromise.value();

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -10,6 +10,7 @@ import {ResolutionOptions, ResolutionSession} from './resolution-session';
 import {v1 as uuidv1} from 'uuid';
 
 import * as debugModule from 'debug';
+import {ValueOrPromise} from '.';
 const debug = debugModule('loopback:context');
 
 /**
@@ -408,12 +409,7 @@ export class Context {
   getValueOrPromise<T>(
     keyWithPath: string,
     optionsOrSession?: ResolutionOptions | ResolutionSession,
-  ): T | PromiseLike<T> | undefined {
-    // ^^^ Note that boundValue can be any Promise-like implementation,
-    // not necessarily the native Promise instance. As such, it may be
-    // missing newer APIs like Promise#catch() and cannot be casted
-    // directly to a Promise. Callers of this method should use
-    // Promise.resolve() to convert the result into a native Promise.
+  ): ValueOrPromise<T | undefined> {
     const {key, path} = Binding.parseKeyWithPath(keyWithPath);
 
     // backwards compatibility

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -6,7 +6,7 @@
 export * from '@loopback/metadata';
 
 export {
-  isPromise,
+  isPromiseLike,
   BoundValue,
   Constructor,
   ValueOrPromise,

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -10,7 +10,7 @@ import {
   Constructor,
   ValueOrPromise,
   MapObject,
-  isPromise,
+  isPromiseLike,
   resolveList,
   resolveMap,
 } from './value-promise';
@@ -57,7 +57,7 @@ export function instantiateClass<T>(
   const argsOrPromise = resolveInjectedArguments(ctor, '', ctx, session);
   const propertiesOrPromise = resolveInjectedProperties(ctor, ctx, session);
   let inst: ValueOrPromise<T>;
-  if (isPromise(argsOrPromise)) {
+  if (isPromiseLike(argsOrPromise)) {
     // Instantiate the class asynchronously
     inst = argsOrPromise.then(args => {
       /* istanbul ignore if */
@@ -74,13 +74,13 @@ export function instantiateClass<T>(
     // Instantiate the class synchronously
     inst = new ctor(...argsOrPromise);
   }
-  if (isPromise(propertiesOrPromise)) {
+  if (isPromiseLike(propertiesOrPromise)) {
     return propertiesOrPromise.then(props => {
       /* istanbul ignore if */
       if (debug.enabled) {
         debug('Injected properties for %s:', ctor.name, props);
       }
-      if (isPromise(inst)) {
+      if (isPromiseLike(inst)) {
         // Inject the properties asynchronously
         return inst.then(obj => Object.assign(obj, props));
       } else {
@@ -89,7 +89,7 @@ export function instantiateClass<T>(
       }
     });
   } else {
-    if (isPromise(inst)) {
+    if (isPromiseLike(inst)) {
       /* istanbul ignore if */
       if (debug.enabled) {
         debug('Injected properties for %s:', ctor.name, propertiesOrPromise);
@@ -257,7 +257,7 @@ export function invokeMethod(
     typeof targetWithMethods[method] === 'function',
     `Method ${method} not found`,
   );
-  if (isPromise(argsOrPromise)) {
+  if (isPromiseLike(argsOrPromise)) {
     // Invoke the target method asynchronously
     return argsOrPromise.then(args => {
       /* istanbul ignore if */

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -32,8 +32,8 @@ export type MapObject<T> = {[name: string]: T};
  *
  * @param value The value to check.
  */
-export function isPromise<T>(
-  value: T | PromiseLike<T>,
+export function isPromiseLike<T>(
+  value: T | PromiseLike<T> | undefined,
 ): value is PromiseLike<T> {
   if (!value) return false;
   if (typeof value !== 'object' && typeof value !== 'function') return false;
@@ -45,7 +45,7 @@ export function isPromise<T>(
  * @param value Value of an object
  * @param path Path to the property
  */
-export function getDeepProperty(value: BoundValue, path: string) {
+export function getDeepProperty(value: BoundValue, path: string): BoundValue {
   const props = path.split('.').filter(Boolean);
   for (const p of props) {
     if (value == null) {
@@ -99,7 +99,7 @@ export function resolveMap<T, V>(
 
   for (const key in map) {
     const valueOrPromise = resolver(map[key], key, map);
-    if (isPromise(valueOrPromise)) {
+    if (isPromiseLike(valueOrPromise)) {
       if (!asyncResolvers) asyncResolvers = [];
       asyncResolvers.push(valueOrPromise.then(setter(key)));
     } else {
@@ -158,7 +158,7 @@ export function resolveList<T, V>(
   // tslint:disable-next-line:prefer-for-of
   for (let ix = 0; ix < list.length; ix++) {
     const valueOrPromise = resolver(list[ix], ix, list);
-    if (isPromise(valueOrPromise)) {
+    if (isPromiseLike(valueOrPromise)) {
       if (!asyncResolvers) asyncResolvers = [];
       asyncResolvers.push(valueOrPromise.then(setter(ix)));
     } else {
@@ -190,7 +190,7 @@ export function tryWithFinally<T>(
     finalAction();
     throw err;
   }
-  if (isPromise(result)) {
+  if (isPromiseLike(result)) {
     // Once (promise.finally)[https://github.com/tc39/proposal-promise-finally
     // is supported, the following can be simplifed as
     // `result = result.finally(finalAction);`

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -21,8 +21,13 @@ export type BoundValue = any;
 /**
  * Representing a value or promise. This type is used to represent results of
  * synchronous/asynchronous resolution of values.
+ *
+ * Note that we are using PromiseLike instead of native Promise to describe
+ * the asynchronous variant. This allows producers of async values to use
+ * any Promise implementation (e.g. Bluebird) instead of native Promises
+ * provided by JavaScript runtime.
  */
-export type ValueOrPromise<T> = T | Promise<T>;
+export type ValueOrPromise<T> = T | PromiseLike<T>;
 
 export type MapObject<T> = {[name: string]: T};
 

--- a/packages/context/test/acceptance/class-level-bindings.ts
+++ b/packages/context/test/acceptance/class-level-bindings.ts
@@ -150,7 +150,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     }
 
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store = ctx.getSync<Store>('store');
 
     expect(store.getter).to.be.Function();
     expect(await store.getter()).to.equal('value');
@@ -166,7 +166,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     }
 
     ctx.bind('store').toClass(Store);
-    const store = ctx.getSync('store');
+    const store = ctx.getSync<Store>('store');
 
     expect(store.setter).to.be.Function();
     store.setter('a-value');
@@ -181,7 +181,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     ctx.bind('config').to({test: 'test-config'});
     ctx.bind('component').toClass(TestComponent);
 
-    const resolved = await ctx.get('component');
+    const resolved = await ctx.get<TestComponent>('component');
     expect(resolved.config).to.equal('test-config');
   });
 
@@ -257,7 +257,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       .bind('store.locations.sj')
       .toDynamicValue(async () => 'San Jose')
       .tag('store:location');
-    const store: Store = await ctx.get('store');
+    const store = await ctx.get<Store>('store');
     expect(store.locations).to.eql(['San Francisco', 'San Jose']);
   });
 
@@ -292,7 +292,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       .bind('store.locations.sj')
       .toProvider(LocationProvider)
       .tag('store:location');
-    const store: Store = await ctx.get('store');
+    const store = await ctx.get<Store>('store');
     expect(store.locations).to.eql(['San Francisco', 'San Jose']);
     expect(resolutionPath).to.eql(
       'store --> @Store.constructor[0] --> store.locations.sj --> ' +

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -125,7 +125,7 @@ describe('Binding', () => {
   describe('toDynamicValue(dynamicValueFn)', () => {
     it('support a factory', async () => {
       const b = ctx.bind('msg').toDynamicValue(() => Promise.resolve('hello'));
-      const value: string = await ctx.get('msg');
+      const value = await ctx.get<string>('msg');
       expect(value).to.equal('hello');
       expect(b.type).to.equal(BindingType.DYNAMIC_VALUE);
     });
@@ -136,7 +136,7 @@ describe('Binding', () => {
       ctx.bind('msg').toDynamicValue(() => Promise.resolve('world'));
       const b = ctx.bind('myService').toClass(MyService);
       expect(b.type).to.equal(BindingType.CLASS);
-      const myService: MyService = await ctx.get('myService');
+      const myService = await ctx.get<MyService>('myService');
       expect(myService.getMessage()).to.equal('hello world');
     });
   });
@@ -145,7 +145,7 @@ describe('Binding', () => {
     it('binding returns the expected value', async () => {
       ctx.bind('msg').to('hello');
       ctx.bind('provider_key').toProvider(MyProvider);
-      const value: string = await ctx.get('provider_key');
+      const value = await ctx.get<string>('provider_key');
       expect(value).to.equal('hello world');
     });
 
@@ -159,7 +159,7 @@ describe('Binding', () => {
     it('support asynchronous dependencies of provider class', async () => {
       ctx.bind('msg').toDynamicValue(() => Promise.resolve('hello'));
       ctx.bind('provider_key').toProvider(MyProvider);
-      const value: string = await ctx.get('provider_key');
+      const value = await ctx.get<string>('provider_key');
       expect(value).to.equal('hello world');
     });
 

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -4,7 +4,13 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, Binding, BindingScope, BindingType, isPromise} from '../..';
+import {
+  Context,
+  Binding,
+  BindingScope,
+  BindingType,
+  isPromiseLike,
+} from '../..';
 
 /**
  * Create a subclass of context so that we can access parents and registry
@@ -493,8 +499,8 @@ describe('Context', () => {
 
     it('returns promise for async values', async () => {
       ctx.bind('key').toDynamicValue(() => Promise.resolve('value'));
-      const valueOrPromise = ctx.getValueOrPromise('key');
-      expect(isPromise(valueOrPromise)).to.be.true();
+      const valueOrPromise = ctx.getValueOrPromise<string>('key');
+      expect(isPromiseLike(valueOrPromise)).to.be.true();
       const value = await valueOrPromise;
       expect(value).to.equal('value');
     });
@@ -509,7 +515,9 @@ describe('Context', () => {
       ctx
         .bind('key')
         .toDynamicValue(() => Promise.resolve({test: 'test-value'}));
-      const value = await ctx.getValueOrPromise('key#test');
+      const valueOrPromise = ctx.getValueOrPromise<string>('key#test');
+      expect(isPromiseLike(valueOrPromise)).to.be.true();
+      const value = await valueOrPromise;
       expect(value).to.equal('test-value');
     });
 

--- a/packages/context/test/unit/is-promise.test.ts
+++ b/packages/context/test/unit/is-promise.test.ts
@@ -5,38 +5,38 @@
 
 import * as bluebird from 'bluebird';
 import {expect} from '@loopback/testlab';
-import {isPromise} from '../..';
+import {isPromiseLike} from '../..';
 
 describe('isPromise', () => {
   it('returns false for undefined', () => {
-    expect(isPromise(undefined)).to.be.false();
+    expect(isPromiseLike(undefined)).to.be.false();
   });
 
   it('returns false for a string value', () => {
-    expect(isPromise('string-value')).to.be.false();
+    expect(isPromiseLike('string-value')).to.be.false();
   });
 
   it('returns false for a plain object', () => {
-    expect(isPromise({foo: 'bar'})).to.be.false();
+    expect(isPromiseLike({foo: 'bar'})).to.be.false();
   });
 
   it('returns false for an array', () => {
-    expect(isPromise([1, 2, 3])).to.be.false();
+    expect(isPromiseLike([1, 2, 3])).to.be.false();
   });
 
   it('returns false for a Date', () => {
-    expect(isPromise(new Date())).to.be.false();
+    expect(isPromiseLike(new Date())).to.be.false();
   });
 
   it('returns true for a native Promise', () => {
-    expect(isPromise(Promise.resolve())).to.be.true();
+    expect(isPromiseLike(Promise.resolve())).to.be.true();
   });
 
   it('returns true for a Bluebird Promise', () => {
-    expect(isPromise(bluebird.resolve())).to.be.true();
+    expect(isPromiseLike(bluebird.resolve())).to.be.true();
   });
 
   it('returns false when .then() is not a function', () => {
-    expect(isPromise({then: 'later'})).to.be.false();
+    expect(isPromiseLike({then: 'later'})).to.be.false();
   });
 });

--- a/packages/example-rpc-server/src/servers/rpc-router.ts
+++ b/packages/example-rpc-server/src/servers/rpc-router.ts
@@ -22,9 +22,9 @@ export async function routeHandler(
   const ctrl = request.body.controller;
   const method = request.body.method;
   const input = request.body.input;
-  let controller;
+  let controller: Controller;
   try {
-    controller = await server.get(`controllers.${ctrl}`);
+    controller = await server.get<Controller>(`controllers.${ctrl}`);
     if (!controller[method]) {
       throw new Error(
         `No method was found on controller "${ctrl}" with name "${method}".`,

--- a/packages/repository/src/decorators/repository.ts
+++ b/packages/repository/src/decorators/repository.ts
@@ -139,7 +139,9 @@ async function resolve(ctx: Context, injection: Injection) {
 
   let dataSource = meta.dataSource;
   if (meta.dataSourceName) {
-    dataSource = await ctx.get('datasources.' + meta.dataSourceName);
+    dataSource = await ctx.get<DataSource>(
+      'datasources.' + meta.dataSourceName,
+    );
   }
   assert(
     dataSource instanceof DataSourceConstructor,

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -6,7 +6,7 @@
 export const jugglerModule = require('loopback-datasource-juggler');
 
 import * as assert from 'assert';
-import {isPromise} from '@loopback/context';
+import {isPromiseLike} from '@loopback/context';
 import {DataObject, Options} from './common-types';
 import {Entity} from './model';
 import {Filter, Where} from './query';
@@ -51,8 +51,11 @@ export function bindModel<T extends typeof juggler.ModelBase>(
  */
 /* tslint:disable-next-line:no-any */
 function ensurePromise<T>(p: juggler.PromiseOrVoid<T>): Promise<T> {
-  if (p && isPromise(p)) {
-    return p;
+  if (p && isPromiseLike(p)) {
+    // Juggler uses promise-like Bluebird instead of native Promise
+    // implementation. We need to convert the promise returned by juggler
+    // methods to proper native Promise instance.
+    return Promise.resolve(p);
   } else {
     return Promise.reject(new Error('The value should be a Promise: ' + p));
   }

--- a/packages/repository/src/loopback-datasource-juggler.ts
+++ b/packages/repository/src/loopback-datasource-juggler.ts
@@ -11,9 +11,11 @@ import {EventEmitter} from 'events';
 
 export declare namespace juggler {
   /**
-   * Return type for promisified Node.js async methods
+   * Return type for promisified Node.js async methods.
+   *
+   * Note that juggler uses Bluebird, not the native Promise.
    */
-  export type PromiseOrVoid<T> = Promise<T> | void;
+  export type PromiseOrVoid<T> = PromiseLike<T> | void;
 
   /**
    * Property definition

--- a/packages/repository/test/unit/decorator/repository-with-di.ts
+++ b/packages/repository/test/unit/decorator/repository-with-di.ts
@@ -64,7 +64,7 @@ describe('repository class', () => {
 
   // tslint:disable-next-line:max-line-length
   it('supports referencing predefined repository by name via constructor', async () => {
-    const myController: MyController = await ctx.get(
+    const myController = await ctx.get<MyController>(
       'controllers.MyController',
     );
     expect(myController.noteRepo instanceof DefaultCrudRepository).to.be.true();

--- a/packages/repository/test/unit/decorator/repository-with-value-provider.ts
+++ b/packages/repository/test/unit/decorator/repository-with-value-provider.ts
@@ -62,7 +62,7 @@ describe('repository class', () => {
 
   // tslint:disable-next-line:max-line-length
   it('supports referencing predefined repository by name via constructor', async () => {
-    const myController: MyController = await ctx.get(
+    const myController = await ctx.get<MyController>(
       'controllers.MyController',
     );
     expect(myController.noteRepo instanceof DefaultCrudRepository).to.be.true();

--- a/packages/repository/test/unit/decorator/repository.ts
+++ b/packages/repository/test/unit/decorator/repository.ts
@@ -54,7 +54,7 @@ describe('repository decorator', () => {
 
   // tslint:disable-next-line:max-line-length
   it('supports referencing predefined repository by name via constructor', async () => {
-    const myController: MyController = await ctx.get(
+    const myController = await ctx.get<MyController>(
       'controllers.MyController',
     );
     expect(myController.noteRepo).exactly(repo);
@@ -62,7 +62,7 @@ describe('repository decorator', () => {
 
   // tslint:disable-next-line:max-line-length
   it('supports referencing predefined repository by name via property', async () => {
-    const myController: MyController = await ctx.get(
+    const myController = await ctx.get<MyController>(
       'controllers.MyController',
     );
     expect(myController.noteRepo2).exactly(repo);
@@ -84,7 +84,8 @@ describe('repository decorator', () => {
       ) {}
     }
     ctx.bind('controllers.Controller2').toClass(Controller2);
-    const myController: MyController = await ctx.get('controllers.Controller2');
+
+    const myController = await ctx.get<MyController>('controllers.Controller2');
     expect(myController.noteRepo).to.be.not.null();
   });
 
@@ -96,7 +97,7 @@ describe('repository decorator', () => {
       ) {}
     }
     ctx.bind('controllers.Controller3').toClass(Controller3);
-    const myController: MyController = await ctx.get('controllers.Controller3');
+    const myController = await ctx.get<MyController>('controllers.Controller3');
     expect(myController.noteRepo).to.be.not.null();
   });
 

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -64,7 +64,7 @@ export class HttpHandler {
     const parsedRequest: ParsedRequest = parseRequestUrl(request);
     const requestContext = this._createRequestContext(request, response);
 
-    const sequence: SequenceHandler = await requestContext.get(
+    const sequence = await requestContext.get<SequenceHandler>(
       RestBindings.SEQUENCE,
     );
     await sequence.handle(parsedRequest, response);

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -220,7 +220,7 @@ export class RestServer extends Context implements Server {
 
     for (const b of this.find('routes.*')) {
       // TODO(bajtos) should we support routes defined asynchronously?
-      const route = this.getSync(b.key);
+      const route = this.getSync<RouteEntry>(b.key);
       this._httpHandler.registerRoute(route);
     }
 
@@ -445,7 +445,7 @@ export class RestServer extends Context implements Server {
    *  - `app.route('get', '/greet', operationSpec, MyController, 'greet')`
    */
   getApiSpec(): OpenApiSpec {
-    const spec = this.getSync(RestBindings.API_SPEC);
+    const spec = this.getSync<OpenApiSpec>(RestBindings.API_SPEC);
     const defs = this.httpHandler.getApiDefinitions();
 
     // Apply deep clone to prevent getApiSpec() callers from
@@ -527,8 +527,8 @@ export class RestServer extends Context implements Server {
     // of API spec, controllers and routes at startup time.
     this._setupHandlerIfNeeded();
 
-    const httpPort = await this.get(RestBindings.PORT);
-    const httpHost = await this.get(RestBindings.HOST);
+    const httpPort = await this.get<number>(RestBindings.PORT);
+    const httpHost = await this.get<string | undefined>(RestBindings.HOST);
     this._httpServer = createServer(this.handleHttp);
     const httpServer = this._httpServer;
 

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -238,7 +238,7 @@ describe('Routing', () => {
       }
 
       async getFlag(): Promise<string> {
-        return this.ctx.get('flag');
+        return this.ctx.get<string>('flag');
       }
     }
     givenControllerInApp(app, FlagController);

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -21,7 +21,7 @@ describe('RestServer', () => {
   describe('"bindElement" binding', () => {
     it('returns a function for creating new bindings', async () => {
       const ctx = await givenRequestContext();
-      const bindElement: BindElement = await ctx.get(RestBindings.BIND_ELEMENT);
+      const bindElement = await ctx.get<BindElement>(RestBindings.BIND_ELEMENT);
       const binding = bindElement('foo').to('bar');
       expect(binding).to.be.instanceOf(Binding);
       expect(ctx.getSync('foo')).to.equal('bar');
@@ -31,7 +31,7 @@ describe('RestServer', () => {
   describe('"getFromContext" binding', () => {
     it('returns a function for getting a value from the context', async () => {
       const ctx = await givenRequestContext();
-      const getFromContext: GetFromContext = await ctx.get(
+      const getFromContext = await ctx.get<GetFromContext>(
         RestBindings.GET_FROM_CONTEXT,
       );
       ctx.bind('foo').to('bar');
@@ -53,7 +53,7 @@ describe('RestServer', () => {
       );
 
       const ctx = await givenRequestContext();
-      const invokeMethod: InvokeMethod = await ctx.get(
+      const invokeMethod = await ctx.get<InvokeMethod>(
         RestBindings.SequenceActions.INVOKE_METHOD,
       );
 


### PR DESCRIPTION
Modify `ctx.get()` and friends to request callers to explicitly specify
what type they are expecting to receive from the context. This prevents
unintentional introduction of `any` type into our codebase.

Consider the following example:

```ts
const bootstrapper = ctx.get('core.Bootstrapper');
bootstrapper.run(options);
```

The variable `bootstrapper` has type `any`, which is super easy to miss
when reading/reviewing such code.

Once we introduce `any`, the compiler does not check anything - we can
invoke arbitrary methods with arbitrary parameters, the result of such
call is `any` again. As far as the compiler is concerned, the following
code is perfectly valid too:

```ts
const bootstrapper = ctx.get('core.Bootstrapper');
const applause = bootstrapper.danceSamba('hey', 'hou');
applause.play();
```

With my commit in place, neither of the examples above compiles and the
first example needs to be fixed as follows:

```ts
const bootstrapper = ctx.get<Bootstrapper>('core.Bootstrapper');
bootstrapper.run(options);
```

While working on this pull request, I discovered and fixed a problem
related to how we treat Promises. In TypeScript, there are two entities
describing Promises:

 - PromiseLike interface describes any object conforming to [Promise/A+
   specification](https://promisesaplus.com/) (i.e. has `p.then()` method).
 - Promise class describes the native Promise class. In ES2018, this
   class has additional methods compared to PromiseLike, e.g.
  `p.catch()`.

In our code, there were places where the type definitions were assuming
the native Promise, but the API allowed consumers to provide any
PromiseLike value. For example, loopback-datasource-juggler always
returns Bluebird promises.

This commit fixes type annotations to use PromiseLike in all places
that a user-provided promise value can enter.

**BREAKING CHANGE**

`ctx.get()` and `ctx.getSync()` require a type now.
See the example below for upgrade instructions:

```diff
- const c: MyController = await ctx.get('MyController');
+ const c = await ctx.get<MyController>('MyController');
```

`isPromise` was renamed to `isPromiseLike` and acts as a type guard
for `PromiseLike`, not `Promise`.  When upgrading affected code, you
need to determine whether the code was accepting any Promise
implementation (i.e. `PromiseLike`) or only native Promises. In the
former case, you should use `isPromiseLike` and potentially convert the
userland Promise instance to a native Promise via
`Promise.resolve(promiseLike)`. In the latter case, you can replace
`isPromise(p)` with `p instanceof Promise`.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- (n/a) Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
