### PR TITLE
ci: disable code coverage and linting on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,13 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
   - npm install
 
 test_script:
-  - node --version
-  - npm --version
-  - npm test
+  - npm run build
+  - npm run mocha --scripts-prepend-node-path
 
 build: off
 skip_branch_with_pr: true


### PR DESCRIPTION
Speed up our AppVeyor CI builds by disabling features that are not
needed:

 - Linting is performed by Travis CI, no need to lint on Windows too
 - Code coverage is collected by Travis jobs, AppVeyor was never
   exporting code coverage to Coveralls.

This change speeds up AppVeyor runs by about 1 minute from ~4m27s to ~3m25s.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
