### PR TITLE
chore: add apidocs for binding keys

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -332,11 +332,13 @@ Please register the new package in the following files:
   new package, please keep the rows sorted by package name.
 - Update [docs/apidocs.html](../apidocs.html) - add a link to API docs for this
   new package.
+- Update [Reserved-binding-keys.md](./Reserved-binding-keys.mds) - add a link to
+  the apidocs on Binding Keys if the new package has any.
 - Update [CODEOWNERS](../../CODEOWNERS) - add a new entry listing the primary
-  maintainers (owners) of the new package
+  maintainers (owners) of the new package.
 - Ask somebody from the IBM team (e.g. [@bajtos](https://github.com/bajtos) or
   [@raymondfeng](https://github.com/raymondfeng) to enlist the new package on
-  <http://apidocs.loopback.io/>
+  <http://apidocs.loopback.io/>.
 
 ## How to test infrastructure changes
 

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -12,18 +12,89 @@ import {BindingKey, MetadataAccessor} from '@loopback/context';
  * Binding keys used by this component.
  */
 export namespace AuthenticationBindings {
+  /**
+   * Key used to bind an authentication strategy to the context for the
+   * authentication function to use.
+   *
+   * ```ts
+   * server
+   *   .bind(AuthenticationBindings.STRATEGY)
+   *   .toProvider(MyPassportStrategyProvider);
+   * ```
+   */
   export const STRATEGY = BindingKey.create<Strategy | undefined>(
     'authentication.strategy',
   );
 
+  /**
+   * Key used to inject the authentication function into the sequence.
+   *
+   * ```ts
+   * class MySequence implements SequenceHandler {
+   *   constructor(
+   *     @inject(AuthenticationBindings.AUTH_ACTION)
+   *     protected authenticateRequest: AuthenticateFn,
+   *     // ... other sequence action injections
+   *   ) {}
+   *
+   *   async handle(req: ParsedRequest, res: ServerResponse) {
+   *     try {
+   *       const route = this.findRoute(req);
+   *
+   *      // Authenticate
+   *       await this.authenticateRequest(req);
+   *
+   *       // Authentication successful, proceed to invoke controller
+   *       const args = await this.parseParams(req, route);
+   *       const result = await this.invoke(route, args);
+   *       this.send(res, result);
+   *     } catch (err) {
+   *       this.reject(res, req, err);
+   *       return;
+   *     }
+   *   }
+   * }
+   * ```
+   */
   export const AUTH_ACTION = BindingKey.create<AuthenticateFn>(
     'authentication.actions.authenticate',
   );
 
+  /**
+   * Key used to inject authentication metadata, which is used to determine
+   * whether a request requires authentication or not.
+   *
+   * ```ts
+   * class MyPassportStrategyProvider implements Provider<Strategy | undefined> {
+   *   constructor(
+   *     @inject(AuthenticationBindings.METADATA)
+   *     private metadata: AuthenticationMetadata,
+   *   ) {}
+   *   value(): ValueOrPromise<Strategy | undefined> {
+   *     if (this.metadata) {
+   *       const name = this.metadata.strategy;
+   *       // logic to determine which authentication strategy to return
+   *     }
+   *   }
+   * }
+   * ```
+   */
   export const METADATA = BindingKey.create<AuthenticationMetadata | undefined>(
     'authentication.operationMetadata',
   );
 
+  /**
+   * Key used to inject the user instance retrieved by the
+   * authentication function
+   *
+   * class MyController {
+   *   constructor(
+   *     @inject(AuthenticationBindings.CURRENT_USER) private user: UserProfile,
+   *   ) {}
+   *
+   * // ... routes that may need authentication
+   * }
+   */
   export const CURRENT_USER = BindingKey.create<UserProfile | undefined>(
     'authentication.currentUser',
   );

--- a/packages/boot/src/keys.ts
+++ b/packages/boot/src/keys.ts
@@ -15,9 +15,14 @@ export namespace BootBindings {
    * Binding key for Boot configuration
    */
   export const BOOT_OPTIONS = BindingKey.create<BootOptions>('boot.options');
+  /**
+   * Binding key for determining project root directory
+   */
   export const PROJECT_ROOT = BindingKey.create<string>('boot.project_root');
 
-  // Key for Binding the BootStrapper Class
+  /**
+   * Binding key for binding the BootStrapper class
+   */
   export const BOOTSTRAPPER_KEY = BindingKey.create<Bootstrapper>(
     'application.bootstrapper',
   );

--- a/packages/openapi-v3/src/keys.ts
+++ b/packages/openapi-v3/src/keys.ts
@@ -8,22 +8,41 @@ import {ParameterObject, RequestBodyObject} from '@loopback/openapi-v3-types';
 // License text available at https://opensource.org/licenses/MIT
 
 export namespace OAI3Keys {
+  /**
+   * Binding key used to set or retrieve `@operation` metadata.
+   */
   export const METHODS_KEY = MetadataAccessor.create<
     Partial<RestEndpoint>,
     MethodDecorator
   >('openapi-v3:methods');
+
+  /**
+   * Binding key used to set or retrieve `param` decorator metadata
+   */
   export const PARAMETERS_KEY = MetadataAccessor.create<
     ParameterObject,
     ParameterDecorator
   >('openapi-v3:parameters');
+
+  /**
+   * Binding key used to set or retrieve `@api` metadata
+   */
   export const CLASS_KEY = MetadataAccessor.create<
     ControllerSpec,
     ClassDecorator
   >('openapi-v3:class');
+
+  /**
+   * Binding key used to set or retrieve a controller spec
+   */
   export const CONTROLLER_SPEC_KEY = MetadataAccessor.create<
     ControllerSpec,
     ClassDecorator
   >('openapi-v3:controller-spec');
+
+  /**
+   * Binding key used to set or retrieve `@requestBody` metadata
+   */
   export const REQUEST_BODY_KEY = MetadataAccessor.create<
     RequestBodyObject,
     ParameterDecorator

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -8,15 +8,12 @@ import {
   PropertyDefinition,
   ModelDefinition,
 } from '@loopback/repository';
-import {MetadataInspector, MetadataAccessor} from '@loopback/context';
+import {MetadataInspector} from '@loopback/context';
 import {
   JSONSchema6 as JSONSchema,
   JSONSchema6TypeName as JSONSchemaTypeName,
 } from 'json-schema';
-
-export const JSON_SCHEMA_KEY = MetadataAccessor.create<JSONSchema>(
-  'loopback:json-schema',
-);
+import {JSON_SCHEMA_KEY} from './keys';
 
 /**
  * Gets the JSON Schema of a TypeScript model/class by seeing if one exists

--- a/packages/repository-json-schema/src/index.ts
+++ b/packages/repository-json-schema/src/index.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from './build-schema';
+export * from './keys';
 
 import {JSONSchema6 as JsonSchema} from 'json-schema';
 export {JsonSchema};

--- a/packages/repository-json-schema/src/keys.ts
+++ b/packages/repository-json-schema/src/keys.ts
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository-json-schema
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {MetadataAccessor} from '@loopback/context';
+import {JSONSchema6 as JSONSchema} from 'json-schema';
+
+/**
+ * Binding key used to set or retrieve repository JSON Schema
+ */
+export const JSON_SCHEMA_KEY = MetadataAccessor.create<JSONSchema>(
+  'loopback:json-schema',
+);

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -26,49 +26,108 @@ import {
 // tslint:disable-next-line:no-unused-variable
 import {OpenAPIObject} from '@loopback/openapi-v3-types';
 
+/**
+ * RestServer-specific bindings
+ */
 export namespace RestBindings {
-  // RestServer-specific bindings
+  /**
+   * Binding key for setting and injecting RestComponentConfig
+   */
   export const CONFIG = CoreBindings.APPLICATION_CONFIG.deepProperty('rest');
+  /**
+   * Binding key for setting and injecting the host name of RestServer
+   */
   export const HOST = BindingKey.create<string | undefined>('rest.host');
+  /**
+   * Binding key for setting and injecting the port number of RestServer
+   */
   export const PORT = BindingKey.create<number>('rest.port');
+  /**
+   * Internal binding key for http-handler
+   */
   export const HANDLER = BindingKey.create<HttpHandler>('rest.handler');
 
+  /**
+   * Binding key for setting and injecting an OpenAPI spec
+   */
   export const API_SPEC = BindingKey.create<OpenApiSpec>('rest.apiSpec');
+  /**
+   * Binding key for setting and injecting a Sequence
+   */
   export const SEQUENCE = BindingKey.create<SequenceHandler>('rest.sequence');
 
+  /**
+   * Bindings for potential actions that could be used in a sequence
+   */
   export namespace SequenceActions {
+    /**
+     * Binding key for setting and injecting a route finding function
+     */
     export const FIND_ROUTE = BindingKey.create<FindRoute>(
       'rest.sequence.actions.findRoute',
     );
+    /**
+     * Binding key for setting and injecting a parameter parsing function
+     */
     export const PARSE_PARAMS = BindingKey.create<ParseParams>(
       'rest.sequence.actions.parseParams',
     );
+    /**
+     * Binding key for setting and injecting a controller route invoking function
+     */
     export const INVOKE_METHOD = BindingKey.create<InvokeMethod>(
       'rest.sequence.actions.invokeMethod',
     );
+    /**
+     * Binding key for setting and injecting an error logging function
+     */
     export const LOG_ERROR = BindingKey.create<LogError>(
       'rest.sequence.actions.logError',
     );
+    /**
+     * Binding key for setting and injecting a response writing function
+     */
     export const SEND = BindingKey.create<Send>('rest.sequence.actions.send');
+    /**
+     * Binding key for setting and injecting a bad response writing function
+     */
     export const REJECT = BindingKey.create<Reject>(
       'rest.sequence.actions.reject',
     );
   }
 
+  /**
+   * Binding key for setting and injecting a wrapper function for retrieving
+   * values from a given context
+   */
   export const GET_FROM_CONTEXT = BindingKey.create<GetFromContext>(
     'getFromContext',
   );
+  /**
+   * Binding key for setting and injecting a wrapper function for setting values
+   * on a given context
+   */
   export const BIND_ELEMENT = BindingKey.create<BindElement>('bindElement');
 
-  // request-specific bindings
-
+  /**
+   * Request-specific bindings
+   */
   export namespace Http {
+    /**
+     * Binding key for setting and injecting the http request
+     */
     export const REQUEST = BindingKey.create<ParsedRequest>(
       'rest.http.request',
     );
+    /**
+     * Binding key for setting and injecting the http response
+     */
     export const RESPONSE = BindingKey.create<ServerResponse>(
       'rest.http.response',
     );
+    /**
+     * Binding key for setting and injecting the http request context
+     */
     export const CONTEXT = BindingKey.create<Context>(
       'rest.http.request.context',
     );


### PR DESCRIPTION
- No changes made to `Reserved-binding-keys.md` since apidocs do not render the docs on the keys at all.
- related to #956 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
