### PR TITLE
chore: ignore all files in sandbox when linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,9 @@
 /coverage
 packages/*/api-docs
 packages/cli/generators/*/templates
-packages/cli/test/integration/.sandbox
+**/.sandbox
 packages/*/dist*
 examples/*/dist*
-sandbox/**/dist*
+sandbox/**/*
 *.json
 *.md


### PR DESCRIPTION
As I was working and ran `npm run prettier:fix`, it started formatting `sandbox/loopback.io`. I don't think we should be formatting stuff in sandbox folder as it's not checked into git. 


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
