### PR TITLE
fix: remove npm run clean for apidocs scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "release": "npm run build:full && lerna publish",
     "update-template-deps": "node bin/update-template-deps -f",
     "version": "npm run update-template-deps && npm run apidocs",
-    "apidocs": "npm run clean && node bin/run-lerna run build:apidocs --parallel --loglevel=silent",
+    "apidocs": "node bin/run-lerna run build:apidocs",
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
     "precoverage": "npm test",
     "coverage": "open coverage/index.html",


### PR DESCRIPTION
We run `npm run apidocs` as part of publish and the clean step
deletes all `dist` folders accidentally.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
