### PR TITLE
test(cli): add a test to verify generated app is passing npm test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ api-docs
 packages/*/*.tgz
 packages/*/dist*
 packages/*/package
+packages/_sandbox
 .sandbox

--- a/packages/build/index.js
+++ b/packages/build/index.js
@@ -10,3 +10,7 @@ exports.prettier = require('./bin/run-prettier');
 exports.tslint = require('./bin/run-tslint');
 exports.nyc = require('./bin/run-nyc');
 exports.dist = require('./bin/select-dist');
+
+const utils = require('./bin/utils');
+exports.runCLI = utils.runCLI;
+exports.runShell = utils.runShell;

--- a/packages/build/index.js
+++ b/packages/build/index.js
@@ -10,6 +10,8 @@ exports.prettier = require('./bin/run-prettier');
 exports.tslint = require('./bin/run-tslint');
 exports.nyc = require('./bin/run-nyc');
 exports.dist = require('./bin/select-dist');
+exports.mocha = require('./bin/run-mocha');
+exports.clean = require('./bin/run-clean');
 
 const utils = require('./bin/utils');
 exports.runCLI = utils.runCLI;

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -48,13 +48,17 @@
   "repository": {
     "type": "git"
   },
+<% if (project.private) { -%>
+  "private": true,
+<% } -%>
   "author": "",
   "license": "MIT",
   "files": [
     "README.md",
     "index.js",
     "index.d.ts",
-    "dist"
+    "dist",
+    "src"
   ],
   "dependencies": {
     "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -48,13 +48,17 @@
   "repository": {
     "type": "git"
   },
+<% if (project.private) { -%>
+  "private": true,
+<% } -%>
   "author": "",
   "license": "MIT",
   "files": [
     "README.md",
     "index.js",
     "index.d.ts",
-    "dist"
+    "dist",
+    "src"
   ],
   "dependencies": {
     "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -55,6 +55,11 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       description: 'Use @loopback/build',
     });
 
+    this.option('private', {
+      type: Boolean,
+      description: 'Mark the project private (excluded from npm publish)',
+    });
+
     // argument validation
     if (this.args.length) {
       const isValid = utils.validate(this.args[0]);
@@ -87,7 +92,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       projectType: this.projectType,
       dependencies: utils.getDependencies(),
     };
-    this.projectOptions = ['name', 'description', 'outdir'].concat(
+    this.projectOptions = ['name', 'description', 'outdir', 'private'].concat(
       this.buildOptions
     );
     this.projectOptions.forEach(n => {

--- a/packages/cli/test/app-run.test.js
+++ b/packages/cli/test/app-run.test.js
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+
+const lerna = require('lerna');
+function lernaBootstrap() {
+  const cmd = new lerna.BootstrapCommand('', {
+    loglevel: 'silent',
+  });
+  return cmd.run();
+}
+
+const runShell = require('@loopback/build').runShell;
+
+describe('app-generator', function() {
+  const generator = path.join(__dirname, '../generators/app');
+  const rootDir = path.join(__dirname, '../../..');
+  const sandbox = path.join(__dirname, '../../_sandbox');
+  const cwd = process.cwd();
+  const props = {
+    name: 'myApp',
+    description: 'My app for LoopBack 4',
+    outdir: sandbox,
+  };
+
+  // WARNING: It takes a while to run `lerna bootstrap`
+  this.timeout(0);
+  before(() => {
+    return helpers
+      .run(generator)
+      .inDir(sandbox)
+      .withPrompts(props);
+  });
+
+  it('passes `npm test` for the generated project', async () => {
+    process.chdir(rootDir);
+    await lernaBootstrap();
+    process.chdir(sandbox);
+    return new Promise((resolve, reject) => {
+      runShell('npm', ['test', '--', '--allow-console-logs']).on(
+        'close',
+        code => {
+          process.chdir(cwd);
+          assert.equal(code, 0);
+          resolve();
+        }
+      );
+    });
+  });
+});

--- a/packages/cli/test/project.js
+++ b/packages/cli/test/project.js
@@ -71,6 +71,17 @@ module.exports = function(projGenerator, props, projectType) {
           assert(helpText.match(/# Project root directory /));
         });
 
+        it('has private option set up', () => {
+          let gen = testUtils.testSetUpGen(projGenerator);
+          let helpText = gen.help();
+          assert(helpText.match(/--private/));
+          assert(
+            helpText.match(
+              /# Mark the project private \(excluded from npm publish\)/
+            )
+          );
+        });
+
         it('has tslint option set up', () => {
           let gen = testUtils.testSetUpGen(projGenerator);
           let helpText = gen.help();


### PR DESCRIPTION
This PR adds a test to verify `lb app` generates an application that passes `npm test`.

1. The test generates a project at `loopback-next/packages/_sandbox`.
2. The test calls `lerna bootstrap` to set up the deps
3. The test calls `npm test`.

WARNING: The test takes sometime to run and it slows our local build. We need to figure out when to run the test (maybe as part of release).

Connects to https://github.com/strongloop/loopback-next/issues/932

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
