### PR TITLE
fix(rest): move @types/cors to dependency

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -25,6 +25,7 @@
     "@loopback/core": "^0.2.1",
     "@loopback/openapi-v3": "^0.3.0",
     "@loopback/openapi-v3-types": "^0.2.1",
+    "@types/cors": "^2.8.3",
     "@types/http-errors": "^1.6.1",
     "@types/node": "^8.5.9",
     "body": "^5.1.0",
@@ -40,7 +41,6 @@
     "@loopback/openapi-spec-builder": "^0.3.0",
     "@loopback/repository": "^0.2.1",
     "@loopback/testlab": "^0.3.0",
-    "@types/cors": "^2.8.3",
     "@types/debug": "0.0.30",
     "@types/js-yaml": "^3.9.1",
     "@types/lodash": "^4.14.96"


### PR DESCRIPTION
Currently, a type from `cors` is being exported as a part of `RestConfig`:
```ts
export interface RestServerConfig {
  host?: string;
  port?: number;
  cors?: cors.CorsOptions; // HERE
  apiExplorerUrl?: string;
  sequence?: Constructor<SequenceHandler>;
}
```

This means we need to move the typing for `cors` form dev-dependency to dependency so that users would have access to the type information.

- related to https://github.com/strongloop/loopback-next/issues/1102

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
