### PR TITLE
ci: report coverage only on Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env: TASK=test
 install: npm install --ignore-scripts
 
 after_success:
-  - npm run coverage:ci
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ $(echo $TRAVIS_NODE_VERSION | cut -d'.' -f1) == "10" ]]; then npm run coverage:ci; fi
 
 matrix:
   include:


### PR DESCRIPTION
Based on https://github.com/strongloop/loopback-next/pull/1374#issuecomment-393059835

> @virkt25 IIRC, we will be reporting coverage data from all matrix entries (platforms) now. Would it make sense to limit coverage report to a single platform, let's say Node.js 10.x on Linux?

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
