### PR TITLE
docs(example-getting-started): fix typo for ds

### DIFF
--- a/packages/example-getting-started/docs/datasource.md
+++ b/packages/example-getting-started/docs/datasource.md
@@ -21,7 +21,7 @@ this tutorial, we'll be using the memory connector provided with the Juggler.
 
 ```json
 {
-  "name": "ds",
+  "name": "db",
   "connector": "memory"
 }
 ```


### PR DESCRIPTION
Quoting from #1185: 
```
Follow the Getting Starting Tutorial
datasources.json:
{
"name": "ds", <-- should be "db"
"connector": "memory"
}
```
The code was fixed by #966, now we're fixing the docs.

Fixes https://github.com/strongloop/loopback-next/issues/1185