### PR TITLE
chore: update release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ integrations.
 - Define your data and endpoints with OpenAPI
 - No maintenance of generated code
 
-## Status: Developer Preview #1
+## Status: Developer Preview #2
 
 LoopBack 4 is a work in progress, the public API is frequently changed in
 backward incompatible ways. See

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -3,11 +3,6 @@
 The REST API package for
 [loopback-next](https://github.com/strongloop/loopback-next).
 
-## STATUS: Developer Preview #1
-
-This package is not yet ready for production use. Additionally, this document is
-also a work-in-progress and some sections may not have corresponding code!
-
 ## Overview
 
 This component provides a REST server for your application instances, complete


### PR DESCRIPTION
When we are ready to release Developer Preview 2, we need to update the status on the readme files.
Change the release name for:
- `README.md`
- `packages/rest/README.md`

connected to: https://github.com/strongloop/loopback-next/issues/1059

Will merge when we are ready.