### PR TITLE
 fix(rest): log unexpected errors to console

### DIFF
--- a/packages/build/bin/run-mocha.js
+++ b/packages/build/bin/run-mocha.js
@@ -37,6 +37,19 @@ function run(argv, dryRun) {
     );
     mochaOpts.unshift('--require', sourceMapRegisterPath);
   }
+
+  const allowConsoleLogsIx = mochaOpts.indexOf('--allow-console-logs');
+  if (allowConsoleLogsIx === -1) {
+    // Fail any tests that are printing to console.
+    mochaOpts.unshift(
+      '--require',
+      require.resolve('../src/fail-on-console-logs')
+    );
+  } else {
+    // Allow tests to print to console, remove --allow-console-logs argument
+    mochaOpts.splice(allowConsoleLogsIx, 1);
+  }
+
   const args = [...mochaOpts];
 
   return utils.runCLI('mocha/bin/mocha', args, dryRun);

--- a/packages/build/src/fail-on-console-logs.js
+++ b/packages/build/src/fail-on-console-logs.js
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/build
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const util = require('util');
+
+const originalConsole = {
+  log: console.log,
+  error: console.error,
+  warn: console.warn,
+};
+
+console.log = recordForbiddenCall('log');
+console.warn = recordForbiddenCall('warn');
+console.error = recordForbiddenCall('error');
+
+const problems = [];
+
+function recordForbiddenCall(methodName) {
+  return function recordForbiddenConsoleUsage(...args) {
+    // Print the original message
+    originalConsole[methodName](...args);
+
+    // Find out who called us.
+    // The first line is the error message,
+    // the second line points to this very function.
+    const stack = new Error().stack.split(/\n/).slice(2);
+
+    // Mocha reporters are allowed to call console functions
+    if (/[\/\\]node_modules[\/\\]mocha[\/\\]/.test(stack[0])) {
+      return;
+    }
+
+    // Record the problem otherwise
+    const msg = util.format(...args);
+    problems.push({msg, stack});
+  }
+}
+
+process.on('exit', (code) => {
+  if (!problems.length) return;
+  const log = originalConsole.log;
+
+  log('\n=== ATTENTION - INVALID USAGE OF CONSOLE LOGS DETECTED ===\n');
+
+  for (const p of problems) {
+    // print the first line of the console log
+    log(p.msg.split(/\n/)[0]);
+    // print the stack trace
+    log(p.stack.join('\n'));
+    // add an empty line as a delimiter
+    log('\n');
+  }
+
+  // ensure the process returns non-zero exit code to indicate test failure
+  process.exitCode = code || 10;
+});

--- a/packages/rest/test/helpers.ts
+++ b/packages/rest/test/helpers.ts
@@ -3,19 +3,18 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Provider} from '@loopback/context';
 import {ServerRequest} from 'http';
-import {LogError} from '../internal-types';
+import {LogError} from '..';
 
-export class LogErrorProvider implements Provider<LogError> {
-  value(): LogError {
-    return (err, statusCode, req) => this.action(err, statusCode, req);
-  }
-
-  action(err: Error, statusCode: number, req: ServerRequest) {
-    if (statusCode < 500) {
-      return;
-    }
+export function createUnexpectedHttpErrorLogger(
+  expectedStatusCode: number = 0,
+): LogError {
+  return function logUnexpectedHttpError(
+    err: Error,
+    statusCode: number,
+    req: ServerRequest,
+  ) {
+    if (statusCode === expectedStatusCode) return;
 
     console.error(
       'Unhandled error in %s %s: %s %s',
@@ -24,5 +23,5 @@ export class LogErrorProvider implements Provider<LogError> {
       statusCode,
       err.stack || err,
     );
-  }
+  };
 }


### PR DESCRIPTION
This is a follow-up and a partial revert of #939.

The first commit adds a check to verify that no console logs are produced by our tests, beyond what Mocha prints. This is needed to ensure clean test output in the future.

The second commit reverts the default implementation of `LogError` sequence action to use `console.error` again (instead of `debug`) and fixes tests to suppress error messages for requests that fail with the expected error.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- Related API Documentation was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `packages/example-*` were updated
