### PR TITLE
chore(openapi-v3): disable package-lock

### DIFF
--- a/packages/openapi-v3/.npmrc
+++ b/packages/openapi-v3/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Disables the package-lock file for this package. Noticed it getting created after bootstrapping the monorepo.


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
