### PR TITLE
fix: multiple instances of the same repository class

### DIFF
--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -9,7 +9,9 @@ summary:
 ---
 
 A Repository is a type of _Service_ that represents a collection of data within
-a DataSource.
+a DataSource. A repository class is a lightweight object, its instances can be
+created with low runtime overhead. Typically a new repository instance is
+created for each incoming request.
 
 ## Example Application
 

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -15,7 +15,7 @@ import {
   NamedParameters,
   PositionalParameters,
 } from '../common-types';
-import {Entity} from '../model';
+import {Entity, ModelDefinition} from '../model';
 import {Filter, Where} from '../query';
 import {EntityCrudRepository} from './repository';
 
@@ -88,7 +88,19 @@ export class DefaultCrudRepository<T extends Entity, ID>
       `Entity ${entityClass.name} must have at least one id/pk property.`,
     );
 
-    // Create an internal legacy Model attached to the datasource
+    this.setupPersistedModel(definition);
+  }
+
+  // Create an internal legacy Model attached to the datasource
+  private setupPersistedModel(definition: ModelDefinition) {
+    const dataSource = this.dataSource;
+
+    const model = dataSource.getModel(definition.name);
+    if (model) {
+      // The backing persisted model has been already defined.
+      this.modelClass = model as typeof juggler.PersistedModel;
+      return;
+    }
 
     // We need to convert property definitions from PropertyDefinition
     // to plain data object because of a juggler limitation

--- a/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -67,6 +67,13 @@ describe('DefaultCrudRepository', () => {
     await model.deleteAll();
   });
 
+  it('shares the backing PersistedModel across repo instances', () => {
+    const model1 = new DefaultCrudRepository(Note, ds).modelClass;
+    const model2 = new DefaultCrudRepository(Note, ds).modelClass;
+
+    expect(model1 === model2).to.be.true();
+  });
+
   it('implements Repository.create()', async () => {
     const repo = new DefaultCrudRepository(Note, ds);
     const note = await repo.create({title: 't3', content: 'c3'});


### PR DESCRIPTION
Fix DefaultCrudRepository to re-use legacy juggler Models across all instances of the same Repository class.

Before this change, each call of DefaultCrudRepository constructor was redefining the backing persisted model.

This commit adds a caching mechanism to DefaultCrudRepository: when setting up a backing model, we check datasource's modelBuilder registry to find if the backing model was not already created by an older instance of the repository.

See #1032 and #995.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated