### PR TITLE
fix: change index.d.ts files to point to dist8

### DIFF
--- a/examples/hello-world/index.d.ts
+++ b/examples/hello-world/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/examples/log-extension/index.d.ts
+++ b/examples/log-extension/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/examples/rpc-server/index.d.ts
+++ b/examples/rpc-server/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/examples/todo/index.d.ts
+++ b/examples/todo/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/authentication/index.d.ts
+++ b/packages/authentication/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/boot/index.d.ts
+++ b/packages/boot/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/context/index.d.ts
+++ b/packages/context/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/metadata/index.d.ts
+++ b/packages/metadata/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/openapi-spec-builder/index.d.ts
+++ b/packages/openapi-spec-builder/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/openapi-v3-types/index.d.ts
+++ b/packages/openapi-v3-types/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/openapi-v3/index.d.ts
+++ b/packages/openapi-v3/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/repository-json-schema/index.d.ts
+++ b/packages/repository-json-schema/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/repository/index.d.ts
+++ b/packages/repository/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/rest/index.d.ts
+++ b/packages/rest/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/service-proxy/index.d.ts
+++ b/packages/service-proxy/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';

--- a/packages/service-proxy/index.js
+++ b/packages/service-proxy/index.js
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-module.exports = require('./dist');
+module.exports = require('@loopback/dist-util').loadDist(__dirname);

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -8,11 +8,14 @@
   "main": "index",
   "scripts": {
     "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",
-    "build": "lb-tsc es2017",
+    "build": "npm run build:dist8 && npm run build:dist10",
     "build:apidocs": "lb-apidocs",
-    "clean": "lb-clean loopback-service-proxy*.tgz dist package api-docs",
+    "build:current": "lb-tsc",
+    "build:dist8": "lb-tsc es2017",
+    "build:dist10": "lb-tsc es2018",
+    "clean": "lb-clean loopback-service-proxy*.tgz dist* package api-docs",
     "integration": "lb-mocha \"DIST/test/integration/**/*.js\"",
-    "pretest": "npm run build",
+    "pretest": "npm run build:current",
     "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\" \"DIST/test/integration/**/*.js\"",
     "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-service-proxy*.tgz && tree package && npm run clean"
@@ -36,7 +39,8 @@
     "README.md",
     "index.js",
     "index.d.ts",
-    "dist/src",
+    "dist*/src",
+    "dist*/index*",
     "src"
   ],
   "repository": {

--- a/packages/testlab/index.d.ts
+++ b/packages/testlab/index.d.ts
@@ -3,4 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './dist';
+export * from './dist8';


### PR DESCRIPTION
Apps generated by the CLI tool won't compile atm because the type files in `@loopback` packages point towards a folder that doesn't exist (`dist`)

This PR changes `dist` to `dist8`


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
