### PR TITLE
Introduce strongly-typed metadata key

### DIFF
--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -4,9 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Strategy} from 'passport';
-import {BindingKey} from '@loopback/context';
 import {AuthenticateFn, UserProfile} from './providers/authentication.provider';
 import {AuthenticationMetadata} from './decorators/authenticate.decorator';
+import {BindingKey, MetadataAccessor} from '@loopback/context';
+
 /**
  * Binding keys used by this component.
  */
@@ -31,4 +32,6 @@ export namespace AuthenticationBindings {
 /**
  * The key used to store log-related via @loopback/metadata and reflection.
  */
-export const AUTHENTICATION_METADATA_KEY = 'authentication.operationsMetadata';
+export const AUTHENTICATION_METADATA_KEY = MetadataAccessor.create<
+  AuthenticationMetadata
+>('authentication.operationsMetadata');

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -9,14 +9,19 @@ import {
   ParameterDecoratorFactory,
   PropertyDecoratorFactory,
   MetadataMap,
+  MetadataAccessor,
 } from '@loopback/metadata';
 import {BoundValue, ValueOrPromise, resolveList} from './value-promise';
 import {Context} from './context';
 import {BindingKey, BindingAddress} from './binding-key';
 import {ResolutionSession} from './resolution-session';
 
-const PARAMETERS_KEY = 'inject:parameters';
-const PROPERTIES_KEY = 'inject:properties';
+const PARAMETERS_KEY = MetadataAccessor.create<Injection, ParameterDecorator>(
+  'inject:parameters',
+);
+const PROPERTIES_KEY = MetadataAccessor.create<Injection, PropertyDecorator>(
+  'inject:properties',
+);
 
 /**
  * A function to provide resolution of injected values

--- a/packages/context/test/unit/binding-key.unit.ts
+++ b/packages/context/test/unit/binding-key.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {BindingKey} from '../../src/binding-key';
+import {BindingKey} from '../..';
 
 describe('BindingKey', () => {
   describe('create', () => {

--- a/packages/metadata/README.md
+++ b/packages/metadata/README.md
@@ -412,6 +412,25 @@ const allParamsForConstructor = MetadataInspector.getAllParameterMetaData<
 >('my-parameter-decorator-key', MyController, '');
 ```
 
+### Use strong-typed metadata access key
+
+You can use MetadataAccessor to provide type checks for metadata access via
+keys. For example,
+
+```ts
+const CLASS_KEY = MetadataAccessor.create<MyClassMetadata, ClassDecorator>(
+    'my-class-decorator-key',
+  );
+
+// Create a class decorator with the key
+const myClassDecorator = ClassDecoratorFactory.createDecorator(CLASS_KEY);
+
+// Inspect a class with the key
+const myClassMeta = MetadataInspector.getClassMetaData(CLASS_KEY, MyController);
+```
+
+Please note MetadataKey can be an instance of MetadataAccessor or a string.
+
 ### Inspect design-time metadata of properties/methods
 
 ```ts

--- a/packages/metadata/docs.json
+++ b/packages/metadata/docs.json
@@ -4,7 +4,8 @@
     "src/decorator-factory.ts",
     "src/index.ts",
     "src/inspector.ts",
-    "src/reflect.ts"
+    "src/reflect.ts",
+    "src/types.ts"
   ],
   "codeSectionDepth": 4
 }

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -6,17 +6,10 @@
 import {Reflector} from './reflect';
 import * as _ from 'lodash';
 import * as debugModule from 'debug';
+import {MetadataMap, DecoratorType, MetadataKey} from './types';
 const debug = debugModule('loopback:metadata:decorator');
 
 // tslint:disable:no-any
-
-/**
- * An object mapping keys to corresponding metadata
- */
-export interface MetadataMap<T> {
-  [propertyOrMethodName: string]: T;
-}
-
 /**
  * Options for a decorator
  */
@@ -36,15 +29,6 @@ export interface DecoratorOptions {
   cloneInputSpec?: boolean;
   [name: string]: any;
 }
-
-/**
- * Decorator function types
- */
-export type DecoratorType =
-  | ClassDecorator
-  | PropertyDecorator
-  | MethodDecorator
-  | ParameterDecorator;
 
 /**
  * Base factory class for decorator functions
@@ -311,8 +295,8 @@ export class DecoratorFactory<
     T,
     M extends T | MetadataMap<T> | MetadataMap<T[]>,
     D extends DecoratorType
-  >(key: string, spec: T, options?: DecoratorOptions): D {
-    const inst = new this<T, M, D>(key, spec, options);
+  >(key: MetadataKey<T, D>, spec: T, options?: DecoratorOptions): D {
+    const inst = new this<T, M, D>(key.toString(), spec, options);
     return inst.create();
   }
 
@@ -396,7 +380,11 @@ export class ClassDecoratorFactory<T> extends DecoratorFactory<
    * @param spec Metadata object from the decorator function
    * @param options Options for the decorator
    */
-  static createDecorator<T>(key: string, spec: T, options?: DecoratorOptions) {
+  static createDecorator<T>(
+    key: MetadataKey<T, ClassDecorator>,
+    spec: T,
+    options?: DecoratorOptions,
+  ) {
     return super._createDecorator<T, T, ClassDecorator>(key, spec, options);
   }
 }
@@ -452,7 +440,11 @@ export class PropertyDecoratorFactory<T> extends DecoratorFactory<
    * @param spec Metadata object from the decorator function
    * @param options Options for the decorator
    */
-  static createDecorator<T>(key: string, spec: T, options?: DecoratorOptions) {
+  static createDecorator<T>(
+    key: MetadataKey<T, PropertyDecorator>,
+    spec: T,
+    options?: DecoratorOptions,
+  ) {
     return super._createDecorator<T, MetadataMap<T>, PropertyDecorator>(
       key,
       spec,
@@ -517,7 +509,11 @@ export class MethodDecoratorFactory<T> extends DecoratorFactory<
    * @param spec Metadata object from the decorator function
    * @param options Options for the decorator
    */
-  static createDecorator<T>(key: string, spec: T, options?: DecoratorOptions) {
+  static createDecorator<T>(
+    key: MetadataKey<T, MethodDecorator>,
+    spec: T,
+    options?: DecoratorOptions,
+  ) {
     return super._createDecorator<T, MetadataMap<T>, MethodDecorator>(
       key,
       spec,
@@ -609,7 +605,11 @@ export class ParameterDecoratorFactory<T> extends DecoratorFactory<
    * @param spec Metadata object from the decorator function
    * @param options Options for the decorator
    */
-  static createDecorator<T>(key: string, spec: T, options?: DecoratorOptions) {
+  static createDecorator<T>(
+    key: MetadataKey<T, ParameterDecorator>,
+    spec: T,
+    options?: DecoratorOptions,
+  ) {
     return super._createDecorator<T, MetadataMap<T[]>, ParameterDecorator>(
       key,
       spec,
@@ -737,7 +737,11 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
    * @param spec Metadata object from the decorator function
    * @param options Options for the decorator
    */
-  static createDecorator<T>(key: string, spec: T, options?: DecoratorOptions) {
+  static createDecorator<T>(
+    key: MetadataKey<T, MethodDecorator>,
+    spec: T,
+    options?: DecoratorOptions,
+  ) {
     return super._createDecorator<T, MetadataMap<T[]>, MethodDecorator>(
       key,
       spec,

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+export * from './types';
 export * from './reflect';
 export * from './decorator-factory';
 export * from './inspector';

--- a/packages/metadata/src/inspector.ts
+++ b/packages/metadata/src/inspector.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Reflector, NamespacedReflect} from './reflect';
-import {MetadataMap} from './decorator-factory';
+import {
+  MetadataKey,
+  MetadataMap,
+  DesignTimeMethodMetadata,
+  DecoratorType,
+} from './types';
 
 /**
  * TypeScript reflector without a namespace. The TypeScript compiler can be
@@ -13,44 +18,6 @@ import {MetadataMap} from './decorator-factory';
  * See https://www.typescriptlang.org/docs/handbook/decorators.html
  */
 const TSReflector = new NamespacedReflect();
-
-/**
- * Design time metadata for a method.
- *
- * @example
- * ```ts
- * class MyController
- * {
- *   myMethod(x: string, y: number, z: MyClass): boolean {
- *     // ...
- *     return true;
- *   }
- * }
- * ```
- *
- * The `myMethod` above has design-time metadata as follows:
- * ```ts
- * {
- *   type: Function,
- *   parameterTypes: [String, Number, MyClass],
- *   returnType: Boolean
- * }
- * ```
- */
-export interface DesignTimeMethodMetadata {
-  /**
-   * Type of the method itself. It is `Function`
-   */
-  type: Function;
-  /**
-   * An array of parameter types
-   */
-  parameterTypes: Function[];
-  /**
-   * Return type
-   */
-  returnType: Function;
-}
 
 /**
  * Options for inspection
@@ -87,13 +54,13 @@ export class MetadataInspector {
    * @param options Options for inspection
    */
   static getClassMetadata<T>(
-    key: string,
+    key: MetadataKey<T, ClassDecorator>,
     target: Function,
     options?: InspectionOptions,
   ): T | undefined {
     return options && options.ownMetadataOnly
-      ? Reflector.getOwnMetadata(key, target)
-      : Reflector.getMetadata(key, target);
+      ? Reflector.getOwnMetadata(key.toString(), target)
+      : Reflector.getMetadata(key.toString(), target);
   }
 
   /**
@@ -104,12 +71,12 @@ export class MetadataInspector {
    * @param member Optional property or method name
    */
   static defineMetadata<T>(
-    key: string,
+    key: MetadataKey<T, DecoratorType>,
     value: T,
     target: Object,
     member?: string | symbol,
   ) {
-    Reflector.defineMetadata(key, value, target, member);
+    Reflector.defineMetadata(key.toString(), value, target, member);
   }
 
   /**
@@ -120,13 +87,13 @@ export class MetadataInspector {
    * @param options Options for inspection
    */
   static getAllMethodMetadata<T>(
-    key: string,
+    key: MetadataKey<T, MethodDecorator>,
     target: Object,
     options?: InspectionOptions,
   ): MetadataMap<T> | undefined {
     return options && options.ownMetadataOnly
-      ? Reflector.getOwnMetadata(key, target)
-      : Reflector.getMetadata(key, target);
+      ? Reflector.getOwnMetadata(key.toString(), target)
+      : Reflector.getMetadata(key.toString(), target);
   }
 
   /**
@@ -139,7 +106,7 @@ export class MetadataInspector {
    * @param options Options for inspection
    */
   static getMethodMetadata<T>(
-    key: string,
+    key: MetadataKey<T, MethodDecorator>,
     target: Object,
     methodName?: string | symbol,
     options?: InspectionOptions,
@@ -147,8 +114,8 @@ export class MetadataInspector {
     methodName = methodName || '';
     const meta: MetadataMap<T> =
       options && options.ownMetadataOnly
-        ? Reflector.getOwnMetadata(key, target)
-        : Reflector.getMetadata(key, target);
+        ? Reflector.getOwnMetadata(key.toString(), target)
+        : Reflector.getMetadata(key.toString(), target);
     return meta && meta[methodName];
   }
 
@@ -160,13 +127,13 @@ export class MetadataInspector {
    * @param options Options for inspection
    */
   static getAllPropertyMetadata<T>(
-    key: string,
+    key: MetadataKey<T, PropertyDecorator>,
     target: Object,
     options?: InspectionOptions,
   ): MetadataMap<T> | undefined {
     return options && options.ownMetadataOnly
-      ? Reflector.getOwnMetadata(key, target)
-      : Reflector.getMetadata(key, target);
+      ? Reflector.getOwnMetadata(key.toString(), target)
+      : Reflector.getMetadata(key.toString(), target);
   }
 
   /**
@@ -179,15 +146,15 @@ export class MetadataInspector {
    * @param options Options for inspection
    */
   static getPropertyMetadata<T>(
-    key: string,
+    key: MetadataKey<T, PropertyDecorator>,
     target: Object,
     propertyName: string | symbol,
     options?: InspectionOptions,
   ): T | undefined {
     const meta: MetadataMap<T> =
       options && options.ownMetadataOnly
-        ? Reflector.getOwnMetadata(key, target)
-        : Reflector.getMetadata(key, target);
+        ? Reflector.getOwnMetadata(key.toString(), target)
+        : Reflector.getMetadata(key.toString(), target);
     return meta && meta[propertyName];
   }
 
@@ -201,7 +168,7 @@ export class MetadataInspector {
    * @param options Options for inspection
    */
   static getAllParameterMetadata<T>(
-    key: string,
+    key: MetadataKey<T, ParameterDecorator>,
     target: Object,
     methodName?: string | symbol,
     options?: InspectionOptions,
@@ -209,8 +176,8 @@ export class MetadataInspector {
     methodName = methodName || '';
     const meta: MetadataMap<T[]> =
       options && options.ownMetadataOnly
-        ? Reflector.getOwnMetadata(key, target)
-        : Reflector.getMetadata(key, target);
+        ? Reflector.getOwnMetadata(key.toString(), target)
+        : Reflector.getMetadata(key.toString(), target);
     return meta && meta[methodName];
   }
 
@@ -225,7 +192,7 @@ export class MetadataInspector {
    * @param options Options for inspection
    */
   static getParameterMetadata<T>(
-    key: string,
+    key: MetadataKey<T, ParameterDecorator>,
     target: Object,
     methodName: string | symbol,
     index: number,
@@ -234,8 +201,8 @@ export class MetadataInspector {
     methodName = methodName || '';
     const meta: MetadataMap<T[]> =
       options && options.ownMetadataOnly
-        ? Reflector.getOwnMetadata(key, target)
-        : Reflector.getMetadata(key, target);
+        ? Reflector.getOwnMetadata(key.toString(), target)
+        : Reflector.getMetadata(key.toString(), target);
     const params = meta && meta[methodName];
     return params && params[index];
   }

--- a/packages/metadata/src/types.ts
+++ b/packages/metadata/src/types.ts
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/metadata
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT'
+
+/**
+ * Decorator function types
+ */
+export type DecoratorType =
+  | ClassDecorator
+  | PropertyDecorator
+  | MethodDecorator
+  | ParameterDecorator;
+
+/**
+ * A strongly-typed metadata accessor via reflection
+ * @typeparam T Type of the metadata value
+ * @typeparam D Type of the decorator
+ */
+export class MetadataAccessor<T, D extends DecoratorType = DecoratorType> {
+  private constructor(public readonly key: string) {}
+
+  toString() {
+    return this.key;
+  }
+
+  /**
+   * Create a strongly-typed metadata accessor
+   * @param key The metadata key
+   * @typeparam T Type of the metadata value
+   * @typeparam D Type of the decorator
+   */
+  static create<T, D extends DecoratorType = DecoratorType>(key: string) {
+    return new MetadataAccessor<T, D>(key);
+  }
+}
+
+/**
+ * Key for metadata access via reflection
+ * @typeparam T Type of the metadata value
+ * @typeparam D Type of the decorator
+ */
+export type MetadataKey<T, D extends DecoratorType> =
+  | MetadataAccessor<T, D>
+  | string;
+
+/**
+ * An object mapping keys to corresponding metadata
+ */
+export interface MetadataMap<T> {
+  [propertyOrMethodName: string]: T;
+}
+
+/**
+ * Design time metadata for a method.
+ *
+ * @example
+ * ```ts
+ * class MyController
+ * {
+ *   myMethod(x: string, y: number, z: MyClass): boolean {
+ *     // ...
+ *     return true;
+ *   }
+ * }
+ * ```
+ *
+ * The `myMethod` above has design-time metadata as follows:
+ * ```ts
+ * {
+ *   type: Function,
+ *   parameterTypes: [String, Number, MyClass],
+ *   returnType: Boolean
+ * }
+ * ```
+ */
+export interface DesignTimeMethodMetadata {
+  /**
+   * Type of the method itself. It is `Function`
+   */
+  type: Function;
+  /**
+   * An array of parameter types
+   */
+  parameterTypes: Function[];
+  /**
+   * Return type
+   */
+  returnType: Function;
+}

--- a/packages/metadata/test/unit/inspector.unit.ts
+++ b/packages/metadata/test/unit/inspector.unit.ts
@@ -11,6 +11,7 @@ import {
   ParameterDecoratorFactory,
   MetadataInspector,
 } from '../..';
+import {MetadataAccessor} from '../..';
 
 describe('Inspector for a class', () => {
   /**
@@ -29,13 +30,15 @@ describe('Inspector for a class', () => {
 
   class AnotherController extends BaseController {}
 
+  const TEST_META = MetadataAccessor.create<object, ClassDecorator>('test');
+
   it('inspects metadata of a base class', () => {
     const meta = MetadataInspector.getClassMetadata('test', BaseController);
     expect(meta).to.eql({x: 1});
   });
 
   it('inspects metadata of a sub class', () => {
-    const meta = MetadataInspector.getClassMetadata('test', SubController);
+    const meta = MetadataInspector.getClassMetadata(TEST_META, SubController);
     expect(meta).to.eql({x: 1, y: 2});
   });
 
@@ -107,6 +110,8 @@ describe('Inspector for instance properties', () => {
     myProp: string;
   }
 
+  const TEST_META = MetadataAccessor.create<object, PropertyDecorator>('test');
+
   it('inspects metadata of all properties of a base class', () => {
     const meta = MetadataInspector.getAllPropertyMetadata(
       'test',
@@ -117,7 +122,7 @@ describe('Inspector for instance properties', () => {
 
   it('inspects metadata of a property of a base class', () => {
     const meta = MetadataInspector.getPropertyMetadata(
-      'test',
+      TEST_META,
       BaseController.prototype,
       'myProp',
     );
@@ -237,6 +242,8 @@ describe('Inspector for instance methods', () => {
 
   class AnotherController extends BaseController {}
 
+  const TEST_META = MetadataAccessor.create<object, MethodDecorator>('test');
+
   it('inspects metadata of all methods of a base class', () => {
     const meta = MetadataInspector.getAllMethodMetadata(
       'test',
@@ -247,7 +254,7 @@ describe('Inspector for instance methods', () => {
 
   it('inspects metadata of a method of a base class', () => {
     const meta = MetadataInspector.getMethodMetadata(
-      'test',
+      TEST_META,
       BaseController.prototype,
       'myMethod',
     );
@@ -256,7 +263,7 @@ describe('Inspector for instance methods', () => {
 
   it('inspects metadata of all methods of a sub class', () => {
     const meta = MetadataInspector.getAllMethodMetadata(
-      'test',
+      TEST_META,
       SubController.prototype,
     );
     expect(meta).to.eql({myMethod: {x: 1, y: 2}});
@@ -372,9 +379,11 @@ describe('Inspector for parameters of an instance method', () => {
 
   class AnotherController extends BaseController {}
 
+  const TEST_META = MetadataAccessor.create<object, ParameterDecorator>('test');
+
   it('inspects metadata of all parameters of a method of the base class', () => {
     const meta = MetadataInspector.getAllParameterMetadata(
-      'test',
+      TEST_META,
       BaseController.prototype,
       'myMethod',
     );
@@ -392,7 +401,7 @@ describe('Inspector for parameters of an instance method', () => {
 
   it('inspects metadata of a parameter of a method of the sub class', () => {
     const meta = MetadataInspector.getParameterMetadata(
-      'test',
+      TEST_META,
       SubController.prototype,
       'myMethod',
       0,

--- a/packages/metadata/test/unit/metadata-accessor.test.ts
+++ b/packages/metadata/test/unit/metadata-accessor.test.ts
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/metadata
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  MetadataAccessor,
+  ClassDecoratorFactory,
+  MetadataInspector,
+} from '../..';
+
+describe('MetadataAccessor', () => {
+  it('creates an accessor with a string key', () => {
+    expect(
+      MetadataAccessor.create<string, ClassDecorator>('foo'),
+    ).to.have.property('key', 'foo');
+  });
+
+  it('overrides toString()', () => {
+    expect(
+      MetadataAccessor.create<object, ClassDecorator>('bar').toString(),
+    ).to.equal('bar');
+  });
+
+  it('can be used to create decorator', () => {
+    const nameKey = MetadataAccessor.create<string, ClassDecorator>('name');
+
+    function classDecorator(name: string) {
+      return ClassDecoratorFactory.createDecorator<string>(nameKey, name);
+    }
+
+    @classDecorator('my-controller')
+    class MyController {}
+
+    expect(MetadataInspector.getClassMetadata(nameKey, MyController)).to.equal(
+      'my-controller',
+    );
+  });
+});

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -208,7 +208,7 @@ export function getControllerSpec(constructor: Function): ControllerSpec {
   if (!spec) {
     spec = resolveControllerSpec(constructor);
     MetadataInspector.defineMetadata(
-      OAI3Keys.CONTROLLER_SPEC_KEY,
+      OAI3Keys.CONTROLLER_SPEC_KEY.key,
       spec,
       constructor,
     );

--- a/packages/openapi-v3/src/keys.ts
+++ b/packages/openapi-v3/src/keys.ts
@@ -1,12 +1,31 @@
+import {MetadataAccessor} from '@loopback/context';
+import {RestEndpoint, ControllerSpec} from '.';
+import {ParameterObject, RequestBodyObject} from '@loopback/openapi-v3-types';
+
 // Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
 export namespace OAI3Keys {
-  export const METHODS_KEY = 'openapi-v3:methods';
-  export const PARAMETERS_KEY = 'openapi-v3:parameters';
-  export const CLASS_KEY = 'openapi-v3:class';
-  export const CONTROLLER_SPEC_KEY = 'openapi-v3:controller-spec';
-  export const REQUEST_BODY_KEY = 'openapi-v3:request-body';
+  export const METHODS_KEY = MetadataAccessor.create<
+    Partial<RestEndpoint>,
+    MethodDecorator
+  >('openapi-v3:methods');
+  export const PARAMETERS_KEY = MetadataAccessor.create<
+    ParameterObject,
+    ParameterDecorator
+  >('openapi-v3:parameters');
+  export const CLASS_KEY = MetadataAccessor.create<
+    ControllerSpec,
+    ClassDecorator
+  >('openapi-v3:class');
+  export const CONTROLLER_SPEC_KEY = MetadataAccessor.create<
+    ControllerSpec,
+    ClassDecorator
+  >('openapi-v3:controller-spec');
+  export const REQUEST_BODY_KEY = MetadataAccessor.create<
+    RequestBodyObject,
+    ParameterDecorator
+  >('openapi-v3:request-body');
 }

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -10,9 +10,11 @@ import {
 } from '@loopback/repository';
 import {includes} from 'lodash';
 import {Definition, PrimitiveType} from 'typescript-json-schema';
-import {MetadataInspector} from '@loopback/context';
+import {MetadataInspector, MetadataAccessor} from '@loopback/context';
 
-export const JSON_SCHEMA_KEY = 'loopback:json-schema';
+export const JSON_SCHEMA_KEY = MetadataAccessor.create<JsonDefinition>(
+  'loopback:json-schema',
+);
 
 /**
  * Type definition for JSON Schema
@@ -43,7 +45,7 @@ export function getJsonSchema(ctor: Function): JsonDefinition {
     return jsonSchema;
   } else {
     const newSchema = modelToJsonSchema(ctor);
-    MetadataInspector.defineMetadata(JSON_SCHEMA_KEY, newSchema, ctor);
+    MetadataInspector.defineMetadata(JSON_SCHEMA_KEY.key, newSchema, ctor);
     return newSchema;
   }
 }

--- a/packages/repository/src/decorators/metadata.ts
+++ b/packages/repository/src/decorators/metadata.ts
@@ -61,7 +61,7 @@ export class ModelMetadataHelper {
           ),
         );
         MetadataInspector.defineMetadata(
-          MODEL_WITH_PROPERTIES_KEY,
+          MODEL_WITH_PROPERTIES_KEY.key,
           meta,
           target,
         );

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -8,6 +8,7 @@ import {
   ClassDecoratorFactory,
   PropertyDecoratorFactory,
   MetadataMap,
+  MetadataAccessor,
 } from '@loopback/context';
 import {
   ModelDefinition,
@@ -15,9 +16,18 @@ import {
   PropertyDefinition,
 } from '../model';
 
-export const MODEL_KEY = 'loopback:model';
-export const MODEL_PROPERTIES_KEY = 'loopback:model-properties';
-export const MODEL_WITH_PROPERTIES_KEY = 'loopback:model-and-properties';
+export const MODEL_KEY = MetadataAccessor.create<
+  Partial<ModelDefinitionSyntax>,
+  ClassDecorator
+>('loopback:model');
+export const MODEL_PROPERTIES_KEY = MetadataAccessor.create<
+  PropertyDefinition,
+  PropertyDecorator
+>('loopback:model-properties');
+export const MODEL_WITH_PROPERTIES_KEY = MetadataAccessor.create<
+  ModelDefinition,
+  ClassDecorator
+>('loopback:model-and-properties');
 
 export type PropertyMap = MetadataMap<PropertyDefinition>;
 

--- a/packages/repository/test/unit/decorator/metadata.unit.ts
+++ b/packages/repository/test/unit/decorator/metadata.unit.ts
@@ -93,7 +93,7 @@ describe('Repository', () => {
       // Intentionally change the metadata to be different from the Phlange
       // class metadata
       MetadataInspector.defineMetadata(
-        MODEL_WITH_PROPERTIES_KEY,
+        MODEL_WITH_PROPERTIES_KEY.key,
         classMeta,
         Phlange,
       );


### PR DESCRIPTION
This PR introduces a strong-typed MetadataKey for metadata access via reflection. It's inspired by #1169.


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
