### PR TITLE
fix: make the code compatible with TypeScript 2.9.x

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,12 +21,12 @@
     "glob": "^7.1.2",
     "mocha": "^5.1.1",
     "nyc": "^11.7.1",
-    "prettier": "^1.12.1",
+    "prettier": "^1.13.3",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.5",
     "strong-docs": "^3.0.1",
     "tslint": "^5.9.1",
-    "typescript": "^2.8.1"
+    "typescript": "^2.9.1"
   },
   "bin": {
     "lb-tsc": "./bin/compile-package.js",

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -58,7 +58,7 @@ export interface InjectionMetadata {
  */
 export interface Injection<ValueType = BoundValue> {
   target: Object;
-  member?: string | symbol;
+  member?: string;
   methodDescriptorOrParameterIndex?:
     | TypedPropertyDescriptor<ValueType>
     | number;
@@ -102,7 +102,7 @@ export function inject(
   metadata = Object.assign({decorator: '@inject'}, metadata);
   return function markParameterOrPropertyAsInjected(
     target: Object,
-    member: string | symbol,
+    member: string,
     methodDescriptorOrParameterIndex?:
       | TypedPropertyDescriptor<BoundValue>
       | number,
@@ -296,7 +296,7 @@ function resolveAsSetter(ctx: Context, injection: Injection) {
  */
 export function describeInjectedArguments(
   target: Object,
-  method?: string | symbol,
+  method?: string,
 ): Readonly<Injection>[] {
   method = method || '';
   const meta = MetadataInspector.getAllParameterMetadata<Readonly<Injection>>(

--- a/packages/metadata/README.md
+++ b/packages/metadata/README.md
@@ -295,7 +295,7 @@ method parameters. Please note `M` is a map for methods/properties/parameters.
 protected mergeWithInherited(
   inheritedMetadata: M,
   target: Object,
-  member?: string | symbol,
+  member?: string,
   descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
 ): M {
   // ...
@@ -304,7 +304,7 @@ protected mergeWithInherited(
 protected mergeWithOwn(
   ownMetadata: M,
   target: Object,
-  member?: string | symbol,
+  member?: string,
   descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
 ): M {
   // ...

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -124,7 +124,7 @@ export class DecoratorFactory<
    */
   static getTargetName(
     target: Object,
-    member?: string | symbol,
+    member?: string,
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     let name =
@@ -151,7 +151,7 @@ export class DecoratorFactory<
    * @param target Class or the prototype
    * @param member Method name
    */
-  static getNumberOfParameters(target: Object, member?: string | symbol) {
+  static getNumberOfParameters(target: Object, member?: string) {
     if (target instanceof Function && !member) {
       // constructor
       return target.length;
@@ -210,7 +210,7 @@ export class DecoratorFactory<
   protected mergeWithInherited(
     inheritedMetadata: M,
     target: Object,
-    member?: string | symbol,
+    member?: string,
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ): M {
     throw new Error('mergeWithInherited() is not implemented');
@@ -232,7 +232,7 @@ export class DecoratorFactory<
   protected mergeWithOwn(
     ownMetadata: M,
     target: Object,
-    member?: string | symbol,
+    member?: string,
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ): M {
     throw new Error('mergeWithOwn() is not implemented');
@@ -254,7 +254,7 @@ export class DecoratorFactory<
    */
   protected decorate(
     target: Object,
-    member?: string | symbol,
+    member?: string,
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     const targetName = DecoratorFactory.getTargetName(
@@ -349,7 +349,7 @@ export class ClassDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithInherited(
     inheritedMetadata: T,
     target: Object,
-    member?: string | symbol,
+    member?: string,
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     return this.withTarget(<T>this.inherit(inheritedMetadata), target);
@@ -358,7 +358,7 @@ export class ClassDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithOwn(
     ownMetadata: T,
     target: Object,
-    member?: string | symbol,
+    member?: string,
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     if (ownMetadata != null) {
@@ -400,7 +400,7 @@ export class PropertyDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithInherited(
     inheritedMetadata: MetadataMap<T>,
     target: Object,
-    propertyName?: string | symbol,
+    propertyName?: string,
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     inheritedMetadata = inheritedMetadata || {};
@@ -415,7 +415,7 @@ export class PropertyDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithOwn(
     ownMetadata: MetadataMap<T>,
     target: Object,
-    propertyName?: string | symbol,
+    propertyName?: string,
     descriptorOrParameterIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     ownMetadata = ownMetadata || {};
@@ -430,7 +430,7 @@ export class PropertyDecoratorFactory<T> extends DecoratorFactory<
   }
 
   create(): PropertyDecorator {
-    return (target: Object, propertyName: string | symbol) =>
+    return (target: Object, propertyName: string) =>
       this.decorate(target, propertyName);
   }
 
@@ -464,7 +464,7 @@ export class MethodDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithInherited(
     inheritedMetadata: MetadataMap<T>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     methodDescriptor?: TypedPropertyDescriptor<any> | number,
   ) {
     inheritedMetadata = inheritedMetadata || {};
@@ -479,7 +479,7 @@ export class MethodDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithOwn(
     ownMetadata: MetadataMap<T>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     methodDescriptor?: TypedPropertyDescriptor<any> | number,
   ) {
     ownMetadata = ownMetadata || {};
@@ -498,7 +498,7 @@ export class MethodDecoratorFactory<T> extends DecoratorFactory<
   create(): MethodDecorator {
     return (
       target: Object,
-      methodName: string | symbol,
+      methodName: string,
       descriptor: TypedPropertyDescriptor<any>,
     ) => this.decorate(target, methodName, descriptor);
   }
@@ -533,7 +533,7 @@ export class ParameterDecoratorFactory<T> extends DecoratorFactory<
   private getOrInitMetadata(
     meta: MetadataMap<T[]>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
   ) {
     const method = methodName ? methodName : '';
     let methodMeta = meta[method];
@@ -550,7 +550,7 @@ export class ParameterDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithInherited(
     inheritedMetadata: MetadataMap<T[]>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     parameterIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     inheritedMetadata = inheritedMetadata || {};
@@ -570,7 +570,7 @@ export class ParameterDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithOwn(
     ownMetadata: MetadataMap<T[]>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     parameterIndex?: TypedPropertyDescriptor<any> | number,
   ) {
     ownMetadata = ownMetadata || {};
@@ -592,11 +592,8 @@ export class ParameterDecoratorFactory<T> extends DecoratorFactory<
   }
 
   create(): ParameterDecorator {
-    return (
-      target: Object,
-      methodName: string | symbol,
-      parameterIndex: number,
-    ) => this.decorate(target, methodName, parameterIndex);
+    return (target: Object, methodName: string, parameterIndex: number) =>
+      this.decorate(target, methodName, parameterIndex);
   }
 
   /**
@@ -642,7 +639,7 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
    */
   private getParameterIndex(
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     methodDescriptor?: TypedPropertyDescriptor<any> | number,
   ) {
     const numOfParams = DecoratorFactory.getNumberOfParameters(
@@ -674,7 +671,7 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithInherited(
     inheritedMetadata: MetadataMap<T[]>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     methodDescriptor?: TypedPropertyDescriptor<any> | number,
   ) {
     inheritedMetadata = inheritedMetadata || {};
@@ -703,7 +700,7 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
   protected mergeWithOwn(
     ownMetadata: MetadataMap<T[]>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     methodDescriptor?: TypedPropertyDescriptor<any> | number,
   ) {
     ownMetadata = ownMetadata || {};
@@ -726,7 +723,7 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
   create(): MethodDecorator {
     return (
       target: Object,
-      methodName: string | symbol,
+      methodName: string,
       descriptor: TypedPropertyDescriptor<any>,
     ) => this.decorate(target, methodName, descriptor);
   }

--- a/packages/metadata/src/inspector.ts
+++ b/packages/metadata/src/inspector.ts
@@ -74,7 +74,7 @@ export class MetadataInspector {
     key: MetadataKey<T, DecoratorType>,
     value: T,
     target: Object,
-    member?: string | symbol,
+    member?: string,
   ) {
     Reflector.defineMetadata(key.toString(), value, target, member);
   }
@@ -108,7 +108,7 @@ export class MetadataInspector {
   static getMethodMetadata<T>(
     key: MetadataKey<T, MethodDecorator>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     options?: InspectionOptions,
   ): T | undefined {
     methodName = methodName || '';
@@ -148,7 +148,7 @@ export class MetadataInspector {
   static getPropertyMetadata<T>(
     key: MetadataKey<T, PropertyDecorator>,
     target: Object,
-    propertyName: string | symbol,
+    propertyName: string,
     options?: InspectionOptions,
   ): T | undefined {
     const meta: MetadataMap<T> =
@@ -170,7 +170,7 @@ export class MetadataInspector {
   static getAllParameterMetadata<T>(
     key: MetadataKey<T, ParameterDecorator>,
     target: Object,
-    methodName?: string | symbol,
+    methodName?: string,
     options?: InspectionOptions,
   ): T[] | undefined {
     methodName = methodName || '';
@@ -194,7 +194,7 @@ export class MetadataInspector {
   static getParameterMetadata<T>(
     key: MetadataKey<T, ParameterDecorator>,
     target: Object,
-    methodName: string | symbol,
+    methodName: string,
     index: number,
     options?: InspectionOptions,
   ): T | undefined {
@@ -214,7 +214,7 @@ export class MetadataInspector {
    */
   static getDesignTypeForProperty(
     target: Object,
-    propertyName: string | symbol,
+    propertyName: string,
   ): Function {
     return TSReflector.getMetadata('design:type', target, propertyName);
   }
@@ -226,7 +226,7 @@ export class MetadataInspector {
    */
   static getDesignTypeForMethod(
     target: Object,
-    methodName: string | symbol,
+    methodName: string,
   ): DesignTimeMethodMetadata {
     const type = TSReflector.getMetadata('design:type', target, methodName);
     const parameterTypes = TSReflector.getMetadata(

--- a/packages/metadata/src/reflect.ts
+++ b/packages/metadata/src/reflect.ts
@@ -28,7 +28,7 @@ export class NamespacedReflect {
     metadataKey: string,
     metadataValue: any,
     target: Object,
-    propertyKey?: string | symbol,
+    propertyKey?: string,
   ) {
     metadataKey = this.getMetadataKey(metadataKey);
     if (propertyKey) {
@@ -41,11 +41,7 @@ export class NamespacedReflect {
   /**
    * lookup metadata from a target object and its prototype chain
    */
-  getMetadata(
-    metadataKey: string,
-    target: Object,
-    propertyKey?: string | symbol,
-  ): any {
+  getMetadata(metadataKey: string, target: Object, propertyKey?: string): any {
     metadataKey = this.getMetadataKey(metadataKey);
     if (propertyKey) {
       return Reflect.getMetadata(metadataKey, target, propertyKey);
@@ -59,7 +55,7 @@ export class NamespacedReflect {
   getOwnMetadata(
     metadataKey: string,
     target: Object,
-    propertyKey?: string | symbol,
+    propertyKey?: string,
   ): any {
     metadataKey = this.getMetadataKey(metadataKey);
     if (propertyKey) {
@@ -77,7 +73,7 @@ export class NamespacedReflect {
   hasMetadata(
     metadataKey: string,
     target: Object,
-    propertyKey?: string | symbol,
+    propertyKey?: string,
   ): boolean {
     metadataKey = this.getMetadataKey(metadataKey);
     if (propertyKey) {
@@ -89,7 +85,7 @@ export class NamespacedReflect {
   hasOwnMetadata(
     metadataKey: string,
     target: Object,
-    propertyKey?: string | symbol,
+    propertyKey?: string,
   ): boolean {
     metadataKey = this.getMetadataKey(metadataKey);
     if (propertyKey) {
@@ -101,7 +97,7 @@ export class NamespacedReflect {
   deleteMetadata(
     metadataKey: string,
     target: Object,
-    propertyKey?: string | symbol,
+    propertyKey?: string,
   ): boolean {
     metadataKey = this.getMetadataKey(metadataKey);
     if (propertyKey) {
@@ -110,7 +106,7 @@ export class NamespacedReflect {
     return Reflect.deleteMetadata(metadataKey, target);
   }
 
-  getMetadataKeys(target: Object, propertyKey?: string | symbol): string[] {
+  getMetadataKeys(target: Object, propertyKey?: string): string[] {
     let keys: string[];
     if (propertyKey) {
       keys = Reflect.getMetadataKeys(target, propertyKey);
@@ -131,7 +127,7 @@ export class NamespacedReflect {
     return metaKeys;
   }
 
-  getOwnMetadataKeys(target: Object, propertyKey?: string | symbol): string[] {
+  getOwnMetadataKeys(target: Object, propertyKey?: string): string[] {
     let keys: string[];
     if (propertyKey) {
       keys = Reflect.getOwnMetadataKeys(target, propertyKey);
@@ -155,7 +151,7 @@ export class NamespacedReflect {
   decorate(
     decorators: (PropertyDecorator | MethodDecorator)[] | ClassDecorator[],
     target: Object,
-    targetKey?: string | symbol,
+    targetKey?: string,
     descriptor?: PropertyDescriptor,
   ): PropertyDescriptor | Function {
     if (targetKey) {
@@ -171,7 +167,7 @@ export class NamespacedReflect {
     metadataValue: any,
   ): {
     (target: Function): void;
-    (target: Object, targetKey: string | symbol): void;
+    (target: Object, targetKey: string): void;
   } {
     metadataKey = this.getMetadataKey(metadataKey);
     return Reflect.metadata(metadataKey, metadataValue);

--- a/packages/metadata/test/unit/reflect.unit.ts
+++ b/packages/metadata/test/unit/reflect.unit.ts
@@ -470,7 +470,7 @@ describe('Reflect Context', () => {
       expect(result).to.be.true();
     });
 
-    function deleteMetadata(target: Object, propertyKey?: string | symbol) {
+    function deleteMetadata(target: Object, propertyKey?: string) {
       if (propertyKey) {
         const keys = reflectContext.getOwnMetadataKeys(target, propertyKey);
         for (const k of keys) {

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -31,7 +31,7 @@ import {OAI3Keys} from '../keys';
  * @param paramSpec Parameter specification.
  */
 export function param(paramSpec: ParameterObject) {
-  return function(target: Object, member: string | symbol, index: number) {
+  return function(target: Object, member: string, index: number) {
     paramSpec = paramSpec || {};
     // Get the design time method parameter metadata
     const methodSig = MetadataInspector.getDesignTypeForMethod(target, member);

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -78,7 +78,7 @@ export const REQUEST_BODY_INDEX = 'x-parameter-index';
  * ```
  */
 export function requestBody(requestBodySpec?: Partial<RequestBodyObject>) {
-  return function(target: Object, member: string | symbol, index: number) {
+  return function(target: Object, member: string, index: number) {
     // Use 'application/json' as default content if `requestBody` is undefined
     requestBodySpec = requestBodySpec || {content: {}};
 

--- a/packages/repository/src/decorators/repository.decorator.ts
+++ b/packages/repository/src/decorators/repository.decorator.ts
@@ -16,7 +16,7 @@ import {Class} from '../common-types';
  */
 export type RepositoryDecorator = (
   target: Object,
-  key?: string | symbol,
+  key?: string,
   // tslint:disable-next-line:no-any
   descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
 ) => void;
@@ -144,7 +144,7 @@ export function repository(
   const meta = new RepositoryMetadata(stringOrModel, dataSource);
   return function(
     target: Object,
-    key?: symbol | string,
+    key?: string,
     // tslint:disable-next-line:no-any
     descriptorOrIndex?: TypedPropertyDescriptor<any> | number,
   ) {

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -64,8 +64,7 @@ export class RestApplication extends Application implements HttpServerLike {
   }
 
   constructor(config?: ApplicationConfig) {
-    const cfg = Object.assign({}, config);
-    super(cfg);
+    super(Object.assign({}, config));
     this.component(RestComponent);
   }
 

--- a/packages/service-proxy/src/decorators/service.decorator.ts
+++ b/packages/service-proxy/src/decorators/service.decorator.ts
@@ -40,11 +40,7 @@ export class ServiceProxyMetadata implements InjectionMetadata {
 }
 
 export function serviceProxy(dataSource: string | juggler.DataSource) {
-  return function(
-    target: Object,
-    key: symbol | string,
-    parameterIndex?: number,
-  ) {
+  return function(target: Object, key: string, parameterIndex?: number) {
     if (key || typeof parameterIndex === 'number') {
       const meta = new ServiceProxyMetadata(dataSource);
       inject('', meta, resolve)(target, key, parameterIndex);


### PR DESCRIPTION
TypeScript 2.9.x complains about usage of `symbol` as string or index.


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
