### PR TITLE
chore: work around apidocs rendering issue for openapi-v3

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,7 @@
     "nyc": "^11.4.1",
     "prettier": "^1.10.2",
     "source-map-support": "^0.5.3",
-    "strong-docs": "^1.7.1",
+    "strong-docs": "^1.9.1",
     "tslint": "^5.9.1",
     "typescript": "^2.6.2"
   },

--- a/packages/openapi-v3/src/parameter-decorator.ts
+++ b/packages/openapi-v3/src/parameter-decorator.ts
@@ -102,84 +102,84 @@ export namespace param {
   export const query = {
     /**
      * Define a parameter of "integer" type that's read from the query string.
-     * Usage: `@param.query.string('paramName')`
+     * Usage: ` @param.query.string('paramName')`
      *
      * @param name Parameter name.
      */
     string: createParamShortcut('query', builtinTypes.string),
     /**
      * Define a parameter of "number" type that's read from the query string.
-     * Usage: `@param.query.number('paramName')`
+     * Usage: ` @param.query.number('paramName')`
      *
      * @param name Parameter name.
      */
     number: createParamShortcut('query', builtinTypes.number),
     /**
      * Define a parameter of "boolean" type that's read from the query string.
-     * Usage: `@param.query.boolean('paramName')`
+     * Usage: ` @param.query.boolean('paramName')`
      *
      * @param name Parameter name.
      */
     boolean: createParamShortcut('query', builtinTypes.boolean),
     /**
      * Define a parameter of "integer" type that's read from the query string.
-     * Usage: `@param.query.integer('paramName')`
+     * Usage: ` @param.query.integer('paramName')`
      *
      * @param name Parameter name.
      */
     integer: createParamShortcut('query', builtinTypes.integer),
     /**
      * Define a parameter of "long" type that's read from the query string.
-     * Usage: `@param.query.long('paramName')`
+     * Usage: ` @param.query.long('paramName')`
      *
      * @param name Parameter name.
      */
     long: createParamShortcut('query', builtinTypes.long),
     /**
      * Define a parameter of "float" type that's read from the query string.
-     * Usage: `@param.query.float('paramName')`
+     * Usage: ` @param.query.float('paramName')`
      *
      * @param name Parameter name.
      */
     float: createParamShortcut('query', builtinTypes.float),
     /**
      * Define a parameter of "double" type that's read from the query string.
-     * Usage: `@param.query.double('paramName')`
+     * Usage: ` @param.query.double('paramName')`
      *
      * @param name Parameter name.
      */
     double: createParamShortcut('query', builtinTypes.double),
     /**
      * Define a parameter of "byte" type that's read from the query string.
-     * Usage: `@param.query.byte('paramName')`
+     * Usage: ` @param.query.byte('paramName')`
      *
      * @param name Parameter name.
      */
     byte: createParamShortcut('query', builtinTypes.byte),
     /**
      * Define a parameter of "binary" type that's read from the query string.
-     * Usage: `@param.query.binary('paramName')`
+     * Usage: ` @param.query.binary('paramName')`
      *
      * @param name Parameter name.
      */
     binary: createParamShortcut('query', builtinTypes.binary),
     /**
      * Define a parameter of "date" type that's read from the query string.
-     * Usage: `@param.query.date('paramName')`
+     * Usage: ` @param.query.date('paramName')`
      *
      * @param name Parameter name.
      */
     date: createParamShortcut('query', builtinTypes.date),
     /**
      * Define a parameter of "dateTime" type that's read from the query string.
-     * Usage: `@param.query.dateTime('paramName')`
+     * Usage: ` @param.query.dateTime('paramName')`
      *
      * @param name Parameter name.
      */
     dateTime: createParamShortcut('query', builtinTypes.dateTime),
     /**
      * Define a parameter of "password" type that's read from the query string.
-     * Usage: `@param.query.password('paramName')`
+     * Usage: ` @param.query.password('paramName')`
      *
      * @param name Parameter name.
      */
@@ -189,7 +189,7 @@ export namespace param {
   export const header = {
     /**
      * Define a parameter of "string" type that's read from a request header.
-     * Usage: `@param.header.string('paramName')`
+     * Usage: ` @param.header.string('paramName')`
      *
      * @param name Parameter name, it must match the header name
      * (e.g. `Content-Type`).
@@ -197,7 +197,7 @@ export namespace param {
     string: createParamShortcut('header', builtinTypes.string),
     /**
      * Define a parameter of "number" type that's read from a request header.
-     * Usage: `@param.header.number('paramName')`
+     * Usage: ` @param.header.number('paramName')`
      *
      * @param name Parameter name, it must match the header name
      * (e.g. `Content-Length`).
@@ -205,7 +205,7 @@ export namespace param {
     number: createParamShortcut('header', builtinTypes.number),
     /**
      * Define a parameter of "boolean" type that's read from a request header.
-     * Usage: `@param.header.boolean('paramName')`
+     * Usage: ` @param.header.boolean('paramName')`
      *
      * @param name Parameter name, it must match the header name
      * (e.g. `DNT` or `X-Do-Not-Track`).
@@ -213,7 +213,7 @@ export namespace param {
     boolean: createParamShortcut('header', builtinTypes.boolean),
     /**
      * Define a parameter of "integer" type that's read from a request header.
-     * Usage: `@param.header.integer('paramName')`
+     * Usage: ` @param.header.integer('paramName')`
      *
      * @param name Parameter name, it must match the header name
      * (e.g. `Content-Length`).
@@ -221,56 +221,56 @@ export namespace param {
     integer: createParamShortcut('header', builtinTypes.integer),
     /**
      * Define a parameter of "long" type that's read from a request header.
-     * Usage: `@param.header.long('paramName')`
+     * Usage: ` @param.header.long('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
     long: createParamShortcut('header', builtinTypes.long),
     /**
      * Define a parameter of "float" type that's read from a request header.
-     * Usage: `@param.header.float('paramName')`
+     * Usage: ` @param.header.float('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
     float: createParamShortcut('header', builtinTypes.float),
     /**
      * Define a parameter of "double" type that's read from a request header.
-     * Usage: `@param.header.double('paramName')`
+     * Usage: ` @param.header.double('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
     double: createParamShortcut('header', builtinTypes.double),
     /**
      * Define a parameter of "byte" type that's read from a request header.
-     * Usage: `@param.header.byte('paramName')`
+     * Usage: ` @param.header.byte('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
     byte: createParamShortcut('header', builtinTypes.byte),
     /**
      * Define a parameter of "binary" type that's read from a request header.
-     * Usage: `@param.header.binary('paramName')`
+     * Usage: ` @param.header.binary('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
     binary: createParamShortcut('header', builtinTypes.binary),
     /**
      * Define a parameter of "date" type that's read from a request header.
-     * Usage: `@param.header.date('paramName')`
+     * Usage: ` @param.header.date('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
     date: createParamShortcut('header', builtinTypes.date),
     /**
      * Define a parameter of "dateTime" type that's read from a request header.
-     * Usage: `@param.header.dateTime('paramName')`
+     * Usage: ` @param.header.dateTime('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
     dateTime: createParamShortcut('header', builtinTypes.dateTime),
     /**
      * Define a parameter of "password" type that's read from a request header.
-     * Usage: `@param.header.password('paramName')`
+     * Usage: ` @param.header.password('paramName')`
      *
      * @param name Parameter name, it must match the header name
      */
@@ -279,84 +279,84 @@ export namespace param {
   export const path = {
     /**
      * Define a parameter of "string" type that's read from request path.
-     * Usage: `@param.path.string('paramName')`
+     * Usage: ` @param.path.string('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     string: createParamShortcut('path', builtinTypes.string),
     /**
      * Define a parameter of "number" type that's read from request path.
-     * Usage: `@param.path.number('paramName')`
+     * Usage: ` @param.path.number('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     number: createParamShortcut('path', builtinTypes.number),
     /**
      * Define a parameter of "boolean" type that's read from request path.
-     * Usage: `@param.path.boolean('paramName')`
+     * Usage: ` @param.path.boolean('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     boolean: createParamShortcut('path', builtinTypes.boolean),
     /**
      * Define a parameter of "integer" type that's read from request path.
-     * Usage: `@param.path.integer('paramName')`
+     * Usage: ` @param.path.integer('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     integer: createParamShortcut('path', builtinTypes.integer),
     /**
      * Define a parameter of "long" type that's read from request path.
-     * Usage: `@param.path.long('paramName')`
+     * Usage: ` @param.path.long('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     long: createParamShortcut('path', builtinTypes.long),
     /**
      * Define a parameter of "float" type that's read from request path.
-     * Usage: `@param.path.float('paramName')`
+     * Usage: ` @param.path.float('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     float: createParamShortcut('path', builtinTypes.float),
     /**
      * Define a parameter of "double" type that's read from request path.
-     * Usage: `@param.path.double('paramName')`
+     * Usage: ` @param.path.double('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     double: createParamShortcut('path', builtinTypes.double),
     /**
      * Define a parameter of "byte" type that's read from request path.
-     * Usage: `@param.path.byte('paramName')`
+     * Usage: ` @param.path.byte('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     byte: createParamShortcut('path', builtinTypes.byte),
     /**
      * Define a parameter of "binary" type that's read from request path.
-     * Usage: `@param.path.binary('paramName')`
+     * Usage: ` @param.path.binary('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     binary: createParamShortcut('path', builtinTypes.binary),
     /**
      * Define a parameter of "date" type that's read from request path.
-     * Usage: `@param.path.date('paramName')`
+     * Usage: ` @param.path.date('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     date: createParamShortcut('path', builtinTypes.date),
     /**
      * Define a parameter of "dateTime" type that's read from request path.
-     * Usage: `@param.path.dateTime('paramName')`
+     * Usage: ` @param.path.dateTime('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */
     dateTime: createParamShortcut('path', builtinTypes.dateTime),
     /**
      * Define a parameter of "password" type that's read from request path.
-     * Usage: `@param.path.password('paramName')`
+     * Usage: ` @param.path.password('paramName')`
      *
      * @param name Parameter name matching one of the placeholders in the path
      */


### PR DESCRIPTION
At the moment, `@param ...` is rendered as an email link. We add a leading
space to `@param` as a workaround.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
