### PR TITLE
[don't merge]poc: customize statusCode using response spec

### DIFF
--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -112,6 +112,18 @@ export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
 
     return this.withOperation(verb, path, spec);
   }
+
+  withOperationReturningStringWithStatusCode(
+    verb: string,
+    path: string,
+    statusCode: number,
+    operationName?: string,
+  ): this {
+    const spec = anOperationSpec().withStringResponse(statusCode);
+    if (operationName) spec.withOperationName(operationName);
+
+    return this.withOperation(verb, path, spec);
+  }
 }
 
 /**

--- a/packages/rest/src/internal-types.ts
+++ b/packages/rest/src/internal-types.ts
@@ -52,7 +52,11 @@ export type InvokeMethod = (
  * @param response The response the response to send to.
  * @param result The operation result to send.
  */
-export type Send = (response: ServerResponse, result: OperationRetval) => void;
+export type Send = (
+  response: ServerResponse,
+  result: OperationRetval,
+  route?: ResolvedRoute,
+) => void;
 
 /**
  * Reject the request with an error.

--- a/packages/rest/src/sequence.ts
+++ b/packages/rest/src/sequence.ts
@@ -108,7 +108,7 @@ export class DefaultSequence implements SequenceHandler {
       const result = await this.invoke(route, args);
 
       debug('%s result -', route.describe(), result);
-      this.send(res, result);
+      this.send(res, result, route);
     } catch (err) {
       this.reject(res, req, err);
     }

--- a/packages/rest/src/writer.ts
+++ b/packages/rest/src/writer.ts
@@ -6,6 +6,7 @@
 import {ServerResponse as Response} from 'http';
 import {OperationRetval} from './internal-types';
 import {HttpError} from 'http-errors';
+import {ResolvedRoute} from './router/routing-table';
 import {Readable} from 'stream';
 
 /**
@@ -20,6 +21,7 @@ export function writeResultToResponse(
   response: Response,
   // result returned back from invoking controller method
   result: OperationRetval,
+  route?: ResolvedRoute,
 ): void {
   if (result) {
     if (result instanceof Readable || typeof result.pipe === 'function') {
@@ -47,6 +49,14 @@ export function writeResultToResponse(
         response.setHeader('Content-Type', 'text/plain');
         result = result.toString();
         break;
+    }
+    if (route) {
+      const spec = route.spec;
+      const responsesCode = Object.keys(spec.responses || {});
+      if (responsesCode.length >= 1) {
+        const successStatusCode = responsesCode[0];
+        response.statusCode = parseInt(successStatusCode);
+      }
     }
     response.write(result);
   }

--- a/packages/rest/test/integration/http-handler.integration.ts
+++ b/packages/rest/test/integration/http-handler.integration.ts
@@ -58,6 +58,12 @@ describe('HttpHandler', () => {
         .withOperationReturningString('get', '/hello', 'hello')
         .withOperationReturningString('get', '/bye', 'bye')
         .withOperationReturningString('post', '/hello', 'postHello')
+        .withOperationReturningStringWithStatusCode(
+          'post',
+          '/createHello',
+          201,
+          'createHello',
+        )
         .build();
 
       class HelloController {
@@ -72,9 +78,17 @@ describe('HttpHandler', () => {
         public async postHello(): Promise<string> {
           return 'hello posted';
         }
+
+        public async createHello(): Promise<string> {
+          return 'hello created';
+        }
       }
 
       givenControllerClass(HelloController, spec);
+    });
+
+    it('returns 201 for "POST /createHello"', () => {
+      return client.post('/createHello').expect(201, 'hello created');
     });
 
     it('executes hello() for "GET /hello"', () => {


### PR DESCRIPTION
A PoC based on discussion in PR https://github.com/strongloop/loopback-next/pull/1245/files.
I highly doubt this PoC is less hacky than https://github.com/strongloop/loopback-next/pull/1245/ ...
While want to keep it open for a while to drive some discussion.

Had a talk with @bajtos , he points out an important thing: When a response returns `201`, it also includes a header with the URI of created item. see https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2

Here is a summary of discussions I have seen within team:

## Plan 1 - set `statusCode` in controller

See @bajtos 's proposal in https://github.com/strongloop/loopback-next/issues/788#issuecomment-381639062

Discussion from @raymondfeng @virkt25 in [comment](https://github.com/strongloop/loopback-next/pull/1245/files#diff-576584d72083bead0929c10dfc101b01R201)

A advantage of this approach is the returned result contains `statusCode`, `header`, `body`...etc, everything.

My concern for it is would all methods return a `httpResponse` to be identified with `create`? 

The handler can detect the type of returned result, which may allow us to handle a `httpResponse` result and `body` result differently. 

## Plan 2 - read `statusCode` from `response` spec

This PoC implements ^ in a simpler way. It adds a 3rd parameter in `send` provider to expose `route.spec` to the writer. While ideally we should bind route's spec to Context.

From @bajtos 
> In general, I think we should eventually bind route's spec to Context, because I expect this to be useful in other places too.

While this PR exposes a few problems for this approach:
https://github.com/strongloop/loopback-next/pull/1260#issuecomment-381712236

