### PR TITLE
doc: list Testing guides under Best Practices

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -110,10 +110,6 @@ children:
   url: Calling-other-APIs-and-web-services.html
   output: 'web, pdf'
 
-- title: 'Testing your application'
-  url: Testing-your-application.html
-  output: 'web, pdf'
-
 - title: 'For current LoopBack users'
   url: LoopBack-3.x.html
   output: 'web, pdf'
@@ -167,6 +163,14 @@ children:
 
   - title: 'Preparing the API for consumption'
     url: Preparing-the-API-for-consumption.html
+    output: 'web, pdf'
+
+  - title: 'Testing your application'
+    url: Testing-your-application.html
+    output: 'web, pdf'
+
+  - title: 'Testing your extension'
+    url: Testing-your-extension.html
     output: 'web, pdf'
 
 - title: 'Extending LoopBack 4'


### PR DESCRIPTION
I found it weird that our sidebar is listing "Testing your application" at top level, while most of other testing-related content is nested under "Best practices".

This pull request moves "Testing your application" to "Best practices" section and also adds a link to "Testing your extensions" to best practices.

Please consider this change as a quick improvement of the current status. In the future, we will probably want to revamp the sidebar and these best practices guides. Such bigger change is out of scope of this pull request though!

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
