### PR TITLE
fix: replace gulp-rename with our own implementation

### DIFF
--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -7,7 +7,7 @@
 const ProjectGenerator = require('../../lib/project-generator');
 const utils = require('../../lib/utils');
 
-module.exports = class extends ProjectGenerator {
+module.exports = class AppGenerator extends ProjectGenerator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);

--- a/packages/cli/generators/extension/index.js
+++ b/packages/cli/generators/extension/index.js
@@ -9,7 +9,7 @@ const utils = require('../../lib/utils');
 
 const ProjectGenerator = require('../../lib/project-generator');
 
-module.exports = class extends ProjectGenerator {
+module.exports = class ExtensionGenerator extends ProjectGenerator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
-const rename = require('gulp-rename');
 const BaseGenerator = require('./base-generator');
 const utils = require('./utils');
 
@@ -61,6 +60,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     });
 
     this._setupRenameTransformer();
+    super._setupGenerator();
   }
 
   /**
@@ -68,17 +68,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
    * from files that have it during project generation.
    */
   _setupRenameTransformer() {
-    this.registerTransformStream(
-      rename(function(file) {
-        // extname already contains a leading '.'
-        const fileName = `${file.basename}${file.extname}`;
-        const result = fileName.match(/(.+)(.ts|.json|.js|.md)\.ejs$/);
-        if (result) {
-          file.extname = result[2];
-          file.basename = result[1];
-        }
-      }),
-    );
+    this.registerTransformStream(utils.renameEJS());
   }
 
   setOptions() {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,6 @@
     "chalk": "^2.3.2",
     "change-case": "^3.0.2",
     "debug": "^3.1.0",
-    "gulp-rename": "^1.2.2",
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",
     "pacote": "^8.1.1",


### PR DESCRIPTION
We need to do in-place rename so that the file can be managed by mem-fs
for. The gulp-rename@1.2.3 breaks us as the clone of file object causes
mem-fs-editor to rewrite a file that's already committed.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
