### PR TITLE
refactor: clean usage of OAI's ExtensionValue

### DIFF
--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -5,13 +5,13 @@
 
 import * as assert from 'assert';
 import {
-  ExtensionValue,
   OpenApiSpec,
   OperationObject,
   ResponseObject,
   ParameterObject,
   createEmptyApiSpec,
   RequestBodyObject,
+  ISpecificationExtension,
 } from '@loopback/openapi-v3-types';
 
 /**
@@ -30,11 +30,7 @@ export function anOperationSpec() {
   return new OperationSpecBuilder();
 }
 
-export interface Extendable {
-  [extension: string]: ExtensionValue;
-}
-
-export class BuilderBase<T extends Extendable> {
+export class BuilderBase<T extends ISpecificationExtension> {
   protected _spec: T;
 
   constructor(initialSpec: T) {
@@ -47,7 +43,11 @@ export class BuilderBase<T extends Extendable> {
    * @param key The property name starting with "x-".
    * @param value The property value.
    */
-  withExtension(key: string, value: ExtensionValue): this {
+  withExtension(
+    key: string,
+    // tslint:disable-next-line:no-any
+    value: any,
+  ): this {
     assert(
       key.startsWith('x-'),
       `Invalid extension ${key}, extension keys must be prefixed with "x-"`,

--- a/packages/openapi-v3-types/src/openapi-v3-spec-types.ts
+++ b/packages/openapi-v3-types/src/openapi-v3-spec-types.ts
@@ -12,12 +12,6 @@ import {OpenAPIObject} from 'openapi3-ts';
 export * from 'openapi3-ts';
 
 export type OpenApiSpec = OpenAPIObject;
-/**
- * Custom extensions can use arbitrary type as the value,
- * e.g. a string, an object or an array.
- */
-// tslint:disable-next-line:no-any
-export type ExtensionValue = any;
 
 /**
  * Create an empty OpenApiSpec object that's still a valid openapi document.

--- a/packages/openapi-v3-types/src/type-guards.ts
+++ b/packages/openapi-v3-types/src/type-guards.ts
@@ -3,11 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  SchemaObject,
-  ReferenceObject,
-  ExtensionValue,
-} from './openapi-v3-spec-types';
+import {SchemaObject, ReferenceObject} from './openapi-v3-spec-types';
 
 /**
  * Type guard for OpenAPI 3.0.0 schema object
@@ -20,6 +16,6 @@ export function isSchemaObject(
   return !schema.hasOwnProperty('$ref');
 }
 
-export function isReferenceObject(obj: ExtensionValue): obj is ReferenceObject {
+export function isReferenceObject(obj: object): obj is ReferenceObject {
   return obj.hasOwnProperty('$ref');
 }

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -4,11 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {JsonDefinition} from '@loopback/repository-json-schema';
-import {SchemaObject, ExtensionValue} from '@loopback/openapi-v3-types';
+import {SchemaObject} from '@loopback/openapi-v3-types';
 import * as _ from 'lodash';
 
-export function jsonToSchemaObject(jsonDef: JsonDefinition): SchemaObject {
-  const json = jsonDef as {[name: string]: ExtensionValue}; // gets around index signature error
+export function jsonToSchemaObject(json: JsonDefinition): SchemaObject {
   const result: SchemaObject = {};
   const propsToIgnore = [
     'anyOf',
@@ -63,7 +62,7 @@ export function jsonToSchemaObject(jsonDef: JsonDefinition): SchemaObject {
       case 'enum': {
         const newEnum = [];
         const primitives = ['string', 'number', 'boolean'];
-        for (const element of json.enum) {
+        for (const element of json.enum!) {
           if (primitives.includes(typeof element) || element === null) {
             newEnum.push(element);
           } else {
@@ -76,14 +75,14 @@ export function jsonToSchemaObject(jsonDef: JsonDefinition): SchemaObject {
         break;
       }
       case '$ref': {
-        result.$ref = json.$ref.replace(
+        result.$ref = json.$ref!.replace(
           '#/definitions',
           '#/components/schemas',
         );
         break;
       }
       default: {
-        result[property] = json[property];
+        result[property] = json[property as keyof JsonDefinition];
         break;
       }
     }


### PR DESCRIPTION
Move the definition of ExtensionValue from openapi-v3-types (where it is no longer used) to openapi-spec-build.

Fix openapi type guards to use a more correct `object` type instead of `ExtensionValue`, since the guards are not dealing with any extensions.

Fixa json-to-schema converter to use `any` instead of `ExtensionValue` when converting a JSON Schema object to an indexable object.

This is a follow-up for #1265.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- (n/a) New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- (n/a) API Documentation in code was updated
- (n/a) Documentation in [/docs/site](../tree/master/docs/site) was updated
- (n/a) Affected artifact templates in `packages/cli` were updated
- (n/a) Affected example projects in `examples/*` were updated