### PR TITLE
chore(repository-json-schema): replace JsonDefinition with JSONSchema6

### DIFF
--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -26,13 +26,11 @@
   "dependencies": {
     "@loopback/context": "^0.8.1",
     "@loopback/repository": "^0.8.1",
-    "lodash": "^4.17.5",
-    "typescript-json-schema": "^0.22.0"
+    "@types/json-schema": "^6.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^0.6.0",
     "@loopback/testlab": "^0.8.0",
-    "@types/lodash": "^4.14.106",
     "@types/node": "^8.10.4"
   },
   "files": [

--- a/packages/repository-json-schema/src/index.ts
+++ b/packages/repository-json-schema/src/index.ts
@@ -4,3 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from './build-schema';
+
+import {JSONSchema6 as JSONSchema} from 'json-schema';
+export {JSONSchema};

--- a/packages/repository-json-schema/test/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/test/integration/build-schema.integration.ts
@@ -4,10 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {model, property} from '@loopback/repository';
-import {modelToJsonSchema} from '../../src/build-schema';
+import {
+  modelToJsonSchema,
+  JSON_SCHEMA_KEY,
+  getJsonSchema,
+  JSONSchema,
+} from '../..';
 import {expect} from '@loopback/testlab';
 import {MetadataInspector} from '@loopback/context';
-import {JSON_SCHEMA_KEY, getJsonSchema} from '../../index';
 
 describe('build-schema', () => {
   describe('modelToJsonSchema', () => {
@@ -339,7 +343,7 @@ describe('build-schema', () => {
       class TestModel {
         @property() foo: number;
       }
-      const cachedSchema = {
+      const cachedSchema: JSONSchema = {
         properties: {
           cachedProperty: {
             type: 'string',

--- a/packages/repository-json-schema/test/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/test/unit/build-schema.unit.ts
@@ -1,9 +1,5 @@
 import {expect} from '@loopback/testlab';
-import {
-  isComplexType,
-  stringTypeToWrapper,
-  metaToJsonProperty,
-} from '../../index';
+import {isComplexType, stringTypeToWrapper, metaToJsonProperty} from '../..';
 
 describe('build-schema', () => {
   describe('stringTypeToWrapper', () => {


### PR DESCRIPTION
- ditches the heavy `typescript-json-schema` module in favor of light-weight and more accurate `JSONSchema6`
- fixes #1132 
- related to #1256 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
