### PR TITLE
chore: add yeoman-environment dep

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
     "rimraf": "^2.6.2",
     "sinon": "^4.5.0",
     "yeoman-assert": "^3.1.1",
+    "yeoman-environment": "^2.0.6",
     "yeoman-test": "^1.7.0"
   },
   "dependencies": {

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -5,13 +5,10 @@
 
 'use strict';
 
-const _ = require('lodash');
 const yeoman = require('yeoman-environment');
 const path = require('path');
 const helpers = require('yeoman-test');
 const fs = require('fs');
-const util = require('util');
-const RunContext = require('yeoman-test/lib/run-context');
 
 exports.testSetUpGen = function(genName, arg) {
   arg = arg || {};


### PR DESCRIPTION
Add `yeoman-environment` dependency in `@loopback/cli` and remove unused variables. Was getting the following error when running `npm test` at the top level:
```
> node packages/build/bin/run-mocha "packages/*/DIST/test/**/*.js" "examples/*/DIST/test/**/*.js" "packages/cli/test/*.js" "packages/build/test/*/*.js"

Error: Cannot find module 'yeoman-environment'
    at Function.Module._resolveFilename (module.js:527:15)
    at Function.Module._load (module.js:476:23)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/badmike/loopback/loopback-next/packages/cli/test/test-utils.js:9:16)
    at Module._compile (module.js:624:30)
    at Module.replacementCompile (/Users/badmike/loopback/loopback-next/packages/build/node_modules/nyc/node_modules/append-transform/index.js:58:13)
    at Module.replacementCompile (/Users/badmike/loopback/loopback-next/packages/build/node_modules/nyc/node_modules/append-transform/index.js:58:13)
    at module.exports (/Users/badmike/loopback/loopback-next/packages/build/node_modules/nyc/node_modules/default-require-extensions/js.js:8:9)
    at /Users/badmike/loopback/loopback-next/packages/build/node_modules/nyc/node_modules/append-transform/index.js:62:4
    at /Users/badmike/loopback/loopback-next/packages/build/node_modules/nyc/node_modules/append-transform/index.js:62:4
    at Object.<anonymous> (/Users/badmike/loopback/loopback-next/packages/build/node_modules/nyc/node_modules/append-transform/index.js:62:4)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
...
```
I'm currently seeing the following issue with `tslint`'s `no-unused-variable` rule and trying to figure out what the issue is:
```
ERROR: /Users/badmike/loopback/loopback-next/packages/metadata/src/types.ts[20, 31]: 'T' is declared but its value is never read.
ERROR: /Users/badmike/loopback/loopback-next/packages/metadata/src/types.ts[20, 34]: 'D' is declared but its value is never read.
```

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
