### PR TITLE
feat(rest): expose app.requestHandler function

### DIFF
--- a/packages/authentication/test/acceptance/basic-auth.ts
+++ b/packages/authentication/test/acceptance/basic-auth.ts
@@ -188,7 +188,7 @@ describe('Basic Authentication', () => {
   }
 
   function whenIMakeRequestTo(restServer: RestServer): Client {
-    return createClientForHandler(restServer.handleHttp);
+    return createClientForHandler(restServer.requestHandler);
   }
 });
 

--- a/packages/boot/test/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/test/acceptance/controller.booter.acceptance.ts
@@ -23,7 +23,7 @@ describe('controller booter acceptance tests', () => {
     await app.start();
 
     const server: RestServer = await app.getServer(RestServer);
-    const client: Client = createClientForHandler(server.handleHttp);
+    const client: Client = createClientForHandler(server.requestHandler);
 
     // Default Controllers = /controllers with .controller.js ending (nested = true);
     await client.get('/one').expect(200, 'ControllerOne.one()');

--- a/packages/cli/generators/app/templates/test/ping.controller.test.ts.ejs
+++ b/packages/cli/generators/app/templates/test/ping.controller.test.ts.ejs
@@ -17,7 +17,7 @@ describe('PingController', () => {
   });
 
   before(() => {
-    client = createClientForHandler(server.handleHttp);
+    client = createClientForHandler(server.requestHandler);
   });
 
   after(async () => {

--- a/packages/cli/test/app-run.test.js
+++ b/packages/cli/test/app-run.test.js
@@ -11,7 +11,7 @@ const helpers = require('yeoman-test');
 const lerna = require('lerna');
 const build = require('@loopback/build');
 
-describe('app-generator', function() {
+describe('app-generator (SLOW)', function() {
   const generator = path.join(__dirname, '../generators/app');
   const rootDir = path.join(__dirname, '../../..');
   const sandbox = path.join(__dirname, '../../_sandbox');

--- a/packages/example-getting-started/test/acceptance/application.test.ts
+++ b/packages/example-getting-started/test/acceptance/application.test.ts
@@ -19,7 +19,7 @@ describe('Application', () => {
   before(givenARestServer);
   before(givenTodoRepository);
   before(() => {
-    client = createClientForHandler(server.handleHttp);
+    client = createClientForHandler(server.requestHandler);
   });
   after(async () => {
     await app.stop();

--- a/packages/example-log-extension/test/acceptance/log.extension.acceptance.ts
+++ b/packages/example-log-extension/test/acceptance/log.extension.acceptance.ts
@@ -5,7 +5,6 @@
 
 import {
   RestApplication,
-  RestServer,
   SequenceHandler,
   RestBindings,
   FindRoute,
@@ -42,7 +41,6 @@ import {logToMemory, resetLogs} from '../in-memory-logger';
 
 describe('log extension acceptance test', () => {
   let app: LogApp;
-  let server: RestServer;
   let spy: SinonSpy;
 
   class LogApp extends LogMixin(RestApplication) {}
@@ -73,7 +71,7 @@ describe('log extension acceptance test', () => {
 
   it('logs information at DEBUG or higher', async () => {
     setAppLogToDebug();
-    const client: Client = createClientForHandler(server.handleHttp);
+    const client: Client = createClientForHandler(app.requestHandler);
 
     await client.get('/nolog').expect(200, 'nolog called');
     expect(spy.called).to.be.False();
@@ -99,7 +97,7 @@ describe('log extension acceptance test', () => {
 
   it('logs information at INFO or higher', async () => {
     setAppLogToInfo();
-    const client: Client = createClientForHandler(server.handleHttp);
+    const client: Client = createClientForHandler(app.requestHandler);
 
     await client.get('/nolog').expect(200, 'nolog called');
     expect(spy.called).to.be.False();
@@ -125,7 +123,7 @@ describe('log extension acceptance test', () => {
 
   it('logs information at WARN or higher', async () => {
     setAppLogToWarn();
-    const client: Client = createClientForHandler(server.handleHttp);
+    const client: Client = createClientForHandler(app.requestHandler);
 
     await client.get('/nolog').expect(200, 'nolog called');
     expect(spy.called).to.be.False();
@@ -151,7 +149,7 @@ describe('log extension acceptance test', () => {
 
   it('logs information at ERROR', async () => {
     setAppLogToError();
-    const client: Client = createClientForHandler(server.handleHttp);
+    const client: Client = createClientForHandler(app.requestHandler);
 
     await client.get('/nolog').expect(200, 'nolog called');
     expect(spy.called).to.be.False();
@@ -177,7 +175,7 @@ describe('log extension acceptance test', () => {
 
   it('logs no information when logLevel is set to OFF', async () => {
     setAppLogToOff();
-    const client: Client = createClientForHandler(server.handleHttp);
+    const client: Client = createClientForHandler(app.requestHandler);
 
     await client.get('/nolog').expect(200, 'nolog called');
     expect(spy.called).to.be.False();
@@ -234,14 +232,13 @@ describe('log extension acceptance test', () => {
       }
     }
 
-    server.sequence(LogSequence);
+    app.sequence(LogSequence);
   }
 
   async function createApp() {
     app = new LogApp();
     app.bind(EXAMPLE_LOG_BINDINGS.TIMER).to(timer);
     app.bind(EXAMPLE_LOG_BINDINGS.LOGGER).to(logToMemory);
-    server = await app.getServer(RestServer);
   }
 
   function setAppLogToDebug() {

--- a/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/rest/test/acceptance/sequence/sequence.acceptance.ts
@@ -17,6 +17,7 @@ import {
   RestServer,
   RestComponent,
   RestApplication,
+  HttpServerLike,
 } from '../../..';
 import {api} from '@loopback/openapi-v3';
 import {Application} from '@loopback/core';
@@ -104,8 +105,7 @@ describe('Sequence', () => {
     const restApp = new RestApplication();
     restApp.sequence(MySequence);
 
-    const appServer = await restApp.getServer(RestServer);
-    await whenIRequest(appServer)
+    await whenIRequest(restApp)
       .get('/name')
       .expect('MySequence was invoked.');
   });
@@ -213,7 +213,7 @@ describe('Sequence', () => {
     app.controller(controller);
   }
 
-  function whenIRequest(restServer: RestServer = server): Client {
-    return createClientForHandler(restServer.handleHttp);
+  function whenIRequest(restServerOrApp: HttpServerLike = server): Client {
+    return createClientForHandler(restServerOrApp.requestHandler);
   }
 });

--- a/packages/rest/test/integration/rest-server.integration.ts
+++ b/packages/rest/test/integration/rest-server.integration.ts
@@ -32,7 +32,7 @@ describe('RestServer (integration)', () => {
       }
     });
 
-    return createClientForHandler(server.handleHttp)
+    return createClientForHandler(server.requestHandler)
       .get('/')
       .expect(500);
   });
@@ -44,7 +44,7 @@ describe('RestServer (integration)', () => {
       response.end();
     });
 
-    await createClientForHandler(server.handleHttp)
+    await createClientForHandler(server.requestHandler)
       .get('/')
       .expect(200, 'Hello')
       .expect('Access-Control-Allow-Origin', '*')
@@ -58,7 +58,7 @@ describe('RestServer (integration)', () => {
       response.end();
     });
 
-    await createClientForHandler(server.handleHttp)
+    await createClientForHandler(server.requestHandler)
       .options('/')
       .expect(204)
       .expect('Access-Control-Allow-Origin', '*')
@@ -78,7 +78,7 @@ describe('RestServer (integration)', () => {
     };
     server.route(new Route('get', '/greet', greetSpec, function greet() {}));
 
-    const response = await createClientForHandler(server.handleHttp).get(
+    const response = await createClientForHandler(server.requestHandler).get(
       '/openapi.json',
     );
     expect(response.body).to.containDeep({
@@ -118,7 +118,7 @@ describe('RestServer (integration)', () => {
     };
     server.route(new Route('get', '/greet', greetSpec, function greet() {}));
 
-    const response = await createClientForHandler(server.handleHttp).get(
+    const response = await createClientForHandler(server.requestHandler).get(
       '/openapi.yaml',
     );
     const expected = yaml.safeLoad(`
@@ -159,7 +159,7 @@ servers:
     };
     server.route(new Route('get', '/greet', greetSpec, function greet() {}));
 
-    const response = await createClientForHandler(server.handleHttp).get(
+    const response = await createClientForHandler(server.requestHandler).get(
       '/swagger-ui',
     );
     await server.get(RestBindings.PORT);
@@ -190,7 +190,7 @@ servers:
     };
     server.route(new Route('get', '/greet', greetSpec, function greet() {}));
 
-    const response = await createClientForHandler(server.handleHttp).get(
+    const response = await createClientForHandler(server.requestHandler).get(
       '/swagger-ui',
     );
     await server.get(RestBindings.PORT);


### PR DESCRIPTION
Each RestServer provides an HTTP handler function that can be used with core HTTP server or any compatible framework like Express.

This pull request exposes the handler function on the RestApplication class to simplify the usage.

See also: 
 - #846 [Docs] Update documentation and examples to use RestApplication
 - #955  fix(example-getting-started): use RestApplication 
 - #968 refactor: simplify app setup via RestApplication (part II)
 - #994 feat(rest): app.route() and app.api() 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- (n/a) Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
