### PR TITLE
[RFC] feat(context): allow tags to have an optional value

### DIFF
--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -17,7 +17,7 @@ export {
   getDeepProperty,
 } from './value-promise';
 
-export {Binding, BindingScope, BindingType} from './binding';
+export {Binding, BindingScope, BindingType, TagMap} from './binding';
 
 export {Context} from './context';
 export {BindingKey, BindingAddress} from './binding-key';

--- a/packages/context/test/acceptance/tagged-bindings.acceptance.ts
+++ b/packages/context/test/acceptance/tagged-bindings.acceptance.ts
@@ -17,11 +17,11 @@ describe('Context bindings - Tagged bindings', () => {
       before(tagBinding);
 
       it('has a tag name', () => {
-        expect(binding.tags.has('qux')).to.be.true();
+        expect(binding.tagNames).to.containEql('controller');
       });
 
       function tagBinding() {
-        binding.tag('qux');
+        binding.tag('controller');
       }
     });
 
@@ -29,12 +29,29 @@ describe('Context bindings - Tagged bindings', () => {
       before(tagBinding);
 
       it('has tags', () => {
-        expect(binding.tags.has('x')).to.be.true();
-        expect(binding.tags.has('y')).to.be.true();
+        expect(binding.tagNames).to.containEql('controller');
+        expect(binding.tagNames).to.containEql('rest');
       });
 
       function tagBinding() {
-        binding.tag(['x', 'y']);
+        binding.tag('controller', 'rest');
+      }
+    });
+
+    context('when the binding is tagged with name/value objects', () => {
+      before(tagBinding);
+
+      it('has tags', () => {
+        expect(binding.tagNames).to.containEql('controller');
+        expect(binding.tagNames).to.containEql('name');
+        expect(binding.tagMap).to.containEql({
+          name: 'my-controller',
+          controller: 'controller',
+        });
+      });
+
+      function tagBinding() {
+        binding.tag({name: 'my-controller'}, 'controller');
       }
     });
   });

--- a/packages/context/test/acceptance/tagged-bindings.feature.md
+++ b/packages/context/test/acceptance/tagged-bindings.feature.md
@@ -5,12 +5,12 @@
 - I want to tag bindings
 - So I can group dependencies together via a known name
 
-## Scenario: Single tag
+## Scenario: Single named tag
 
 - Given a context
 - And a binding named `foo` with value `bar`
-- When I tag it `qux`
-- Then it should be tagged with `qux`
+- When I tag it `controller`
+- Then it should be tagged with `controller`
 
 ```ts
 // create a container for bindings
@@ -20,7 +20,48 @@ let ctx = new Context();
 let binding = ctx
   .bind('foo')
   .to('bar')
-  .tag('qux');
+  .tag('controller');
 
-console.log(binding.tags); // => Set { 'qux' }
+console.log(binding.tagNames); // =>  ['controller']
+```
+
+## Scenario: Multiple named tags
+
+- Given a context
+- And a binding named `foo` with value `bar`
+- When I tag it `controller` and `rest`
+- Then it should be tagged with `controller` and `rest`
+
+```ts
+// create a container for bindings
+let ctx = new Context();
+
+// create a tagged binding
+let binding = ctx
+  .bind('foo')
+  .to('bar')
+  .tag('controller', 'rest');
+
+console.log(binding.tagNames); // =>  ['controller', 'rest']
+```
+
+## Scenario: Tags with both name and value
+
+- Given a context
+- And a binding named `foo` with value `bar`
+- When I tag it `{name: 'my-controller'}` and `controller`
+- Then it should be tagged with `{name: 'my-controller', controller: 'controller'}`
+
+```ts
+// create a container for bindings
+let ctx = new Context();
+
+// create a tagged binding
+let binding = ctx
+  .bind('foo')
+  .to('bar')
+  .tag({name: 'my-controller'}, 'controller');
+
+console.log(binding.tagNames); // => ['name', 'controller']
+console.log(binding.tagMap); // => {name: 'my-controller', controller: 'controller'}
 ```

--- a/packages/context/test/unit/binding.unit.ts
+++ b/packages/context/test/unit/binding.unit.ts
@@ -41,16 +41,37 @@ describe('Binding', () => {
   describe('tag', () => {
     it('tags the binding', () => {
       binding.tag('t1');
-      expect(binding.tags.has('t1')).to.be.true();
+      expect(binding.tagNames).to.eql(['t1']);
       binding.tag('t2');
-      expect(binding.tags.has('t1')).to.be.true();
-      expect(binding.tags.has('t2')).to.be.true();
+      expect(binding.tagNames).to.eql(['t1', 't2']);
+      expect(binding.tagMap).to.eql({t1: 't1', t2: 't2'});
     });
 
-    it('tags the binding with an array', () => {
-      binding.tag(['t1', 't2']);
-      expect(binding.tags.has('t1')).to.be.true();
-      expect(binding.tags.has('t2')).to.be.true();
+    it('tags the binding with rest args', () => {
+      binding.tag('t1', 't2');
+      expect(binding.tagNames).to.eql(['t1', 't2']);
+    });
+
+    it('tags the binding with name/value', () => {
+      binding.tag({name: 'my-controller'});
+      expect(binding.tagNames).to.eql(['name']);
+      expect(binding.tagMap).to.eql({name: 'my-controller'});
+    });
+
+    it('tags the binding with names and name/value objects', () => {
+      binding.tag('controller', {name: 'my-controller'}, 'rest');
+      expect(binding.tagNames).to.eql(['controller', 'name', 'rest']);
+      expect(binding.tagMap).to.eql({
+        controller: 'controller',
+        name: 'my-controller',
+        rest: 'rest',
+      });
+    });
+
+    it('throws an error if one of the arguments is an array', () => {
+      expect(() => binding.tag(['t1', 't2'])).to.throw(
+        /Tag must be a string or an object \(but not array\):/,
+      );
     });
   });
 
@@ -158,7 +179,7 @@ describe('Binding', () => {
       expect(json).to.eql({
         key: key,
         scope: BindingScope.TRANSIENT,
-        tags: [],
+        tags: {},
         isLocked: false,
       });
     });
@@ -166,13 +187,13 @@ describe('Binding', () => {
     it('converts a binding with more attributes to plain JSON object', () => {
       const myBinding = new Binding(key, true)
         .inScope(BindingScope.CONTEXT)
-        .tag('model')
+        .tag('model', {name: 'my-model'})
         .to('a');
       const json = myBinding.toJSON();
       expect(json).to.eql({
         key: key,
         scope: BindingScope.CONTEXT,
-        tags: ['model'],
+        tags: {model: 'model', name: 'my-model'},
         isLocked: true,
         type: BindingType.CONSTANT,
       });

--- a/packages/core/test/unit/application.unit.ts
+++ b/packages/core/test/unit/application.unit.ts
@@ -16,14 +16,14 @@ describe('Application', () => {
 
     it('binds a controller', () => {
       const binding = app.controller(MyController);
-      expect(Array.from(binding.tags)).to.containEql('controller');
+      expect(Array.from(binding.tagNames)).to.containEql('controller');
       expect(binding.key).to.equal('controllers.MyController');
       expect(findKeysByTag(app, 'controller')).to.containEql(binding.key);
     });
 
     it('binds a controller with custom name', () => {
       const binding = app.controller(MyController, 'my-controller');
-      expect(Array.from(binding.tags)).to.containEql('controller');
+      expect(Array.from(binding.tagNames)).to.containEql('controller');
       expect(binding.key).to.equal('controllers.my-controller');
       expect(findKeysByTag(app, 'controller')).to.containEql(binding.key);
     });
@@ -65,7 +65,7 @@ describe('Application', () => {
     it('defaults to constructor name', async () => {
       const app = new Application();
       const binding = app.server(FakeServer);
-      expect(Array.from(binding.tags)).to.containEql('server');
+      expect(Array.from(binding.tagNames)).to.containEql('server');
       const result = await app.getServer(FakeServer.name);
       expect(result.constructor.name).to.equal(FakeServer.name);
     });
@@ -81,8 +81,8 @@ describe('Application', () => {
     it('allows binding of multiple servers as an array', async () => {
       const app = new Application();
       const bindings = app.servers([FakeServer, AnotherServer]);
-      expect(Array.from(bindings[0].tags)).to.containEql('server');
-      expect(Array.from(bindings[1].tags)).to.containEql('server');
+      expect(Array.from(bindings[0].tagNames)).to.containEql('server');
+      expect(Array.from(bindings[1].tagNames)).to.containEql('server');
       const fakeResult = await app.getServer(FakeServer);
       expect(fakeResult.constructor.name).to.equal(FakeServer.name);
       const AnotherResult = await app.getServer(AnotherServer);

--- a/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -55,7 +55,7 @@ describe('RestServer.getApiSpec()', () => {
       new Route('get', '/greet', {responses: {}}, greet),
     );
     expect(binding.key).to.eql('routes.get %2Fgreet');
-    expect(binding.tags.has('route')).to.be.true();
+    expect(binding.tagNames).containEql('route');
   });
 
   it('binds a route via app.route(..., Controller, method)', () => {
@@ -72,7 +72,7 @@ describe('RestServer.getApiSpec()', () => {
       'greet',
     );
     expect(binding.key).to.eql('routes.get %2Fgreet%2Ejson');
-    expect(binding.tags.has('route')).to.be.true();
+    expect(binding.tagNames).containEql('route');
   });
 
   it('returns routes registered via app.route(route)', () => {


### PR DESCRIPTION
This PR enhances our binding tags to allow optional values. For example, we can associate a `controller` binding with tags such as:
- 'controller' (tag name only)
- {name: 'MyController'} (tag with name and value)
- {extensionPoint: 'controllers'}

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
