### PR TITLE
docs: update Repositories.md to use openapi-v3

### DIFF
--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -7,30 +7,40 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Repositories.html
 summary:
 ---
-A Repository is a type of _Service_ that represents a collection of data within a DataSource.
 
-
+A Repository is a type of _Service_ that represents a collection of data within
+a DataSource.
 
 ## Example Application
-You can look at [the account application as an example.](https://github.com/strongloop/loopback4-example-microservices/tree/master/services/account)
+
+You can look at
+[the account application as an example.](https://github.com/strongloop/loopback4-example-microservices/tree/master/services/account)
 
 ## Installation
-Legacy juggler support has been enabled in `loopback-next` and can be imported from the `@loopback/repository` package. In order to do this, save `@loopback/repository` as a dependency in your application.
 
-You can then install your favorite connector by saving it as part of your application dependencies.
+Legacy juggler support has been enabled in `loopback-next` and can be imported
+from the `@loopback/repository` package. In order to do this, save
+`@loopback/repository` as a dependency in your application.
+
+You can then install your favorite connector by saving it as part of your
+application dependencies.
 
 ## Repository Mixin
-`@loopback/repository` provides a mixin for your Application that enables convenience methods that automatically bind repository classes for you. Repositories declared by components are also bound automatically.
 
-Repositories are bound to `repositories.${ClassName}`. See example below for usage.
+`@loopback/repository` provides a mixin for your Application that enables
+convenience methods that automatically bind repository classes for you.
+Repositories declared by components are also bound automatically.
+
+Repositories are bound to `repositories.${ClassName}`. See example below for
+usage.
+
 ```ts
-import { Application } from '@loopback/core';
-import { RepositoryMixin } from '@loopback/repository';
-import { AccountRepository, CategoryRepository } from './repository';
+import {Application} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
+import {AccountRepository, CategoryRepository} from './repository';
 
 // Using the Mixin
 class MyApplication extends RepositoryMixin(Application) {}
-
 
 const app = new MyApplication();
 // AccountRepository will be bound to key `repositories.AccountRepository`
@@ -41,11 +51,14 @@ app.repository(CategoryRepository);
 
 ## Configure datasources
 
-You can define a DataSource using legacy Juggler in your LoopBack 4 app as follows:
+You can define a DataSource using legacy Juggler in your LoopBack 4 app as
+follows:
 
-```js
+```ts
+// src/datsources/db.datasource.ts
 import {juggler, DataSourceConstructor} from '@loopback/repository';
 
+// this is just an example, 'test' database doesn't actually exist
 export const db = new DataSourceConstructor({
   connector: 'mysql',
   host: 'localhost',
@@ -58,7 +71,9 @@ export const db = new DataSourceConstructor({
 
 ## Define models
 
-Models are defined as regular JavaScript classes. If you want your model to be persisted in a database, your model must have an `id` property and inherit from `Entity` base class.
+Models are defined as regular JavaScript classes. If you want your model to be
+persisted in a database, your model must have an `id` property and inherit from
+`Entity` base class.
 
 TypeScript version:
 
@@ -78,40 +93,38 @@ export class Account extends Entity {
 JavaScript version:
 
 ```js
-import {
-  Entity,
-  model,
-  property,
-  ModelDefinition
-} from '@loopback/repository';
+import {Entity, ModelDefinition} from '@loopback/repository';
 
-export class Account extends Entity {
-  static definition = new ModelDefinition({
-    name: 'Account',
-    properties: {
-      id: {type: 'number', id: true},
-      name: {type: 'string', required: true},
-    }
-  });
-}
+export class Account extends Entity {}
+
+Account.definition = new ModelDefinition({
+  name: 'Account',
+  properties: {
+    id: {type: 'number', id: true},
+    name: {type: 'string', required: true},
+  },
+});
 ```
 
 ## Define repositories
 
-Use `DefaultCrudRepository` class to create a repository leveraging the legacy juggler bridge and binding your Entity-based class with a datasource you have configured earlier.
+Use `DefaultCrudRepository` class to create a repository leveraging the legacy
+juggler bridge and binding your Entity-based class with a datasource you have
+configured earlier. It's recommended that you use
+[Dependency Injection](Dependency-injection.md) to retrieve your datasource.
 
 TypeScript version:
 
 ```ts
-import {DefaultCrudRepository} from '@loopback/repository';
-import {Account} from '../models/account.model';
-import {db} from '../datasources/db.datasource';
+import {DefaultCrudRepository, DataSourceType} from '@loopback/repository';
+import {inject} from '@loopback/context';
+import {Account} from '../models';
 
 export class AccountRepository extends DefaultCrudRepository<
   Account,
   typeof Account.prototype.id
 > {
-  constructor() {
+  constructor(@inject('datasources.db') protected db: DataSourceType) {
     super(Account, db);
   }
 }
@@ -119,7 +132,7 @@ export class AccountRepository extends DefaultCrudRepository<
 
 JavaScript version:
 
-```ts
+```js
 import {DefaultCrudRepository} from '@loopback/repository';
 import {Account} from '../models/account.model';
 import {db} from '../datasources/db.datasource';
@@ -133,175 +146,174 @@ export class AccountRepository extends DefaultCrudRepository {
 
 ### Controller Configuration
 
-Once your DataSource is defined for your repository, all the CRUD methods you call in your repository will use Juggler and your connector's methods unless you overwrite them. In your controller, you will need to define a repository property and create a new instance of the repository you configured your DataSource for in the constructor of your controller class as follows:
+Once your DataSource is defined for your repository, all the CRUD methods you
+call in your repository will use the Juggler and your connector's methods unless
+you overwrite them. In your controller, you will need to define a repository
+property and create a new instance of the repository you configured your
+DataSource for in the constructor of your controller class as follows:
 
-```js
+```ts
 export class AccountController {
   constructor(
-    @inject('repositories.account')
-    public repository: AccountRepository
+    @repository(AccountRepository.name) public repository: AccountRepository,
   ) {}
-}
 ```
 
 ### Defining CRUD methods for your application
 
-When you want to define new CRUD methods for your application, you will need to modify the API Definitions and their corresponding methods in your controller. Here are examples of some basic CRUD methods:
-1. Create API Definition:
-```javascript
-'/accounts/create': {
-  post: {
-    'x-operation-name': 'createAccount',
-    parameters: [
-      {
-        name: 'accountInstance',
-        in: 'body',
-        description: 'The account instance to create.',
-        required: true,
-        type: 'object'
+When you want to define new CRUD methods for your application, you will need to
+modify the API Definitions and their corresponding methods in your controller.
+Here are examples of some basic CRUD methods:
+
+1.  Create API Definition:
+
+```json
+{
+  "/accounts/create": {
+    "post": {
+      "x-operation-name": "createAccount",
+      "requestBody": {
+        "description": "The account instance to create.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object"
+            }
+          }
+        }
       },
-    ],
-    responses: {
-      200: {
-        schema: {
-          accountInstance: "#/definitions/Account"
-        },
-      },
-    },
-  },
+      "responses": {
+        "200": {
+          "description": "Account instance created",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Account"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }
 ```
+
 Create Controller method:
-```javascript
-async createAccount(accountInstance) {
+
+```ts
+async createAccount(accountInstance: Account) {
   return await this.repository.create(accountInstance);
 }
 ```
-2. Find API Definition:
-```javascript
-'/accounts': {
-  get: {
-    'x-operation-name': 'getAccount',
-    parameters: [
-      {
-        name: 'filter',
-        in: 'query',
-        description: 'The criteria used to narrow down the number of accounts returned.',
-        required: false,
-        type: 'object'
-      }
-    ],
-    responses: {
-      200: {
-        schema: {
-          type: 'array',
-          items: '#/definitions/Account'
-        },
-      },
-    },
-  },
-}
-```
-Find Controller method:
-```javascript
-async getAccount(filter) {
-  return await this.repository.find(JSON.parse(filter));
-}
-```
-3. Update API Definition:
-```javascript
-'/accounts/update': {
-  post: {
-    'x-operation-name': 'updateAccount',
-    parameters: [
-      {
-        name: 'where',
-        in: 'query',
-        description: 'The criteria used to narrow down the number of accounts returned.',
-        required: true,
-        type: 'object'
-      },
-      {
-        name: 'data',
-        in: 'body',
-        description: 'An object of model property name/value pairs',
-        required: true,
-        type: 'object'
-      }
-    ],
-    responses: {
-      200: {
-        schema: {
-          type: 'object',
-          description: 'update information',
-          properties: {
-            count: {
-              type: 'number',
-              description: 'number of records updated'
+
+2.  Find API Definition:
+
+```json
+{
+  "/accounts": {
+    "get": {
+      "x-operation-name": "getAccount",
+      "responses": {
+        "200": {
+          "description": "List of accounts",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
             }
           }
-        },
-      },
-    },
-  },
-}
-```
-Update Controller method:
-```javascript
-async updateAccount(where, data) {
-  return await this.repository.update(JSON.parse(where), data);
+        }
+      }
+    }
+  }
 }
 ```
 
-Please See [Testing Your Application](Testing-Your-Application.md) section in order to set up and write unit, acceptance, and integration tests for your application.
+Find Controller method:
+
+```ts
+async getAccount() {
+  return await this.repository.find();
+}
+```
+
+Don't forget to register the complete version of your OpenAPI spec through
+`app.api()`.
+
+Please See [Testing Your Application](Testing-Your-Application.md) section in
+order to set up and write unit, acceptance, and integration tests for your
+application.
 
 ## Persisting Data without Juggler [Using MySQL database]
-LoopBack 4 gives you the flexibility to create your own custom Datasources which utilize your own custom connector for your favourite back end database. You can then fine tune your CRUD methods to your liking.
+
+{% include important.html content="This section has not been updated and code
+examples may not work out of the box." %}
+
+LoopBack 4 gives you the flexibility to create your own custom Datasources which
+utilize your own custom connector for your favourite back end database. You can
+then fine tune your CRUD methods to your liking.
 
 ### Example Application
-You can look at [the account-without-juggler application as an example.](https://github.com/strongloop/loopback-next-example/tree/master/services/account-without-juggler)
+
+You can look at
+[the account-without-juggler application as an example.](https://github.com/strongloop/loopback-next-example/tree/master/services/account-without-juggler)
 
 ### Steps to create your own concrete DataSource
 
-1. Implement the `CrudConnector` interface from `@loopback/repository` package. [Here is one way to do it](https://github.com/strongloop/loopback-next-example/blob/master/services/account-without-juggler/repositories/account/datasources/mysqlconn.ts)
-2. Implement the `DataSource` interface from `@loopback/repository`. To implement the `DataSource` interface, you must give it a name, supply your custom connector class created in the previous step, and instantiate it:
-    ```javascript
+1.  Implement the `CrudConnector` interface from `@loopback/repository` package.
+    [Here is one way to do it](https://github.com/strongloop/loopback-next-example/blob/master/services/account-without-juggler/repositories/account/datasources/mysqlconn.ts)
+
+2.  Implement the `DataSource` interface from `@loopback/repository`. To
+    implement the `DataSource` interface, you must give it a name, supply your
+    custom connector class created in the previous step, and instantiate it:
+
+    ```ts
     export class MySQLDs implements DataSource {
-      name: 'mysqlDs'
-      connector: MySqlConn
-      settings: Object
+      name: 'mysqlDs';
+      connector: MySqlConn;
+      settings: Object;
 
       constructor() {
-        this.settings = require('./mysql.json'); //connection configuration
+        this.settings = require('./mysql.json'); // connection configuration
         this.connector = new MySqlConn(this.settings);
       }
     }
     ```
-3. Extend `CrudRepositoryImpl` class from `@loopback/repository` and supply your custom DataSource and model to it:
 
-    ```javascript
-    import { CrudRepositoryImpl } from '@loopback/repository';
-    import { MySQLDs } from './datasources/mysqlds';
-    import { Account } from './models/Account';
+3.  Extend `CrudRepositoryImpl` class from `@loopback/repository` and supply
+    your custom DataSource and model to it:
 
-    export class newRepository extends CrudRepositoryImpl<Account, string> {
+    ```ts
+    import {CrudRepositoryImpl} from '@loopback/repository';
+    import {MySQLDs} from './datasources/mysqlds';
+    import {Account} from './models/Account';
+
+    export class NewRepository extends CrudRepositoryImpl<Account, string> {
       constructor() {
-        let ds = new MySQLDs();
+        const ds = new MySQLDs();
         super(ds, Account);
       }
     }
     ```
 
-You can override the functions it provides, which ultimately call on your connector's implementation of them, or write new ones.
+You can override the functions it provides, which ultimately call on your
+connector's implementation of them, or write new ones.
 
 ### Configure Controller
 
-The next step is to wire your new DataSource to your controller.
-This step is essentially the same as above, but can also be done as follows using DI:
+The next step is to wire your new DataSource to your controller. This step is
+essentially the same as above, but can also be done as follows using Dependency
+Injection:
 
-1. Bind instance of your repository to a certain key in your application class
+1.  Bind instance of your repository to a certain key in your application class
 
-    ```javascript
+    ```ts
     class AccountMicroservice extends Application {
       private _startTime: Date;
 
@@ -309,23 +321,25 @@ This step is essentially the same as above, but can also be done as follows usin
         super();
         const app = this;
         app.controller(AccountController);
-        app.bind('repositories.account').toClass(AccountRepository);
+        app.bind('repositories.NewRepository').toClass(NewRepository);
       }
     ```
 
-2. Inject the bound instance into the repository property of your controller. `inject` can be imported from `@loopback/context`.
+2.  Inject the bound instance into the repository property of your controller.
+    `inject` can be imported from `@loopback/context`.
 
-    ```javascript
+    ```ts
     export class AccountController {
-      @inject('repositories.account') private repository: newRepository;
+      @repository(NewRepository.name) private repository: NewRepository;
     }
     ```
 
 ### Example custom connector CRUD methods
 
-Here is an example of a `find` function which uses the node-js `mysql` driver to retrieve all the rows that match a particular filter for a model instance.
+Here is an example of a `find` function which uses the node-js `mysql` driver to
+retrieve all the rows that match a particular filter for a model instance.
 
-```javascript
+```ts
 public find(
   modelClass: Class<Entity>,
   filter: Filter,


### PR DESCRIPTION
Please review from the 2nd commit

I wasn't able to verify the code snippets for creating your own connector since there's too many functions to implement. I also don't know too much about working with databases to verify the code that I may have had to write.

I personally think that we need to have a working product that uses its own connector, and if others agree I can create a new issue for it. I know the microservices repo has one but if we were to use that, we'd need to pull it out of that repo.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
