### PR TITLE
docs: fix links and liquid formatting

### DIFF
--- a/docs/site/Application-generator.md
+++ b/docs/site/Application-generator.md
@@ -89,7 +89,7 @@ the following files and directories:
 
 `ping.controller.ts` is a file used to provide the application with a responsive
 endpoint. It contains logic to respond with a greeting message when the
-appliaction receives a `GET` request from endpoint `/ping`.
+application receives a `GET` request from endpoint `/ping`.
 
 `cd` to the application's newly created directory and run `npm start` to see the
 application running at `localhost:3000`. Go to `localhost:3000/ping` to be

--- a/docs/site/Application.md
+++ b/docs/site/Application.md
@@ -177,7 +177,8 @@ injected through dependency injections. Visit
 
 {% include note.html content=" Binding configuration such as component binding,
 provider binding, or binding scopes are not possible with the constructor-based
-configuration approach. " %}
+configuration approach.
+" %}
 
 ```ts
 export class MyApplication extends RestApplication {

--- a/docs/site/Best-practices-with-Loopback-4.md
+++ b/docs/site/Best-practices-with-Loopback-4.md
@@ -11,7 +11,8 @@ summary:
 {% include important.html content=" The API-first approach for building LoopBack
 applications is not yet fully supported. Therefore, some of the sections in this
 page are outdated and may not work out of the box. They will be revisited after
-our MVP release. " %}
+our MVP release.
+" %}
 
 LoopBack 4 is more than just a framework: It’s an ecosystem that encourages
 developers to follow best practices through predefined standards. This section

--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -69,7 +69,8 @@ to select:
 - The repository for this model that provides datasource connectivity
 
 {% include warning.html content= " If you do not have a model and repository to
-select, then you will receive an error! " lang=page.lang %}
+select, then you will receive an error! " lang=page.lang
+%}
 
 Here's an example of what the template will produce given a `Todo` model and a
 `TodoRepository`:

--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -88,7 +88,8 @@ class MyController {
 {% include note.html title="A note on binding names" content="To avoid name
 conflicts, add a unique prefix to your binding key (for example, `my-component.`
 in the example above). See [Reserved binding keys](Reserved-binding-keys.md) for
-the list of keys reserved for the framework use. " %}
+the list of keys reserved for the framework use.
+" %}
 
 ### Asynchronous providers
 

--- a/docs/site/Defining-the-API-using-code-first-approach.md
+++ b/docs/site/Defining-the-API-using-code-first-approach.md
@@ -48,7 +48,8 @@ defined.
 
 {% include note.html content=" `Todo` model from
 [tutorial](https://github.com/strongloop/loopback-next/blob/master/packages/example-todo/docs/model.md#srcmodelstodomodelts)
-is used for demonstration here. " %}
+is used for demonstration here.
+" %}
 
 First, write a simple TypeScript class describing your model and its properties:
 
@@ -175,7 +176,9 @@ tutorial.
 {% include note.html content=" If you would like to create your API manually or
 already have one designed, refer to
 [Defining the API using design-first approach](Defining-the-API-using-design-first-approach.md)
-page for best practices. " %}
+page for best practices.
+" %}
 
 {% include next.html content= "
-[Defining your testing strategy](./Defining-your-testing-strategy.md) " %}
+[Defining your testing strategy](./Defining-your-testing-strategy.md)
+" %}

--- a/docs/site/Defining-the-API-using-design-first-approach.md
+++ b/docs/site/Defining-the-API-using-design-first-approach.md
@@ -11,7 +11,8 @@ summary:
 {% include important.html content="The top-down approach for building LoopBack
 applications is not yet fully supported. Therefore, the steps outlined in this
 page are outdated and may not work out of the box. They will be revisited after
-our MVP release. "%}
+our MVP release.
+"%}
 
 ## Define the API from top to bottom (design-first)
 
@@ -433,6 +434,8 @@ from [Testing your application](Testing-your-application.md) for more details.
 {% include note.html content=" If you would like to make tweaks to your API as
 you develop your application, refer to
 [Defining the API using code-first approach](Defining-the-API-using-code-first-approach.md)
-page for best practices. " %}
+page for best practices.
+" %}
 
-{% include next.html content= " [Testing the API](./Testing-the-API.md) " %}
+{% include next.html content= " [Testing the API](./Testing-the-API.md)
+" %}

--- a/docs/site/Defining-your-testing-strategy.md
+++ b/docs/site/Defining-your-testing-strategy.md
@@ -132,4 +132,5 @@ See [Testing Your Application](Testing-Your-application.md) for a reference
 manual on automated tests.
 
 {% include next.html content= "
-[Implementing features](./Implementing-features.md) " %}
+[Implementing features](./Implementing-features.md)
+" %}

--- a/docs/site/Examples-and-tutorials.md
+++ b/docs/site/Examples-and-tutorials.md
@@ -13,7 +13,7 @@ LoopBack 4 comes with the following example projects:
 - **[hello-world](https://github.com/strongloop/loopback-next/tree/master/packages/example-hello-world)**:
   Tutorial on setting up a simple hello-world application using LoopBack 4.
 
-- **[todo](https://loopback.io/doc/en/lb4/todo-tutorial.html)**:
+- **[todo](todo-tutorial.md)**:
   Tutorial on building a simple application with LoopBack 4 key concepts using
   bottom-up approach.
 

--- a/docs/site/Implementing-features.md
+++ b/docs/site/Implementing-features.md
@@ -9,7 +9,8 @@ summary:
 ---
 
 {% include previous.html content=" This article continues from \[Defining your
-testing stategy(./Defining-your-testing-strategy.md). " %}
+testing stategy(./Defining-your-testing-strategy.md).
+" %}
 
 ## Incrementally implement features
 
@@ -452,7 +453,8 @@ only the methods actually used by the controller. This will allow you to
 discover the best repository API that serves the need of the controller.
 However, you don't want to design a new repository API, you want to re-use the
 repository implementation provided by LoopBack. Therefore using the actual
-Repository class/interface is the right approach. " %}
+Repository class/interface is the right approach.
+" %}
 
 In traditional object-oriented languages like Java or C#, in order to allow the
 unit tests to provide a custom implementation of the repository API, the
@@ -703,4 +705,5 @@ to print a common log entry too. Start by writing a unit-test that invokes
 `MySequence` directly.
 
 {% include next.html content= "
-[Preparing the API for consumption](./Preparing-the-API-for-consumption.md) " %}
+[Preparing the API for consumption](./Preparing-the-API-for-consumption.md)
+" %}

--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -255,9 +255,7 @@ illustrates this point by having the custom type `Category` as a property of our
 #### Supported JSON keywords
 
 {% include note.html content="
-
 This feature is still a work in progress and is incomplete.
-
 " %}
 
 Following are the supported keywords that can be explicitly passed into the

--- a/docs/site/Preparing-the-API-for-consumption.md
+++ b/docs/site/Preparing-the-API-for-consumption.md
@@ -9,7 +9,8 @@ summary:
 ---
 
 {% include previous.html content=" This article continues
-from [Implementing features](./Implementing-features.md). " %}
+from [Implementing features](./Implementing-features.md).
+" %}
 
 ## Preparing your API for consumption
 
@@ -35,7 +36,8 @@ Open <http://localhost:3000/swagger-ui> to see the API endpoints defined by
 {% include note.html content=" Swagger UI provides users with interactive
 environment to test the API endpoints defined by the raw spec found at
 <http://localhost:3000/openapi.json>. The API spec is also available in YAML
-flavour at <http://localhost:3000/openapi.yaml> " %}
+flavour at <http://localhost:3000/openapi.yaml>
+" %}
 
 {% include image.html file="lb4/10000000.png" alt="" %}
 

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -253,7 +253,8 @@ application.
 ## Persisting Data without Juggler [Using MySQL database]
 
 {% include important.html content="This section has not been updated and code
-examples may not work out of the box." %}
+examples may not work out of the box.
+" %}
 
 LoopBack 4 gives you the flexibility to create your own custom Datasources which
 utilize your own custom connector for your favorite back end database. You can

--- a/docs/site/Reserved-binding-keys.md
+++ b/docs/site/Reserved-binding-keys.md
@@ -36,7 +36,8 @@ app.bind(BindKeyNameSpace.KeyName).to('value');
 developers creating a new Binding, to avoid conflict with other packages, it is
 recommended that the binding key start with the package name as the prefix.
 Example: `@loopback/authentication` component uses the prefix `authentication`
-for its binding keys. " %}
+for its binding keys.
+" %}
 
 ## Package: authentication
 

--- a/docs/site/Testing-the-API.md
+++ b/docs/site/Testing-the-API.md
@@ -8,14 +8,15 @@ permalink: /doc/en/lb4/Testing-the-API.html
 summary:
 ---
 
-{% include previous.md content=" This article continues off
-from [Defining and validating the API](./Defining-and-validating-the-API.md). "
-%}
+{% include previous.html content=" This article continues off
+from [Defining and validating the API](./Defining-and-validating-the-API.md).
+" %}
 
 {% include important.html content="The top-down approach for building LoopBack
 applications is not yet fully supported. Therefore, the steps outlined in this
 page are outdated and may not work out of the box. They will be revisited after
-our MVP release. "%}
+our MVP release.
+" %}
 
 ## Smoke test API input/output
 
@@ -222,4 +223,5 @@ Please refer to
 from [Testing your application](Testing-your-application.md) for more details.
 
 {% include next.html content= "
-[Defining your testing strategy](./Defining-your-testing-strategy.md) " %}
+[Defining your testing strategy](./Defining-your-testing-strategy.md)
+" %}

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -36,7 +36,8 @@ step-by-step tutorial, see
 [Incrementally implement features](Implementing-features.md).
 
 {% include important.html content=" A great test suite requires you to think
-smaller and favor fast and focused unit tests over slow end-to-end tests. " %}
+smaller and favor fast and focused unit tests over slow end-to-end tests.
+" %}
 
 This article is a reference guide for common types of tests and test helpers.
 
@@ -123,8 +124,7 @@ export async function givenEmptyDatabase() {
 }
 ```
 
-{% include code-caption.html
-content="test/integration/controllers/product.controller.test.ts" %}
+{% include code-caption.html content="test/integration/controllers/product.controller.test.ts" %}
 
 ```ts
 // in your test file
@@ -314,7 +314,8 @@ There are three kinds of test doubles provided by Sinon.JS:
 {% include note.html content=" We recommend against using test mocks. With test
 mocks, the expectations must be defined before the tested scenario is executed,
 which breaks the recommended test layout 'arrange-act-assert' (or
-'given-when-then') and also produces code that's difficult to comprehend. " %}
+'given-when-then') and also produces code that's difficult to comprehend.
+" %}
 
 #### Create a stub Repository
 
@@ -393,8 +394,7 @@ repository's `find()` method with a correct query, and returns back the query
 results. See [Create a stub repository](#create-a-stub-repository) for a
 detailed explanation.
 
-{% include code-caption.html
-content="test/unit/controllers/product.controller.test.ts" %}
+{% include code-caption.html content="test/unit/controllers/product.controller.test.ts" %}
 
 ```ts
 import {expect, sinon} from '@loopback/testlab';
@@ -538,8 +538,7 @@ Integration tests are one of the places to put the best practices in
 Here is an example showing how to write an integration test for a custom
 repository method `findByName`:
 
-{% include code-caption.html content=
-"test/integration/repositories/category.repository.test.ts" %}
+{% include code-caption.html content="test/integration/repositories/category.repository.test.ts" %}
 
 ```ts
 import {
@@ -574,8 +573,7 @@ commands and queries produce expected results when executed on a real database.
 These tests are similar to repository tests with controllers added as another
 ingredient.
 
-{% include code-caption.html content=
-"test/integration/controllers/product.controller.test.ts" %}
+{% include code-caption.html content="test/integration/controllers/product.controller.test.ts" %}
 
 ```ts
 import {expect} from '@loopback/testlab';
@@ -660,7 +658,8 @@ describe('API specification', () => {
 {% include important.html content=" The top-down approach for building LoopBack
 applications is not yet fully supported. Therefore, the code outlined in this
 section is outdated and may not work out of the box. It will be revisitedafter
-our MVP release. " %}
+our MVP release.
+" %}
 
 The formal validity of your application's spec does not guarantee that your
 implementation is actually matching the specified behavior. To keep your spec in

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -10,13 +10,15 @@ summary: LoopBack is a platform for building APIs and microservices in Node.js
 ---
 
 {% include important.html content="LoopBack 4 is the next step in the evolution
-of LoopBack. It is still in early development and is not yet released. " %}
+of LoopBack. It is still in early development and is not yet released.
+" %}
 
 {% include see-also.html title="GitHub Repo" content=' LoopBack 4 framework code
 is being developed in one "mono-repository",
 [loopback-next](https://github.com/strongloop/loopback-next), rather than
 multiple repos, as in v3. However, examples and externally-developed components
-will be in separate repositories. '%}
+will be in separate repositories.
+'%}
 
 ## Built for API developers
 

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -26,31 +26,31 @@ children:
     children:
 
     - title: 'Create your app scaffolding'
-      url: 'todo-tutorial/scaffolding.html'
+      url: todo-tutorial-scaffolding.html
       output: 'web, pdf'
 
     - title: 'Adding legacy juggler'
-      url: 'todo-tutorial/juggler.html'
+      url: todo-tutorial-juggler.html
       output: 'web, pdf'
 
     - title: 'Add your Todo model'
-      url: 'todo-tutorial/model.html'
+      url: todo-tutorial-model.html
       output: 'web, pdf'
 
     - title: 'Add a Datasource'
-      url: 'todo-tutorial/datasource.html'
+      url: todo-tutorial-datasource.html
       output: 'web, pdf'
 
     - title: 'Add a Repository'
-      url: 'todo-tutorial/repository.html'
+      url: todo-tutorial-repository.html
       output: 'web, pdf'
 
     - title: 'Add a Controller'
-      url: 'todo-tutorial/controller.html'
+      url: todo-tutorial-controller.html
       output: 'web, pdf'
 
     - title: 'Putting it all together'
-      url: 'todo-tutorial/putting-it-together.html'
+      url: todo-tutorial-putting-it-together.html
       output: 'web, pdf'
 
 - title: 'Key concepts'

--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -4,7 +4,7 @@ title: 'Add a Controller'
 keywords: LoopBack 4.0, LoopBack 4
 tags:
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/todo-tutorial/controller.html
+permalink: /doc/en/lb4/todo-tutorial-controller.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Controller
 ---
 
@@ -56,7 +56,7 @@ new controller instances.
 > **NOTE**: You can customize the lifecycle of _all_ bindings in LoopBack 4!
 > Controllers can easily be made to use singleton lifecycles to minimize startup
 > costs. For more information, see the
-> [Dependency injection](../Dependency-injection.md)
+> [Dependency injection](Dependency-injection.md)
 > section of our docs.
 
 Now that we have the repository wireup, let's create our first handler function.
@@ -181,10 +181,10 @@ Some additional things to note about this example:
   `@param.path.number('id')`.
 
 Now that we've wired up the controller, our last step is to tie it all into the
-[Application](putting-it-together.md)!
+[Application](todo-tutorial-putting-it-together.md)!
 
 ### Navigation
 
-Previous step: [Add a repository](repository.md)
+Previous step: [Add a repository](todo-tutorial-repository.md)
 
-Final step: [Putting it all together](putting-it-together.md)
+Final step: [Putting it all together](todo-tutorial-putting-it-together.md)

--- a/docs/site/todo-tutorial-datasource.md
+++ b/docs/site/todo-tutorial-datasource.md
@@ -4,7 +4,7 @@ title: 'Add a Datasource'
 keywords: LoopBack 4.0, LoopBack 4
 tags:
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/todo-tutorial/datasource.html
+permalink: /doc/en/lb4/todo-tutorial-datasource.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Datasource
 ---
 
@@ -13,9 +13,9 @@ summary: LoopBack 4 Todo Application Tutorial - Add a Datasource
 Datasources are LoopBack's way of connecting to various sources of data, such as
 databases, APIs, message queues and more. In LoopBack 4, datasources can be
 represented as strongly-typed objects and freely made available for
-[injection](../Dependency-injection.md) throughout
+[injection](Dependency-injection.md) throughout
 the application. Typically, in LoopBack 4, datasources are used in conjunction
-with [Repositories](../Repositories.md) to provide
+with [Repositories](Repositories.md) to provide
 access to data.
 
 Since our Todo API will need to persist instances of Todo items, we'll need to
@@ -51,11 +51,11 @@ const config = require(dsConfigPath);
 export const db = new DataSourceConstructor(config);
 ```
 
-Once you're ready, we'll move onto adding a [repository](repository.md) for the
+Once you're ready, we'll move onto adding a [repository](todo-tutorial-repository.md) for the
 datasource.
 
 ### Navigation
 
-Previous step: [Add your Todo model](model.md)
+Previous step: [Add your Todo model](todo-tutorial-model.md)
 
-Next step: [Add a repository](repository.md)
+Next step: [Add a repository](todo-tutorial-repository.md)

--- a/docs/site/todo-tutorial-juggler.md
+++ b/docs/site/todo-tutorial-juggler.md
@@ -4,7 +4,7 @@ title: 'Adding legacy juggler'
 keywords: LoopBack 4.0, LoopBack 4
 tags:
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/todo-tutorial/juggler.html
+permalink: /doc/en/lb4/todo-tutorial-juggler.html
 summary: LoopBack 4 Todo Application Tutorial - Adding legacy juggler
 ---
 
@@ -85,11 +85,11 @@ Once you're ready, we'll move on to the [Add your Todo model](model.md) section.
 For more information on the Legacy Juggler, check out the
 [@loopback/repository package](https://github.com/strongloop/loopback-next/tree/master/packages/repository)
 or see the
-[Repositories section](../Repositories.md) of our
+[Repositories section](Repositories.md) of our
 docs.
 
 ### Navigation
 
-Previous step: [Scaffolding your application](scaffolding.md)
+Previous step: [Scaffolding your application](todo-tutorial-scaffolding.md)
 
-Next step: [Add your Todo model](model.md)
+Next step: [Add your Todo model](todo-tutorial-model.md)

--- a/docs/site/todo-tutorial-model.md
+++ b/docs/site/todo-tutorial-model.md
@@ -4,7 +4,7 @@ title: 'Add Todo Model'
 keywords: LoopBack 4.0, LoopBack 4
 tags:
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/todo-tutorial/model.html
+permalink: /doc/en/lb4/todo-tutorial-model.html
 summary: LoopBack 4 Todo Application Tutorial - Add Todo Model
 ---
 
@@ -105,11 +105,11 @@ export class Todo extends Entity {
 }
 ```
 
-Now that we have our model, it's time to add a [datasource](datasource.md) so we
+Now that we have our model, it's time to add a [datasource](todo-tutorial-datasource.md) so we
 can perform real CRUD operations!
 
 ### Navigation
 
-Previous step: [Adding the Legacy Juggler](juggler.md)
+Previous step: [Adding the Legacy Juggler](todo-tutorial-juggler.md)
 
-Next step: [Add a datasource](datasource.md)
+Next step: [Add a datasource](todo-tutorial-datasource.md)

--- a/docs/site/todo-tutorial-putting-it-together.md
+++ b/docs/site/todo-tutorial-putting-it-together.md
@@ -4,15 +4,15 @@ title: 'Putting it all together'
 keywords: LoopBack 4.0, LoopBack 4
 tags:
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/todo-tutorial/putting-it-together.html
+permalink: /doc/en/lb4/todo-tutorial-putting-it-together.html
 summary: LoopBack 4 Todo Application Tutorial - Putting it all together
 ---
 
 ### Putting it all together
 
 We've got all of our artifacts now, and all that's left is to bind them to our
-[Application](../Application.md) so that LoopBack's
-[Dependency injection](../Dependency-injection.md)
+[Application](Application.md) so that LoopBack's
+[Dependency injection](Dependency-injection.md)
 system can tie it all together for us!
 
 LoopBack's
@@ -29,9 +29,9 @@ artifacts and inject them into our application for use.
 > - Repositories: `./src/repositories`
 >
 > To find out how to customize this behavior, see the
-> [Booters](../Booting-an-Application.md#booters)
+> [Booters](Booting-an-Application.md#booters)
 > section of
-> [Booting an Application](../Booting-an-Application.md).
+> [Booting an Application](Booting-an-Application.md).
 
 #### src/application.ts
 
@@ -123,10 +123,10 @@ That's it! You've just created your first LoopBack 4 application!
 ### More examples and tutorials
 
 Eager to continue learning about LoopBack 4? Check out our
-[examples and tutorials](../Examples-and-tutorials.md)
+[examples and tutorials](Examples-and-tutorials.md)
 section to find examples for creating your own custom components, sequences and
 more!
 
 ### Navigation
 
-Previous step: [Add a controller](controller.md)
+Previous step: [Add a controller](todo-tutorial-controller.md)

--- a/docs/site/todo-tutorial-repository.md
+++ b/docs/site/todo-tutorial-repository.md
@@ -4,7 +4,7 @@ title: 'Add a Repository'
 keywords: LoopBack 4.0, LoopBack 4
 tags:
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/todo-tutorial/repository.html
+permalink: /doc/en/lb4/todo-tutorial-repository.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Repository
 ---
 
@@ -51,11 +51,11 @@ export class TodoRepository extends DefaultCrudRepository<
 ```
 
 Now we have everything we need to perform CRUD operations for our Todo list,
-we'll need to build the [Controller](controller.md) to handle our incoming
+we'll need to build the [Controller](todo-tutorial-controller.md) to handle our incoming
 requests.
 
 ### Navigation
 
-Previous step: [Add a datasource](datasource.md)
+Previous step: [Add a datasource](todo-tutorial-datasource.md)
 
-Next step: [Add a controller](controller.md)
+Next step: [Add a controller](todo-tutorial-controller.md)

--- a/docs/site/todo-tutorial-scaffolding.md
+++ b/docs/site/todo-tutorial-scaffolding.md
@@ -4,7 +4,7 @@ title: 'Create your app scaffolding'
 keywords: LoopBack 4.0, LoopBack 4
 tags:
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/todo-tutorial/scaffolding.html
+permalink: /doc/en/lb4/todo-tutorial-scaffolding.html
 summary: LoopBack 4 Todo Application Tutorial - Create app scaffolding
 ---
 
@@ -83,7 +83,7 @@ tslint.json
 | LICENSE                            | A copy of the MIT license. If you do not wish to use this license, please delete this file.                                                                                                                                                           |
 | src/application.ts                 | The application class, which extends [`RestApplication`](http://apidocs.strongloop.com/@loopback%2frest/#RestApplication) by default. This is the root of your application, and is where your application will be configured.                         |
 | src/index.ts                       | The starting point of your microservice. This file creates an instance of your application, runs the booter, then attempts to start the [`RestServer`](http://apidocs.strongloop.com/@loopback%2frest/#RestServer) instance bound to the application. |
-| src/sequence.ts                    | An extension of the [Sequence](http://loopback.io/doc/en/lb4/Sequence.html) class used to define the set of actions to take during a REST request/response.                                                                                           |
+| src/sequence.ts                    | An extension of the [Sequence](Sequence.md) class used to define the set of actions to take during a REST request/response.                                                                                           |
 | src/controllers/README.md          | Provides information about the controller directory, how to generate new controllers, and where to find more information.                                                                                                                             |
 | src/controllers/ping.controller.ts | A basic controller that responds to GET requests at `/ping`.                                                                                                                                                                                          |
 | src/datasources/README.md          | Provides information about the datasources directory, how to generate new datasources, and where to find more information.                                                                                                                            |
@@ -95,4 +95,4 @@ tslint.json
 
 ### Navigation
 
-Next step: [Adding the legacy juggler](juggler.md)
+Next step: [Adding the legacy juggler](todo-tutorial-juggler.md)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -92,7 +92,7 @@
       "@loopback/repository-json-schema": "^0.4.1",
       "@loopback/repository": "^0.4.1",
       "@loopback/openapi-v2": "^0.3.0",
-      "@loopback/docs": "^0.3.2",
+      "@loopback/docs": "^0.3.3",
       "fs-extra": "^5.0.0",
       "rimraf": "^2.6.2"
     }

--- a/packages/example-todo/README.md
+++ b/packages/example-todo/README.md
@@ -28,17 +28,17 @@ npm i -g @loopback/cli
 ## Tutorial
 
 To follow this tutorial, begin with the
-[Create your app scaffolding](http://loopback.io/doc/en/lb4/todo-tutorial/scaffolding.html) section.
+[Create your app scaffolding](http://loopback.io/doc/en/lb4/todo-tutorial-scaffolding.html) section.
 
 ### Steps
 
-1. [Create your app scaffolding](http://loopback.io/doc/en/lb4/todo-tutorial/scaffolding.html)
-2. [Adding legacy juggler](http://loopback.io/doc/en/lb4/todo-tutorial/juggler.html)
-3. [Add your Todo model](http://loopback.io/doc/en/lb4/todo-tutorial/model.html)
-4. [Add a datasource](http://loopback.io/doc/en/lb4/todo-tutorial/datasource.html)
-5. [Add a repository](http://loopback.io/doc/en/lb4/todo-tutorial/repository.html)
-6. [Add a controller](http://loopback.io/doc/en/lb4/todo-tutorial/controller.html)
-7. [Putting it all together](http://loopback.io/doc/en/lb4/todo-tutorial/putting-it-together.html)
+1. [Create your app scaffolding](http://loopback.io/doc/en/lb4/todo-tutorial-scaffolding.html)
+2. [Adding legacy juggler](http://loopback.io/doc/en/lb4/todo-tutorial-juggler.html)
+3. [Add your Todo model](http://loopback.io/doc/en/lb4/todo-tutorial-model.html)
+4. [Add a datasource](http://loopback.io/doc/en/lb4/todo-tutorial-datasource.html)
+5. [Add a repository](http://loopback.io/doc/en/lb4/todo-tutorial-repository.html)
+6. [Add a controller](http://loopback.io/doc/en/lb4/todo-tutorial-controller.html)
+7. [Putting it all together](http://loopback.io/doc/en/lb4/todo-tutorial-putting-it-together.html)
 
 ## Try it out
 
@@ -46,7 +46,6 @@ If you'd like to see the final results of this tutorial as an example
 application, follow these steps:
 
 1. Run the `lb4 example` command to select and clone the todo repository:
-
 ```sh
 $ lb4 example
 ? What example would you like to clone? (Use arrow keys)
@@ -57,18 +56,17 @@ $ lb4 example
 ```
 
 2. Jump into the directory and then install the required dependencies:
-
 ```sh
 cd loopback4-example-todo && npm i
 ```
 
 3. Finally, start the application!
 
-```sh
-$ npm start
+    ```sh
+    $ npm start
 
-Server is running on port 3000
-```
+    Server is running on port 3000
+    ```
 
 Feel free to look around in the application's code to get a feel for how it
 works, or if you're still interested in learning how to build it step-by-step,


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

- Fixes loopback.io LB4 sidebar for Todo Tutorial.
- Fixes formatting which was broken for includes after running markdown linter.
- Fixes numbering issue on todo-tutorial issue.


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
