### PR TITLE
test: build loopback.io to validate docs package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,21 @@ after_success:
 
 jobs:
   include:
+    - stage: loopback.io
+      before_install:
+        - |
+          if git diff --name-only --quiet $TRAVIS_BRANCH docs/; then
+            echo "No changes to @loopback/docs in this PR"
+            exit 0
+          else
+            echo "Testing @loopback/docs"
+          fi
+      before_script: skip
+      script:
+        - npm run verify:docs
+      after_success: skip
+      os:
+        - linux
     - stage: commit linting
       before_install:
         - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/bin/verify-docs.sh
+++ b/bin/verify-docs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ev
+
+# Make sure we use the correct repo root dir
+DIR=`dirname $0`
+REPO_ROOT=$DIR/..
+pushd $REPO_ROOT >/dev/null
+rm -rf sandbox/loopback.io/
+# Shadow clone is faster
+git clone --depth 1 https://github.com/strongloop/loopback.io.git sandbox/loopback.io
+lerna bootstrap --scope loopback.io-workflow-scripts
+pushd $REPO_ROOT/sandbox/loopback.io/ >/dev/null
+bundle install
+npm run build
+popd >/dev/null
+popd >/dev/null

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "build:full": "npm run clean:lerna && npm run bootstrap && npm test",
     "pretest": "npm run clean && npm run build",
     "test": "node packages/build/bin/run-nyc npm run mocha --scripts-prepend-node-path",
+    "verify:docs": "npm run build:site && node packages/build/bin/run-clean \"sandbox/loopback.io\"",
+    "build:site": "./bin/verify-docs.sh",
     "mocha": "node packages/build/bin/run-mocha \"packages/*/DIST/test/**/*.js\" \"examples/*/DIST/test/**/*.js\" \"packages/cli/test/*.js\" \"packages/build/test/*/*.js\"",
     "posttest": "npm run lint"
   },


### PR DESCRIPTION
Simpler approach to https://github.com/strongloop/loopback-next/pull/1251

A simple script clone's loopback.io, bootstrap's it and attempts to build the site. If it fails, CI will fail. 

--- 

Not adding it as a regular test since the script is not Windows compatible.

---

~The 2 items from #1251 with regards to changes to loopback.io repo would still need to happen.~ (DONE)

fixes #1232 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
