### PR TITLE
fix(repository): clarify argument type for `@repository` 

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -76,7 +76,7 @@ Here's an example of what the template will produce given a `Todo` model and a
 `TodoRepository`:
 
 ```ts
-import {Filter, Where} from '@loopback/repository';
+import {Filter, Where, repository} from '@loopback/repository';
 import {
   post,
   param,
@@ -86,13 +86,12 @@ import {
   del,
   requestBody
 } from '@loopback/rest';
-import {inject} from '@loopback/context';
 import {Todo} from '../models';
 import {TodoRepository} from '../repositories';
 
 export class TodoController {
   constructor(
-    @inject('repositories.TodoRepository')
+    @repository(TodoRepository)
     public todoRepository: TodoRepository,
   ) {}
 

--- a/docs/site/Controllers.md
+++ b/docs/site/Controllers.md
@@ -195,7 +195,7 @@ import {repository} from '@loopback/repository';
 
 export class HelloController {
   constructor(
-    @repository(HelloRepository.name) protected repository: HelloRepository,
+    @repository(HelloRepository) protected repository: HelloRepository,
   ) {}
 
   // returns a list of our objects
@@ -273,7 +273,7 @@ import {repository} from '@loopback/repository';
 
 export class HelloController {
   constructor(
-    @repository(HelloRepository.name) protected repo: HelloRepository,
+    @repository(HelloRepository) protected repo: HelloRepository,
   ) {}
 
   // returns a list of our objects

--- a/docs/site/Decorators.md
+++ b/docs/site/Decorators.md
@@ -575,7 +575,8 @@ For usage examples, see [Define Models](Repositories.md#define-models)
 ### Repository Decorator
 
 Syntax:
-[`@repository(model: string | typeof Entity, dataSource?: string | juggler.DataSource)`](http://apidocs.loopback.io/@loopback%2frepository/#1503)
+
+[@repository(modelOrRepo: string | Class<Repository<Model>> | typeof Entity, dataSource?: string | juggler.DataSource)](http://apidocs.loopback.io/@loopback%2frepository/#1503)
 
 This decorator either injects an existing repository or creates a repository
 from a model and a datasource.

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -155,7 +155,7 @@ DataSource for in the constructor of your controller class as follows:
 ```ts
 export class AccountController {
   constructor(
-    @repository(AccountRepository.name) public repository: AccountRepository,
+    @repository(AccountRepository) public repository: AccountRepository,
   ) {}
 ```
 
@@ -331,7 +331,7 @@ Injection:
 
    ```ts
    export class AccountController {
-     @repository(NewRepository.name) private repository: NewRepository;
+     @repository(NewRepository) private repository: NewRepository;
    }
    ```
 

--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -41,7 +41,7 @@ import {TodoRepository} from '../repositories';
 
 export class TodoController {
   constructor(
-    @repository(TodoRepository.name) protected todoRepo: TodoRepository,
+    @repository(TodoRepository) protected todoRepo: TodoRepository,
   ) {}
 }
 ```
@@ -71,7 +71,7 @@ import {HttpErrors, post, param, requestBody} from '@loopback/rest';
 
 export class TodoController {
   constructor(
-    @repository(TodoRepository.name) protected todoRepo: TodoRepository,
+    @repository(TodoRepository) protected todoRepo: TodoRepository,
   ) {}
 
   @post('/todo')
@@ -121,7 +121,7 @@ import {
 
 export class TodoController {
   constructor(
-    @repository(TodoRepository.name) protected todoRepo: TodoRepository,
+    @repository(TodoRepository) protected todoRepo: TodoRepository,
   ) {}
 
   @post('/todo')

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -18,12 +18,7 @@ import {
 } from '@loopback/rest';
 
 export class TodoController {
-  // TODO(bajtos) Fix documentation (and argument names?) of @repository()
-  // to allow the usage below.
-  // See https://github.com/strongloop/loopback-next/issues/744
-  constructor(
-    @repository(TodoRepository.name) protected todoRepo: TodoRepository,
-  ) {}
+  constructor(@repository(TodoRepository) protected todoRepo: TodoRepository) {}
 
   @post('/todo')
   async createTodo(@requestBody() todo: Todo) {

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -1,4 +1,4 @@
-import {Filter, Where} from '@loopback/repository';
+import {Filter, Where, repository} from '@loopback/repository';
 import {
   post,
   param,
@@ -8,14 +8,13 @@ import {
   del,
   requestBody
 } from '@loopback/openapi-v3';
-import {inject} from '@loopback/context';
 import {<%= modelName %>} from '../models';
 import {<%= repositoryName %>} from '../repositories';
 
 export class <%= name %>Controller {
 
   constructor(
-    @inject('repositories.<%= repositoryName %>')
+    @repository(<%= repositoryName %>)
     public <%= repositoryNameCamel %> : <%= repositoryName %>,
   ) {}
 

--- a/packages/cli/test/controller.js
+++ b/packages/cli/test/controller.js
@@ -281,10 +281,7 @@ describe('lb4 controller', () => {
     assert.fileContent(tmpDir + withInputName, /class FooBarController/);
 
     // Repository and injection
-    assert.fileContent(
-      tmpDir + withInputName,
-      /\@inject\('repositories.BarRepository'\)/
-    );
+    assert.fileContent(tmpDir + withInputName, /\@repository\(BarRepository\)/);
     assert.fileContent(
       tmpDir + withInputName,
       /barRepository \: BarRepository/

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -93,7 +93,7 @@ import {post, requestBody, get, param} from '@loopback/openapi-v3';
 export class NoteController {
   constructor(
     // Use constructor dependency injection to set up the repository
-    @repository(NoteRepository.name) public noteRepo: NoteRepository,
+    @repository(NoteRepository) public noteRepo: NoteRepository,
   ) {}
 
   // Create a new note

--- a/packages/repository/test/unit/decorator/repository-with-di.ts
+++ b/packages/repository/test/unit/decorator/repository-with-di.ts
@@ -16,57 +16,80 @@ import {
   DataSourceType,
 } from '../../../';
 
-class MyController {
-  constructor(@repository('noteRepo') public noteRepo: Repository<Entity>) {}
-}
-
 describe('repository class', () => {
   let ctx: Context;
 
-  before(function() {
-    const ds: DataSourceType = new DataSourceConstructor({
-      name: 'db',
-      connector: 'memory',
-    });
-
-    class Note extends Entity {
-      static definition = new ModelDefinition({
-        name: 'note',
-        properties: {
-          title: 'string',
-          content: 'string',
-          id: {type: 'number', id: true},
-        },
-      });
-
-      title: string;
-      content: string;
-
-      constructor(data?: Partial<Note>) {
-        super(data);
-      }
-    }
-
-    class MyRepository extends DefaultCrudRepository<Entity, string> {
-      constructor(
-        @inject('models.Note') myModel: typeof Note,
-        @inject('dataSources.memory') dataSource: DataSourceType,
-      ) {
-        super(myModel, dataSource);
-      }
-    }
-    ctx = new Context();
-    ctx.bind('models.Note').to(Note);
-    ctx.bind('dataSources.memory').to(ds);
-    ctx.bind('repositories.noteRepo').toClass(MyRepository);
-    ctx.bind('controllers.MyController').toClass(MyController);
-  });
+  before(givenCtx);
 
   // tslint:disable-next-line:max-line-length
   it('supports referencing predefined repository by name via constructor', async () => {
-    const myController = await ctx.get<MyController>(
-      'controllers.MyController',
+    const myController = await ctx.get<StringBoundController>(
+      'controllers.StringBoundController',
     );
     expect(myController.noteRepo instanceof DefaultCrudRepository).to.be.true();
   });
+
+  it('supports referencing predefined repository via constructor', async () => {
+    const myController = await ctx.get<RepositoryBoundController>(
+      'controllers.RepositoryBoundController',
+    );
+    expect(myController.noteRepo instanceof DefaultCrudRepository).to.be.true();
+  });
+
+  const ds: DataSourceType = new DataSourceConstructor({
+    name: 'db',
+    connector: 'memory',
+  });
+
+  class Note extends Entity {
+    static definition = new ModelDefinition({
+      name: 'note',
+      properties: {
+        title: 'string',
+        content: 'string',
+        id: {type: 'number', id: true},
+      },
+    });
+
+    title: string;
+    content: string;
+
+    constructor(data?: Partial<Note>) {
+      super(data);
+    }
+  }
+
+  class MyRepository extends DefaultCrudRepository<Entity, string> {
+    constructor(
+      @inject('models.Note') myModel: typeof Note,
+      @inject('dataSources.memory') dataSource: DataSourceType,
+    ) {
+      super(myModel, dataSource);
+    }
+  }
+
+  class StringBoundController {
+    constructor(
+      @repository('MyRepository') public noteRepo: Repository<Entity>,
+    ) {}
+  }
+
+  class RepositoryBoundController {
+    constructor(
+      @repository(MyRepository) public noteRepo: Repository<Entity>,
+    ) {}
+  }
+
+  function givenCtx() {
+    ctx = new Context();
+    ctx.bind('models.Note').to(Note);
+    ctx.bind('dataSources.memory').to(ds);
+    ctx.bind('repositories.MyRepository').toClass(MyRepository);
+    ctx
+      .bind('controllers.StringBoundController')
+      .toClass(StringBoundController);
+    ctx
+      .bind('controllers.RepositoryBoundController')
+      .toClass(RepositoryBoundController);
+  }
 });


### PR DESCRIPTION
This PR splits `@repository` decorator into two overloaded methods for clarity in their two separate use cases: repository injection and repository generation based on a model and a datasource.

I had a question come up while I was working on the PR. Is advocating repository injection through `@repository(MyRepository.name)` the approach we want to take? I'd think that this is something that would go against the principles of Inversion of Control, which is what our Context system is based on.

I thought the point of the context system was to allow different `components` of an app to be swapped out in a single file. For example, if a user has a test repository and a production repository that he needs to swap out for deployment, our Context system should theoretically provide a single place for the user to swap out the repositories. In the case with `@repository(TestRepository.name)`, the user would have to also go into the controller to physically change `TestRepository` to `ProductionRepository`.

Maybe my understanding of Inversion of Control or our selling point of the framework is wrong, but I'd like to hear what others think about this conflict between what our framework is designed for and how we're designing the framework.

- connected to https://github.com/strongloop/loopback-next/issues/744

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
