### PR TITLE
chore: fix the travis build status badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # loopback-next
 
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/strongloop/loopback) [![Travis Build Status](https://img.shields.io/travis/rust-lang/rust.svg)](https://travis-ci.org/strongloop/loopback-next) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/3v1qmusv168a0kb0/branch/master?svg=true)](https://ci.appveyor.com/project/bajtos/loopback-next/branch/master) [![Coverage Status](https://coveralls.io/repos/github/strongloop/loopback-next/badge.svg?branch=master)](https://coveralls.io/github/strongloop/loopback-next?branch=master)
+[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/strongloop/loopback) [![Travis Build Status](https://travis-ci.org/strongloop/loopback-next.svg?branch=master)](https://travis-ci.org/strongloop/loopback-next) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/3v1qmusv168a0kb0/branch/master?svg=true)](https://ci.appveyor.com/project/bajtos/loopback-next/branch/master) [![Coverage Status](https://coveralls.io/repos/github/strongloop/loopback-next/badge.svg?branch=master)](https://coveralls.io/github/strongloop/loopback-next?branch=master)
 
 LoopBack makes it easy to build modern applications that require complex integrations.
 


### PR DESCRIPTION
It's surprising and embarrassing that nobody has noticed that our travis build status is always failing due to a fixed link to https://img.shields.io/travis/rust-lang/rust.svg.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
