### PR TITLE
refactor(rest): mount CORS as a regular middleware

### DIFF
--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -173,6 +173,18 @@ export class RestServer extends Context implements Server, HttpServerLike {
     this._expressApp = express();
     this.requestHandler = this._expressApp;
 
+    // Allow CORS support for all endpoints so that users
+    // can test with online SwaggerUI instance
+    const corsOptions = options.cors || {
+      origin: '*',
+      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      preflightContinue: false,
+      optionsSuccessStatus: 204,
+      maxAge: 86400,
+      credentials: true,
+    };
+    this._expressApp.use(cors(corsOptions));
+
     // Mount our router & request handler
     this._expressApp.use((req, res, next) => {
       this._handleHttpRequest(req, res, options!).catch(next);
@@ -191,24 +203,6 @@ export class RestServer extends Context implements Server, HttpServerLike {
     response: Response,
     options: RestServerConfig,
   ) {
-    // allow CORS support for all endpoints so that users
-    // can test with online SwaggerUI instance
-
-    const corsOptions = options.cors || {
-      origin: '*',
-      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-      preflightContinue: false,
-      optionsSuccessStatus: 204,
-      maxAge: 86400,
-      credentials: true,
-    };
-
-    // TODO(bajtos) Register cors as a middleware in _setupRequestHandler
-    cors(corsOptions)(request, response, () => {});
-    if (request.method === 'OPTIONS') {
-      return Promise.resolve();
-    }
-
     if (
       request.method === 'GET' &&
       request.url &&

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -66,6 +66,25 @@ describe('RestServer (integration)', () => {
       .expect('Access-Control-Max-Age', '86400');
   });
 
+  it('allows custom CORS configuration', async () => {
+    const server = await givenAServer({
+      rest: {
+        port: 0,
+        cors: {
+          optionsSuccessStatus: 200,
+          maxAge: 1,
+        },
+      },
+    });
+
+    server.handler(({response}, sequence) => void response.send('Hello'));
+
+    await createClientForHandler(server.requestHandler)
+      .options('/')
+      .expect(200)
+      .expect('Access-Control-Max-Age', '1');
+  });
+
   it('exposes "GET /openapi.json" endpoint', async () => {
     const server = await givenAServer({rest: {port: 0}});
     const greetSpec = {


### PR DESCRIPTION
Clean up the RestServer implementation by moving CORS out of `_handleHttpRequest()` and mounting it as a regular Express middleware instead.

This is a follow-up for #1326 as part of #1038.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated