### PR TITLE
test: build loopback.io submodule to ensure it works with docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "loopback.io"]
+	path = loopback.io
+	url = https://github.com/strongloop/loopback.io.git
+	branch = gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,17 @@ after_success:
 
 jobs:
   include:
+    - stage: loopback.io
+      before_script:
+        - npm run bootstrap
+      script:
+        - cd loopback.io
+        - bundle install
+        - npm run fetch-readmes
+        - bundle exec jekyll build
+      after_success: skip
+      os:
+        - linux
     - stage: commit linting
       before_install:
         - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.9.1",
-  "packages": ["packages/*", "examples/*", "docs", "sandbox/*"],
+  "packages": ["packages/*", "examples/*", "docs", "sandbox/*", "loopback.io"],
   "command": {
     "publish": {
       "forcePublish": "@loopback/cli,@loopback/docs",


### PR DESCRIPTION
loopback.io has broken multiple times because of formatting errors in `@loopback/docs` as jekyll is not able to build the site with invalid syntax in markdown files. 

This PR introduces loopback.io as a submodule of loopback-next and a Travis Stage is added that attempts to build the loopback.io site. If the build fails, the CI will fail and we can look at the error. 

Travis Stages will look as follows: https://travis-ci.org/strongloop/loopback-next/builds/365796133?utm_source=github_status&utm_medium=notification

This also allows us to locally test the changes in docs against a local copy of loopback.io as the bootstrapped repo will link to the local copy of `@loopback/docs`. You must initialize the `loopback.io` submodule by running the following command:

`git submodule update --init --recursive`

Then in loopback.io you must run the `fetch-readmes` script and use `npm run start` to start the site.

---

CON: Travis CI Builds will take an additional ~3-5 minutes for the new stage.

If we want to go ahead with this PR, the following needs to take place (In loopback.io):
- [ ] `loopback.io/packagae.json` devDependency on `@loopback/docs` needs to be changed from `latest` to `*` as lerna doesn't play nice with `latest` (it installs it from npm instead of local). `*` will install the latest published version from npm in production and link to local copy in loopback-next.
- [ ] `loopback.io/update-lb4-docs.js` Remove the lines that delete the sidebar folder from source (not sure why we are even doing this ... but in the mono-repo after bootstrapping to local it means removing it from our `@loopback/docs` package. 

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
