### PR TITLE
fix(cli): exit gracefully if the project name fails validation

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -60,20 +60,14 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       description: 'Mark the project private (excluded from npm publish)',
     });
 
-    // argument validation
-    if (this.args.length) {
-      const isValid = utils.validate(this.args[0]);
-      if (typeof isValid === 'string') throw new Error(isValid);
-    }
-
-    this.setupRenameTransformer();
+    this._setupRenameTransformer();
   }
 
   /**
    * Registers a Transform Stream with Yeoman. Removes `.ejs` extension
    * from files that have it during project generation.
    */
-  setupRenameTransformer() {
+  _setupRenameTransformer() {
     this.registerTransformStream(
       rename(function(file) {
         // extname already contains a leading '.'
@@ -88,6 +82,14 @@ module.exports = class ProjectGenerator extends BaseGenerator {
   }
 
   setOptions() {
+    if (this.options.name) {
+      const msg = utils.validate(this.options.name);
+      if (typeof msg === 'string') {
+        this.exit(msg);
+        return false;
+      }
+    }
+
     this.projectInfo = {
       projectType: this.projectType,
       dependencies: utils.getDependencies(),
@@ -137,8 +139,8 @@ module.exports = class ProjectGenerator extends BaseGenerator {
         when:
           this.projectInfo.outdir == null ||
           // prompts if option was set to a directory that already exists
-          utils.validateyNotExisting(this.projectInfo.outdir) !== true,
-        validate: utils.validateyNotExisting,
+          utils.validateNotExisting(this.projectInfo.outdir) !== true,
+        validate: utils.validateNotExisting,
         default: utils.kebabCase(this.projectInfo.name),
       },
     ];

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -91,7 +91,7 @@ exports.validateClassName = function(name) {
 /**
  * Validate project directory to not exist
  */
-exports.validateyNotExisting = function(path) {
+exports.validateNotExisting = function(path) {
   if (fs.existsSync(path)) {
     return util.format('Directory %s already exists.', path);
   }
@@ -114,7 +114,7 @@ exports.camelCase = camelCase;
 
 exports.validate = function(name) {
   const isValid = validate(name).validForNewPackages;
-  if (!isValid) return 'Not a valid npm package name';
+  if (!isValid) return 'Invalid npm package name: ' + name;
   return isValid;
 };
 

--- a/packages/cli/test/project.js
+++ b/packages/cli/test/project.js
@@ -11,6 +11,7 @@ const testUtils = require('./test-utils');
 const sinon = require('sinon');
 const path = require('path');
 const deps = require('../lib/utils').getDependencies();
+const expect = require('@loopback/testlab').expect;
 
 module.exports = function(projGenerator, props, projectType) {
   return function() {
@@ -27,12 +28,24 @@ module.exports = function(projGenerator, props, projectType) {
         assert(!helpText.match(/loopback4:/));
       });
     });
+
     describe('_setupGenerator', () => {
       describe('args validation', () => {
         it('errors out if validation fails', () => {
-          assert.throws(() => {
-            testUtils.testSetUpGen(projGenerator, {args: 'fooBar'});
-          }, Error);
+          const result = testUtils.executeGenerator(projGenerator)
+            .withArguments(['fooBar']);
+          return expect(result).to.be.rejectedWith(
+            /Invalid npm package name\: fooBar/
+          );
+        });
+
+        it('errors out if validation fails', () => {
+          const result = testUtils.executeGenerator(projGenerator)
+            .withOptions({name: 'fooBar'})
+            .toPromise();
+          return expect(result).to.be.rejectedWith(
+            /Invalid npm package name\: fooBar/
+          );
         });
 
         it('succeeds if no arg is provided', () => {

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -36,8 +36,10 @@ exports.executeGenerator = function(GeneratorOrNamespace, settings) {
   runner.toPromise = function() {
     return new Promise((resolve, reject) => {
       this.on('end', () => {
-        if (this.generator.exitGeneration) {
+        if (this.generator.exitGeneration instanceof Error) {
           reject(this.generator.exitGeneration);
+        } else if (this.generator.exitGeneration) {
+          reject(new Error(this.generator.exitGeneration));
         } else {
           resolve(this.targetDirectory);
         }


### PR DESCRIPTION
Currently `lb4 app fooBar` fails by throwing an error with a stack trace. The PR makes the error exit the generator gracefully.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
