### PR TITLE
fix(testlab): fix throw() and rejectedWith() types

### DIFF
--- a/packages/testlab/should-as-function.d.ts
+++ b/packages/testlab/should-as-function.d.ts
@@ -118,7 +118,8 @@ interface ShouldAssertion {
   enumerables(...properties: string[]): ShouldAssertion;
   startWith(expected: string, message?: any): ShouldAssertion;
   endWith(expected: string, message?: any): ShouldAssertion;
-  throw(message?: any): ShouldAssertion;
+  throw(propereties?: {}): ShouldAssertion;
+  throw(message: Function | string | RegExp, properties?: {}): ShouldAssertion;
 
   //promises
   eventually: ShouldAssertion;
@@ -126,7 +127,8 @@ interface ShouldAssertion {
   fulfilled(): Promise<any>;
   fulfilledWith(value: any): Promise<any>;
   rejected(): Promise<any>;
-  rejectedWith(err: Error | string | RegExp): Promise<any>;
+  rejectedWith(err: Function | string | RegExp, properties?: {}): Promise<any>;
+  rejectedWith(properties: {}): Promise<any>;
 
   //http
   header(field: string, val?: string): ShouldAssertion;


### PR DESCRIPTION
Fixed up some type definitions so that they reflect the actual parameters of some functions from `should-js`.

Alternatively, I think there should be a way for the type definition here to be synchronized to the one straight from `should-js`.

Uber-alternatively, we should switch to using `chai` since `should-js` is not very active compared to `chai`.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
