### PR TITLE
 docs: remove setupControllers from getting started. lb4

### DIFF
--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -70,20 +70,6 @@ Let's add a simple "Hello World" controller as follows:
   }
   ```
 
-* Update `/src/application.ts` to load the controller:
-    * Import `HelloController` at the top of the file
-      ```ts
-      import {HelloController} from './controllers/hello.controller';
-      ```
-
-    * Add controller in `setupControllers()`
-      ```ts
-      setupControllers() {
-        this.controller(PingController);
-        this.controller(HelloController);
-      }
-      ```
-
 * Start the application using `npm start`.
     * *Note: If your application is still running, press **CTRL+C** to stop it before restarting it*
 


### PR DESCRIPTION
`docs: remove setupControllers from getting started`
There is no setupControllers() in lb4 anymore/anyway.
http://loopback.io/doc/en/lb4/Getting-started.html

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
