### PR TITLE
docs: update GDPR consideration page title

### DIFF
--- a/docs/site/Deploy-for-GDPR-readiness.md
+++ b/docs/site/Deploy-for-GDPR-readiness.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploy for GDPR Readiness"
+title: "LoopBack considerations for GDPR readiness"
 layout: page
 keywords: LoopBack, GDPR
 tags: gdpr
@@ -8,10 +8,6 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Deploy-for-GDPR-readiness.html
 summary: LoopBack considerations for GDPR readiness.
 ---
-
-# LoopBack considerations for GDPR readiness
-
-___________________________________________________________________________________________________
 
 ## Notice:
 

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -215,6 +215,6 @@ children:
     url: Glossary.html
     output: 'web, pdf'
 
-  - title: 'Deploy for GDPR Readiness'
+  - title: 'Considerations for GDPR readiness'
     url: Deploy-for-GDPR-readiness.html
     output: 'web, pdf'


### PR DESCRIPTION
Similar to https://github.com/strongloop/loopback.io/pull/699 but with LB4.
- Change the page title to LoopBack considerations for GDPR readiness
- remove the redundant title for the page