### PR TITLE
feat(repository): hasMany model relation

### DIFF
--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -25,7 +25,9 @@
   "devDependencies": {
     "@loopback/build": "^0.6.5",
     "@loopback/testlab": "^0.10.4",
-    "@types/node": "^10.1.1"
+    "@types/lodash": "^4.14.108",
+    "@types/node": "^10.1.1",
+    "lodash": "^4.17.10"
   },
   "dependencies": {
     "@loopback/context": "^0.11.2",

--- a/packages/repository/src/repositories/constraint-utils.ts
+++ b/packages/repository/src/repositories/constraint-utils.ts
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Filter, WhereBuilder, Where, FilterBuilder} from '../query';
+import {AnyObject, DataObject} from '../common-types';
+import {cloneDeep, isArray} from 'lodash';
+import {Entity} from '../model';
+
+/**
+ * A utility function which takes a filter and enforces constraint(s)
+ * on it
+ * @param originalFilter the filter to apply the constrain(s) to
+ * @param constraint the constraint which is to be applied on the filter
+ * @returns Filter the modified filter with the constraint, otherwise
+ * the original filter
+ */
+export function constrainFilter(
+  originalFilter: Filter | undefined,
+  constraint: AnyObject,
+): Filter {
+  const builder = new FilterBuilder(originalFilter);
+  return builder.impose(constraint).build();
+}
+
+/**
+ * A utility function which takes a where filter and enforces constraint(s)
+ * on it
+ * @param originalWhere the where filter to apply the constrain(s) to
+ * @param constraint the constraint which is to be applied on the filter
+ * @returns Filter the modified filter with the constraint, otherwise
+ * the original filter
+ */
+export function constrainWhere(
+  originalWhere: Where | undefined,
+  constraint: AnyObject,
+): Where {
+  const builder = new WhereBuilder(originalWhere);
+  return builder.impose(constraint).build();
+}
+
+export function constrainDataObject<T extends Entity>(
+  originalData: DataObject<T>,
+  constraint: AnyObject,
+): DataObject<T>;
+
+export function constrainDataObject<T extends Entity>(
+  originalData: DataObject<T>[],
+  constraint: AnyObject,
+): DataObject<T>[];
+/**
+ * A utility function which takes a model instance data and enforces constraint(s)
+ * on it
+ * @param originalData the model data to apply the constrain(s) to
+ * @param constraint the constraint which is to be applied on the filter
+ * @returns the modified data with the constraint, otherwise
+ * the original instance data
+ */
+// tslint:disable-next-line:no-any
+export function constrainDataObject(originalData: any, constraint: any): any {
+  const constrainedData = cloneDeep(originalData);
+  if (typeof originalData === 'object') {
+    addConstraintToDataObject(constrainedData, constraint);
+  } else if (isArray(originalData)) {
+    for (const data in originalData) {
+      addConstraintToDataObject(constrainedData[data], constraint[data]);
+    }
+  }
+  return constrainedData;
+
+  function addConstraintToDataObject(
+    modelData: AnyObject,
+    constrainObject: AnyObject,
+  ) {
+    for (const c in constrainObject) {
+      if (c in modelData) {
+        console.warn(
+          'Overwriting %s with %s',
+          modelData[c],
+          constrainObject[c],
+        );
+      }
+      modelData[c] = constrainObject[c];
+    }
+  }
+}

--- a/packages/repository/src/repositories/index.ts
+++ b/packages/repository/src/repositories/index.ts
@@ -6,3 +6,6 @@
 export * from './kv.repository';
 export * from './legacy-juggler-bridge';
 export * from './repository';
+export * from './relation.factory';
+export * from './relation.repository';
+export * from './constraint-utils';

--- a/packages/repository/src/repositories/relation.factory.ts
+++ b/packages/repository/src/repositories/relation.factory.ts
@@ -1,0 +1,55 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {EntityCrudRepository} from './repository';
+import {Class} from '../common-types';
+import {RelationType} from '../decorators/relation.decorator';
+import {Entity} from '../model';
+import {
+  HasManyEntityCrudRepository,
+  DefaultHasManyEntityCrudRepository,
+} from './relation.repository';
+
+export interface RelationDefinitionBase {
+  type: RelationType;
+  modelFrom: Class<Entity> | string;
+  keyTo: string;
+  keyFrom: string;
+}
+
+export interface HasManyDefinition extends RelationDefinitionBase {
+  type: RelationType.hasMany;
+}
+/**
+ * Enforces a constraint on a repository based on a relationship contract
+ * between models. Returns a relational repository that exposes applicable CRUD
+ * method APIs for the related target repository. For example, if a Customer model is
+ * related to an Order model via a HasMany relation, then, the relational
+ * repository returned by this method would be constrained by a Customer model
+ * instance's id(s).
+ *
+ * @param constraint The constraint to apply to the target repository. For
+ * example, {id: '5'}.
+ * @param relationMetadata The relation metadata used to used to describe the
+ * relationship and determine how to apply the constraint.
+ * @param targetRepository The repository which represents the target model of a
+ * relation attached to a datasource.
+ *
+ */
+export function hasManyRepositoryFactory<SourceID, T extends Entity, ID>(
+  sourceModelId: SourceID,
+  relationMetadata: HasManyDefinition,
+  targetRepository: EntityCrudRepository<T, ID>,
+): HasManyEntityCrudRepository<T, ID> {
+  switch (relationMetadata.type) {
+    case RelationType.hasMany:
+      const fkConstraint = {[relationMetadata.keyTo]: sourceModelId};
+
+      return new DefaultHasManyEntityCrudRepository(
+        targetRepository,
+        fkConstraint,
+      );
+  }
+}

--- a/packages/repository/src/repositories/relation.repository.ts
+++ b/packages/repository/src/repositories/relation.repository.ts
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {EntityCrudRepository} from './repository';
+import {constrainDataObject, constrainFilter} from './constraint-utils';
+import {AnyObject, Options} from '../common-types';
+import {Entity} from '../model';
+import {Filter} from '../query';
+
+/**
+ * CRUD operations for a target repository of a HasMany relation
+ */
+export interface HasManyEntityCrudRepository<T extends Entity, ID> {
+  /**
+   * Create a target model instance
+   * @param targetModelData The target model data
+   * @param options Options for the operation
+   * @returns A promise which resolves to the newly created target model instance
+   */
+  create(targetModelData: Partial<T>, options?: Options): Promise<T>;
+  /**
+   * Find target model instance(s)
+   * @param Filter A filter object for where, order, limit, etc.
+   * @param options Options for the operation
+   * @returns A promise which resolves with the found target instance(s)
+   */
+  find(filter?: Filter | undefined, options?: Options): Promise<T[]>;
+}
+
+export class DefaultHasManyEntityCrudRepository<
+  T extends Entity,
+  TargetRepository extends EntityCrudRepository<T, typeof Entity.prototype.id>,
+  ID
+> implements HasManyEntityCrudRepository<T, ID> {
+  /**
+   * Constructor of DefaultHasManyEntityCrudRepository
+   * @param sourceInstance the source model instance
+   * @param targetRepository the related target model repository instance
+   * @param foreignKeyName the foreign key name to constrain the target repository
+   * instance
+   */
+  constructor(
+    public targetRepository: TargetRepository,
+    public constraint: AnyObject,
+  ) {}
+
+  async create(targetModelData: Partial<T>, options?: Options): Promise<T> {
+    return await this.targetRepository.create(
+      constrainDataObject(targetModelData, this.constraint) as Partial<T>,
+      options,
+    );
+  }
+
+  async find(filter?: Filter | undefined, options?: Options): Promise<T[]> {
+    return await this.targetRepository.find(
+      constrainFilter(filter, this.constraint),
+      options,
+    );
+  }
+}

--- a/packages/repository/test/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many.relation.acceptance.ts
@@ -1,0 +1,126 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  model,
+  property,
+  Entity,
+  DefaultCrudRepository,
+  juggler,
+  EntityCrudRepository,
+  hasManyRepositoryFactory,
+  HasManyDefinition,
+  RelationType,
+} from '../..';
+import {expect} from '@loopback/testlab';
+
+describe('HasMany relation', () => {
+  // Given a Customer and Order models - see definitions at the bottom
+
+  beforeEach(givenCrudRepositoriesForCustomerAndOrder);
+
+  let existingCustomerId: number;
+  //FIXME: this should be inferred from relational decorators
+  let customerHasManyOrdersRelationMeta: HasManyDefinition;
+
+  beforeEach(async () => {
+    existingCustomerId = (await givenPersistedCustomerInstance()).id;
+    customerHasManyOrdersRelationMeta = givenHasManyRelationMetadata();
+  });
+
+  it('can create an instance of the related model', async () => {
+    // A controller method - CustomerOrdersController.create()
+    // customerRepo and orderRepo would be injected via constructor arguments
+    async function create(customerId: number, orderData: Partial<Order>) {
+      // Ideally, we would like to write
+      // customerRepo.orders.create(customerId, orderData);
+      // or customerRepo.orders({id: customerId}).*
+      // The initial "involved" implementation is below
+
+      //FIXME: should be automagically instantiated via DI or other means
+      const customerOrders = hasManyRepositoryFactory(
+        customerId,
+        customerHasManyOrdersRelationMeta,
+        orderRepo,
+      );
+      return await customerOrders.create(orderData);
+    }
+
+    const description = 'an order desc';
+    const order = await create(existingCustomerId, {description});
+
+    expect(order.toObject()).to.containDeep({
+      customerId: existingCustomerId,
+      description,
+    });
+    const persisted = await orderRepo.findById(order.id);
+    expect(persisted.toObject()).to.deepEqual(order.toObject());
+  });
+
+  // This should be enforced by the database to avoid race conditions
+  it('reject create request when the customer does not exist');
+
+  //--- HELPERS ---//
+
+  @model()
+  class Customer extends Entity {
+    @property({
+      type: 'number',
+      id: true,
+    })
+    id: number;
+
+    @property({
+      type: 'string',
+    })
+    name: string;
+  }
+
+  @model()
+  class Order extends Entity {
+    @property({
+      type: 'number',
+      id: true,
+    })
+    id: number;
+
+    @property({
+      type: 'string',
+      required: true,
+    })
+    description: string;
+
+    @property({
+      type: 'number',
+      required: true,
+    })
+    customerId: number;
+  }
+
+  let customerRepo: EntityCrudRepository<
+    Customer,
+    typeof Customer.prototype.id
+  >;
+  let orderRepo: EntityCrudRepository<Order, typeof Order.prototype.id>;
+  function givenCrudRepositoriesForCustomerAndOrder() {
+    const db = new juggler.DataSource({connector: 'memory'});
+
+    customerRepo = new DefaultCrudRepository(Customer, db);
+    orderRepo = new DefaultCrudRepository(Order, db);
+  }
+
+  async function givenPersistedCustomerInstance() {
+    return customerRepo.create({name: 'a customer'});
+  }
+
+  function givenHasManyRelationMetadata(): HasManyDefinition {
+    return {
+      modelFrom: Customer,
+      keyFrom: 'id',
+      keyTo: 'customerId',
+      type: RelationType.hasMany,
+    };
+  }
+});


### PR DESCRIPTION
This PR aims to incrementally implement the `hasMany` model relations in LoopBack 4 from discussions and code in #1194. It has the following components:

- `constrainedRepositoryFactory` to create relational repository instances based on specified constraint and relation metadata
- `HasManyEntityCrudRepository` interface which specifies the shape of the public APIs exposed by the `HasMany` relation
- `DefaultHasManyEntityCrudRepository` class which implements those APIs by calling utility functions on a target repository instance to constrain its CRUD methods.
- `constrain*` utility functions which apply constraints on a data object, filter, or where object.

**TODOs**: 
- [ ] There is manual spoon feeding of the relation metadata and constraint. This should be automatically generated/inferred as the PR progresses or in a follow-up PR.
- [ ] Add missing unit tests for some/all of the components in this PR or a follow-up PR.

Connect to #995 and #1372.


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
