### PR TITLE
feat(repository-json-schema): include type in err

### DIFF
--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -71,7 +71,7 @@ export function stringTypeToWrapper(type: string): Function {
       break;
     }
     default: {
-      throw new Error('Unsupported type');
+      throw new Error('Unsupported type: ' + type);
     }
   }
   return wrapper;


### PR DESCRIPTION
Minor: Improve the helpfulness of the error message, so the developer know which type is causing the problem.

When I use a type in my model which does not exist (e.g. 'date') I get an error but I don't get the line number or the model name to help me find and fix the problem.

```
Cannot start the application. Error: Unsupported type
    at stringTypeToWrapper (.../node_modules/@loopback/repository-json-schema/dist/src/build-schema.js:50:19)
    at metaToJsonProperty (.../node_modules/@loopback/repository-json-schema/dist/src/build-schema.js:76:16)
    ...
```

This PR will simply include the actual type in the error message, to give the developer a nudge in the right direction.

```
Cannot start the application. Error: Unsupported type: date
    at stringTypeToWrapper (.../node_modules/@loopback/repository-json-schema/dist/src/build-schema.js:50:19)
    at metaToJsonProperty (.../node_modules/@loopback/repository-json-schema/dist/src/build-schema.js:76:16)
    ...
```

The tests which are checking for this error use a regexp which matches with or without the extra info, so they did not need to be changed.

## Checklist

- [x] `npm test` passes on your machine (all but 1, consistent with previous commit!)
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
