### PR TITLE
feat: run `tsc` relative to the root directory of loopback-next monorepo 

### DIFF
--- a/bin/run-lerna.js
+++ b/bin/run-lerna.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * This is an internal script to run `lerna` command with enviornment variable
+ * `LERNA_ROOT_PATH` set to the root directory of `loopback-next` monorepo
+ */
+'use strict';
+
+const path = require('path');
+const lerna = require('lerna');
+const build = require('../packages/build');
+
+function run(argv, options) {
+  const ls = new lerna.LsCommand(
+    null,
+    {json: true, loglevel: 'silent'},
+    path.join(__dirname, '..'),
+  );
+  const rootPath = ls.repository.rootPath;
+
+  process.env.LERNA_ROOT_PATH = rootPath;
+  let args = argv.slice(2);
+
+  return build.runCLI('lerna/bin/lerna', args, options);
+}
+
+module.exports = run;
+if (require.main === module) run(process.argv);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier:fix": "npm run prettier:cli -- --write",
     "clean": "lerna run clean --loglevel=silent --parallel && node packages/build/bin/run-clean \"packages/*/dist*\"",
     "clean:lerna": "lerna clean --yes --parallel --loglevel=silent",
-    "build": "lerna run build --parallel --loglevel=silent",
+    "build": "node bin/run-lerna run build --parallel --loglevel=silent",
     "build:full": "npm run clean:lerna && npm run bootstrap && npm test",
     "pretest": "npm run clean && npm run build",
     "test": "node packages/build/bin/run-nyc npm run mocha --scripts-prepend-node-path",

--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -100,8 +100,10 @@ function run(argv, options) {
 
   const args = [];
 
+  const cwd = process.env.LERNA_ROOT_PATH || process.cwd();
   if (tsConfigFile) {
-    args.push('-p', tsConfigFile);
+    // Make the config file relative the current directory
+    args.push('-p', path.relative(cwd, tsConfigFile));
   }
 
   if (outDir) {
@@ -114,7 +116,12 @@ function run(argv, options) {
 
   args.push(...compilerOpts);
 
-  return utils.runCLI('typescript/lib/tsc', args, options);
+  if (options === true) {
+    options = {dryRun: true};
+  } else {
+    options = options || {};
+  }
+  return utils.runCLI('typescript/lib/tsc', args, {cwd, ...options});
 }
 
 module.exports = run;


### PR DESCRIPTION
This PR adds `run-lerna` script to allow `LERNA_ROOT_PATH` to be passed into `lerna` commands.

The run-lerna script adds the following logic:

- Set LERNA_ROOT_PATH env var

Fixes #1010 

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
