### PR TITLE
chore: update issues template to be simpler

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,37 +1,15 @@
-<!--
-Questions:
-  https://groups.google.com/forum/#!forum/loopbackjs
-  https://gitter.im/strongloop/loopback
-Immediate support:
-  https://strongloop.com/api-connect-faqs/
-  https://strongloop.com/node-js/subscription-plans/
--->
+## Description / Steps to reproduce / Feature proposal
 
-# Description/Steps to reproduce
+## Current Behavior
+
+## Expected Behavior
+
 
 <!--
-If feature: A description of the feature
-If bug: Steps to reproduce
+HELP US HELP YOU, PLEASE
+- Do a quick search to avoid duplicate issues
+- Provide as much information as possible (reproduction sandbox, use case for features, etc.)
+- Consider using a more suitable venue for questions such as Stack Overflow, Gitter, etc.
 -->
 
-# Link to reproduction sandbox
-
-<!--
-Link to an app sandbox for reproduction
-
-Note: Failure to provide a sandbox application for reproduction purposes will result in the issue being closed.
--->
-
-# Expected result
-
-<!--
-Also include actual results if bug
--->
-
-# Additional information
-
-<!--
-Copy+paste the output of these two commands:
-  node -e 'console.log(process.platform, process.arch, process.versions.node)'
-  npm ls --prod --depth 0 | grep loopback
--->
+_See [Reporting Issues](http://loopback.io/doc/en/contrib/Reporting-issues.html) for more tips on writing good issues_


### PR DESCRIPTION
A proposal for a new issues template that is simpler and allows users to ask questions / provide feedback via issues.

fixes #979 and #47

---

_It's hard to change this template by just discussing it so I hope this proposal provides ground for discussion based on something concrete. We can iterate over the content as needed till everyone agrees to a new revision (I think we all agree we need a new template)._

_P.S. Remember we can always try something out and re-iterate when / if needed_

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
