### PR TITLE
feat: add local commit message linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/cli": "^6.1.3",
-    "@commitlint/config-conventional": "^6.1.3",
-    "@commitlint/config-lerna-scopes": "^6.1.3",
-    "@commitlint/travis-cli": "^6.1.3",
+    "@commitlint/cli": "^7.0.0",
+    "@commitlint/config-conventional": "^7.0.0",
+    "@commitlint/config-lerna-scopes": "^7.0.0",
+    "@commitlint/travis-cli": "^7.0.0",
     "@types/mocha": "^5.0.0",
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
+    "husky": "^0.14.3",
     "lerna": "^2.9.1"
   },
   "scripts": {
@@ -48,7 +49,8 @@
     "verify:docs": "npm run build:site -- --verify",
     "build:site": "./bin/build-docs-site.sh",
     "mocha": "node packages/build/bin/run-mocha \"packages/*/DIST/test/**/*.js\" \"examples/*/DIST/test/**/*.js\" \"packages/cli/test/**/*.js\" \"packages/build/test/*/*.js\"",
-    "posttest": "npm run lint"
+    "posttest": "npm run lint",
+    "commitmsg": "commitlint -E GIT_PARAMS"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
fixes #585

Signed-off-by: Taranveer Virk <taranveer@virk.cc>

---

To test -- try `git commit -m "foo: fail"` OR `git commit -m "chore(not-a-package): should give error"`

Override for hook is to use `--no-verify` option **BUT** I do not recommend that since CI will fail on an invalid commit message. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
