### PR TITLE
chore: enable publishing of examples to npm

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -2,7 +2,6 @@
   "name": "@loopback/example-hello-world",
   "version": "0.5.1",
   "description": "A simple hello-world Application using LoopBack 4",
-  "private": true,
   "main": "index.js",
   "engines": {
     "node": ">=8"

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -2,7 +2,6 @@
   "name": "@loopback/example-log-extension",
   "version": "0.7.1",
   "description": "An example extension project for LoopBack 4",
-  "private": true,
   "main": "index.js",
   "engines": {
     "node": ">=8"

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -2,7 +2,6 @@
   "name": "@loopback/example-rpc-server",
   "version": "0.5.1",
   "description": "A basic RPC server using a made-up protocol.",
-  "private": true,
   "keywords": [
     "loopback-application",
     "loopback"

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -2,7 +2,6 @@
   "name": "@loopback/example-todo",
   "version": "0.7.1",
   "description": "Tutorial example on how to build an application with LoopBack 4.",
-  "private": true,
   "main": "index.js",
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
This is the first step of reworking `lb4 example` to download example packages from `npm` instead of `GitHub` - see #1120


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated