### PR TITLE
fix(cli): update tsconfig.json to include index.ts

### DIFF
--- a/packages/cli/generators/project/templates/tsconfig.json.ejs
+++ b/packages/cli/generators/project/templates/tsconfig.json.ejs
@@ -19,7 +19,8 @@
 <% } -%>
   "include": [
     "src",
-    "test"
+    "test",
+    "index.ts"
   ],
   "exclude": [
     "node_modules/**",


### PR DESCRIPTION
Previously, `tsconfig.json` would not compile `index.ts` at app-level of apps generated by `lb4`, but it was compiled anyway because `ping.controller.test.ts` imported from the file, meaning it wasn't excluded because it was a dependency.

This PR fixes this.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
