### PR TITLE
fix(cli): move sequence customization to app constructor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,9 @@
   "editor.tabSize": 2,
   "editor.trimAutoWhitespace": true,
   "editor.formatOnSave": true,
-
+  "[html]": {
+    "editor.formatOnSave": false
+  },
   "files.exclude": {
     "**/.DS_Store": true,
     "**/.git": true,

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -10,6 +10,10 @@ import {BootMixin, Booter, Binding} from '@loopback/boot';
 export class <%= project.applicationName %> extends BootMixin(RestApplication) {
   constructor(options?: ApplicationConfig) {
     super(options);
+
+    // Set up the custom sequence
+    this.sequence(MySequence);
+
     this.projectRoot = __dirname;
     // Customize @loopback/boot Booter Conventions here
     this.bootOptions = {
@@ -23,12 +27,9 @@ export class <%= project.applicationName %> extends BootMixin(RestApplication) {
   }
 
   async start() {
-    const server = await this.getServer(RestServer);
-    // Set up the custom sequence
-    server.sequence(MySequence);
-
     await super.start();
 
+    const server = await this.getServer(RestServer);
     const port = await server.get('rest.port');
     console.log(`Server is running at http://127.0.0.1:${port}`);
     console.log(`Try http://127.0.0.1:${port}/ping`);


### PR DESCRIPTION
This is a follow-up for #1022 which re-introduced a bad practice of customizing app behavior in `app.start`, something we are trying to get rid of (see e.g. #968 and #994).

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
