### PR TITLE
chore: disable prefixed output for lerna run

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,20 @@
 {
-  "lerna": "2.8.0",
+  "lerna": "2.9.1",
   "packages": ["packages/*", "docs"],
   "command": {
     "publish": {
       "conventionalCommits": true,
       "message": "chore: publish release"
+    },
+    "run": {
+      "prefix": false,
+      "loglevel": "silent",
+      "parallel": true
+    },
+    "clean": {
+      "loglevel": "silent",
+      "concurrency": 8,
+      "yes": true
     }
   },
   "version": "independent"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^8.10.0",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
-    "lerna": "^2.9.0"
+    "lerna": "^2.9.1"
   },
   "scripts": {
     "bootstrap": "npm i && lerna bootstrap",
@@ -34,9 +34,9 @@
     "prettier:cli": "node packages/build/bin/run-prettier \"**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",
-    "clean": "lerna run clean --loglevel=silent --parallel && node packages/build/bin/run-clean \"packages/*/dist*\"",
-    "clean:lerna": "lerna clean --yes --parallel --loglevel=silent",
-    "build": "node bin/run-lerna run build --parallel --loglevel=silent",
+    "clean": "lerna run clean && node packages/build/bin/run-clean \"packages/*/dist*\"",
+    "clean:lerna": "lerna clean",
+    "build": "node bin/run-lerna run build",
     "build:full": "npm run clean:lerna && npm run bootstrap && npm test",
     "pretest": "npm run clean && npm run build",
     "test": "node packages/build/bin/run-nyc npm run mocha --scripts-prepend-node-path",


### PR DESCRIPTION
This is a follow-up to https://github.com/strongloop/loopback-next/pull/1189

See https://github.com/lerna/lerna/pull/1352

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
