### PR TITLE
feat(context): add more utils to resolve valueOrPromises

### DIFF
--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -13,6 +13,8 @@ export {
   MapObject,
   resolveList,
   resolveMap,
+  resolveUntil,
+  transformValueOrPromise,
   tryWithFinally,
   getDeepProperty,
 } from './value-promise';


### PR DESCRIPTION
This PR is spin-off from https://github.com/strongloop/loopback-next/pull/983. It extracts a few utilities to help handle ValueOrPromise.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
