### PR TITLE
refactor(CLI Templates): move start error catch to application.main

### DIFF
--- a/packages/cli/generators/app/templates/index.js.ejs
+++ b/packages/cli/generators/app/templates/index.js.ejs
@@ -2,5 +2,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.error('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/cli/generators/app/templates/src/index.ts.ejs
+++ b/packages/cli/generators/app/templates/src/index.ts.ejs
@@ -5,12 +5,7 @@ export {<%= project.applicationName %>};
 
 export async function main(options?: ApplicationConfig) {
   const app = new <%= project.applicationName %>(options);
-
-  try {
-    await app.boot();
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.boot();
+  await app.start();
   return app;
 }

--- a/packages/example-getting-started/index.js
+++ b/packages/example-getting-started/index.js
@@ -7,5 +7,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.error('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/example-getting-started/src/index.ts
+++ b/packages/example-getting-started/src/index.ts
@@ -9,12 +9,9 @@ import {RestServer} from '@loopback/rest';
 
 export async function main(options?: ApplicationConfig) {
   const app = new TodoListApplication(options);
-  try {
-    await app.boot();
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.boot();
+  await app.start();
+
   const server = await app.getServer(RestServer);
   const port = await server.get<number>('rest.port');
   console.log(`Server is running at http://127.0.0.1:${port}`);

--- a/packages/example-hello-world/index.js
+++ b/packages/example-hello-world/index.js
@@ -7,5 +7,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.error('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/example-hello-world/src/index.ts
+++ b/packages/example-hello-world/src/index.ts
@@ -7,10 +7,6 @@ import {HelloWorldApplication} from './application';
 
 export async function main() {
   const app = new HelloWorldApplication();
-  try {
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.start();
   return app;
 }

--- a/packages/example-rpc-server/index.js
+++ b/packages/example-rpc-server/index.js
@@ -7,5 +7,8 @@ const application = (module.exports = require('./dist'));
 
 if (require.main === module) {
   // Run the application
-  application.main();
+  application.main().catch(err => {
+    console.error('Cannot start the application.', err);
+    process.exit(1);
+  });
 }

--- a/packages/example-rpc-server/src/index.ts
+++ b/packages/example-rpc-server/src/index.ts
@@ -9,11 +9,7 @@ import {ApplicationConfig} from '@loopback/core';
 export async function main(options?: ApplicationConfig) {
   const app = new MyApplication(options);
 
-  try {
-    await app.start();
-  } catch (err) {
-    console.error(`Unable to start application: ${err}`);
-  }
+  await app.start();
   return app;
 }
 


### PR DESCRIPTION
This is a fix for issue #925 which moves the the start error handler to the top-most caller instead of being handled by the main function.

fix #925

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `packages/example-*` were updated
