### PR TITLE
Introduce typed binding key

### DIFF
--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -137,9 +137,13 @@ function upon injection.
 **custom-send.provider.ts**
 
 ```ts
-import {Send, ServerResponse, OperationRetval} from '@loopback/rest';
-import {Provider, inject} from '@loopback/context';
-import {RestBindings} from '@loopback/rest';
+import {Send, ServerResponse} from '@loopback/rest';
+import {Provider, BoundValue, inject} from '@loopback/context';
+import {
+  writeResultToResponse,
+  RestBindings,
+  ParsedRequest
+} from '@loopback/rest';
 
 // Note: This is an example class; we do not provide this for you.
 import {Formatter} from '../utils';
@@ -148,7 +152,7 @@ export class CustomSendProvider implements Provider<Send> {
   // In this example, the injection key for formatter is simple
   constructor(
     @inject('utils.formatter') public formatter: Formatter,
-    @inject(RestBindings.Http.REQUEST) public request: Request,
+    @inject(RestBindings.Http.REQUEST) public request: ParsedRequest,
   ) {}
 
   value() {

--- a/examples/log-extension/README.md
+++ b/examples/log-extension/README.md
@@ -91,11 +91,12 @@ user (for this extension that'll be the logLevel `enum`).
  * Binding keys used by this component.
  */
 export namespace EXAMPLE_LOG_BINDINGS {
-  export const METADATA = 'example.log.metadata';
-  export const APP_LOG_LEVEL = 'example.log.level';
-  export const TIMER = 'example.log.timer';
-  export const LOGGER = 'example.log.logger';
-  export const LOG_ACTION = 'example.log.action';
+  export const APP_LOG_LEVEL = BindingKey.create<LOG_LEVEL>(
+    'example.log.level',
+  );
+  export const TIMER = BindingKey.create<TimerFn>('example.log.timer');
+  export const LOGGER = BindingKey.create<LogWriterFn>('example.log.logger');
+  export const LOG_ACTION = BindingKey.create<LogFn>('example.log.action');
 }
 
 /**
@@ -243,7 +244,7 @@ export function LogMixin<T extends Constructor<any>>(superClass: T) {
       this.component(LogComponent);
     }
 
-    logLevel(level: number) {
+    logLevel(level: LOG_LEVEL) {
       this.bind(EXAMPLE_LOG_BINDINGS.APP_LOG_LEVEL).to(level);
     }
   };
@@ -418,8 +419,8 @@ import {TimerProvider} from './providers/timer.provider';
 
 export class LogComponent implements Component {
   providers?: ProviderMap = {
-    [EXAMPLE_LOG_BINDINGS.TIMER]: TimerProvider,
-    [EXAMPLE_LOG_BINDINGS.LOG_ACTION]: LogActionProvider,
+    [EXAMPLE_LOG_BINDINGS.TIMER.key]: TimerProvider,
+    [EXAMPLE_LOG_BINDINGS.LOG_ACTION.key]: LogActionProvider,
   };
 }
 ```

--- a/examples/log-extension/src/component.ts
+++ b/examples/log-extension/src/component.ts
@@ -10,7 +10,7 @@ import {TimerProvider} from './providers/timer.provider';
 
 export class LogComponent implements Component {
   providers?: ProviderMap = {
-    [EXAMPLE_LOG_BINDINGS.TIMER]: TimerProvider,
-    [EXAMPLE_LOG_BINDINGS.LOG_ACTION]: LogActionProvider,
+    [EXAMPLE_LOG_BINDINGS.TIMER.key]: TimerProvider,
+    [EXAMPLE_LOG_BINDINGS.LOG_ACTION.key]: LogActionProvider,
   };
 }

--- a/examples/log-extension/src/decorators/log.decorator.ts
+++ b/examples/log-extension/src/decorators/log.decorator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {LOG_LEVEL, EXAMPLE_LOG_BINDINGS} from '../keys';
+import {LOG_LEVEL, EXAMPLE_LOG_METADATA_KEY} from '../keys';
 import {
   Constructor,
   MethodDecoratorFactory,
@@ -21,7 +21,7 @@ import {LevelMetadata} from '../types';
 export function log(level?: number) {
   if (level === undefined) level = LOG_LEVEL.WARN;
   return MethodDecoratorFactory.createDecorator<LevelMetadata>(
-    EXAMPLE_LOG_BINDINGS.METADATA,
+    EXAMPLE_LOG_METADATA_KEY,
     {
       level,
     },
@@ -40,7 +40,7 @@ export function getLogMetadata(
 ): LevelMetadata {
   return (
     MetadataInspector.getMethodMetadata<LevelMetadata>(
-      EXAMPLE_LOG_BINDINGS.METADATA,
+      EXAMPLE_LOG_METADATA_KEY,
       controllerClass.prototype,
       methodName,
     ) || {level: LOG_LEVEL.OFF}

--- a/examples/log-extension/src/keys.ts
+++ b/examples/log-extension/src/keys.ts
@@ -3,16 +3,25 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {BindingKey} from '@loopback/context';
+import {TimerFn, LogFn, LogWriterFn} from './types';
+
 /**
  * Binding keys used by this component.
  */
 export namespace EXAMPLE_LOG_BINDINGS {
-  export const METADATA = 'example.log.metadata';
-  export const APP_LOG_LEVEL = 'example.log.level';
-  export const TIMER = 'example.log.timer';
-  export const LOGGER = 'example.log.logger';
-  export const LOG_ACTION = 'example.log.action';
+  export const APP_LOG_LEVEL = BindingKey.create<LOG_LEVEL>(
+    'example.log.level',
+  );
+  export const TIMER = BindingKey.create<TimerFn>('example.log.timer');
+  export const LOGGER = BindingKey.create<LogWriterFn>('example.log.logger');
+  export const LOG_ACTION = BindingKey.create<LogFn>('example.log.action');
 }
+
+/**
+ * The key used to store log-related via @loopback/metadata and reflection.
+ */
+export const EXAMPLE_LOG_METADATA_KEY = 'example.log.metadata';
 
 /**
  * Enum to define the supported log levels

--- a/examples/log-extension/src/mixins/log.mixin.ts
+++ b/examples/log-extension/src/mixins/log.mixin.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Constructor} from '@loopback/context';
-import {EXAMPLE_LOG_BINDINGS} from '../keys';
+import {EXAMPLE_LOG_BINDINGS, LOG_LEVEL} from '../keys';
 import {LogComponent} from '../component';
 
 /**
@@ -35,10 +35,10 @@ export function LogMixin<T extends Constructor<any>>(superClass: T) {
      * @param level The log level to set for @log decorator
      *
      * ```ts
-     * app.logLevel(LogLevel.INFO);
+     * app.logLevel(LOG_LEVEL.INFO);
      * ```
      */
-    logLevel(level: number) {
+    logLevel(level: LOG_LEVEL) {
       this.bind(EXAMPLE_LOG_BINDINGS.APP_LOG_LEVEL).to(level);
     }
   };

--- a/examples/log-extension/src/providers/log-action.provider.ts
+++ b/examples/log-extension/src/providers/log-action.provider.ts
@@ -23,7 +23,7 @@ export class LogActionProvider implements Provider<LogFn> {
   writeLog: LogWriterFn = logToConsole;
 
   @inject(EXAMPLE_LOG_BINDINGS.APP_LOG_LEVEL, {optional: true})
-  logLevel: number = LOG_LEVEL.WARN;
+  logLevel: LOG_LEVEL = LOG_LEVEL.WARN;
 
   constructor(
     @inject.getter(CoreBindings.CONTROLLER_CLASS)

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -154,7 +154,7 @@ Finally, put it all together in your application class:
 ```ts
 // src/application.ts
 import {BootMixin, Binding, Booter} from '@loopback/boot';
-import {RestApplication, RestServer} from '@loopback/rest';
+import {RestApplication, RestServer, RestBindings} from '@loopback/rest';
 import {
   AuthenticationComponent,
   AuthenticationBindings,
@@ -181,7 +181,7 @@ export class MyApp extends BootMixin(RestApplication) {
     await super.start();
 
     const server = await this.getServer(RestServer);
-    const port = await server.get('rest.port');
+    const port = await server.get(RestBindings.PORT);
     console.log(`REST server running on port: ${port}`);
   }
 }

--- a/packages/authentication/src/auth-component.ts
+++ b/packages/authentication/src/auth-component.ts
@@ -5,7 +5,7 @@
 
 import {AuthenticationBindings} from './keys';
 import {Component, ProviderMap} from '@loopback/core';
-import {AuthenticationProvider} from './providers/authenticate';
+import {AuthenticateActionProvider} from './providers/authenticate';
 import {AuthMetadataProvider} from './providers/auth-metadata';
 
 export class AuthenticationComponent implements Component {
@@ -14,8 +14,8 @@ export class AuthenticationComponent implements Component {
   // TODO(bajtos) inject configuration
   constructor() {
     this.providers = {
-      [AuthenticationBindings.AUTH_ACTION]: AuthenticationProvider,
-      [AuthenticationBindings.METADATA]: AuthMetadataProvider,
+      [AuthenticationBindings.AUTH_ACTION.key]: AuthenticateActionProvider,
+      [AuthenticationBindings.METADATA.key]: AuthMetadataProvider,
     };
   }
 }

--- a/packages/authentication/src/decorators/authenticate.ts
+++ b/packages/authentication/src/decorators/authenticate.ts
@@ -8,7 +8,7 @@ import {
   Constructor,
   MethodDecoratorFactory,
 } from '@loopback/context';
-import {AuthenticationBindings} from '../keys';
+import {AUTHENTICATION_METADATA_KEY} from '../keys';
 
 /**
  * Authentication metadata stored via Reflection API
@@ -26,7 +26,7 @@ export interface AuthenticationMetadata {
  */
 export function authenticate(strategyName: string, options?: Object) {
   return MethodDecoratorFactory.createDecorator<AuthenticationMetadata>(
-    AuthenticationBindings.METADATA,
+    AUTHENTICATION_METADATA_KEY,
     {
       strategy: strategyName,
       options: options || {},
@@ -45,7 +45,7 @@ export function getAuthenticateMetadata(
   methodName: string,
 ): AuthenticationMetadata | undefined {
   return MetadataInspector.getMethodMetadata<AuthenticationMetadata>(
-    AuthenticationBindings.METADATA,
+    AUTHENTICATION_METADATA_KEY,
     controllerClass.prototype,
     methodName,
   );

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -3,12 +3,32 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Strategy} from 'passport';
+import {BindingKey} from '@loopback/context';
+import {AuthenticateFn, UserProfile} from './providers/authenticate';
+import {AuthenticationMetadata} from './decorators/authenticate';
 /**
  * Binding keys used by this component.
  */
 export namespace AuthenticationBindings {
-  export const STRATEGY = 'authentication.strategy';
-  export const AUTH_ACTION = 'authentication.actions.authenticate';
-  export const METADATA = 'authentication.operationMetadata';
-  export const CURRENT_USER = 'authentication.currentUser';
+  export const STRATEGY = BindingKey.create<Strategy | undefined>(
+    'authentication.strategy',
+  );
+
+  export const AUTH_ACTION = BindingKey.create<AuthenticateFn>(
+    'authentication.actions.authenticate',
+  );
+
+  export const METADATA = BindingKey.create<AuthenticationMetadata | undefined>(
+    'authentication.operationMetadata',
+  );
+
+  export const CURRENT_USER = BindingKey.create<UserProfile | undefined>(
+    'authentication.currentUser',
+  );
 }
+
+/**
+ * The key used to store log-related via @loopback/metadata and reflection.
+ */
+export const AUTHENTICATION_METADATA_KEY = 'authentication.operationsMetadata';

--- a/packages/authentication/src/providers/authenticate.ts
+++ b/packages/authentication/src/providers/authenticate.ts
@@ -37,9 +37,9 @@ export interface UserProfile {
 /**
  * @description Provider of a function which authenticates
  * @example `context.bind('authentication_key')
- *   .toProvider(AuthenticationProvider)`
+ *   .toProvider(AuthenticateActionProvider)`
  */
-export class AuthenticationProvider implements Provider<AuthenticateFn> {
+export class AuthenticateActionProvider implements Provider<AuthenticateFn> {
   constructor(
     // The provider is instantiated for Sequence constructor,
     // at which time we don't have information about the current
@@ -58,38 +58,25 @@ export class AuthenticationProvider implements Provider<AuthenticateFn> {
    * @returns authenticateFn
    */
   value(): AuthenticateFn {
-    return async (request: ParsedRequest) => {
-      return await authenticateRequest(
-        this.getStrategy,
-        request,
-        this.setCurrentUser,
-      );
-    };
+    return request => this.action(request);
   }
-}
 
-/**
- * The implementation of authenticate() sequence action.
- * @param strategy Passport strategy
- * @param request Parsed Request
- * @param setCurrentUser The setter function to update the current user
- *   in the per-request Context
- */
-async function authenticateRequest(
-  getStrategy: Getter<Strategy>,
-  request: ParsedRequest,
-  setCurrentUser: Setter<UserProfile>,
-): Promise<UserProfile | undefined> {
-  const strategy = await getStrategy();
-  if (!strategy) {
-    // The invoked operation does not require authentication.
-    return undefined;
+  /**
+   * The implementation of authenticate() sequence action.
+   * @param request Parsed Request
+   */
+  async action(request: ParsedRequest): Promise<UserProfile | undefined> {
+    const strategy = await this.getStrategy();
+    if (!strategy) {
+      // The invoked operation does not require authentication.
+      return undefined;
+    }
+    if (!strategy.authenticate) {
+      return Promise.reject(new Error('invalid strategy parameter'));
+    }
+    const strategyAdapter = new StrategyAdapter(strategy);
+    const user = await strategyAdapter.authenticate(request);
+    this.setCurrentUser(user);
+    return user;
   }
-  if (!strategy.authenticate) {
-    return Promise.reject(new Error('invalid strategy parameter'));
-  }
-  const strategyAdapter = new StrategyAdapter(strategy);
-  const user = await strategyAdapter.authenticate(request);
-  setCurrentUser(user);
-  return user;
 }

--- a/packages/authentication/test/unit/authenticate-action.test.ts
+++ b/packages/authentication/test/unit/authenticate-action.test.ts
@@ -7,32 +7,36 @@ import {expect} from '@loopback/testlab';
 import {Context, instantiateClass} from '@loopback/context';
 import {ParsedRequest} from '@loopback/rest';
 import {
-  AuthenticationProvider,
+  AuthenticateActionProvider,
   AuthenticateFn,
   UserProfile,
   AuthenticationBindings,
 } from '../..';
 import {MockStrategy} from './fixtures/mock-strategy';
+import {Strategy} from 'passport';
 
-describe('AuthenticationProvider', () => {
+describe('AuthenticateActionProvider', () => {
   describe('constructor()', () => {
     it('instantiateClass injects authentication.strategy in the constructor', async () => {
       const context = new Context();
       const strategy = new MockStrategy();
       context.bind(AuthenticationBindings.STRATEGY).to(strategy);
-      const provider = await instantiateClass(AuthenticationProvider, context);
+      const provider = await instantiateClass(
+        AuthenticateActionProvider,
+        context,
+      );
       expect(await provider.getStrategy()).to.be.equal(strategy);
     });
   });
 
   describe('value()', () => {
-    let provider: AuthenticationProvider;
+    let provider: AuthenticateActionProvider;
     let strategy: MockStrategy;
     let currentUser: UserProfile | undefined;
 
     const mockUser: UserProfile = {name: 'user-name', id: 'mock-id'};
 
-    beforeEach(givenAuthenticationProvider);
+    beforeEach(givenAuthenticateActionProvider);
 
     it('returns a function which authenticates a request and returns a user', async () => {
       const authenticate: AuthenticateFn = await Promise.resolve(
@@ -56,7 +60,7 @@ describe('AuthenticationProvider', () => {
         context.bind(AuthenticationBindings.STRATEGY).to(strategy);
         context
           .bind(AuthenticationBindings.AUTH_ACTION)
-          .toProvider(AuthenticationProvider);
+          .toProvider(AuthenticateActionProvider);
         const request = <ParsedRequest>{};
         const authenticate = await context.get<AuthenticateFn>(
           AuthenticationBindings.AUTH_ACTION,
@@ -67,10 +71,10 @@ describe('AuthenticationProvider', () => {
 
       it('throws an error if the injected passport strategy is not valid', async () => {
         const context: Context = new Context();
-        context.bind(AuthenticationBindings.STRATEGY).to({});
+        context.bind(AuthenticationBindings.STRATEGY).to({} as Strategy);
         context
           .bind(AuthenticationBindings.AUTH_ACTION)
-          .toProvider(AuthenticationProvider);
+          .toProvider(AuthenticateActionProvider);
         const authenticate = await context.get<AuthenticateFn>(
           AuthenticationBindings.AUTH_ACTION,
         );
@@ -89,7 +93,7 @@ describe('AuthenticationProvider', () => {
         context.bind(AuthenticationBindings.STRATEGY).to(strategy);
         context
           .bind(AuthenticationBindings.AUTH_ACTION)
-          .toProvider(AuthenticationProvider);
+          .toProvider(AuthenticateActionProvider);
         const authenticate = await context.get<AuthenticateFn>(
           AuthenticationBindings.AUTH_ACTION,
         );
@@ -105,10 +109,10 @@ describe('AuthenticationProvider', () => {
       });
     });
 
-    function givenAuthenticationProvider() {
+    function givenAuthenticateActionProvider() {
       strategy = new MockStrategy();
       strategy.setMockUser(mockUser);
-      provider = new AuthenticationProvider(
+      provider = new AuthenticateActionProvider(
         () => Promise.resolve(strategy),
         u => (currentUser = u),
       );

--- a/packages/boot/src/keys.ts
+++ b/packages/boot/src/keys.ts
@@ -3,6 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {BindingKey} from '@loopback/context';
+import {BootOptions} from './interfaces';
+import {Bootstrapper} from './bootstrapper';
+
 /**
  * Namespace for core binding keys
  */
@@ -10,11 +14,14 @@ export namespace BootBindings {
   /**
    * Binding key for Boot configuration
    */
-  export const BOOT_OPTIONS = 'boot.options';
-  export const PROJECT_ROOT = 'boot.project_root';
+  export const BOOT_OPTIONS = BindingKey.create<BootOptions>('boot.options');
+  export const PROJECT_ROOT = BindingKey.create<string>('boot.project_root');
 
   // Key for Binding the BootStrapper Class
-  export const BOOTSTRAPPER_KEY = 'application.bootstrapper';
+  export const BOOTSTRAPPER_KEY = BindingKey.create<Bootstrapper>(
+    'application.bootstrapper',
+  );
+
   export const BOOTER_TAG = 'booter';
   export const BOOTER_PREFIX = 'booters';
 }

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -1,5 +1,5 @@
 import {ApplicationConfig} from '@loopback/core';
-import {RestApplication, RestServer} from '@loopback/rest';
+import {RestApplication, RestServer, RestBindings} from '@loopback/rest';
 import {MySequence} from './sequence';
 
 /* tslint:disable:no-unused-variable */
@@ -30,7 +30,7 @@ export class <%= project.applicationName %> extends BootMixin(RestApplication) {
     await super.start();
 
     const server = await this.getServer(RestServer);
-    const port = await server.get('rest.port');
+    const port = await server.get(RestBindings.PORT);
     console.log(`Server is running at http://127.0.0.1:${port}`);
     console.log(`Try http://127.0.0.1:${port}/ping`);
   }

--- a/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
+++ b/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
@@ -1,4 +1,4 @@
-import {ServerRequest} from '@loopback/rest';
+import {ParsedRequest, RestBindings} from '@loopback/rest';
 import {get} from '@loopback/openapi-v3';
 import {inject} from '@loopback/context';
 
@@ -6,7 +6,7 @@ import {inject} from '@loopback/context';
  * A simple controller to bounce back http requests
  */
 export class PingController {
-  constructor(@inject('rest.http.request') private req: ServerRequest) {}
+  constructor(@inject(RestBindings.Http.REQUEST) private req: ParsedRequest) {}
 
   // Map to `GET /ping`
   @get('/ping')

--- a/packages/context/src/BindingKey.ts
+++ b/packages/context/src/BindingKey.ts
@@ -1,0 +1,106 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export type BindingAddress<T> = string | BindingKey<T>;
+
+// tslint:disable-next-line:no-unused-variable
+export class BindingKey<ValueType> {
+  static readonly PROPERTY_SEPARATOR = '#';
+
+  /**
+   * Create a new key for a binding bound to a value of type `ValueType`.
+   *
+   * **Example**
+   *
+   * ```ts
+   * BindingKey.create<string>('application.name');
+   * BindingKey.create<number>('config', 'rest.port);
+   * BindingKey.create<number>('config#rest.port');
+   * ```
+   *
+   * @param key The binding key. When propertyPath is not provided, the key
+   *   is allowed to contain propertyPath as encoded via `BindingKey#toString()`
+   * @param propertyPath Optional path to a deep property of the bound value.
+   */
+  public static create<ValueType>(
+    key: string,
+    propertyPath?: string,
+  ): BindingKey<ValueType> {
+    // TODO(bajtos) allow chaining of propertyPaths, e.g.
+    //   BindingKey.create('config#rest', 'port')
+    // should create {key: 'config', path: 'rest.port'}
+    if (propertyPath) {
+      BindingKey.validate(key);
+      return new BindingKey<ValueType>(key, propertyPath);
+    }
+
+    return BindingKey.parseKeyWithPath(key);
+  }
+
+  private constructor(
+    public readonly key: string,
+    public readonly propertyPath?: string,
+  ) {}
+
+  toString() {
+    return this.propertyPath
+      ? `${this.key}${BindingKey.PROPERTY_SEPARATOR}${this.propertyPath}`
+      : this.key;
+  }
+
+  /**
+   * Get a binding address for retrieving a deep property of the object
+   * bound to the current binding key.
+   *
+   * @param propertyPath A dot-separated path to a (deep) property, e.g. "server.port".
+   */
+  deepProperty<PropertyValueType>(propertyPath: string) {
+    // TODO(bajtos) allow chaining of propertyPaths, e.g.
+    //   BindingKey.create('config', 'rest').deepProperty('port')
+    // should create {key: 'config', path: 'rest.port'}
+    return BindingKey.create<PropertyValueType>(this.key, propertyPath);
+  }
+
+  /**
+   * Validate the binding key format. Please note that `#` is reserved.
+   * Returns a string representation of the binding key.
+   *
+   * @param key Binding key, such as `a`, `a.b`, `a:b`, or `a/b`
+   */
+  static validate<T>(key: BindingAddress<T>): string {
+    if (!key) throw new Error('Binding key must be provided.');
+    key = key.toString();
+    if (key.includes(BindingKey.PROPERTY_SEPARATOR)) {
+      throw new Error(
+        `Binding key ${key} cannot contain` +
+          ` '${BindingKey.PROPERTY_SEPARATOR}'.`,
+      );
+    }
+    return key;
+  }
+
+  /**
+   * Parse a string containing both the binding key and the path to the deeply
+   * nested property to retrieve.
+   *
+   * @param keyWithPath The key with an optional path,
+   *  e.g. "application.instance" or "config#rest.port".
+   */
+  static parseKeyWithPath<T>(keyWithPath: BindingAddress<T>): BindingKey<T> {
+    if (typeof keyWithPath !== 'string') {
+      return BindingKey.create<T>(keyWithPath.key, keyWithPath.propertyPath);
+    }
+
+    const index = keyWithPath.indexOf(BindingKey.PROPERTY_SEPARATOR);
+    if (index === -1) {
+      return new BindingKey<T>(keyWithPath);
+    }
+
+    return BindingKey.create<T>(
+      keyWithPath.substr(0, index).trim(),
+      keyWithPath.substr(index + 1),
+    );
+  }
+}

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from './context';
+import {BindingKey} from './BindingKey';
 import {ResolutionSession} from './resolution-session';
 import {instantiateClass} from './resolver';
 import {
@@ -97,52 +98,6 @@ export enum BindingType {
 }
 
 export class Binding<T = BoundValue> {
-  static PROPERTY_SEPARATOR = '#';
-
-  /**
-   * Validate the binding key format. Please note that `#` is reserved.
-   * @param key Binding key, such as `a, a.b, a:b, a/b
-   */
-  static validateKey(key: string) {
-    if (!key) throw new Error('Binding key must be provided.');
-    if (key.includes(Binding.PROPERTY_SEPARATOR)) {
-      throw new Error(
-        `Binding key ${key} cannot contain` +
-          ` '${Binding.PROPERTY_SEPARATOR}'.`,
-      );
-    }
-    return key;
-  }
-
-  /**
-   * Build a binding key from a key and a path
-   * @param key The key
-   * @param path The path
-   *
-   */
-  static buildKeyWithPath(key: string, path: string) {
-    return `${key}${Binding.PROPERTY_SEPARATOR}${path}`;
-  }
-
-  /**
-   * Parse a string containing both the binding key and the path to the deeply
-   * nested property to retrieve.
-   *
-   * @param keyWithPath The key with an optional path,
-   *  e.g. "application.instance" or "config#rest.port".
-   */
-  static parseKeyWithPath(keyWithPath: string) {
-    const index = keyWithPath.indexOf(Binding.PROPERTY_SEPARATOR);
-    if (index === -1) {
-      return {key: keyWithPath, path: undefined};
-    }
-
-    return {
-      key: keyWithPath.substr(0, index).trim(),
-      path: keyWithPath.substr(index + 1),
-    };
-  }
-
   public readonly key: string;
   public readonly tags: Set<string> = new Set();
   public scope: BindingScope = BindingScope.TRANSIENT;
@@ -159,7 +114,7 @@ export class Binding<T = BoundValue> {
   public valueConstructor: Constructor<T>;
 
   constructor(key: string, public isLocked: boolean = false) {
-    Binding.validateKey(key);
+    BindingKey.validate(key);
     this.key = key;
   }
 

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -20,6 +20,7 @@ export {
 export {Binding, BindingScope, BindingType} from './binding';
 
 export {Context} from './context';
+export {BindingKey, BindingAddress} from './BindingKey';
 export {ResolutionSession} from './resolution-session';
 export {inject, Setter, Getter, Injection, InjectionMetadata} from './inject';
 export {Provider} from './provider';

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -12,6 +12,7 @@ import {
 } from '@loopback/metadata';
 import {BoundValue, ValueOrPromise, resolveList} from './value-promise';
 import {Context} from './context';
+import {BindingKey, BindingAddress} from './BindingKey';
 import {ResolutionSession} from './resolution-session';
 
 const PARAMETERS_KEY = 'inject:parameters';
@@ -50,14 +51,14 @@ export interface InjectionMetadata {
 /**
  * Descriptor for an injection point
  */
-export interface Injection {
+export interface Injection<ValueType = BoundValue> {
   target: Object;
   member?: string | symbol;
   methodDescriptorOrParameterIndex?:
-    | TypedPropertyDescriptor<BoundValue>
+    | TypedPropertyDescriptor<ValueType>
     | number;
 
-  bindingKey: string; // Binding key
+  bindingKey: BindingAddress<ValueType>; // Binding key
   metadata?: InjectionMetadata; // Related metadata
   resolve?: ResolverFunction; // A custom resolve function
 }
@@ -89,7 +90,7 @@ export interface Injection {
  *
  */
 export function inject(
-  bindingKey: string,
+  bindingKey: string | BindingKey<BoundValue>,
   metadata?: InjectionMetadata,
   resolve?: ResolverFunction,
 ) {
@@ -192,7 +193,7 @@ export namespace inject {
    * @param metadata Optional metadata to help the injection
    */
   export const getter = function injectGetter(
-    bindingKey: string,
+    bindingKey: BindingAddress<BoundValue>,
     metadata?: InjectionMetadata,
   ) {
     metadata = Object.assign({decorator: '@inject.getter'}, metadata);
@@ -213,7 +214,7 @@ export namespace inject {
    * @param metadata Optional metadata to help the injection
    */
   export const setter = function injectSetter(
-    bindingKey: string,
+    bindingKey: BindingAddress<BoundValue>,
     metadata?: InjectionMetadata,
   ) {
     metadata = Object.assign({decorator: '@inject.setter'}, metadata);

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -12,6 +12,10 @@ import {DecoratorFactory} from '@loopback/metadata';
 const debugSession = debugModule('loopback:context:resolver:session');
 const getTargetName = DecoratorFactory.getTargetName;
 
+// NOTE(bajtos) The following import is required to satisfy TypeScript compiler
+// tslint:disable-next-line:no-unused-variable
+import {BindingKey} from './BindingKey';
+
 /**
  * A function to be executed with the resolution session
  */

--- a/packages/context/test/unit/BindingKey.test.ts
+++ b/packages/context/test/unit/BindingKey.test.ts
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {BindingKey} from '../../src/BindingKey';
+
+describe('BindingKey', () => {
+  describe('create', () => {
+    it('creates a key with a binding key only', () => {
+      expect(BindingKey.create('foo')).to.have.properties({
+        key: 'foo',
+        propertyPath: undefined,
+      });
+    });
+
+    it('creates a key with a binding key and a property path', () => {
+      expect(BindingKey.create('foo', 'port')).to.have.properties({
+        key: 'foo',
+        propertyPath: 'port',
+      });
+    });
+
+    it('creates a key with a property path parsed from the key arg', () => {
+      const keyString = BindingKey.create('foo', 'port').toString();
+      expect(BindingKey.create(keyString)).to.have.properties({
+        key: 'foo',
+        propertyPath: 'port',
+      });
+    });
+
+    it('rejects a key with an encoded path when the path arg is provided', () => {
+      expect(() => BindingKey.create('foo#port', 'port')).to.throw(
+        /Binding key.*cannot contain/,
+      );
+    });
+  });
+
+  describe('buildKeyWithPath', () => {
+    it('composes address parts using correct separator', () => {
+      expect(BindingKey.create('foo', 'bar').toString()).to.equal('foo#bar');
+    });
+  });
+
+  describe('parseKeyWithPath', () => {
+    it('parses key without path', () => {
+      expect(BindingKey.parseKeyWithPath('foo')).to.have.properties({
+        key: 'foo',
+        propertyPath: undefined,
+      });
+    });
+
+    it('parses key with path', () => {
+      expect(BindingKey.parseKeyWithPath('foo#bar')).to.have.properties({
+        key: 'foo',
+        propertyPath: 'bar',
+      });
+    });
+  });
+});

--- a/packages/context/test/unit/binding.ts
+++ b/packages/context/test/unit/binding.ts
@@ -54,24 +54,6 @@ describe('Binding', () => {
     });
   });
 
-  describe('key', () => {
-    it('build key with path', () => {
-      expect(Binding.buildKeyWithPath('foo', 'bar')).to.equal('foo#bar');
-    });
-    it('parse key without path', () => {
-      expect(Binding.parseKeyWithPath('foo')).to.eql({
-        key: 'foo',
-        path: undefined,
-      });
-    });
-    it('parse key with path', () => {
-      expect(Binding.parseKeyWithPath('foo#bar')).to.eql({
-        key: 'foo',
-        path: 'bar',
-      });
-    });
-  });
-
   describe('inScope', () => {
     it('defaults the transient binding scope', () => {
       expect(binding.scope).to.equal(BindingScope.TRANSIENT);

--- a/packages/context/test/unit/context.ts
+++ b/packages/context/test/unit/context.ts
@@ -10,6 +10,7 @@ import {
   BindingScope,
   BindingType,
   isPromiseLike,
+  BindingKey,
 } from '../..';
 
 /**
@@ -76,7 +77,7 @@ describe('Context', () => {
     });
 
     it('rejects a key containing property separator', () => {
-      const key = 'a' + Binding.PROPERTY_SEPARATOR + 'b';
+      const key = 'a' + BindingKey.PROPERTY_SEPARATOR + 'b';
       expect(() => ctx.bind(key)).to.throw(/Binding key .* cannot contain/);
     });
   });
@@ -288,7 +289,7 @@ describe('Context', () => {
     });
 
     it('rejects a key containing property separator', () => {
-      const key = 'a' + Binding.PROPERTY_SEPARATOR + 'b';
+      const key = 'a' + BindingKey.PROPERTY_SEPARATOR + 'b';
       expect(() => ctx.getBinding(key)).to.throw(
         /Binding key .* cannot contain/,
       );
@@ -307,7 +308,7 @@ describe('Context', () => {
     });
 
     it('returns the value with property separator', () => {
-      const SEP = Binding.PROPERTY_SEPARATOR;
+      const SEP = BindingKey.PROPERTY_SEPARATOR;
       const val = {x: {y: 'Y'}};
       ctx.bind('foo').to(val);
       const value = ctx.getSync(`foo${SEP}x`);
@@ -414,7 +415,7 @@ describe('Context', () => {
     });
 
     it('returns the value with property separator', async () => {
-      const SEP = Binding.PROPERTY_SEPARATOR;
+      const SEP = BindingKey.PROPERTY_SEPARATOR;
       const val = {x: {y: 'Y'}};
       ctx.bind('foo').toDynamicValue(() => Promise.resolve(val));
       const value = await ctx.get(`foo${SEP}x`);

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -3,6 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {BindingKey} from '@loopback/context';
+import {Application, ControllerClass} from './application';
+
 /**
  * Namespace for core binding keys
  */
@@ -11,11 +14,16 @@ export namespace CoreBindings {
   /**
    * Binding key for application instance itself
    */
-  export const APPLICATION_INSTANCE = 'application.instance';
+  export const APPLICATION_INSTANCE = BindingKey.create<Application>(
+    'application.instance',
+  );
+
   /**
    * Binding key for application configuration
    */
-  export const APPLICATION_CONFIG = 'application.config';
+  export const APPLICATION_CONFIG = BindingKey.create<object>(
+    'application.config',
+  );
 
   // server
   /**
@@ -28,12 +36,18 @@ export namespace CoreBindings {
    * Binding key for the controller class resolved in the current request
    * context
    */
-  export const CONTROLLER_CLASS = 'controller.current.ctor';
+  export const CONTROLLER_CLASS = BindingKey.create<ControllerClass>(
+    'controller.current.ctor',
+  );
+
   /**
    * Binding key for the controller method resolved in the current request
    * context
    */
-  export const CONTROLLER_METHOD_NAME = 'controller.current.operation';
+  export const CONTROLLER_METHOD_NAME = BindingKey.create<string>(
+    'controller.current.operation',
+  );
+
   /**
    * Binding key for the controller method metadata resolved in the current
    * request context

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -62,7 +62,7 @@ export class HttpHandler {
     response: ServerResponse,
   ): Promise<void> {
     const parsedRequest: ParsedRequest = parseRequestUrl(request);
-    const requestContext = this._createRequestContext(request, response);
+    const requestContext = this._createRequestContext(parsedRequest, response);
 
     const sequence = await requestContext.get<SequenceHandler>(
       RestBindings.SEQUENCE,
@@ -71,7 +71,7 @@ export class HttpHandler {
   }
 
   protected _createRequestContext(
-    req: ServerRequest,
+    req: ParsedRequest,
     res: ServerResponse,
   ): Context {
     const requestContext = new Context(this._rootContext);

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -3,35 +3,74 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {ServerResponse} from 'http';
 import {CoreBindings} from '@loopback/core';
+import {BindingKey, Context} from '@loopback/context';
+import {OpenApiSpec} from '@loopback/openapi-v3-types';
+
+import {HttpHandler} from './http-handler';
+import {SequenceHandler} from './sequence';
+import {
+  BindElement,
+  FindRoute,
+  GetFromContext,
+  InvokeMethod,
+  LogError,
+  ParsedRequest,
+  ParseParams,
+  Reject,
+  Send,
+} from './internal-types';
+
+// NOTE(bajtos) The following import is required to satisfy TypeScript compiler
+// tslint:disable-next-line:no-unused-variable
+import {OpenAPIObject} from '@loopback/openapi-v3-types';
 
 export namespace RestBindings {
   // RestServer-specific bindings
-  export const CONFIG = `${CoreBindings.APPLICATION_CONFIG}#rest`;
-  export const HOST = 'rest.host';
-  export const PORT = 'rest.port';
-  export const HANDLER = 'rest.handler';
+  export const CONFIG = CoreBindings.APPLICATION_CONFIG.deepProperty('rest');
+  export const HOST = BindingKey.create<string | undefined>('rest.host');
+  export const PORT = BindingKey.create<number>('rest.port');
+  export const HANDLER = BindingKey.create<HttpHandler>('rest.handler');
 
-  export const API_SPEC = 'rest.apiSpec';
-  export const SEQUENCE = 'rest.sequence';
+  export const API_SPEC = BindingKey.create<OpenApiSpec>('rest.apiSpec');
+  export const SEQUENCE = BindingKey.create<SequenceHandler>('rest.sequence');
 
   export namespace SequenceActions {
-    export const FIND_ROUTE = 'rest.sequence.actions.findRoute';
-    export const PARSE_PARAMS = 'rest.sequence.actions.parseParams';
-    export const INVOKE_METHOD = 'rest.sequence.actions.invokeMethod';
-    export const LOG_ERROR = 'rest.sequence.actions.logError';
-    export const SEND = 'rest.sequence.actions.send';
-    export const REJECT = 'rest.sequence.actions.reject';
+    export const FIND_ROUTE = BindingKey.create<FindRoute>(
+      'rest.sequence.actions.findRoute',
+    );
+    export const PARSE_PARAMS = BindingKey.create<ParseParams>(
+      'rest.sequence.actions.parseParams',
+    );
+    export const INVOKE_METHOD = BindingKey.create<InvokeMethod>(
+      'rest.sequence.actions.invokeMethod',
+    );
+    export const LOG_ERROR = BindingKey.create<LogError>(
+      'rest.sequence.actions.logError',
+    );
+    export const SEND = BindingKey.create<Send>('rest.sequence.actions.send');
+    export const REJECT = BindingKey.create<Reject>(
+      'rest.sequence.actions.reject',
+    );
   }
 
-  export const GET_FROM_CONTEXT = 'getFromContext';
-  export const BIND_ELEMENT = 'bindElement';
+  export const GET_FROM_CONTEXT = BindingKey.create<GetFromContext>(
+    'getFromContext',
+  );
+  export const BIND_ELEMENT = BindingKey.create<BindElement>('bindElement');
 
   // request-specific bindings
 
   export namespace Http {
-    export const REQUEST = 'rest.http.request';
-    export const RESPONSE = 'rest.http.response';
-    export const CONTEXT = 'rest.http.request.context';
+    export const REQUEST = BindingKey.create<ParsedRequest>(
+      'rest.http.request',
+    );
+    export const RESPONSE = BindingKey.create<ServerResponse>(
+      'rest.http.response',
+    );
+    export const CONTEXT = BindingKey.create<Context>(
+      'rest.http.request.context',
+    );
   }
 }

--- a/packages/rest/src/rest-component.ts
+++ b/packages/rest/src/rest-component.ts
@@ -28,14 +28,14 @@ import {createEmptyApiSpec} from '@loopback/openapi-v3-types';
 
 export class RestComponent implements Component {
   providers: ProviderMap = {
-    [RestBindings.SequenceActions.LOG_ERROR]: LogErrorProvider,
-    [RestBindings.SequenceActions.FIND_ROUTE]: FindRouteProvider,
-    [RestBindings.SequenceActions.INVOKE_METHOD]: InvokeMethodProvider,
-    [RestBindings.SequenceActions.REJECT]: RejectProvider,
-    [RestBindings.BIND_ELEMENT]: BindElementProvider,
-    [RestBindings.GET_FROM_CONTEXT]: GetFromContextProvider,
-    [RestBindings.SequenceActions.PARSE_PARAMS]: ParseParamsProvider,
-    [RestBindings.SequenceActions.SEND]: SendProvider,
+    [RestBindings.SequenceActions.LOG_ERROR.key]: LogErrorProvider,
+    [RestBindings.SequenceActions.FIND_ROUTE.key]: FindRouteProvider,
+    [RestBindings.SequenceActions.INVOKE_METHOD.key]: InvokeMethodProvider,
+    [RestBindings.SequenceActions.REJECT.key]: RejectProvider,
+    [RestBindings.BIND_ELEMENT.key]: BindElementProvider,
+    [RestBindings.GET_FROM_CONTEXT.key]: GetFromContextProvider,
+    [RestBindings.SequenceActions.PARSE_PARAMS.key]: ParseParamsProvider,
+    [RestBindings.SequenceActions.SEND.key]: SendProvider,
   };
   servers: {
     [name: string]: Constructor<Server>;

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -34,6 +34,7 @@ const debug = require('debug')('loopback:core:routing-table');
 // e.g. via wayfarer/trie or find-my-way
 // See https://github.com/strongloop/loopback-next/issues/98
 import * as pathToRegexp from 'path-to-regexp';
+import {CoreBindings} from '@loopback/core';
 
 /**
  * Parse the URL of the incoming request and set additional properties
@@ -306,8 +307,10 @@ export class ControllerRoute extends BaseRoute {
 
   updateBindings(requestContext: Context) {
     const ctor = this._controllerCtor;
-    requestContext.bind('controller.current.ctor').to(ctor);
-    requestContext.bind('controller.current.operation').to(this._methodName);
+    requestContext.bind(CoreBindings.CONTROLLER_CLASS).to(ctor);
+    requestContext
+      .bind(CoreBindings.CONTROLLER_METHOD_NAME)
+      .to(this._methodName);
   }
 
   async invokeHandler(

--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -17,7 +17,7 @@ import {
 
 import {api, get, post, param, requestBody} from '@loopback/openapi-v3';
 
-import {Application} from '@loopback/core';
+import {Application, CoreBindings} from '@loopback/core';
 
 import {
   ParameterObject,
@@ -334,8 +334,8 @@ describe('Routing', () => {
     @api(spec)
     class GetCurrentController {
       constructor(
-        @inject('controller.current.ctor') private ctor: Function,
-        @inject('controller.current.operation') private operation: string,
+        @inject(CoreBindings.CONTROLLER_CLASS) private ctor: Function,
+        @inject(CoreBindings.CONTROLLER_METHOD_NAME) private operation: string,
       ) {
         expect(GetCurrentController).eql(ctor);
       }

--- a/packages/rest/test/unit/rest-component.test.ts
+++ b/packages/rest/test/unit/rest-component.test.ts
@@ -57,7 +57,7 @@ describe('RestComponent', () => {
 
         class CustomRestComponent extends RestComponent {
           providers: ProviderMap = {
-            [RestBindings.SequenceActions.LOG_ERROR]: CustomLogger,
+            [RestBindings.SequenceActions.LOG_ERROR.key]: CustomLogger,
           };
           constructor(
             @inject(CoreBindings.APPLICATION_INSTANCE) application: Application,

--- a/packages/rest/test/unit/rest-server/rest-server.test.ts
+++ b/packages/rest/test/unit/rest-server/rest-server.test.ts
@@ -7,21 +7,13 @@ import {expect} from '@loopback/testlab';
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
 import {Binding, Context} from '@loopback/context';
 import {Application} from '@loopback/core';
-import {
-  RestServer,
-  BindElement,
-  GetFromContext,
-  Route,
-  InvokeMethod,
-  RestBindings,
-  RestComponent,
-} from '../../..';
+import {RestServer, Route, RestBindings, RestComponent} from '../../..';
 
 describe('RestServer', () => {
   describe('"bindElement" binding', () => {
     it('returns a function for creating new bindings', async () => {
       const ctx = await givenRequestContext();
-      const bindElement = await ctx.get<BindElement>(RestBindings.BIND_ELEMENT);
+      const bindElement = await ctx.get(RestBindings.BIND_ELEMENT);
       const binding = bindElement('foo').to('bar');
       expect(binding).to.be.instanceOf(Binding);
       expect(ctx.getSync('foo')).to.equal('bar');
@@ -31,9 +23,7 @@ describe('RestServer', () => {
   describe('"getFromContext" binding', () => {
     it('returns a function for getting a value from the context', async () => {
       const ctx = await givenRequestContext();
-      const getFromContext = await ctx.get<GetFromContext>(
-        RestBindings.GET_FROM_CONTEXT,
-      );
+      const getFromContext = await ctx.get(RestBindings.GET_FROM_CONTEXT);
       ctx.bind('foo').to('bar');
       expect(await getFromContext('foo')).to.equal('bar');
     });
@@ -53,7 +43,7 @@ describe('RestServer', () => {
       );
 
       const ctx = await givenRequestContext();
-      const invokeMethod = await ctx.get<InvokeMethod>(
+      const invokeMethod = await ctx.get(
         RestBindings.SequenceActions.INVOKE_METHOD,
       );
 


### PR DESCRIPTION
Modify Context, Binding, and related methods to allow developers to add a type information to individual binding keys. These binding keys will allow the compiler to verify that a correct value is passed to binding setters (`.to()`, `.toClass()`, etc.) and automatically infer the type of the value returned by `ctx.get()` and `ctx.getSync()`.

~~This is an early prototype to discuss whether we want to follow the proposed direction.~~

@raymondfeng @strongloop/lb-next-dev @strongloop/loopback-next thoughts?

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Related API Documentation was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
- [ ] Documentation updates
