### PR TITLE
chore(build): upgrade dependencies

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -18,14 +18,14 @@
     "cross-spawn": "^6.0.5",
     "debug": "^3.1.0",
     "fs-extra": "^5.0.0",
-    "mocha": "^5.0.5",
-    "nyc": "^11.6.0",
-    "prettier": "^1.11.1",
+    "mocha": "^5.1.1",
+    "nyc": "^11.7.1",
+    "prettier": "^1.12.1",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.4",
     "strong-docs": "^1.10.2",
     "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
+    "typescript": "^2.8.1"
   },
   "bin": {
     "lb-tsc": "./bin/compile-package.js",


### PR DESCRIPTION
Upgrade to typescript 2.8.x and prettier 1.12.x.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
