### PR TITLE
chore: add a script to prune dist folder from non packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier:cli": "node packages/build/bin/run-prettier \"**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",
-    "clean": "lerna run clean --loglevel=silent --parallel",
+    "clean": "lerna run clean --loglevel=silent --parallel && node packages/build/bin/run-clean \"packages/*/dist*\"",
     "clean:lerna": "lerna clean --yes --parallel --loglevel=silent",
     "build": "lerna run build --parallel --loglevel=silent",
     "build:full": "npm run clean:lerna && npm run bootstrap && npm test",

--- a/packages/build/bin/run-clean.js
+++ b/packages/build/bin/run-clean.js
@@ -24,7 +24,7 @@ Example usage:
 'use strict';
 
 function run(argv, options) {
-  const fs = require('fs-extra');
+  const rimraf = require('rimraf');
   const path = require('path');
   const utils = require('./utils');
   var files = argv.slice(2);
@@ -42,7 +42,7 @@ function run(argv, options) {
         console.error('Skipping ' + f + ' as it is not inside the project');
       }
     } else {
-      if (!options.dryRun) fs.removeSync(f);
+      if (!options.dryRun) rimraf.sync(f);
       removed.push(f);
     }
   });

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -17,9 +17,11 @@
     "@types/node": "^8.9.5",
     "cross-spawn": "^6.0.3",
     "debug": "^3.1.0",
+    "fs-extra": "^5.0.0",
     "mocha": "^5.0.0",
     "nyc": "^11.4.1",
     "prettier": "^1.10.2",
+    "rimraf": "^2.6.2",
     "source-map-support": "^0.5.3",
     "strong-docs": "^1.9.1",
     "tslint": "^5.9.1",
@@ -44,8 +46,5 @@
     "test": "npm run mocha",
     "mocha": "node bin/run-mocha --timeout 30000 \"test/integration/*.js\"",
     "posttest": "npm run lint"
-  },
-  "devDependencies": {
-    "fs-extra": "^5.0.0"
   }
 }


### PR DESCRIPTION
During development, we often switch between branches that have different
packages for the monorepo. This script cleans up the `dist` folder of
non-package directories under 'packages' so that `npm test` won't run
left-over tests from non-packages.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
