### PR TITLE
Add GeoCoder Service to examples/todo

### DIFF
--- a/docs/site/Calling-other-APIs-and-Web-Services.md
+++ b/docs/site/Calling-other-APIs-and-Web-Services.md
@@ -56,6 +56,12 @@ const ds: juggler.DataSource = new juggler.DataSource({
 });
 ```
 
+Install the REST connector used by the new datasource:
+
+```
+$ npm install --save loopback-connector-rest
+```
+
 ### Bind data sources to the context
 
 ```ts

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -7,7 +7,6 @@
     "node": ">=8"
   },
   "scripts": {
-    "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",
     "build": "npm run build:dist8 && npm run build:dist10",
     "build:apidocs": "lb-apidocs",
     "build:current": "lb-tsc",
@@ -23,9 +22,8 @@
     "tslint": "lb-tslint",
     "tslint:fix": "npm run tslint -- --fix",
     "pretest": "npm run build:current",
-    "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
+    "test": "lb-mocha \"DIST/test/*/**/*.js\"",
     "test:dev": "lb-mocha --allow-console-logs DIST/test/**/*.js && npm run posttest",
-    "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-todo*.tgz && tree package && npm run clean",
     "prestart": "npm run build:current",
     "start": "node ."
@@ -46,12 +44,17 @@
     "@loopback/openapi-v3": "^0.10.9",
     "@loopback/openapi-v3-types": "^0.7.7",
     "@loopback/repository": "^0.11.3",
-    "@loopback/rest": "^0.11.3"
+    "@loopback/rest": "^0.11.3",
+    "@loopback/service-proxy": "^0.5.5",
+    "loopback-connector-rest": "^3.1.1"
   },
   "devDependencies": {
     "@loopback/build": "^0.6.8",
+    "@loopback/http-caching-proxy": "^0.2.3",
     "@loopback/testlab": "^0.10.7",
-    "@types/node": "^10.1.1"
+    "@types/lodash": "^4.14.109",
+    "@types/node": "^10.1.1",
+    "lodash": "^4.17.10"
   },
   "keywords": [
     "loopback",

--- a/examples/todo/src/application.ts
+++ b/examples/todo/src/application.ts
@@ -3,9 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ApplicationConfig} from '@loopback/core';
+import {ApplicationConfig, Provider, Constructor} from '@loopback/core';
 import {RestApplication} from '@loopback/rest';
 import {MySequence} from './sequence';
+import {GeocoderServiceProvider} from './services';
 
 /* tslint:disable:no-unused-variable */
 // Binding and Booter imports are required to infer types for BootMixin!
@@ -39,5 +40,19 @@ export class TodoListApplication extends BootMixin(
         nested: true,
       },
     };
+
+    // TODO(bajtos) Services should be created and registered by @loopback/boot
+    this.setupServices();
+  }
+
+  setupServices() {
+    this.service(GeocoderServiceProvider);
+  }
+
+  // TODO(bajtos) app.service should be provided either by core Application
+  // class or a mixin provided by @loopback/service-proxy
+  service<T>(provider: Constructor<Provider<T>>) {
+    const key = `services.${provider.name.replace(/Provider$/, '')}`;
+    this.bind(key).toProvider(provider);
   }
 }

--- a/examples/todo/src/datasources/geocoder.datasource.json
+++ b/examples/todo/src/datasources/geocoder.datasource.json
@@ -1,0 +1,27 @@
+{
+  "connector": "rest",
+  "options": {
+    "headers": {
+      "accept": "application/json",
+      "content-type": "application/json"
+    }
+  },
+  "operations": [
+    {
+      "template": {
+        "method": "GET",
+        "url": "https://geocoding.geo.census.gov/geocoder/locations/onelineaddress",
+        "query": {
+          "format": "{format=json}",
+          "benchmark": "Public_AR_Current",
+          "address": "{address}"
+        },
+        "responsePath": "$.result.addressMatches[*].coordinates"
+      },
+      "functions": {
+        "geocode": ["address"]
+      }
+    }
+  ]
+}
+

--- a/examples/todo/src/datasources/geocoder.datasource.ts
+++ b/examples/todo/src/datasources/geocoder.datasource.ts
@@ -1,0 +1,26 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {inject} from '@loopback/core';
+import {juggler, DataSource} from '@loopback/repository';
+const config = require('./geocoder.datasource.json');
+
+export class GeocoderDataSource extends juggler.DataSource {
+  static dataSourceName = 'geocoder';
+
+  constructor(
+    @inject('datasources.config.geocoder', {optional: true})
+    dsConfig: DataSource = config,
+  ) {
+    dsConfig = Object.assign({}, dsConfig, {
+      // A workaround for the current design flaw where inside our monorepo,
+      //   packages/service-proxy/node_modules/loopback-datasource-juggler
+      // cannot see/load the connector from
+      //   examples/todo/node_modules/loopback-connector-rest
+      connector: require('loopback-connector-rest'),
+    });
+    super(dsConfig);
+  }
+}

--- a/examples/todo/src/models/todo.model.ts
+++ b/examples/todo/src/models/todo.model.ts
@@ -29,7 +29,22 @@ export class Todo extends Entity {
   })
   isComplete: boolean;
 
+  @property({
+    type: 'string',
+  })
+  remindAtAddress: string; // address,city,zipcode
+
+  // TODO(bajtos) Use LoopBack's GeoPoint type here
+  @property({
+    type: 'string',
+  })
+  remindAtGeo: string; // latitude,longitude
+
   getId() {
     return this.id;
+  }
+
+  constructor(data?: Partial<Todo>) {
+    super(data);
   }
 }

--- a/examples/todo/src/services/geocoder.service.ts
+++ b/examples/todo/src/services/geocoder.service.ts
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {getService, juggler} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {GeocoderDataSource} from '../datasources/geocoder.datasource';
+
+export interface GeoPoint {
+  /**
+   * latitude
+   */
+  y: number;
+
+  /**
+   * longitude
+   */
+  x: number;
+}
+
+export interface GeocoderService {
+  geocode(address: string): Promise<GeoPoint[]>;
+}
+
+export class GeocoderServiceProvider implements Provider<GeocoderService> {
+  constructor(
+    @inject('datasources.geocoder')
+    protected datasource: juggler.DataSource = new GeocoderDataSource(),
+  ) {}
+
+  value(): GeocoderService {
+    return getService(this.datasource);
+  }
+}

--- a/examples/todo/src/services/index.ts
+++ b/examples/todo/src/services/index.ts
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './geocoder.service';

--- a/examples/todo/test/integration/services/geocoder.service.integration.ts
+++ b/examples/todo/test/integration/services/geocoder.service.integration.ts
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {GeocoderService, GeocoderServiceProvider} from '../../../src/services';
+import {
+  HttpCachingProxy,
+  givenCachingProxy,
+  getProxiedGeoCoderConfig,
+} from '../../helpers';
+import {GeocoderDataSource} from '../../../src/datasources/geocoder.datasource';
+
+describe('GeoLookupService', function() {
+  // tslint:disable-next-line:no-invalid-this
+  this.timeout(30 * 1000);
+
+  let cachingProxy: HttpCachingProxy;
+  before(async () => (cachingProxy = await givenCachingProxy()));
+  after(() => cachingProxy.stop());
+
+  let service: GeocoderService;
+  before(givenGeoService);
+
+  it('resolves an address to a geo point', async () => {
+    const points = await service.geocode('1 New Orchard Road, Armonk, 10504');
+
+    expect(points).to.deepEqual([
+      {
+        y: 41.109653,
+        x: -73.72467,
+      },
+    ]);
+  });
+
+  function givenGeoService() {
+    const config = getProxiedGeoCoderConfig(cachingProxy);
+    const dataSource = new GeocoderDataSource(config);
+    service = new GeocoderServiceProvider(dataSource).value();
+  }
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,12 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// package dependencies
 export {Component, ProviderMap} from './component';
-
-// loopback dependencies
-export {inject, Context} from '@loopback/context';
-export {Server} from './server';
+export * from './server';
 export * from './application';
 export * from './component';
 export * from './keys';
+
+// Re-export public Core API coming from dependencies
+export * from '@loopback/context';

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -20,6 +20,7 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
+    "@loopback/dist-util": "^0.3.2",
     "cacache": "^11.0.2",
     "debug": "^3.1.0",
     "p-event": "^1.3.0",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@loopback/context": "^0.11.6",
     "@loopback/core": "^0.8.8",
+    "@loopback/dist-util": "^0.3.2",
     "loopback-datasource-juggler": "^3.20.2"
   },
   "files": [


### PR DESCRIPTION
This pull request improves our Todo example to demonstrate how to use Services in practice. To do so, we leverage [US Census Geocoder](https://geocoding.geo.census.gov/geocoder/) ([API docs](https://geocoding.geo.census.gov/geocoder/Geocoding_Services_API.html))  to add location-based reminders to our Todo items. 

Based on the outcome of this work, I'll update our Services docs with best practices on testing, see
https://github.com/strongloop/loopback-next/issues/1311, and also update [Todo tutorial](http://loopback.io/doc/en/lb4/todo-tutorial.html) to match the new Todo example implementation. These documentation updates are out of scope of this pull request though!

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated