### PR TITLE
chore: add a sandbox location to enable testing w/ source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ api-docs
 **/*.tgz
 **/dist*
 **/package
-packages/_sandbox
 .sandbox

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.9.1",
-  "packages": ["packages/*", "examples/*", "docs"],
+  "packages": ["packages/*", "examples/*", "docs", "sandbox/*"],
   "command": {
     "publish": {
       "forcePublish": "@loopback/cli,@loopback/docs",

--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -14,7 +14,7 @@ const build = require('@loopback/build');
 describe('app-generator (SLOW)', function() {
   const generator = path.join(__dirname, '../../generators/app');
   const rootDir = path.join(__dirname, '../../../..');
-  const sandbox = path.join(__dirname, '../../../_sandbox');
+  const sandbox = path.join(__dirname, '../../sandbox/sandbox-app');
   const cwd = process.cwd();
   const appName = '@loopback/sandbox-app';
   const props = {

--- a/sandbox/.gitignore
+++ b/sandbox/.gitignore
@@ -1,0 +1,4 @@
+**/*
+!README.md
+!.gitignore
+

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,27 @@
+# sandbox
+
+This directory can be used to add applications or modules that need to be tested
+against the LoopBack 4 source code (as symbolically linked dependencies). Sub
+directories with `package.json` will be picked up by `lerna` as a package of the
+`loopback-next` monorepo.
+
+## Usage
+
+To add a new package for sandbox testing:
+
+```sh
+git clone git@github.com:strongloop/loopback-next.git
+cd loopback-next/sandbox
+```
+
+Now you can scaffold your Node.js modules or copy existing projects into the
+`sandbox` directory.
+
+To link the `@loopback/*` dependencies against the source code:
+
+```sh
+cd loopback/next
+npm run bootstrap
+```
+
+Your project is ready against the LoopBack 4 source code now.


### PR DESCRIPTION
This PR formalizes the idea to allow packages to be tested against our source code from git. It adds a `sandbox` folder to contain modules/applications that need to be bootstrapped by lerna.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
