### PR TITLE
docs: Throw error instead of returning rejected promise

### DIFF
--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -77,7 +77,7 @@ export class TodoController {
   @post('/todo')
   async createTodo(@requestBody() todo: Todo) {
     if (!todo.title) {
-      return Promise.reject(new HttpErrors.BadRequest('title is required'));
+      throw new HttpErrors.BadRequest('title is required');
     }
     return await this.todoRepo.create(todo);
   }
@@ -127,7 +127,7 @@ export class TodoController {
   @post('/todo')
   async createTodo(@requestBody() todo: Todo) {
     if (!todo.title) {
-      return Promise.reject(new HttpErrors.BadRequest('title is required'));
+      throw new HttpErrors.BadRequest('title is required');
     }
     return await this.todoRepo.create(todo);
   }

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -25,7 +25,7 @@ export class TodoController {
     // TODO(bajtos) This should be handled by the framework
     // See https://github.com/strongloop/loopback-next/issues/118
     if (!todo.title) {
-      return Promise.reject(new HttpErrors.BadRequest('title is required'));
+      throw new HttpErrors.BadRequest('title is required');
     }
     return await this.todoRepo.create(todo);
   }

--- a/packages/authentication/src/providers/authentication.provider.ts
+++ b/packages/authentication/src/providers/authentication.provider.ts
@@ -72,7 +72,7 @@ export class AuthenticateActionProvider implements Provider<AuthenticateFn> {
       return undefined;
     }
     if (!strategy.authenticate) {
-      return Promise.reject(new Error('invalid strategy parameter'));
+      throw new Error('invalid strategy parameter');
     }
     const strategyAdapter = new StrategyAdapter(strategy);
     const user = await strategyAdapter.authenticate(request);

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -100,9 +100,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
       .getArtifactList(this.artifactInfo.modelDir, 'model')
       .then(list => {
         if (_.isEmpty(list)) {
-          return Promise.reject(
-            new Error(`No models found in ${this.artifactInfo.modelDir}`)
-          );
+          throw new Error(`No models found in ${this.artifactInfo.modelDir}`);
         }
         modelList = list;
         return utils.getArtifactList(
@@ -113,11 +111,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
       })
       .then(list => {
         if (_.isEmpty(list)) {
-          return Promise.reject(
-            new Error(
-              `No repositories found in ${this.artifactInfo.repositoryDir}`
-            )
-          );
+          throw new Error(`No repositories found in ${this.artifactInfo.repositoryDir}`);
         }
         repositoryList = list;
         return this.prompt([

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -152,9 +152,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
       this.modelClass.findById(id, filter, options),
     );
     if (!model) {
-      return Promise.reject(
-        new Error(`no ${this.modelClass.name} found with id "${id}"`),
-      );
+      throw new Error(`no ${this.modelClass.name} found with id "${id}"`);
     }
     return this.toEntity(model);
   }

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -60,7 +60,7 @@ export async function parseOperationArgs(
   return buildOperationArguments(operationSpec, request, pathParams, body);
 }
 
-function loadRequestBodyIfNeeded(
+async function loadRequestBodyIfNeeded(
   operationSpec: OperationObject,
   request: ServerRequest,
 ): Promise<MaybeBody> {
@@ -68,15 +68,14 @@ function loadRequestBodyIfNeeded(
 
   const contentType = getContentType(request);
   if (contentType && !/json/.test(contentType)) {
-    const err = new HttpErrors.UnsupportedMediaType(
+    throw new HttpErrors.UnsupportedMediaType(
       `Content-type ${contentType} is not supported.`,
     );
-    return Promise.reject(err);
   }
 
-  return parseJsonBody(request).catch((err: HttpError) => {
+  return await parseJsonBody(request).catch((err: HttpError) => {
     err.statusCode = 400;
-    return Promise.reject(err);
+    throw err;
   });
 }
 

--- a/packages/testlab/test/integration/test-sandbox.integration.ts
+++ b/packages/testlab/test/integration/test-sandbox.integration.ts
@@ -118,7 +118,7 @@ describe('TestSandbox integration tests', () => {
   }
 
   async function deleteSandbox() {
-    if (!await pathExists(path)) return;
+    if (!(await pathExists(path))) return;
     await remove(sandbox.getPath());
   }
 });


### PR DESCRIPTION
I recommend `throw` over `return Promise.reject()` because:

1. It is shorter, which makes it easier to read.
2. It retains some parity between synchronous and asynchronous code. (It will continue to work as expected if those lines were extracted into a synchronous function.)

There are [some occasions](https://gist.github.com/joeytwiddle/21331531f50885345e063d59ec7f11f2) when you cannot use `throw` in place of returning a rejection, but if you are in the body of an async function then it is always safe.

If you have considered this style but rejected it, I would be interested to learn your reasoning, if it happens to be available online somewhere. Cheers!

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
