### PR TITLE
refactor(repository-json-schema): rename JSONSchema to JsonSchema

### DIFF
--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {JSONSchema} from '@loopback/repository-json-schema';
+import {JsonSchema} from '@loopback/repository-json-schema';
 import {SchemaObject} from '@loopback/openapi-v3-types';
 import * as _ from 'lodash';
 
@@ -11,7 +11,7 @@ import * as _ from 'lodash';
  * Converts JSON Schemas into a SchemaObject
  * @param json JSON Schema to convert from
  */
-export function jsonToSchemaObject(json: JSONSchema): SchemaObject {
+export function jsonToSchemaObject(json: JsonSchema): SchemaObject {
   const result: SchemaObject = {};
   const propsToIgnore = [
     'anyOf',
@@ -71,7 +71,7 @@ export function jsonToSchemaObject(json: JSONSchema): SchemaObject {
         break;
       }
       default: {
-        result[property] = json[property as keyof JSONSchema];
+        result[property] = json[property as keyof JsonSchema];
         break;
       }
     }
@@ -84,9 +84,9 @@ export function jsonToSchemaObject(json: JSONSchema): SchemaObject {
  * Helper function used to interpret boolean values as JSON Schemas.
  * See http://json-schema.org/draft-06/json-schema-release-notes.html
  * @param jsonOrBool converts boolean values into their representative JSON Schemas
- * @returns JSONSchema
+ * @returns A JSON Schema document representing the input value.
  */
-export function jsonOrBooleanToJSON(jsonOrBool: boolean | JSONSchema) {
+export function jsonOrBooleanToJSON(jsonOrBool: boolean | JsonSchema) {
   if (typeof jsonOrBool === 'object') {
     return jsonOrBool;
   } else {

--- a/packages/openapi-v3/test/unit/json-to-schema.unit.ts
+++ b/packages/openapi-v3/test/unit/json-to-schema.unit.ts
@@ -7,13 +7,13 @@ import {expect} from '@loopback/testlab';
 
 import {SchemaObject} from '@loopback/openapi-v3-types';
 import {jsonToSchemaObject, jsonOrBooleanToJSON} from '../..';
-import {JSONSchema} from '@loopback/repository-json-schema';
+import {JsonSchema} from '@loopback/repository-json-schema';
 
 describe('jsonToSchemaObject', () => {
   it('does nothing when given an empty object', () => {
     expect({}).to.eql({});
   });
-  const typeDef: JSONSchema = {type: ['string', 'number']};
+  const typeDef: JsonSchema = {type: ['string', 'number']};
   const expectedType: SchemaObject = {type: 'string'};
   it('converts type', () => {
     propertyConversionTest(typeDef, expectedType);
@@ -34,7 +34,7 @@ describe('jsonToSchemaObject', () => {
   });
 
   it('converts allOf', () => {
-    const allOfDef: JSONSchema = {
+    const allOfDef: JsonSchema = {
       allOf: [typeDef, typeDef],
     };
     const expectedAllOf: SchemaObject = {
@@ -44,7 +44,7 @@ describe('jsonToSchemaObject', () => {
   });
 
   it('converts definitions', () => {
-    const definitionsDef: JSONSchema = {
+    const definitionsDef: JsonSchema = {
       definitions: {foo: typeDef, bar: typeDef},
     };
     const expectedDef: SchemaObject = {
@@ -54,7 +54,7 @@ describe('jsonToSchemaObject', () => {
   });
 
   it('converts properties', () => {
-    const propertyDef: JSONSchema = {
+    const propertyDef: JsonSchema = {
       properties: {
         foo: typeDef,
       },
@@ -68,8 +68,8 @@ describe('jsonToSchemaObject', () => {
   });
 
   context('additionalProperties', () => {
-    it('is converted properly when the type is JSONSchema', () => {
-      const additionalDef: JSONSchema = {
+    it('is converted properly when the type is JsonSchema', () => {
+      const additionalDef: JsonSchema = {
         additionalProperties: typeDef,
       };
       const expectedAdditional: SchemaObject = {
@@ -79,7 +79,7 @@ describe('jsonToSchemaObject', () => {
     });
 
     it('is converted properly when it is "false"', () => {
-      const noAdditionalDef: JSONSchema = {
+      const noAdditionalDef: JsonSchema = {
         additionalProperties: false,
       };
       const expectedDef: SchemaObject = {};
@@ -88,7 +88,7 @@ describe('jsonToSchemaObject', () => {
   });
 
   it('converts items', () => {
-    const itemsDef: JSONSchema = {
+    const itemsDef: JsonSchema = {
       type: 'array',
       items: typeDef,
     };
@@ -100,7 +100,7 @@ describe('jsonToSchemaObject', () => {
   });
 
   it('retains given properties in the conversion', () => {
-    const inputDef: JSONSchema = {
+    const inputDef: JsonSchema = {
       title: 'foo',
       type: 'object',
       properties: {
@@ -150,7 +150,7 @@ describe('jsonOrBooleanToJson', () => {
   });
 
   it('makes no changes to JSON Schema', () => {
-    const jsonSchema: JSONSchema = {
+    const jsonSchema: JsonSchema = {
       properties: {
         number: {type: 'number'},
       },

--- a/packages/repository-json-schema/src/index.ts
+++ b/packages/repository-json-schema/src/index.ts
@@ -5,5 +5,5 @@
 
 export * from './build-schema';
 
-import {JSONSchema6 as JSONSchema} from 'json-schema';
-export {JSONSchema};
+import {JSONSchema6 as JsonSchema} from 'json-schema';
+export {JsonSchema};

--- a/packages/repository-json-schema/test/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/test/integration/build-schema.integration.ts
@@ -8,7 +8,7 @@ import {
   modelToJsonSchema,
   JSON_SCHEMA_KEY,
   getJsonSchema,
-  JSONSchema,
+  JsonSchema,
 } from '../..';
 import {expect} from '@loopback/testlab';
 import {MetadataInspector} from '@loopback/context';
@@ -343,7 +343,7 @@ describe('build-schema', () => {
       class TestModel {
         @property() foo: number;
       }
-      const cachedSchema: JSONSchema = {
+      const cachedSchema: JsonSchema = {
         properties: {
           cachedProperty: {
             type: 'string',


### PR DESCRIPTION
Our current convention is to treat abbreviations longer than 2
characters as regular words and capitalize only the first character.

We already use "Json" form across the codebase instead of "JSON".

This commit applies the same convention to the JSON Schema type
introduced by the recent commit e9e6b12c7f (see #1286).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated