### PR TITLE
fix(boot): warn if attempts to call app.repository without RepositoryMixin

### DIFF
--- a/packages/boot/src/booters/repository.booter.ts
+++ b/packages/boot/src/booters/repository.booter.ts
@@ -29,31 +29,8 @@ export class RepositoryBooter extends BaseArtifactBooter {
     public repositoryOptions: ArtifactOptions = {},
   ) {
     super();
-
-    /**
-     * Repository Booter requires the use of RepositoryMixin (so we have `app.repository`)
-     * for binding a Repository Class. We check for it's presence and run
-     * accordingly.
-     */
-    // tslint:disable-next-line:no-any
-    if (!this.app.repository) {
-      console.warn(
-        'app.repository() function is needed for RepositoryBooter. You can add ' +
-          'it to your Application using RepositoryMixin from @loopback/repository.',
-      );
-
-      /**
-       * If RepositoryMixin is not used and a `.repository()` function is not
-       * available, we change the methods to be empty so bootstrapper can
-       * still run without any side-effects of loading this Booter.
-       */
-      this.configure = async () => {};
-      this.discover = async () => {};
-      this.load = async () => {};
-    } else {
-      // Set Repository Booter Options if passed in via bootConfig
-      this.options = Object.assign({}, RepositoryDefaults, repositoryOptions);
-    }
+    // Set Repository Booter Options if passed in via bootConfig
+    this.options = Object.assign({}, RepositoryDefaults, repositoryOptions);
   }
 
   /**
@@ -62,10 +39,24 @@ export class RepositoryBooter extends BaseArtifactBooter {
    */
   async load() {
     await super.load();
-    this.classes.forEach(cls => {
-      // tslint:disable-next-line:no-any
-      this.app.repository(cls);
-    });
+    /**
+     * If Repository Classes were discovered, we need to make sure RepositoryMixin
+     * was used (so we have `app.repository()`) to perform the binding of a
+     * Repository Class.
+     */
+    if (this.classes.length > 0) {
+      if (!this.app.repository) {
+        console.warn(
+          'app.repository() function is needed for RepositoryBooter. You can add ' +
+            'it to your Application using RepositoryMixin from @loopback/repository.',
+        );
+      } else {
+        this.classes.forEach(cls => {
+          // tslint:disable-next-line:no-any
+          this.app.repository(cls);
+        });
+      }
+    }
   }
 }
 

--- a/packages/boot/test/unit/booters/repository.booter.unit.ts
+++ b/packages/boot/test/unit/booters/repository.booter.unit.ts
@@ -23,13 +23,24 @@ describe('repository booter unit tests', () => {
 
   beforeEach(() => sandbox.reset());
   beforeEach(getApp);
-  before(createStub);
-  after(restoreStub);
+  beforeEach(createStub);
+  afterEach(restoreStub);
 
   it('gives a warning if called on an app without RepositoryMixin', async () => {
     const normalApp = new Application();
-    // tslint:disable-next-line:no-unused-expression
-    new RepositoryBooter(normalApp as AppWithRepository, SANDBOX_PATH);
+    await sandbox.copyFile(
+      resolve(__dirname, '../../fixtures/multiple.artifact.js'),
+    );
+
+    const booterInst = new RepositoryBooter(
+      normalApp as AppWithRepository,
+      SANDBOX_PATH,
+    );
+
+    // Load uses discovered property
+    booterInst.discovered = [resolve(SANDBOX_PATH, 'multiple.artifact.js')];
+    await booterInst.load();
+
     sinon.assert.calledOnce(stub);
     sinon.assert.calledWith(
       stub,


### PR DESCRIPTION
console warning is excessive / clutters the logs for users. For someone not using the RepositoryMixin, they can enable debug to help identify the issue.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
