### PR TITLE
chore: add `docs` as a package for loopback-next

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@loopback/docs",
+  "version": "0.1.0",
+  "description": "Documentation for LoopBack 4",
+  "homepage": "https://github.com/strongloop/loopback-next/tree/master/docs",
+  "author": {
+    "name": "IBM"
+  },
+  "engines": {
+    "node": ">=8"
+  },
+  "files": [
+    "**/*"
+  ],
+  "keywords": [
+    "LoopBack",
+    "docs"
+  ],
+  "devDependencies": {
+  },
+  "dependencies": {
+  },
+  "scripts": {
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-next"
+  },
+  "copyright.owner": "IBM Corp.",
+  "license": "MIT"
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.8.0",
-  "packages": ["packages/*"],
+  "packages": ["packages/*", "docs"],
   "command": {
     "publish": {
       "conventionalCommits": true,


### PR DESCRIPTION
This PR adds `docs` as a package for `loopback-next` monorepo so that `lerna` can publish it as a npm module.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
