### PR TITLE
docs: mention VSCode in the CONTRIBUTING guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,6 +33,7 @@ and tools contained in LoopBack repositories.
 
 - [Monorepo overview](./site/MONOREPO.md)
 - [Setting up development environment](./site/DEVELOPING.md#setting-up-development-environment)
+  - [Developing with VisualStudio Code](./site/VSCODE.md)
 - [How to contribute the code](http://loopback.io/doc/en/contrib/code-contrib.html#how-to-contribute-to-the-code)
 - [Building the project](./site/DEVELOPING.md#building-the-project)
 - [Running tests](./site/DEVELOPING.md#running-tests)


### PR DESCRIPTION
I noticed that sometimes newcomers don't realize that our VS Code setup requires few additional plugins. In this pull request, I am adding an explicit mention of VS Code right to our main CONTRIBUTING guide, to give our VSCODE guide more visibility.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
