### PR TITLE
chore: make the code compatible with node 10.0.0

### DIFF
--- a/packages/authentication/test/acceptance/basic-auth.acceptance.ts
+++ b/packages/authentication/test/acceptance/basic-auth.acceptance.ts
@@ -48,7 +48,7 @@ describe('Basic Authentication', () => {
     const client = whenIMakeRequestTo(server);
     const credential =
       users.list.joe.profile.id + ':' + users.list.joe.password;
-    const hash = new Buffer(credential).toString('base64');
+    const hash = Buffer.from(credential).toString('base64');
     await client
       .get('/whoAmI')
       .set('Authorization', 'Basic ' + hash)
@@ -58,7 +58,7 @@ describe('Basic Authentication', () => {
   it('returns error for invalid credentials', async () => {
     const client = whenIMakeRequestTo(server);
     const credential = users.list.Simpson.profile.id + ':' + 'invalid';
-    const hash = new Buffer(credential).toString('base64');
+    const hash = Buffer.from(credential).toString('base64');
     await client
       .get('/whoAmI')
       .set('Authorization', 'Basic ' + hash)

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -45,10 +45,13 @@ export function isClass(target: any): target is Constructor<any> {
 export function loadClassesFromFiles(files: string[]): Constructor<{}>[] {
   const classes: Array<Constructor<{}>> = [];
   for (const file of files) {
-    const data = require(file);
-    for (const cls of Object.values(data)) {
-      if (isClass(cls)) {
-        classes.push(cls);
+    const moduleObj = require(file);
+    // WORKAROUND: use `for in` instead of Object.values().
+    // See https://github.com/nodejs/node/issues/20278
+    for (const k in moduleObj) {
+      const exported = moduleObj[k];
+      if (isClass(exported)) {
+        classes.push(exported);
       }
     }
   }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -22,7 +22,7 @@
     "nyc": "^11.7.1",
     "prettier": "^1.12.1",
     "rimraf": "^2.6.2",
-    "source-map-support": "^0.5.4",
+    "source-map-support": "^0.5.5",
     "strong-docs": "^1.10.2",
     "tslint": "^5.9.1",
     "typescript": "^2.8.1"

--- a/packages/repository/test/unit/type/type.unit.ts
+++ b/packages/repository/test/unit/type/type.unit.ts
@@ -231,8 +231,8 @@ describe('types', () => {
   describe('buffer', () => {
     const bufferType = new types.BufferType();
     it('checks isInstance', () => {
-      expect(bufferType.isInstance(new Buffer([1]))).to.be.true();
-      expect(bufferType.isInstance(new Buffer('123'))).to.be.true();
+      expect(bufferType.isInstance(Buffer.from([1]))).to.be.true();
+      expect(bufferType.isInstance(Buffer.from('123'))).to.be.true();
       expect(bufferType.isInstance('str')).to.be.false();
       expect(bufferType.isInstance(null)).to.be.true();
       expect(bufferType.isInstance(undefined)).to.be.true();
@@ -248,7 +248,7 @@ describe('types', () => {
       expect(bufferType.isCoercible('str')).to.be.true();
       expect(bufferType.isCoercible(null)).to.be.true();
       expect(bufferType.isCoercible(undefined)).to.be.true();
-      expect(bufferType.isCoercible(new Buffer('12'))).to.be.true();
+      expect(bufferType.isCoercible(Buffer.from('12'))).to.be.true();
       expect(bufferType.isCoercible([1, 2])).to.be.true();
       expect(bufferType.isCoercible({x: 1})).to.be.false();
       expect(bufferType.isCoercible(1)).to.be.false();
@@ -260,11 +260,11 @@ describe('types', () => {
     });
 
     it('coerces values', () => {
-      expect(bufferType.coerce('str').equals(new Buffer('str'))).to.be.true();
+      expect(bufferType.coerce('str').equals(Buffer.from('str'))).to.be.true();
       expect(bufferType.coerce([1]).equals(Buffer.from([1]))).to.be.true();
       expect(bufferType.coerce(null)).to.equal(null);
       expect(bufferType.coerce(undefined)).to.equal(undefined);
-      const buf = new Buffer('12');
+      const buf = Buffer.from('12');
       expect(bufferType.coerce(buf)).exactly(buf);
       expect(() => bufferType.coerce(1)).to.throw(/Invalid buffer/);
       expect(() => bufferType.coerce(new Date())).to.throw(/Invalid buffer/);
@@ -274,9 +274,9 @@ describe('types', () => {
 
     it('serializes values', () => {
       expect(
-        bufferType.serialize(new Buffer('str'), {encoding: 'utf-8'}),
+        bufferType.serialize(Buffer.from('str'), {encoding: 'utf-8'}),
       ).to.eql('str');
-      expect(bufferType.serialize(new Buffer('str'))).to.eql('c3Ry');
+      expect(bufferType.serialize(Buffer.from('str'))).to.eql('c3Ry');
       expect(bufferType.serialize(null)).null();
       expect(bufferType.serialize(undefined)).undefined();
     });
@@ -293,7 +293,7 @@ describe('types', () => {
       expect(anyType.isInstance([1, 2])).to.be.true();
       expect(anyType.isInstance(1)).to.be.true();
       expect(anyType.isInstance(new Date())).to.be.true();
-      expect(anyType.isInstance(new Buffer('123'))).to.be.true();
+      expect(anyType.isInstance(Buffer.from('123'))).to.be.true();
     });
 
     it('checks isCoercible', () => {
@@ -305,7 +305,7 @@ describe('types', () => {
       expect(anyType.isCoercible(1)).to.be.true();
       expect(anyType.isCoercible([1, '2'])).to.be.true();
       expect(anyType.isCoercible(new Date())).to.be.true();
-      expect(anyType.isCoercible(new Buffer('123'))).to.be.true();
+      expect(anyType.isCoercible(Buffer.from('123'))).to.be.true();
     });
 
     it('creates defaultValue', () => {
@@ -324,7 +324,7 @@ describe('types', () => {
       expect(anyType.coerce(1)).to.equal(1);
       const date = new Date();
       expect(anyType.coerce(date)).to.equal(date);
-      const buf = new Buffer('12');
+      const buf = Buffer.from('12');
       expect(anyType.coerce(buf)).to.equal(buf);
     });
 


### PR DESCRIPTION
- Replace new Buffer() with Buffer.from()
- Work around https://github.com/nodejs/node/issues/20278
- Upgrade to source-map-support@0.5.5

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
