### PR TITLE
revert on Travis: pin Node.js 10.x version to 10.0.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - "8"
-  - "10.0.0" # Pinned to prevent warning "fs.promises API is experimental"
-             # Waiting for https://github.com/nodejs/node/pull/20632
+  - "10"
 
 os:
   - linux

--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -23,7 +23,9 @@ describe('app-generator (SLOW)', function() {
     outdir: sandbox,
   };
 
-  before(async () => {
+  before('scaffold a new application', async function createAppProject() {
+    // Increase the timeout to 1 minute to accomodate slow CI build machines
+    this.timeout(60 * 1000);
     await helpers
       .run(generator)
       .inDir(sandbox)
@@ -32,21 +34,25 @@ describe('app-generator (SLOW)', function() {
       .withPrompts(props);
   });
 
-  // Run `lerna bootstrap --scope @loopback/sandbox-app`
-  // WARNING: It takes a while to run `lerna bootstrap`
-  this.timeout(0);
-  before(async () => {
+  before('install dependencies', async function installDependencies() {
+    // Run `lerna bootstrap --scope @loopback/sandbox-app`
+    // WARNING: It takes a while to run `lerna bootstrap`
+    this.timeout(15 * 60 * 1000);
     process.chdir(rootDir);
     await lernaBootstrap(appName);
   });
 
-  it('passes `npm test` for the generated project', () => {
-    process.chdir(sandbox);
+  it('passes `npm test` for the generated project', function() {
+    // Increase the timeout to 5 minutes,
+    // the tests can take more than 2 seconds to run.
+    this.timeout(5 * 60 * 1000);
+
     return new Promise((resolve, reject) => {
       build
         .runShell('npm', ['test'], {
           // Disable stdout
           stdio: [process.stdin, 'ignore', process.stderr],
+          cwd: sandbox,
         })
         .on('close', code => {
           assert.equal(code, 0);

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -15,6 +15,10 @@ const expect = require('@loopback/testlab').expect;
 
 module.exports = function(projGenerator, props, projectType) {
   return function() {
+    // Increase the timeout to 60 seconds to accomodate
+    // for possibly slow CI build machines
+    this.timeout(60 * 1000);
+
     describe('help', () => {
       it('prints lb4', () => {
         const env = yeoman.createEnv();


### PR DESCRIPTION
This partially reverts commit a36e2574e0296aedc531bd283e0702e149c40002,
as it is no longer needed on Travis CI - the new Node.js version 10.2.0 has
fixed the problem we were experiencing on Node.js 10.1.0.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
