### PR TITLE
refactor(authentication): extend strategy instead of implement

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -32,8 +32,8 @@
     "@loopback/build": "^0.4.1",
     "@loopback/openapi-spec-builder": "^0.4.1",
     "@loopback/testlab": "^0.5.1",
-    "@types/passport": "^0.4.0",
-    "@types/passport-http": "^0.3.3",
+    "@types/passport": "^0.4.4",
+    "@types/passport-http": "^0.3.6",
     "passport-http": "^0.3.0"
   },
   "keywords": [

--- a/packages/authentication/test/unit/authenticate-action.test.ts
+++ b/packages/authentication/test/unit/authenticate-action.test.ts
@@ -13,9 +13,7 @@ import {
   AuthenticationBindings,
 } from '../..';
 import {MockStrategy} from './fixtures/mock-strategy';
-// FIXME: All of these BDD titles are too verbose and should be reworded
-// to not run afoul of the lint rules!
-// tslint:disable:max-line-length
+
 describe('AuthenticationProvider', () => {
   describe('constructor()', () => {
     it('instantiateClass injects authentication.strategy in the constructor', async () => {

--- a/packages/authentication/test/unit/fixtures/mock-strategy.ts
+++ b/packages/authentication/test/unit/fixtures/mock-strategy.ts
@@ -3,28 +3,25 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Strategy, StrategyCreated, AuthenticateOptions} from 'passport';
+import {Strategy, AuthenticateOptions} from 'passport';
 import {PassportRequest} from '../../..';
 
 /**
  * Test fixture for a mock asynchronous passport-strategy
  */
-export class MockStrategy implements Strategy {
+export class MockStrategy extends Strategy {
   // user to return for successful authentication
   private mockUser: Object;
-  constructor() {}
+
   setMockUser(userObj: Object) {
     this.mockUser = userObj;
   }
+
   /**
    * authenticate() function similar to passport-strategy packages
    * @param req
    */
-  async authenticate(
-    this: StrategyCreated<this> & this,
-    req: Express.Request,
-    options?: AuthenticateOptions,
-  ) {
+  async authenticate(req: Express.Request, options?: AuthenticateOptions) {
     await this.verify(req);
   }
   /**
@@ -36,7 +33,7 @@ export class MockStrategy implements Strategy {
    * pass req.query.testState = 'fail' to mock failed authorization
    * pass req.query.testState = 'error' to mock unexpected error
    */
-  async verify(this: StrategyCreated<this> & this, request: Express.Request) {
+  async verify(request: Express.Request) {
     // A workaround for buggy typings provided by @types/passport
     const req = request as PassportRequest;
 
@@ -58,19 +55,15 @@ export class MockStrategy implements Strategy {
     process.nextTick(this.returnMockUser.bind(this));
   }
 
-  returnMockUser(this: StrategyCreated<this> & this) {
+  returnMockUser() {
     this.success(this.mockUser);
   }
 
-  returnUnauthorized(
-    this: StrategyCreated<this> & this,
-    challenge?: string | number,
-    status?: number,
-  ) {
+  returnUnauthorized(challenge?: string | number, status?: number) {
     this.fail(challenge, status);
   }
 
-  returnError(this: StrategyCreated<this> & this, err: string) {
+  returnError(err: string) {
     this.error(err);
   }
 }

--- a/packages/authentication/test/unit/strategy-adapter.test.ts
+++ b/packages/authentication/test/unit/strategy-adapter.test.ts
@@ -7,7 +7,7 @@ import {expect} from '@loopback/testlab';
 import {StrategyAdapter, UserProfile} from '../..';
 import {ParsedRequest, HttpErrors} from '@loopback/rest';
 import {MockStrategy} from './fixtures/mock-strategy';
-import {StrategyCreated, AuthenticateOptions} from 'passport';
+import {AuthenticateOptions} from 'passport';
 
 describe('Strategy Adapter', () => {
   const mockUser: UserProfile = {name: 'user-name', id: 'mock-id'};
@@ -19,7 +19,6 @@ describe('Strategy Adapter', () => {
       class Strategy extends MockStrategy {
         // override authenticate method to set calledFlag
         async authenticate(
-          this: StrategyCreated<this> & this,
           req: Express.Request,
           options?: AuthenticateOptions,
         ) {


### PR DESCRIPTION
`@types/passport` changes Strategy from to be a `class` instead of an `interface` which is breaking our build. 

See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24682

This PR refactors the MockStrategy so it extends the `Strategy` class instead of `implements` the interface. 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `packages/example-*` were updated
