### PR TITLE
fix(metadata): refine clone of decoration spec

### DIFF
--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -106,14 +106,20 @@ export function inject(
       // Please note propertyKey is `undefined` for constructor
       const paramDecorator: ParameterDecorator = ParameterDecoratorFactory.createDecorator<
         Injection
-      >(PARAMETERS_KEY, {
-        target,
-        member,
-        methodDescriptorOrParameterIndex,
-        bindingKey,
-        metadata,
-        resolve,
-      });
+      >(
+        PARAMETERS_KEY,
+        {
+          target,
+          member,
+          methodDescriptorOrParameterIndex,
+          bindingKey,
+          metadata,
+          resolve,
+        },
+        // Do not deep clone the spec as only metadata is mutable and it's
+        // shallowly cloned
+        {cloneInputSpec: false},
+      );
       paramDecorator(target, member!, methodDescriptorOrParameterIndex);
     } else if (member) {
       // Property or method
@@ -136,14 +142,20 @@ export function inject(
       }
       const propDecorator: PropertyDecorator = PropertyDecoratorFactory.createDecorator<
         Injection
-      >(PROPERTIES_KEY, {
-        target,
-        member,
-        methodDescriptorOrParameterIndex,
-        bindingKey,
-        metadata,
-        resolve,
-      });
+      >(
+        PROPERTIES_KEY,
+        {
+          target,
+          member,
+          methodDescriptorOrParameterIndex,
+          bindingKey,
+          metadata,
+          resolve,
+        },
+        // Do not deep clone the spec as only metadata is mutable and it's
+        // shallowly cloned
+        {cloneInputSpec: false},
+      );
       propDecorator(target, member!);
     } else {
       // It won't happen here as `@inject` is not compatible with ClassDecorator

--- a/packages/context/test/unit/inject.test.ts
+++ b/packages/context/test/unit/inject.test.ts
@@ -145,8 +145,12 @@ describe('property injection', () => {
     class SubTestClass extends TestClass {
       @inject('bar') foo: string;
     }
-    const meta = describeInjectedProperties(SubTestClass.prototype);
-    expect(meta.foo.bindingKey).to.eql('bar');
+
+    const base = describeInjectedProperties(TestClass.prototype);
+    expect(base.foo.bindingKey).to.eql('foo');
+
+    const sub = describeInjectedProperties(SubTestClass.prototype);
+    expect(sub.foo.bindingKey).to.eql('bar');
   });
 
   it('supports inherited and own properties', () => {
@@ -160,5 +164,16 @@ describe('property injection', () => {
     const meta = describeInjectedProperties(SubTestClass.prototype);
     expect(meta.foo.bindingKey).to.eql('foo');
     expect(meta.bar.bindingKey).to.eql('bar');
+  });
+
+  it('does not clone metadata deeply', () => {
+    const options = {x: 1};
+    class TestClass {
+      @inject('foo', options)
+      foo: string;
+    }
+    const meta = describeInjectedProperties(TestClass.prototype);
+    expect(meta.foo.metadata).to.be.not.exactly(options);
+    expect(meta.foo.metadata).to.eql({x: 1, decorator: '@inject'});
   });
 });

--- a/packages/metadata/test/unit/decorator-factory.test.ts
+++ b/packages/metadata/test/unit/decorator-factory.test.ts
@@ -41,7 +41,7 @@ describe('DecoratorFactory.cloneDeep', () => {
     expect(copy).to.be.eql(val);
   });
 
-  it('clones class instances', () => {
+  it('keeps user-defined class instances', () => {
     class MyController {
       constructor(public x: string) {}
     }
@@ -49,9 +49,7 @@ describe('DecoratorFactory.cloneDeep', () => {
       target: new MyController('A'),
     };
     const copy = DecoratorFactory.cloneDeep(val);
-    expect(copy.target).to.not.exactly(val.target);
-    expect(copy).to.be.eql(val);
-    expect(copy.target).to.be.instanceof(MyController);
+    expect(copy.target).to.exactly(val.target);
   });
 
   it('clones dates', () => {

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -108,7 +108,7 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
 
     debug('  parameters for method %s: %j', op, params);
     if (params != null) {
-      params = DecoratorFactory.cloneDeep(params);
+      params = DecoratorFactory.cloneDeep<ParameterObject[]>(params);
       /**
        * If a controller method uses dependency injection, the parameters
        * might be sparsed. For example,

--- a/packages/repository/src/legacy-juggler-bridge.ts
+++ b/packages/repository/src/legacy-juggler-bridge.ts
@@ -77,7 +77,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
   constructor(
     // entityClass should have type "typeof T", but that's not supported by TSC
     public entityClass: typeof Entity & {prototype: T},
-    dataSource: juggler.DataSource,
+    public dataSource: juggler.DataSource,
   ) {
     const definition = entityClass.definition;
     assert(

--- a/packages/repository/src/loopback-datasource-juggler.ts
+++ b/packages/repository/src/loopback-datasource-juggler.ts
@@ -158,6 +158,9 @@ export declare namespace juggler {
     name: string;
     settings: AnyObject;
 
+    connected?: boolean;
+    connecting?: boolean;
+
     constructor(
       name?: string,
       settings?: AnyObject,

--- a/packages/repository/test/unit/decorator/repository.ts
+++ b/packages/repository/test/unit/decorator/repository.ts
@@ -5,7 +5,7 @@
 
 import {expect} from '@loopback/testlab';
 import {Context} from '@loopback/context';
-import {repository} from '../../../';
+import {repository, EntityCrudRepository} from '../../../';
 
 import {Repository} from '../../../';
 import {
@@ -85,7 +85,7 @@ describe('repository decorator', () => {
     }
     ctx.bind('controllers.Controller2').toClass(Controller2);
 
-    const myController = await ctx.get<MyController>('controllers.Controller2');
+    const myController = await ctx.get<Controller2>('controllers.Controller2');
     expect(myController.noteRepo).to.be.not.null();
   });
 
@@ -93,12 +93,16 @@ describe('repository decorator', () => {
     class Controller3 {
       constructor(
         @repository(Note, ds)
-        public noteRepo: Repository<Note>,
+        public noteRepo: EntityCrudRepository<Note, number>,
       ) {}
     }
     ctx.bind('controllers.Controller3').toClass(Controller3);
-    const myController = await ctx.get<MyController>('controllers.Controller3');
-    expect(myController.noteRepo).to.be.not.null();
+    const myController = await ctx.get<Controller3>('controllers.Controller3');
+    const r = myController.noteRepo;
+    expect(r).to.be.instanceof(DefaultCrudRepository);
+    expect((r as DefaultCrudRepository<Note, number>).dataSource).to.be.exactly(
+      ds,
+    );
   });
 
   it('rejects @repository("")', async () => {


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/1182. The root
cause is that DataSource instances are cloned incorrectly.

Fixes #1182

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
