### PR TITLE
docs(testlab): describe Request/Response mocks

### DIFF
--- a/packages/rest/test/unit/parser.unit.ts
+++ b/packages/rest/test/unit/parser.unit.ts
@@ -38,7 +38,7 @@ describe('operationArgsParser', () => {
     expect(args).to.eql([1]);
   });
 
-  it('parsed body parameter', async () => {
+  it('parses body parameter', async () => {
     const req = givenRequest({
       url: '/',
       payload: {key: 'value'},


### PR DESCRIPTION
Improve testlab's README to show how to use `stubServerRequest`, `stubHandlerContext` and `stubExpressContext` for mocking/stubbing HTTP request and response objects.

Close #760 

## Checklist

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated