### PR TITLE
chore: add typedocs for `@param` decorator

### DIFF
--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -95,8 +95,28 @@ const builtinTypes = {
   password: {type: 'string', format: 'password'},
 };
 
+// FIXME: Typedoc does not feed `param` as both a function and a namespace.
+// As a workaround, we add the apidocs for `@param` under the namespace.
 /**
- * Shortcut parameter decorators
+ *
+ * Describe an input parameter of a Controller method. The `@param` decorator
+ * takes an argument of `ParameterObject` to define how to map the parameter
+ * to OpenAPI specification.
+ *
+ * `@param(paramSpec)` must be applied to parameters. For example,
+ * ```ts
+ * class MyController {
+ *   @get('/')
+ *   list(
+ *     @param(offsetSpec) offset?: number,
+ *     @param(pageSizeSpec) pageSize?: number,
+ *   ) {}
+ * }
+ * ```
+ *
+ * @param paramSpec Parameter specification.
+ *
+ * Please also see `@param.*` shortcut parameter decorators
  */
 export namespace param {
   export const query = {


### PR DESCRIPTION
Added a workaround for the `@param` apidocs.

<img width="679" alt="screen shot 2018-05-15 at 1 31 27 pm" src="https://user-images.githubusercontent.com/540892/40082101-d6749480-5844-11e8-9983-d4051ae9a250.png">

Connects to #584 

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
