### PR TITLE
feat(context): add optional typing for Binding

### DIFF
--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Binding} from './binding';
-import {isPromiseLike, getDeepProperty} from './value-promise';
+import {isPromiseLike, getDeepProperty, BoundValue} from './value-promise';
 import {ResolutionOptions, ResolutionSession} from './resolution-session';
 
 import {v1 as uuidv1} from 'uuid';
@@ -43,7 +43,7 @@ export class Context {
    *
    * @param key Binding key
    */
-  bind(key: string): Binding {
+  bind<T = BoundValue>(key: string): Binding<T> {
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Adding binding: %s', key);
@@ -57,7 +57,7 @@ export class Context {
         throw new Error(`Cannot rebind key "${key}" to a locked binding`);
     }
 
-    const binding = new Binding(key);
+    const binding = new Binding<T>(key);
     this.registry.set(key, binding);
     return binding;
   }
@@ -429,10 +429,10 @@ export class Context {
     }
 
     if (isPromiseLike(boundValue)) {
-      return boundValue.then(v => getDeepProperty(v, path) as T);
+      return boundValue.then(v => getDeepProperty<BoundValue, T>(v, path));
     }
 
-    return getDeepProperty(boundValue, path) as T;
+    return getDeepProperty<BoundValue, T>(boundValue, path);
   }
 
   /**

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -46,19 +46,23 @@ export function isPromiseLike<T>(
 }
 
 /**
- * Get nested properties by path
- * @param value Value of an object
+ * Get nested properties of an object by path
+ * @param value Value of the source object
  * @param path Path to the property
  */
-export function getDeepProperty(value: BoundValue, path: string): BoundValue {
+export function getDeepProperty<OUT = BoundValue, IN = BoundValue>(
+  value: IN,
+  path: string,
+): OUT | undefined {
+  let result: BoundValue = value;
   const props = path.split('.').filter(Boolean);
   for (const p of props) {
-    if (value == null) {
-      return value;
+    if (result == null) {
+      return undefined;
     }
-    value = value[p];
+    result = result[p];
   }
-  return value;
+  return <OUT>result;
 }
 
 /**

--- a/packages/context/test/unit/value-promise.test.ts
+++ b/packages/context/test/unit/value-promise.test.ts
@@ -65,10 +65,12 @@ describe('getDeepProperty', () => {
 
   it('allows undefined value', () => {
     expect(getDeepProperty(undefined, 'x.z')).to.be.undefined();
+    expect(getDeepProperty(null, 'x.z')).to.be.undefined();
   });
 
   it('allows null value', () => {
-    expect(getDeepProperty(null, 'x.z')).to.be.null();
+    expect(getDeepProperty({x: {z: null}}, 'x.z')).to.be.null();
+    expect(getDeepProperty(null, '')).to.be.null();
   });
 
   it('allows boolean value', () => {
@@ -95,6 +97,14 @@ describe('getDeepProperty', () => {
     const obj = {a: ['x', 'y']};
     expect(getDeepProperty(obj, 'a.0')).to.eql('x');
     expect(getDeepProperty(obj, 'a.1')).to.eql('y');
+  });
+
+  it('allows to use parameter types', () => {
+    const arr = ['x', 'y'];
+    expect(getDeepProperty<number>(arr, 'length')).to.eql(2);
+    expect(getDeepProperty<string>(arr, '0')).to.eql('x');
+    expect(getDeepProperty<string, string[]>(arr, '1')).to.eql('y');
+    expect(getDeepProperty<string>(arr, '1')).to.eql('y');
   });
 });
 


### PR DESCRIPTION
This PR adds optional typing for `Binding` and `getDeepProperty`.

Related to https://github.com/strongloop/loopback-next/pull/1169

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
