### PR TITLE
feat(cli): add code gen from openapi spec

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -69,6 +69,10 @@ function setupGenerators() {
     path.join(__dirname, '../generators/example'),
     PREFIX + 'example',
   );
+  env.register(
+    path.join(__dirname, '../generators/openapi'),
+    PREFIX + 'openapi',
+  );
   return env;
 }
 

--- a/packages/cli/generators/openapi/README.md
+++ b/packages/cli/generators/openapi/README.md
@@ -1,0 +1,225 @@
+# lb4 openapi
+
+The `openapi` command generates LoopBack 4 artifacts from an
+[OpenAPI specification](https://github.com/OAI/OpenAPI-Specification), including
+version 2.0 and 3.0.
+
+## Basic use
+
+```sh
+Usage:
+  lb4 openapi [<url>] [options]
+
+Options:
+  -h,   --help          # Print the generator's options and usage
+        --url           # URL or file path of the OpenAPI spec
+        --validate      # Validate the OpenAPI spec                  Default: false
+
+Arguments:
+  url  # URL or file path of the OpenAPI spec  Type: String  Required: false
+```
+
+For example,
+
+```sh
+lb4 openapi https://api.apis.guru/v2/specs/api2cart.com/1.0.0/swagger.json
+```
+
+## Mappings
+
+We map OpenAPI operations by tag into `controllers` and schemas into `models` as
+TypeScript classes or types.
+
+### Schemas
+
+The generator first iterates through the `components.schemas` of the
+specification document and maps them into TypeScript classes or types:
+
+- Primitive types --> TypeScript type declaration
+
+```ts
+export type Message = string;
+```
+
+```ts
+export type OrderEnum = 'ascending' | 'descending';
+```
+
+- Array types --> TypeScript type declaration
+
+```ts
+import {Comment} from './comment.model';
+export type Comments = Comment[];
+```
+
+- Object type --> TypeScript class definition
+
+```ts
+import {model, property} from '@loopback/repository';
+import {CartShippingZone} from './cart-shipping-zone.model';
+import {CartStoreInfo} from './cart-store-info.model';
+import {CartWarehouse} from './cart-warehouse.model';
+
+/**
+ * The model class is generated from OpenAPI schema - Cart
+ * Cart
+ */
+@model({name: 'Cart'})
+export class Cart {
+  constructor(data?: Partial<Cart>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  @property({name: 'additional_fields'})
+  additional_fields?: {};
+
+  @property({name: 'custom_fields'})
+  custom_fields?: {};
+
+  @property({name: 'db_prefix'})
+  db_prefix?: string;
+
+  @property({name: 'name'})
+  name?: string;
+
+  @property({name: 'shipping_zones'})
+  shipping_zones?: CartShippingZone[];
+
+  @property({name: 'stores_info'})
+  stores_info?: CartStoreInfo[];
+
+  @property({name: 'url'})
+  url?: string;
+
+  @property({name: 'version'})
+  version?: string;
+
+  @property({name: 'warehouses'})
+  warehouses?: CartWarehouse[];
+}
+```
+
+- Composite type (anyOf|oneOf|allOf) --> TypeScript union/intersection types
+
+```ts
+export type IdType = string | number;
+```
+
+```ts
+import {NewPet} from './new-pet.model.ts';
+export type Pet = NewPet & {id: number};
+```
+
+Embedded schemas are mapped to TypeScript type literals.
+
+### Operations
+
+The generator groups operations (`paths.<path>.<verb>`) by tags. If no tag is
+present, it defaults to `OpenApi`. For each tag, a controller class is generated
+to hold all operations with the same tag.
+
+```ts
+import {operation, param} from '@loopback/rest';
+/* tslint:disable:no-any */
+import {operation, param} from '@loopback/rest';
+import {DateTime} from '../models/date-time.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by account
+ *
+ */
+export class AccountController {
+  constructor() {}
+
+  /**
+   * Get list of carts.
+   */
+  @operation('get', '/account.cart.list.json')
+  async accountCartList(
+    @param({name: 'params', in: 'query'})
+    params: string,
+    @param({name: 'exclude', in: 'query'})
+    exclude: string,
+    @param({name: 'request_from_date', in: 'query'})
+    request_from_date: string,
+    @param({name: 'request_to_date', in: 'query'})
+    request_to_date: string,
+  ): Promise<{
+    result?: {
+      carts?: {
+        cart_id?: string;
+        id?: string;
+        store_key?: string;
+        total_calls?: string;
+        url?: string;
+      }[];
+      carts_count?: number;
+    };
+    return_code?: number;
+    return_message?: string;
+  }> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Update configs in the API2Cart database.
+   */
+  @operation('put', '/account.config.update.json')
+  async accountConfigUpdate(
+    @param({name: 'db_tables_prefix', in: 'query'})
+    db_tables_prefix: string,
+    @param({name: 'client_id', in: 'query'})
+    client_id: string,
+    @param({name: 'bridge_url', in: 'query'})
+    bridge_url: string,
+    @param({name: 'store_root', in: 'query'})
+    store_root: string,
+    @param({name: 'shared_secret', in: 'query'})
+    shared_secret: string,
+  ): Promise<{
+    result?: {
+      updated_items?: number;
+    };
+    return_code?: number;
+    return_message?: string;
+  }> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * List webhooks that was not delivered to the callback.
+   */
+  @operation('get', '/account.failed_webhooks.json')
+  async accountFailedWebhooks(
+    @param({name: 'count', in: 'query'})
+    count: number,
+    @param({name: 'start', in: 'query'})
+    start: number,
+    @param({name: 'ids', in: 'query'})
+    ids: string,
+  ): Promise<{
+    result?: {
+      all_failed_webhook?: string;
+      webhook?: {
+        entity_id?: string;
+        time?: DateTime;
+        webhook_id?: number;
+      }[];
+    };
+    return_code?: number;
+    return_message?: string;
+  }> {
+    throw new Error('Not implemented');
+  }
+}
+```
+
+## OpenAPI Examples
+
+- https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml
+- https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/uspto.yaml
+- https://api.apis.guru/v2/specs/api2cart.com/1.0.0/swagger.json
+- https://api.apis.guru/v2/specs/amazonaws.com/codecommit/2015-04-13/swagger.json

--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -1,0 +1,160 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const BaseGenerator = require('../../lib/base-generator');
+const {debug, debugJson} = require('./utils');
+const {loadAndBuildSpec} = require('./spec-loader');
+const {validateUrlOrFile} = require('./utils');
+const {getControllerFileName} = require('./spec-helper');
+
+const updateIndex = require('../../lib/update-index');
+
+module.exports = class OpenApiGenerator extends BaseGenerator {
+  // Note: arguments and options should be defined in the constructor.
+  constructor(args, opts) {
+    super(args, opts);
+  }
+
+  _setupGenerator() {
+    this.argument('url', {
+      description: 'URL or file path of the OpenAPI spec',
+      required: false,
+      type: String,
+    });
+
+    this.option('url', {
+      description: 'URL or file path of the OpenAPI spec',
+      required: false,
+      type: String,
+    });
+
+    this.option('validate', {
+      description: 'Validate the OpenAPI spec',
+      required: false,
+      default: false,
+      type: Boolean,
+    });
+    return super._setupGenerator();
+  }
+
+  checkLoopBackProject() {
+    return super.checkLoopBackProject();
+  }
+
+  async askForSpecUrlOrPath() {
+    const prompts = [
+      {
+        name: 'url',
+        message: 'Enter the OpenAPI spec url or file path:',
+        default: this.options.url,
+        validate: validateUrlOrFile,
+        when: this.options.url == null,
+      },
+    ];
+    const answers = await this.prompt(prompts);
+    if (answers.url) {
+      this.url = answers.url.trim();
+    } else {
+      this.url = this.options.url;
+    }
+  }
+
+  async loadAndBuildApiSpec() {
+    try {
+      const result = await loadAndBuildSpec(this.url, {
+        log: this.log,
+        validate: this.options.validate,
+      });
+      debugJson('OpenAPI spec', result.apiSpec);
+      Object.assign(this, result);
+    } catch (e) {
+      this.exit(e);
+    }
+  }
+
+  async selectControllers() {
+    if (this.shouldExit()) return;
+    const choices = this.controllerSpecs.map(c => {
+      return {
+        name: c.tag ? `[${c.tag}] ${c.className}` : c.className,
+        value: c.className,
+        checked: true,
+      };
+    });
+    const prompts = [
+      {
+        name: 'controllerSelections',
+        message: 'Select controllers to be generated:',
+        type: 'checkbox',
+        choices: choices,
+      },
+    ];
+    const selections =
+      (await this.prompt(prompts)).controllerSelections ||
+      choices.map(c => c.value);
+    this.selectedControllers = this.controllerSpecs.filter(c =>
+      selections.some(a => a === c.className),
+    );
+    this.selectedControllers.forEach(
+      c => (c.fileName = getControllerFileName(c.tag || c.className)),
+    );
+  }
+
+  async scaffold() {
+    if (this.shouldExit()) return false;
+    this._generateModels();
+    this._generateControllers();
+  }
+
+  _generateControllers() {
+    const source = this.templatePath(
+      'src/controllers/controller-template.ts.ejs',
+    );
+    for (const c of this.selectedControllers) {
+      const controllerFile = c.fileName;
+      if (debug.enabled) {
+        debug(`Artifact output filename set to: ${controllerFile}`);
+      }
+      const dest = this.destinationPath(`src/controllers/${controllerFile}`);
+      if (debug.enabled) {
+        debug('Copying artifact to: %s', dest);
+      }
+      this.fs.copyTpl(source, dest, c, {}, {globOptions: {dot: true}});
+    }
+  }
+
+  _generateModels() {
+    const modelSource = this.templatePath('src/models/model-template.ts.ejs');
+    const typeSource = this.templatePath('src/models/type-template.ts.ejs');
+    for (const m of this.modelSpecs) {
+      if (!m.fileName) continue;
+      const modelFile = m.fileName;
+      if (debug.enabled) {
+        debug(`Artifact output filename set to: ${modelFile}`);
+      }
+      const dest = this.destinationPath(`src/models/${modelFile}`);
+      if (debug.enabled) {
+        debug('Copying artifact to: %s', dest);
+      }
+      const source = m.kind === 'class' ? modelSource : typeSource;
+      this.fs.copyTpl(source, dest, m, {}, {globOptions: {dot: true}});
+    }
+  }
+
+  async end() {
+    await super.end();
+    if (this.shouldExit()) return;
+    const targetDir = this.destinationPath(`src/controllers`);
+    for (const c of this.selectedControllers) {
+      // Check all files being generated to ensure they succeeded
+      const status = this.conflicter.generationStatus[c.fileName];
+      if (status !== 'skip' && status !== 'identical') {
+        await updateIndex(targetDir, c.fileName);
+      }
+    }
+  }
+};

--- a/packages/cli/generators/openapi/schema-helper.js
+++ b/packages/cli/generators/openapi/schema-helper.js
@@ -1,0 +1,346 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const util = require('util');
+const json5 = require('json5');
+
+const {
+  isExtension,
+  titleCase,
+  kebabCase,
+  escapePropertyOrMethodName,
+} = require('./utils');
+
+function toJsonStr(val) {
+  return json5.stringify(val, null, 2);
+}
+
+function setImport(typeSpec) {
+  if (typeSpec.fileName) {
+    typeSpec.import = `import {${typeSpec.className}} from './${getBaseName(
+      typeSpec.fileName,
+    )}';`;
+  }
+}
+
+function getTypeSpec(schema, options) {
+  const objectTypeMapping = options.objectTypeMapping;
+  const schemaMapping = options.schemaMapping || {};
+  const resolvedSchema = resolveSchema(schemaMapping, schema);
+  let typeSpec = objectTypeMapping.get(resolvedSchema);
+  if (!typeSpec) {
+    typeSpec = {};
+    objectTypeMapping.set(resolvedSchema, typeSpec);
+  }
+  setImport(typeSpec);
+  return typeSpec;
+}
+
+function getDefault(schema, options) {
+  let defaultVal = '';
+  if (options && options.includeDefault && schema.default !== undefined) {
+    defaultVal = ' = ' + toJsonStr(schema.default);
+  }
+  return defaultVal;
+}
+
+function getBaseName(tsFileName) {
+  if (tsFileName.endsWith('.ts')) {
+    return tsFileName.substring(0, tsFileName.length - 3);
+  }
+  return tsFileName;
+}
+
+/**
+ * Add the import statements to the given type spec's imports
+ * @param {object} typeSpec
+ * @param {string[]} imports
+ */
+function addImports(typeSpec, ...imports) {
+  typeSpec.imports = typeSpec.imports || [];
+  for (const i of imports) {
+    if (i == null) continue;
+    // Skip circular import
+    if (typeSpec.import === i) continue;
+    if (!typeSpec.imports.includes(i)) {
+      typeSpec.imports.push(i);
+    }
+  }
+}
+
+/**
+ * Collect import statements from a referenced type
+ * @param {*} typeSpec
+ * @param {*} referencedType
+ */
+function collectImports(typeSpec, referencedType) {
+  if (referencedType.className != null) {
+    // Add the referenced import
+    addImports(typeSpec, referencedType.import);
+  } else {
+    if (Array.isArray(referencedType.imports)) {
+      addImports(typeSpec, ...referencedType.imports);
+    }
+  }
+}
+
+/**
+ * Map composite type (oneOf|anyOf|allOf)
+ * @param {object} schema
+ * @param {object} options
+ */
+function mapCompositeType(schema, options) {
+  options = Object.assign({}, options, {includeDefault: false});
+  const typeSpec = getTypeSpec(schema, options);
+  let separator = '';
+  let candidates = [];
+  if (Array.isArray(schema.oneOf)) {
+    separator = ' | ';
+    candidates = schema.oneOf;
+  } else if (Array.isArray(schema.anyOf)) {
+    separator = ' | ';
+    candidates = schema.anyOf;
+  } else if (Array.isArray(schema.allOf)) {
+    separator = ' & ';
+    candidates = schema.allOf;
+  }
+  if (!separator) return undefined;
+  const types = candidates.map(t => mapSchemaType(t, options));
+  const members = Array.from(new Set(types));
+  typeSpec.members = members;
+  const defaultVal = getDefault(schema, options);
+  const memberSignatures = members.map(m => m.signature).join(separator);
+  typeSpec.declaration = memberSignatures;
+  typeSpec.signature = (typeSpec.className || memberSignatures) + defaultVal;
+  members.forEach(m => collectImports(typeSpec, m));
+  return typeSpec;
+}
+
+function mapArrayType(schema, options) {
+  if (schema.type === 'array') {
+    const opts = Object.assign({}, options, {includeDefault: false});
+    const typeSpec = getTypeSpec(schema, options);
+    const itemTypeSpec = mapSchemaType(schema.items, opts);
+    const defaultVal = getDefault(schema, options);
+    typeSpec.name = itemTypeSpec.signature + '[]';
+    typeSpec.declaration = itemTypeSpec.signature + '[]';
+    typeSpec.signature =
+      (typeSpec.className || itemTypeSpec.signature + '[]') + defaultVal;
+    typeSpec.itemType = itemTypeSpec;
+    collectImports(typeSpec, itemTypeSpec);
+    return typeSpec;
+  }
+  return undefined;
+}
+
+function mapObjectType(schema, options) {
+  if (schema.type === 'object' || schema.properties) {
+    const defaultVal = getDefault(schema, options);
+    const typeSpec = getTypeSpec(schema, options);
+    if (typeSpec.className) {
+      typeSpec.kind = 'class';
+    } else {
+      typeSpec.imports = [];
+    }
+    if (typeSpec.declaration != null) {
+      if (typeSpec.declaration === '') {
+        typeSpec.signature = typeSpec.className;
+      }
+      return typeSpec;
+    } else {
+      typeSpec.declaration = ''; // in-progress
+    }
+    const properties = [];
+    const required = schema.required || [];
+    for (const p in schema.properties) {
+      const suffix = required.includes(p) ? '' : '?';
+      const propertyType = mapSchemaType(
+        schema.properties[p],
+        Object.assign({}, options, {
+          includeDefault: !!typeSpec.className, // Only include default for class
+        }),
+      );
+      // The property name might have chars such as `-`
+      const propName = escapePropertyOrMethodName(p);
+      const propSpec = {
+        name: p,
+        signature: `${propName + suffix}: ${propertyType.signature};`,
+        decoration: `@property({name: '${p}'})`,
+      };
+      if (schema.properties[p].description) {
+        propSpec.description = schema.properties[p].description;
+      }
+      collectImports(typeSpec, propertyType);
+      properties.push(propSpec);
+    }
+    typeSpec.properties = properties;
+    const propertySignatures = properties.map(p => p.signature);
+    typeSpec.declaration = `{
+  ${propertySignatures.join('\n  ')}
+}`;
+    typeSpec.signature =
+      (typeSpec.className || typeSpec.declaration) + defaultVal;
+    return typeSpec;
+  }
+  return undefined;
+}
+
+function mapPrimitiveType(schema, options) {
+  /**
+   * integer	integer	int32	    signed 32 bits
+   * long	    integer	int64	    signed 64 bits
+   * float	  number	float
+   * double	  number	double
+   * string	  string
+   * byte	    string	byte	    base64 encoded characters
+   * binary	  string	binary	  any sequence of octets
+   * boolean	boolean
+   * date	    string	date	    As defined by full-date - RFC3339
+   * dateTime	string	date-time	As defined by date-time - RFC3339
+   * password	string	password	A hint to UIs to obscure input.
+   */
+  let jsType = 'string';
+  switch (schema.type) {
+    case 'integer':
+    case 'number':
+      jsType = 'number';
+      break;
+    case 'boolean':
+      jsType = 'boolean';
+      break;
+    case 'string':
+      switch (schema.format) {
+        case 'date':
+        case 'date-time':
+          jsType = 'Date';
+          break;
+        case 'binary':
+          jsType = 'Buffer';
+          break;
+        case 'byte':
+        case 'password':
+          jsType = 'string';
+          break;
+      }
+      break;
+  }
+  // Handle enums
+  if (Array.isArray(schema.enum)) {
+    jsType = schema.enum.map(v => toJsonStr(v)).join(' | ');
+  }
+  const typeSpec = getTypeSpec(schema, options);
+  const defaultVal = getDefault(schema, options);
+  typeSpec.declaration = jsType;
+  typeSpec.signature = typeSpec.className || typeSpec.declaration + defaultVal;
+  typeSpec.name = typeSpec.name || jsType;
+  return typeSpec;
+}
+
+/**
+ *
+ * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#data-types
+ *
+ * @param {object} schema
+ */
+function mapSchemaType(schema, options) {
+  options = options || {};
+  if (!options.objectTypeMapping) {
+    options.objectTypeMapping = new Map();
+  }
+
+  const typeSpec = getTypeSpec(schema, options);
+  if (typeSpec.signature) return typeSpec;
+
+  const compositeType = mapCompositeType(schema, options);
+  if (compositeType) {
+    return compositeType;
+  }
+
+  const arrayType = mapArrayType(schema, options);
+  if (arrayType) {
+    return arrayType;
+  }
+
+  const objectType = mapObjectType(schema, options);
+  if (objectType) {
+    return objectType;
+  }
+
+  return mapPrimitiveType(schema, options);
+}
+
+/**
+ * Map the schema by `x-$ref`
+ * @param {object} schemaMapping
+ * @param {object} schema
+ */
+function resolveSchema(schemaMapping, schema) {
+  if (schema['x-$ref']) {
+    const resolved = schemaMapping[schema['x-$ref']];
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return schema;
+}
+
+/**
+ * Generate model definitions from openapi spec
+ * @param {object} apiSpec
+ */
+function generateModelSpecs(apiSpec, options) {
+  options = options || {};
+  const objectTypeMapping = (options.objectTypeMapping =
+    options.objectTypeMapping || new Map());
+
+  const schemaMapping = (options.schemaMapping = options.schemaMapping || {});
+
+  const schemas =
+    (apiSpec && apiSpec.components && apiSpec.components.schemas) || {};
+
+  // First map schema objects to names
+  for (const s in schemas) {
+    if (isExtension(s)) continue;
+    schemaMapping[`#/components/schemas/${s}`] = schemas[s];
+    const className = titleCase(s);
+    objectTypeMapping.set(schemas[s], {
+      description: schemas[s].description || s,
+      name: s,
+      className,
+      fileName: getModelFileName(s),
+      properties: [],
+      imports: [],
+    });
+  }
+
+  const models = [];
+  // Generate models from schema objects
+  for (const s in schemas) {
+    if (isExtension(s)) continue;
+    const schema = schemas[s];
+    const model = mapSchemaType(schema, {objectTypeMapping, schemaMapping});
+    // `model` is `undefined` for primitive types
+    if (model == null) continue;
+    if (model.className) {
+      models.push(model);
+    }
+  }
+  return models;
+}
+
+function getModelFileName(modelName) {
+  let name = modelName;
+  if (modelName.endsWith('Model')) {
+    name = modelName.substring(0, modelName.length - 'Model'.length);
+  }
+  return kebabCase(name) + '.model.ts';
+}
+
+module.exports = {
+  mapSchemaType,
+  generateModelSpecs,
+  getModelFileName,
+};

--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -1,0 +1,242 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const fs = require('fs');
+const util = require('util');
+
+const debug = require('../../lib/debug')('openapi-generator');
+const {mapSchemaType} = require('./schema-helper');
+const {
+  isExtension,
+  titleCase,
+  debugJson,
+  kebabCase,
+  camelCase,
+  escapeIdentifier,
+  escapePropertyOrMethodName,
+} = require('./utils');
+
+const HTTP_VERBS = [
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+];
+
+/**
+ * Check if a key is an http verb
+ * @param {string} key
+ */
+function isHttpVerb(key) {
+  return key && HTTP_VERBS.includes(key.toLowerCase());
+}
+
+/**
+ * Find the tag description by name
+ * @param {object} apiSpec API spec object
+ * @param {string} tag Tag name
+ */
+function getTagDescription(apiSpec, tag) {
+  if (Array.isArray(apiSpec.tags)) {
+    const tagEntry = apiSpec.tags.find(t => t.name === tag);
+    return tagEntry && tagEntry.description;
+  }
+  return undefined;
+}
+
+/**
+ * Group operations by controller class name
+ * @param {object} apiSpec OpenAPI 3.x spec
+ */
+function groupOperationsByController(apiSpec) {
+  const operationsMapByController = {};
+  if (apiSpec.paths == null) return operationsMapByController;
+  for (const path in apiSpec.paths) {
+    if (isExtension(path)) continue;
+    debug('Path: %s', path);
+    for (const verb in apiSpec.paths[path]) {
+      if (isExtension(verb) || !isHttpVerb(verb)) continue;
+      debug('Verb: %s', verb);
+      const op = apiSpec.paths[path][verb];
+      const operation = {
+        path,
+        verb,
+        spec: op,
+      };
+      debugJson('Operation', operation);
+      // Default to `openapi` if no tags are present
+      let controllers = ['OpenApiController'];
+      if (op['x-controller-name']) {
+        controllers = [op['x-controller-name']];
+      } else if (op.tags) {
+        controllers = op.tags.map(t => titleCase(t + 'Controller'));
+      }
+      controllers.forEach((c, index) => {
+        /**
+         * type ControllerSpec = {
+         *   tag?: string;
+         *   description?: string;
+         *   operations: Operation[]
+         * }
+         */
+        let controllerSpec = operationsMapByController[c];
+        if (!controllerSpec) {
+          controllerSpec = {operations: [operation]};
+          if (op.tags && op.tags[index]) {
+            controllerSpec.tag = op.tags[index];
+            controllerSpec.description =
+              getTagDescription(apiSpec, controllerSpec.tag) || '';
+          }
+          operationsMapByController[c] = controllerSpec;
+        } else {
+          controllerSpec.operations.push(operation);
+        }
+      });
+    }
+  }
+  return operationsMapByController;
+}
+
+/**
+ * Get the method name for an operation spec. If `x-operation-name` is set, use it
+ * as-is. Otherwise, derive the name from `operationId`.
+ *
+ * @param {object} opSpec OpenAPI operation spec
+ */
+function getMethodName(opSpec) {
+  return (
+    opSpec['x-operation-name'] ||
+    escapePropertyOrMethodName(camelCase(opSpec.operationId))
+  );
+}
+
+/**
+ * Build method spec for an operation
+ * @param {object} OpenAPI operation
+ */
+function buildMethodSpec(controllerSpec, op, options) {
+  const methodName = getMethodName(op.spec);
+  let args = [];
+  const parameters = op.spec.parameters;
+  if (parameters) {
+    // Keep track of param names to avoid duplicates
+    const paramNames = {};
+    args = parameters.map(p => {
+      const name = escapeIdentifier(p.name);
+      if (name in paramNames) {
+        name = `${name}${paramNames[name]++}`;
+      } else {
+        paramNames[name] = 1;
+      }
+      const pType = mapSchemaType(p.schema, options);
+      addImportsForType(pType);
+      return `@param({name: '${p.name}', in: '${p.in}'}) ${name}: ${
+        pType.signature
+      }`;
+    });
+  }
+  let returnType = 'any';
+  const responses = op.spec.responses;
+  if (responses) {
+    /**
+     * responses:
+     *   '200':
+     *     description: pet response
+     *     content:
+     *       application/json:
+     *         schema:
+     *           type: array
+     *           items:
+     *             $ref: '#/components/schemas/Pet'
+     */
+    for (const code in responses) {
+      if (isExtension(code)) continue;
+      if (code !== '200') continue;
+      const content = responses[code].content;
+      const jsonType = content && content['application/json'];
+      if (jsonType && jsonType.schema) {
+        returnType = mapSchemaType(jsonType.schema, options);
+        addImportsForType(returnType);
+      }
+    }
+  }
+  const signature = `async ${methodName}(${args.join(', ')}): Promise<${
+    returnType.signature
+  }>`;
+  return {
+    description: op.spec.description,
+    decoration: `@operation('${op.verb}', '${op.path}')`,
+    signature,
+  };
+
+  function addImportsForType(typeSpec) {
+    if (typeSpec.className && typeSpec.import) {
+      const importStmt = typeSpec.import.replace('./', '../models/');
+      if (!controllerSpec.imports.includes(importStmt)) {
+        controllerSpec.imports.push(importStmt);
+      }
+    }
+    if (!typeSpec.className && Array.isArray(typeSpec.imports)) {
+      typeSpec.imports.forEach(i => {
+        i = i.replace('./', '../models/');
+        if (!controllerSpec.imports.includes(i)) {
+          controllerSpec.imports.push(i);
+        }
+      });
+    }
+  }
+}
+
+/**
+ * Build an array of controller specs
+ * @param {object} operationsMapByController
+ */
+function buildControllerSpecs(operationsMapByController, options) {
+  const controllerSpecs = [];
+  for (const controller in operationsMapByController) {
+    const entry = operationsMapByController[controller];
+    const controllerSpec = {
+      tag: entry.tag || '',
+      description: entry.description || '',
+      className: controller,
+      imports: [],
+    };
+    controllerSpec.methods = entry.operations.map(op =>
+      buildMethodSpec(controllerSpec, op, options),
+    );
+    controllerSpecs.push(controllerSpec);
+  }
+  return controllerSpecs;
+}
+
+/**
+ * Generate an array of controller specs for the openapi spec
+ * @param {object} apiSpec
+ */
+function generateControllerSpecs(apiSpec, options) {
+  const operationsMapByController = groupOperationsByController(apiSpec);
+  return buildControllerSpecs(operationsMapByController, options);
+}
+
+function getControllerFileName(controllerName) {
+  let name = controllerName;
+  if (controllerName.endsWith('Controller')) {
+    name = controllerName.substring(
+      0,
+      controllerName.length - 'Controller'.length,
+    );
+  }
+  return kebabCase(name) + '.controller.ts';
+}
+
+module.exports = {
+  getControllerFileName,
+  generateControllerSpecs,
+};

--- a/packages/cli/generators/openapi/spec-loader.js
+++ b/packages/cli/generators/openapi/spec-loader.js
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const chalk = require('chalk');
+const SwaggerParser = require('swagger-parser');
+const swagger2openapi = require('swagger2openapi');
+const {debugJson} = require('./utils');
+const _ = require('lodash');
+const {generateControllerSpecs} = require('./spec-helper');
+const {generateModelSpecs} = require('./schema-helper');
+
+/**
+ * Load swagger specs from the given url or file path; handle yml or json
+ * @param {String} specUrlStr The url or file path to the swagger spec
+ */
+async function loadSpec(specUrlStr, {log, validate} = {}) {
+  if (typeof log === 'function') {
+    log(chalk.blue('Loading ' + specUrlStr + '...'));
+  }
+  const parser = new SwaggerParser();
+  let spec = await parser.parse(specUrlStr);
+  if (spec.swagger === '2.0') {
+    debugJson('Swagger spec loaded: ', spec);
+    spec = (await swagger2openapi.convertObj(spec, {patch: true})).openapi;
+    debugJson('OpenAPI spec converted from Swagger: ', spec);
+  } else if (spec.openapi) {
+    debugJson('OpenAPI spec loaded: ', spec);
+  }
+
+  spec = _.cloneDeepWith(spec, o => {
+    if (o.$ref) {
+      o['x-$ref'] = o.$ref;
+    }
+  });
+
+  // Validate and deference the spec
+  if (validate) {
+    spec = await parser.validate(spec, {
+      dereference: {
+        circular: true, // Allow circular $refs
+      },
+      validate: {
+        spec: true, // Don't validate against the Swagger spec
+      },
+    });
+  } else {
+    spec = await parser.dereference(spec);
+  }
+
+  return spec;
+}
+
+async function loadAndBuildSpec(url, {log, validate} = {}) {
+  const apiSpec = await loadSpec(url, {log, validate});
+  const options = {objectTypeMapping: new Map(), schemaMapping: {}};
+  const modelSpecs = generateModelSpecs(apiSpec, options);
+  const controllerSpecs = generateControllerSpecs(apiSpec, options);
+  return {
+    apiSpec,
+    modelSpecs,
+    controllerSpecs,
+  };
+}
+
+module.exports = {
+  loadSpec,
+  loadAndBuildSpec,
+};

--- a/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
@@ -1,0 +1,30 @@
+/* tslint:disable:no-any */
+import {operation, param} from '@loopback/rest';
+<%_
+imports.forEach(i => {
+-%>
+<%- i %>
+<%_
+});
+-%>
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by <%- tag %>
+ * <%- description %>
+ */
+export class <%- className %> {
+  constructor() {}
+
+  <%_ for (const m of methods) { -%>
+  /**
+   * <%- m.description %>
+   */
+  <%- m.decoration %>
+  <%- m.signature %> {
+    throw new Error('Not implemented');
+  }
+
+  <%_ } -%>
+}
+

--- a/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
@@ -1,0 +1,41 @@
+<%_
+const _properties = locals.properties || [];
+if (_properties.length) {
+-%>
+import {model, property} from '@loopback/repository';
+<%_
+} else {
+-%>
+import {model} from '@loopback/repository';
+<%_
+}
+
+imports.forEach(i => {
+-%>
+<%- i %>
+<%_
+});
+-%>
+
+/**
+ * The model class is generated from OpenAPI schema - <%- name %>
+ * <%- description %>
+ */
+@model({name: '<%- name %>'})
+export class <%- className %> {
+  constructor(data?: Partial<<%- className %>>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  <%_ for (const p of _properties) { -%>
+  /**
+   * <%- p.description || '' %>
+   */
+  <%- p.decoration %>
+  <%- p.signature %>
+
+  <%_ } -%>
+}
+

--- a/packages/cli/generators/openapi/templates/src/models/type-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/type-template.ts.ejs
@@ -1,0 +1,12 @@
+<%_
+imports.forEach(i => {
+-%>
+<%- i %>
+<%_
+});
+-%>
+/**
+ * The model type is generated from OpenAPI schema - <%- name %>
+ */
+export type <%- className %> = <%- declaration %>;
+

--- a/packages/cli/generators/openapi/utils.js
+++ b/packages/cli/generators/openapi/utils.js
@@ -1,0 +1,180 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const fs = require('fs');
+const util = require('util');
+const _ = require('lodash');
+
+const utils = require('../../lib/utils');
+const debug = require('../../lib/debug')('openapi-generator');
+
+/**
+ * Convert a string to title case
+ * @param {string} str
+ */
+function titleCase(str) {
+  return _.startCase(_.camelCase(str)).replace(/\s/g, '');
+}
+
+/**
+ * Check if a given key is openapi extension (x-)
+ * @param {string} key
+ */
+function isExtension(key) {
+  return typeof key === 'string' && key.startsWith('x-');
+}
+
+/**
+ * Dump the json object for debugging
+ * @param {string} msg Message
+ * @param {object} obj The json object
+ */
+function debugJson(msg, obj) {
+  if (debug.enabled) {
+    debug('%s: %s', msg, JSON.stringify(obj, null, 2));
+  }
+}
+
+/**
+ * Validate a url or file path for the open api spec
+ * @param {string} specUrlStr
+ */
+function validateUrlOrFile(specUrlStr) {
+  if (!specUrlStr) {
+    return 'API spec url or file path is required.';
+  }
+  var specUrl = url.parse(specUrlStr);
+  if (specUrl.protocol === 'http:' || specUrl.protocol === 'https:') {
+    return true;
+  } else {
+    var stat = fs.existsSync(specUrlStr) && fs.statSync(specUrlStr);
+    if (stat && stat.isFile()) {
+      return true;
+    } else {
+      return util.format('Path %s is not a file.', specUrlStr);
+    }
+  }
+}
+
+/**
+ * JavaScript keywords
+ */
+const JS_KEYWORDS = [
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'export',
+  'extends',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+  'enum',
+  'implements',
+  'interface',
+  'let',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'static',
+  'await',
+  'abstract',
+  'boolean',
+  'byte',
+  'char',
+  'double',
+  'final',
+  'float',
+  'goto',
+  'int',
+  'long',
+  'native',
+  'short',
+  'synchronized',
+  'throws',
+  'transient',
+  'volatile',
+  'null',
+  'true',
+  'false',
+];
+
+const SAFE_IDENTIFER = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
+
+/**
+ * Escape the name to be a JavaScript identifier. If the name happens to be one
+ * of the JavaScript keywords, a `_` prefix will be added. Otherwise, it will
+ * be converted using camelCase.
+ *
+ * For example,
+ * - `default` -> `_default`
+ * - `my-name` -> 'myName'
+ *
+ * @param {string} name
+ */
+function escapeIdentifier(name) {
+  if (JS_KEYWORDS.includes(name)) {
+    return '_' + name;
+  }
+  if (!name.match(SAFE_IDENTIFER)) {
+    return camelCase(name);
+  }
+  return name;
+}
+
+/**
+ * Escape a property/method name by quoting it if it's not a safe JavaScript
+ * identifier
+ *
+ * For example,
+ * - `default` -> `'default'`
+ * - `my-name` -> `'my-name'`
+ *
+ * @param {string} name
+ */
+function escapePropertyOrMethodName(name) {
+  if (JS_KEYWORDS.includes(name) || !name.match(SAFE_IDENTIFER)) {
+    // Encode the name with ', for example: 'my-name'
+    return `'${name}'`;
+  }
+  return name;
+}
+
+module.exports = {
+  isExtension,
+  titleCase,
+  debug,
+  debugJson,
+  kebabCase: utils.kebabCase,
+  camelCase: _.camelCase,
+  escapeIdentifier,
+  escapePropertyOrMethodName,
+};

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -77,6 +77,7 @@
 <% if (project.projectType === 'application') { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
     "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>",
+    "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>"
 <% } else { -%>

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -70,6 +70,8 @@
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
 <% if (project.projectType === 'application') { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
+    "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>",
+    "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>"
 <% } else { -%>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@loopback/build": "^0.6.9",
     "@loopback/testlab": "^0.10.8",
+    "@types/ejs": "^2.6.0",
     "@types/node": "^10.1.1",
     "glob": "^7.1.2",
     "mem-fs": "^1.1.3",
@@ -44,12 +45,15 @@
     "chalk": "^2.3.2",
     "change-case": "^3.0.2",
     "debug": "^3.1.0",
-    "lodash": "^4.17.5",
+    "json5": "^1.0.1",
+    "lodash": "^4.17.10",
     "minimist": "^1.2.0",
     "pacote": "^8.1.1",
     "pluralize": "^7.0.0",
     "regenerate": "^1.3.3",
     "semver": "^5.5.0",
+    "swagger-parser": "^5.0.0",
+    "swagger2openapi": "^2.11.16",
     "unicode-10.0.0": "^0.7.4",
     "url-slug": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
@@ -59,7 +63,8 @@
     "prepublishOnly": "nsp check",
     "build": "node ./bin/download-connector-list.js",
     "build:current": "npm run build",
-    "test": "lb-mocha \"test/**/*.js\""
+    "test": "lb-mocha \"test/**/*.js\"",
+    "smoke-test": "lb-mocha --allow-console-logs \"smoke-test/**/*.smoke.js\""
   },
   "repository": {
     "type": "git",

--- a/packages/cli/smoke-test/openapi/README.md
+++ b/packages/cli/smoke-test/openapi/README.md
@@ -1,0 +1,27 @@
+# smoke tests
+
+The smoke tests run the `openapi` generator against real-world API specs listed
+by https://api.apis.guru/v2/list.json.
+
+## Basic use
+
+`npm run smoke-test`
+
+By default, it run tests against the following specs:
+
+- https://api.apis.guru/v2/specs/api2cart.com/1.0.0/swagger.json
+- https://api.apis.guru/v2/specs/amazonaws.com/codecommit/2015-04-13/swagger.json
+
+The list of specs can be specified via environment variable `APIS`:
+
+- `APIS=all npm run smoke-test`: run tests against all specs
+- `APIS="<spec1-url> <spec2-url>" npm run smoke-test`: run tests against
+  `<spec1-url>` and `<spec2-url>`
+
+## What the smoke test does
+
+1.  Call `lb4 app` to scaffold an application under `loopback-next/sandbox`
+2.  Run `lerna bootstrap` to install/link dependencies for the application
+3.  Call `lb4 openapi` to generate artifacts from an OpenAPI spec
+4.  Run `npm run prettier:fix` to format the generated code
+5.  Run `npm test` to verify the generated code compiles

--- a/packages/cli/smoke-test/openapi/code-gen-utils.js
+++ b/packages/cli/smoke-test/openapi/code-gen-utils.js
@@ -1,0 +1,99 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const lerna = require('lerna');
+const build = require('@loopback/build');
+
+const appGenerator = path.join(__dirname, '../../generators/app');
+const openapiGenerator = path.join(__dirname, '../../generators/openapi');
+const rootDir = path.join(__dirname, '../../../..');
+const cwd = process.cwd();
+
+/**
+ * Scaffold an application project
+ * @param {string} appName Name of the application
+ */
+async function createAppProject(appName) {
+  // The root directory of the application project
+  // loopback-next/sandbox/<appName>
+  const sandbox = path.join(rootDir, 'sandbox', appName);
+  const pkgName = `@loopback/${appName}`;
+  const props = {
+    name: pkgName,
+    description: 'My sandbox app for LoopBack 4',
+    outdir: sandbox,
+  };
+
+  await helpers
+    .run(appGenerator)
+    .inDir(sandbox)
+    // Mark it private to prevent accidental npm publication
+    .withOptions({private: true})
+    .withPrompts(props);
+
+  process.chdir(rootDir);
+  await lernaBootstrap(pkgName);
+
+  return sandbox;
+}
+
+async function generateOpenApiArtifacts(sandbox, spec) {
+  await helpers
+    .run(openapiGenerator)
+    .cd(sandbox)
+    .withPrompts({
+      url: spec,
+    });
+}
+
+function runNpmTest(sandbox) {
+  return runNpmScript(sandbox, ['test']);
+}
+
+function runPrettier(sandbox) {
+  return runNpmScript(sandbox, ['run', 'prettier:fix']);
+}
+
+function runNpmScript(sandbox, args) {
+  return new Promise((resolve, reject) => {
+    build
+      .runShell('npm', args, {
+        // Disable stdout
+        stdio: [process.stdin, process.stdout, process.stderr],
+        cwd: sandbox,
+      })
+      .on('close', code => {
+        assert.equal(code, 0);
+        resolve();
+      });
+  });
+}
+
+function cleanSandbox(sandbox) {
+  process.chdir(rootDir);
+  build.clean(['node', 'run-clean', sandbox]);
+  process.chdir(cwd);
+}
+
+function lernaBootstrap(scope) {
+  const cmd = new lerna.BootstrapCommand('', {
+    scope: scope,
+    loglevel: 'silent',
+  });
+  return cmd.run();
+}
+
+module.exports = {
+  createAppProject,
+  generateOpenApiArtifacts,
+  cleanSandbox,
+  runNpmTest,
+  runPrettier,
+};

--- a/packages/cli/smoke-test/openapi/real-world-apis.smoke.js
+++ b/packages/cli/smoke-test/openapi/real-world-apis.smoke.js
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const {supertest, TestSandbox} = require('@loopback/testlab');
+const path = require('path');
+const assert = require('yeoman-assert');
+
+const {
+  createAppProject,
+  generateOpenApiArtifacts,
+  cleanSandbox,
+  runPrettier,
+  runNpmTest,
+} = require('./code-gen-utils');
+
+let realWorldAPIs = [
+  {
+    name: 'api2cart.com',
+    version: '1.0.0',
+    swaggerUrl:
+      'https://api.apis.guru/v2/specs/api2cart.com/1.0.0/swagger.json',
+  },
+  {
+    name: 'amazonaws.com/codecommit',
+    version: '2015-04-13',
+    swaggerUrl:
+      'https://api.apis.guru/v2/specs/amazonaws.com/codecommit/2015-04-13/swagger.json',
+  },
+];
+
+describe('Real-world APIs', () => {
+  before(async function() {
+    // Set env var `APIS` to `*` to test against apis.guru directory
+    if (process.env.APIS !== 'all') return;
+
+    if (typeof process.env.APIS === 'string') {
+      realWorldAPIs = process.env.APIS.split(/\s+/)
+        .filter(Boolean)
+        .map(url => ({
+          swaggerUrl: url,
+          name: '',
+          version: '',
+        }));
+      return;
+    }
+
+    // This hook sometimes takes several seconds, due to the large download
+    this.timeout(10000);
+
+    // Download a list of over 1500 real-world Swagger APIs from apis.guru
+    const res = await supertest('https://api.apis.guru')
+      .get('/v2/list.json')
+      .expect(200);
+    if (!res.ok) {
+      throw new Error('Unable to download API listing from apis.guru');
+    }
+
+    // Remove certain APIs that are known to cause problems
+    var apis = res.body;
+
+    // GitHub's CORS policy blocks this request
+    delete apis['googleapis.com:adsense'];
+
+    // These APIs cause infinite loops in json-schema-ref-parser.  Still investigating.
+    // https://github.com/BigstickCarpet/json-schema-ref-parser/issues/56
+    delete apis['bungie.net'];
+    delete apis['stripe.com'];
+
+    // Flatten the list, so there's an API object for every API version
+    realWorldAPIs = [];
+    for (const apiName in apis) {
+      for (const version in apis[apiName].versions) {
+        const api = apis[apiName].versions[version];
+        api.name = apiName;
+        api.version = version;
+        realWorldAPIs.push(api);
+      }
+    }
+  });
+
+  it('generates all the proper files', async function() {
+    this.timeout(0);
+    let count = 0;
+    for (const api of realWorldAPIs) {
+      console.log('Testing %s', api.swaggerUrl);
+      const sandbox = await createAppProject('openapi-test-' + count++);
+      console.log('Sandbox app created: %s', sandbox);
+      await generateOpenApiArtifacts(sandbox, api.swaggerUrl);
+      console.log('OpenApi artifacts generated');
+      await runPrettier(sandbox);
+      console.log('Artifacts formatted with prettier');
+      await runNpmTest(sandbox);
+      console.log('npm test is passing', sandbox);
+      // await cleanSandbox(sandbox);
+    }
+  });
+});

--- a/packages/cli/test/fixtures/openapi/2.0/petstore-expanded-swagger.json
+++ b/packages/cli/test/fixtures/openapi/2.0/petstore-expanded-swagger.json
@@ -1,0 +1,211 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -1,0 +1,101 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Customer
+  description: A simple customer api with irregularity in names
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: Customer
+    description: Customer resource
+paths:
+  /customers:
+    get:
+      tags:
+        - Customer
+      description: Returna all customers
+      parameters:
+        - name: if
+          in: query
+          description: if condition
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: customer response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Customer'
+    post:
+      tags:
+        - Customer
+      description: Creates a new customer
+      operationId: addCustomer
+      x-operation-name: createCustomer
+      requestBody:
+        description: Customer to add
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Customer'
+      responses:
+        '200':
+          description: customer response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customer'
+  /customers/{id}:
+    get:
+      tags:
+        - Customer
+      description: Returns a customer based on a single ID
+      operationId: find customer by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of customer to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: customer response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customer'
+components:
+  schemas:
+    Name:
+      type: string
+    Customer:
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        first-name:
+          type: string
+        last-name:
+          $ref: '#/components/schemas/Name'
+
+

--- a/packages/cli/test/fixtures/openapi/3.0/petstore-expanded.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/petstore-expanded.yaml
@@ -1,0 +1,156 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+
+    NewPet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+

--- a/packages/cli/test/fixtures/openapi/3.0/uspto.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/uspto.yaml
@@ -1,0 +1,211 @@
+openapi: 3.0.0
+servers:
+  - url: '{scheme}://developer.uspto.gov/ds-api'
+    variables:
+      scheme:
+        description: 'The Data Set API is accessible via https and http'
+        enum:
+          - 'https'
+          - 'http'
+        default: 'https'
+info:
+  description: >-
+    The Data Set API (DSAPI) allows the public users to discover and search
+    USPTO exported data sets. This is a generic API that allows USPTO users to
+    make any CSV based data files searchable through API. With the help of GET
+    call, it returns the list of data fields that are searchable. With the help
+    of POST call, data can be fetched based on the filters on the field names.
+    Please note that POST call is used to search the actual data. The reason for
+    the POST call is that it allows users to specify any complex search criteria
+    without worry about the GET size limitations as well as encoding of the
+    input parameters.
+  version: 1.0.0
+  title: USPTO Data Set API
+  contact:
+    name: Open Data Portal
+    url: 'https://developer.uspto.gov'
+    email: developer@uspto.gov
+tags:
+  - name: metadata
+    description: Find out about the data sets
+  - name: search
+    description: Search a data set
+paths:
+  /:
+    get:
+      tags:
+        - metadata
+      operationId: list-data-sets
+      summary: List available data sets
+      responses:
+        '200':
+          description: Returns a list of data sets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dataSetList'
+              example:
+                {
+                  "total": 2,
+                  "apis": [
+                    {
+                      "apiKey": "oa_citations",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/oa_citations/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/oa_citations.json"
+                    },
+                    {
+                      "apiKey": "cancer_moonshot",
+                      "apiVersionNumber": "v1",
+                      "apiUrl": "https://developer.uspto.gov/ds-api/cancer_moonshot/v1/fields",
+                      "apiDocumentationUrl": "https://developer.uspto.gov/ds-api-docs/index.html?url=https://developer.uspto.gov/ds-api/swagger/docs/cancer_moonshot.json"
+                    }
+                  ]
+                }
+  /{dataset}/{version}/fields:
+    get:
+      tags:
+        - metadata
+      summary: >-
+        Provides the general information about the API and the list of fields
+        that can be used to query the dataset.
+      description: >-
+        This GET API returns the list of all the searchable field names that are
+        in the oa_citations. Please see the 'fields' attribute which returns an
+        array of field names. Each field or a combination of fields can be
+        searched using the syntax options shown below.
+      operationId: list-searchable-fields
+      parameters:
+        - name: dataset
+          in: path
+          description: 'Name of the dataset. In this case, the default value is oa_citations'
+          required: true
+          schema:
+            type: string
+            default: oa_citations
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          schema:
+            type: string
+            default: v1
+      responses:
+        '200':
+          description: >-
+            The dataset api for the given version is found and it is accessible
+            to consume.
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: >-
+            The combination of dataset name and version is not found in the
+            system or it is not published yet to be consumed by public.
+          content:
+            application/json:
+              schema:
+                type: string
+  /{dataset}/{version}/records:
+    post:
+      tags:
+        - search
+      summary: >-
+        Provides search capability for the data set with the given search
+        criteria.
+      description: >-
+        This API is based on Solr/Lucense Search. The data is indexed using
+        SOLR. This GET API returns the list of all the searchable field names
+        that are in the Solr Index. Please see the 'fields' attribute which
+        returns an array of field names. Each field or a combination of fields
+        can be searched using the Solr/Lucene Syntax. Please refer
+        https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for
+        the query syntax. List of field names that are searchable can be
+        determined using above GET api.
+      operationId: perform-search
+      parameters:
+        - name: version
+          in: path
+          description: Version of the dataset.
+          required: true
+          schema:
+            type: string
+            default: v1
+        - name: dataset
+          in: path
+          description: 'Name of the dataset. In this case, the default value is oa_citations'
+          required: true
+          schema:
+            type: string
+            default: oa_citations
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: object
+        '404':
+          description: No matching record found for the given criteria.
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                criteria:
+                  description: >-
+                    Uses Lucene Query Syntax in the format of
+                    propertyName:value, propertyName:[num1 TO num2] and date
+                    range format: propertyName:[yyyyMMdd TO yyyyMMdd]. In the
+                    response please see the 'docs' element which has the list of
+                    record objects. Each record structure would consist of all
+                    the fields and their corresponding values.
+                  type: string
+                  default: '*:*'
+                start:
+                  description: Starting record number. Default value is 0.
+                  type: integer
+                  default: 0
+                rows:
+                  description: >-
+                    Specify number of rows to be returned. If you run the search
+                    with default values, in the response you will see 'numFound'
+                    attribute which will tell the number of records available in
+                    the dataset.
+                  type: integer
+                  default: 100
+              required:
+                - criteria
+components:
+  schemas:
+    dataSetList:
+      type: object
+      properties:
+        total:
+          type: integer
+        apis:
+          type: array
+          items:
+            type: object
+            properties:
+              apiKey:
+                type: string
+                description: To be used as a dataset parameter value
+              apiVersionNumber:
+                type: string
+                description: To be used as a version parameter value
+              apiUrl:
+                type: string
+                format: uriref
+                description: "The URL describing the dataset's fields"
+              apiDocumentationUrl:
+                type: string
+                format: uriref
+                description: A URL to the API console for each API
+                

--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -23,7 +23,8 @@ describe('cli', () => {
     main({commands: true}, getLog(entries));
     expect(entries).to.eql([
       'Available commands: ',
-      '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  lb4 example',
+      '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
+        'lb4 example\n  lb4 openapi',
     ]);
   });
 
@@ -40,7 +41,8 @@ describe('cli', () => {
     main({help: true, _: []}, getLog(entries), true);
     expect(entries).to.containEql('Available commands: ');
     expect(entries).to.containEql(
-      '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  lb4 example',
+      '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
+        'lb4 example\n  lb4 openapi',
     );
   });
 

--- a/packages/cli/test/integration/generators/openapi-petstore.integration.js
+++ b/packages/cli/test/integration/generators/openapi-petstore.integration.js
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const generator = path.join(__dirname, '../../../generators/openapi');
+const specPath = path.join(
+  __dirname,
+  '../../fixtures/openapi/3.0/petstore-expanded.yaml',
+);
+
+const testlab = require('@loopback/testlab');
+const TestSandbox = testlab.TestSandbox;
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+const testUtils = require('../../test-utils');
+
+const props = {
+  url: specPath,
+};
+
+describe('openapi-generator specific files', () => {
+  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const controller = path.resolve(
+    SANDBOX_PATH,
+    'src/controllers/open-api.controller.ts',
+  );
+
+  const petModel = path.resolve(SANDBOX_PATH, 'src/models/pet.model.ts');
+  const newPetModel = path.resolve(SANDBOX_PATH, 'src/models/new-pet.model.ts');
+  const errorModel = path.resolve(SANDBOX_PATH, 'src/models/error.model.ts');
+
+  after('reset sandbox', async () => {
+    await sandbox.reset();
+  });
+
+  it('generates all the proper files', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .withPrompts(props);
+    assert.file(controller);
+
+    assert.fileContent(controller, 'export class OpenApiController {');
+    assert.fileContent(controller, `@operation('get', '/pets')`);
+    assert.fileContent(
+      controller,
+      `async findPets(@param({name: 'tags', in: 'query'}) tags: string[], ` +
+        `@param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]>`,
+    );
+
+    assert.fileContent(index, `export * from './open-api.controller';`);
+
+    assert.file(petModel);
+    assert.fileContent(petModel, `import {NewPet} from './new-pet.model';`);
+    assert.fileContent(
+      petModel,
+      `export type Pet = NewPet & {
+  id: number;
+};`,
+    );
+    assert.file(newPetModel);
+    assert.fileContent(newPetModel, `export class NewPet {`);
+    assert.fileContent(newPetModel, `@model({name: 'NewPet'})`);
+    assert.fileContent(newPetModel, `@property({name: 'name'})`);
+    assert.fileContent(newPetModel, `name: string;`);
+    assert.fileContent(newPetModel, `@property({name: 'tag'})`);
+    assert.fileContent(newPetModel, `tag?: string`);
+    assert.file(errorModel);
+  });
+});

--- a/packages/cli/test/integration/generators/openapi-uspto.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto.integration.js
@@ -1,0 +1,80 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const generator = path.join(__dirname, '../../../generators/openapi');
+const specPath = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
+
+const testlab = require('@loopback/testlab');
+const TestSandbox = testlab.TestSandbox;
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+const testUtils = require('../../test-utils');
+
+const props = {
+  url: specPath,
+};
+
+describe('openapi-generator specific files', () => {
+  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const searchController = path.resolve(
+    SANDBOX_PATH,
+    'src/controllers/search.controller.ts',
+  );
+  const metadataController = path.resolve(
+    SANDBOX_PATH,
+    'src/controllers/metadata.controller.ts',
+  );
+  after('reset sandbox', async () => {
+    await sandbox.reset();
+  });
+
+  it('generates all the proper files', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .withPrompts(props);
+    assert.file(searchController);
+
+    assert.fileContent(metadataController, 'export class MetadataController {');
+    assert.fileContent(metadataController, `@operation('get', '/')`);
+    assert.fileContent(
+      metadataController,
+      'async listDataSets(): Promise<DataSetList> {',
+    );
+    assert.fileContent(
+      metadataController,
+      `@operation('get', '/{dataset}/{version}/fields')`,
+    );
+    assert.fileContent(
+      metadataController,
+      `async listSearchableFields(@param({name: 'dataset', in: 'path'}) ` +
+        `dataset: string, @param({name: 'version', in: 'path'}) ` +
+        `version: string): Promise<string> {`,
+    );
+
+    assert.fileContent(index, `export * from './search.controller';`);
+    assert.fileContent(index, `export * from './metadata.controller';`);
+  });
+
+  it('skips controllers not selected', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .withPrompts({
+        url: specPath,
+        controllerSelections: ['MetadataController'],
+      });
+    assert.file(metadataController);
+    assert.noFile(searchController);
+    assert.noFileContent(index, `export * from './search.controller';`);
+    assert.fileContent(index, `export * from './metadata.controller';`);
+  });
+});

--- a/packages/cli/test/integration/generators/swagger-petstore.integration.js
+++ b/packages/cli/test/integration/generators/swagger-petstore.integration.js
@@ -1,0 +1,78 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const generator = path.join(__dirname, '../../../generators/openapi');
+const specPath = path.join(
+  __dirname,
+  '../../fixtures/openapi/2.0/petstore-expanded-swagger.json',
+);
+
+const testlab = require('@loopback/testlab');
+const TestSandbox = testlab.TestSandbox;
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+const testUtils = require('../../test-utils');
+
+const props = {
+  url: specPath,
+};
+
+describe('openapi-generator specific files', () => {
+  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const controller = path.resolve(
+    SANDBOX_PATH,
+    'src/controllers/open-api.controller.ts',
+  );
+
+  const petModel = path.resolve(SANDBOX_PATH, 'src/models/pet.model.ts');
+  const newPetModel = path.resolve(SANDBOX_PATH, 'src/models/new-pet.model.ts');
+  const errorModel = path.resolve(SANDBOX_PATH, 'src/models/error.model.ts');
+
+  after('reset sandbox', async () => {
+    await sandbox.reset();
+  });
+
+  it('generates all the proper files', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .withPrompts(props);
+    assert.file(controller);
+
+    assert.fileContent(controller, 'export class OpenApiController {');
+    assert.fileContent(controller, `@operation('get', '/pets')`);
+    assert.fileContent(
+      controller,
+      `async findPets(@param({name: 'tags', in: 'query'}) tags: string[], ` +
+        `@param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]>`,
+    );
+
+    assert.fileContent(index, `export * from './open-api.controller';`);
+
+    assert.file(petModel);
+    assert.fileContent(petModel, `import {NewPet} from './new-pet.model';`);
+    assert.fileContent(
+      petModel,
+      `export type Pet = NewPet & {
+  id: number;
+};`,
+    );
+    assert.file(newPetModel);
+    assert.fileContent(newPetModel, `export class NewPet {`);
+    assert.fileContent(newPetModel, `constructor(data?: Partial<NewPet>) {`);
+    assert.fileContent(newPetModel, `@model({name: 'NewPet'})`);
+    assert.fileContent(newPetModel, `@property({name: 'name'})`);
+    assert.fileContent(newPetModel, `name: string;`);
+    assert.fileContent(newPetModel, `@property({name: 'tag'})`);
+    assert.fileContent(newPetModel, `tag?: string`);
+    assert.file(errorModel);
+  });
+});

--- a/packages/cli/test/unit/openapi/controller-spec.unit.js
+++ b/packages/cli/test/unit/openapi/controller-spec.unit.js
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const expect = require('@loopback/testlab').expect;
+const {loadAndBuildSpec} = require('../../../generators/openapi/spec-loader');
+const path = require('path');
+
+describe('openapi to controllers/models', () => {
+  const customer = path.join(
+    __dirname,
+    '../../fixtures/openapi/3.0/customer.yaml',
+  );
+
+  it('generates models for customer', async () => {
+    const customerSepc = await loadAndBuildSpec(customer);
+    expect(customerSepc.controllerSpecs).to.eql([
+      {
+        tag: 'Customer',
+        className: 'CustomerController',
+        description: 'Customer resource',
+        imports: ["import {Customer} from '../models/customer.model';"],
+        methods: [
+          {
+            description: 'Returna all customers',
+            decoration: "@operation('get', '/customers')",
+            signature:
+              "async ''(@param({name: 'if', in: 'query'}) _if: string[], " +
+              "@param({name: 'limit', in: 'query'}) limit: number): " +
+              'Promise<Customer[]>',
+          },
+          {
+            description: 'Creates a new customer',
+            decoration: "@operation('post', '/customers')",
+            signature: 'async createCustomer(): Promise<Customer>',
+          },
+          {
+            description: 'Returns a customer based on a single ID',
+            decoration: "@operation('get', '/customers/{id}')",
+            signature:
+              "async findCustomerById(@param({name: 'id', in: 'path'}) " +
+              'id: number): Promise<Customer>',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/cli/test/unit/openapi/schema-helper.unit.js
+++ b/packages/cli/test/unit/openapi/schema-helper.unit.js
@@ -1,0 +1,185 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const expect = require('@loopback/testlab').expect;
+const {mapSchemaType} = require('../../../generators/openapi/schema-helper');
+
+function expectMapping(schema, expectedJSType, options) {
+  const jsType = mapSchemaType(schema, options).signature;
+  expect(jsType).to.equal(expectedJSType);
+}
+
+describe('primitive types', () => {
+  it('maps integer', () => {
+    expectMapping({type: 'integer'}, 'number');
+  });
+
+  it('maps int32 integer', () => {
+    expectMapping({type: 'integer', format: 'int32'}, 'number');
+  });
+
+  it('maps int64 integer', () => {
+    expectMapping({type: 'integer', format: 'int64'}, 'number');
+  });
+
+  it('maps float', () => {
+    expectMapping({type: 'number', format: 'float'}, 'number');
+  });
+
+  it('maps double', () => {
+    expectMapping({type: 'number', format: 'double'}, 'number');
+  });
+
+  it('maps boolean', () => {
+    expectMapping({type: 'boolean'}, 'boolean');
+  });
+
+  it('maps string', () => {
+    expectMapping({type: 'string'}, 'string');
+  });
+
+  it('maps date', () => {
+    expectMapping({type: 'string', format: 'date'}, 'Date');
+  });
+
+  it('maps date-time', () => {
+    expectMapping({type: 'string', format: 'date'}, 'Date');
+  });
+
+  it('maps password', () => {
+    expectMapping({type: 'string', format: 'password'}, 'string');
+  });
+
+  it('maps byte', () => {
+    expectMapping({type: 'string', format: 'byte'}, 'string');
+  });
+
+  it('maps binary', () => {
+    expectMapping({type: 'string', format: 'binary'}, 'Buffer');
+  });
+});
+
+describe('primitive types with default', () => {
+  it('maps integer', () => {
+    expectMapping({type: 'integer', default: 10}, 'number = 10', {
+      includeDefault: true,
+    });
+  });
+
+  it('maps string', () => {
+    expectMapping({type: 'string', default: 'ABC'}, "string = 'ABC'", {
+      includeDefault: true,
+    });
+  });
+
+  it('maps boolean', () => {
+    expectMapping({type: 'boolean', default: false}, 'boolean = false', {
+      includeDefault: true,
+    });
+  });
+});
+
+describe('primitive types with enum', () => {
+  it('maps integer', () => {
+    expectMapping({type: 'integer', enum: [1, 2], default: 2}, '1 | 2');
+  });
+
+  it('maps string', () => {
+    expectMapping({type: 'string', enum: ['A', 'B', 'C']}, "'A' | 'B' | 'C'");
+  });
+});
+
+describe('array types', () => {
+  it('maps integer array', () => {
+    expectMapping({type: 'array', items: {type: 'integer'}}, 'number[]');
+  });
+
+  it('maps number array', () => {
+    expectMapping({type: 'array', items: {type: 'number'}}, 'number[]');
+  });
+
+  it('maps string array', () => {
+    expectMapping({type: 'array', items: {type: 'string'}}, 'string[]');
+  });
+
+  it('maps boolean array', () => {
+    expectMapping({type: 'array', items: {type: 'boolean'}}, 'boolean[]');
+  });
+});
+
+describe('object types', () => {
+  it('maps object', () => {
+    expectMapping(
+      {
+        type: 'object',
+        properties: {
+          id: {type: 'number'},
+          firstName: {type: 'string'},
+          lastName: {type: 'string'},
+          email: {type: 'string'},
+          created: {type: 'string', format: 'date-time'},
+          vip: {type: 'boolean', default: false},
+        },
+        required: ['id', 'email'],
+      },
+      `{
+  id: number;
+  firstName?: string;
+  lastName?: string;
+  email: string;
+  created?: Date;
+  vip?: boolean;
+}`,
+    );
+  });
+
+  it('maps same schema object to the same type', () => {
+    const schemas = {
+      Customer: {
+        type: 'object',
+        properties: {
+          id: {type: 'number'},
+          firstName: {type: 'string'},
+          lastName: {type: 'string'},
+          email: {type: 'string'},
+          created: {type: 'string', format: 'date-time'},
+          vip: {type: 'boolean', default: false},
+        },
+        required: ['id', 'email'],
+      },
+    };
+    const options = {
+      objectTypeMapping: new Map(),
+    };
+    options.objectTypeMapping.set(schemas.Customer, {
+      name: 'Customer',
+      className: 'Customer',
+    });
+    expectMapping(schemas.Customer, 'Customer', options);
+  });
+});
+
+describe('composite types', () => {
+  it('maps oneOf', () => {
+    expectMapping(
+      {oneOf: [{type: 'string'}, {type: 'number'}]},
+      'string | number',
+    );
+  });
+
+  it('maps anyOf', () => {
+    expectMapping(
+      {anyOf: [{type: 'string'}, {type: 'number'}]},
+      'string | number',
+    );
+  });
+
+  it('maps allOf', () => {
+    expectMapping(
+      {allOf: [{type: 'string'}, {type: 'number'}]},
+      'string & number',
+    );
+  });
+});

--- a/packages/cli/test/unit/openapi/schema-model.unit.js
+++ b/packages/cli/test/unit/openapi/schema-model.unit.js
@@ -1,0 +1,213 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const expect = require('@loopback/testlab').expect;
+const {loadSpec} = require('../../../generators/openapi/spec-loader');
+const {
+  generateModelSpecs,
+} = require('../../../generators/openapi/schema-helper');
+const path = require('path');
+
+describe('schema to model', () => {
+  let usptoSpec, petstoreSpec, customerSepc;
+  const uspto = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
+  const petstore = path.join(
+    __dirname,
+    '../../fixtures/openapi/3.0/petstore-expanded.yaml',
+  );
+  const customer = path.join(
+    __dirname,
+    '../../fixtures/openapi/3.0/customer.yaml',
+  );
+
+  before(async () => {
+    usptoSpec = await loadSpec(uspto);
+    petstoreSpec = await loadSpec(petstore);
+    customerSepc = await loadSpec(customer);
+  });
+
+  it('generates models for uspto', () => {
+    const objectTypeMapping = new Map();
+    const models = generateModelSpecs(usptoSpec, {objectTypeMapping});
+    expect(models).to.eql([
+      {
+        name: 'dataSetList',
+        description: 'dataSetList',
+        className: 'DataSetList',
+        fileName: 'data-set-list.model.ts',
+        import: "import {DataSetList} from './data-set-list.model';",
+        imports: [],
+        kind: 'class',
+        properties: [
+          {
+            name: 'total',
+            signature: 'total?: number;',
+            decoration: "@property({name: 'total'})",
+          },
+          {
+            name: 'apis',
+            signature:
+              'apis?: {\n  apiKey?: string;\n  apiVersionNumber?: string;\n' +
+              '  apiUrl?: string;\n  apiDocumentationUrl?: string;\n}[];',
+            decoration: "@property({name: 'apis'})",
+          },
+        ],
+        declaration:
+          '{\n  total?: number;\n  apis?: {\n  apiKey?: string;\n' +
+          '  apiVersionNumber?: string;\n  apiUrl?: string;\n' +
+          '  apiDocumentationUrl?: string;\n}[];\n}',
+        signature: 'DataSetList',
+      },
+    ]);
+  });
+
+  it('generates models for petstore', () => {
+    const objectTypeMapping = new Map();
+    const models = generateModelSpecs(petstoreSpec, {objectTypeMapping});
+    expect(models).to.eql([
+      {
+        name: 'Pet',
+        className: 'Pet',
+        fileName: 'pet.model.ts',
+        description: 'Pet',
+        properties: [],
+        imports: ["import {NewPet} from './new-pet.model';"],
+        members: [
+          {
+            name: 'NewPet',
+            description: 'NewPet',
+            className: 'NewPet',
+            fileName: 'new-pet.model.ts',
+            kind: 'class',
+            properties: [
+              {
+                name: 'name',
+                signature: 'name: string;',
+                decoration: "@property({name: 'name'})",
+              },
+              {
+                name: 'tag',
+                signature: 'tag?: string;',
+                decoration: "@property({name: 'tag'})",
+              },
+            ],
+            imports: [],
+            declaration: '{\n  name: string;\n  tag?: string;\n}',
+            signature: 'NewPet',
+            import: "import {NewPet} from './new-pet.model';",
+          },
+          {
+            declaration: '{\n  id: number;\n}',
+            imports: [],
+            properties: [
+              {
+                name: 'id',
+                signature: 'id: number;',
+                decoration: "@property({name: 'id'})",
+              },
+            ],
+            signature: '{\n  id: number;\n}',
+          },
+        ],
+        declaration: 'NewPet & {\n  id: number;\n}',
+        signature: 'Pet',
+        import: "import {Pet} from './pet.model';",
+      },
+      {
+        name: 'NewPet',
+        description: 'NewPet',
+        className: 'NewPet',
+        fileName: 'new-pet.model.ts',
+        kind: 'class',
+        properties: [
+          {
+            name: 'name',
+            signature: 'name: string;',
+            decoration: "@property({name: 'name'})",
+          },
+          {
+            name: 'tag',
+            signature: 'tag?: string;',
+            decoration: "@property({name: 'tag'})",
+          },
+        ],
+        imports: [],
+        declaration: '{\n  name: string;\n  tag?: string;\n}',
+        signature: 'NewPet',
+        import: "import {NewPet} from './new-pet.model';",
+      },
+      {
+        name: 'Error',
+        description: 'Error',
+        className: 'Error',
+        fileName: 'error.model.ts',
+        kind: 'class',
+        properties: [
+          {
+            name: 'code',
+            signature: 'code: number;',
+            decoration: "@property({name: 'code'})",
+          },
+          {
+            name: 'message',
+            signature: 'message: string;',
+            decoration: "@property({name: 'message'})",
+          },
+        ],
+        imports: [],
+        declaration: '{\n  code: number;\n  message: string;\n}',
+        signature: 'Error',
+        import: "import {Error} from './error.model';",
+      },
+    ]);
+  });
+
+  it('generates models for customer', () => {
+    const objectTypeMapping = new Map();
+    const models = generateModelSpecs(customerSepc, {objectTypeMapping});
+    expect(models).to.eql([
+      {
+        description: 'Name',
+        name: 'Name',
+        className: 'Name',
+        fileName: 'name.model.ts',
+        properties: [],
+        imports: [],
+        import: "import {Name} from './name.model';",
+        declaration: 'string',
+        signature: 'Name',
+      },
+      {
+        description: 'Customer',
+        name: 'Customer',
+        className: 'Customer',
+        fileName: 'customer.model.ts',
+        properties: [
+          {
+            name: 'id',
+            signature: 'id: number;',
+            decoration: "@property({name: 'id'})",
+          },
+          {
+            name: 'first-name',
+            signature: "'first-name'?: string;",
+            decoration: "@property({name: 'first-name'})",
+          },
+          {
+            name: 'last-name',
+            signature: "'last-name'?: Name;",
+            decoration: "@property({name: 'last-name'})",
+          },
+        ],
+        imports: ["import {Name} from './name.model';"],
+        import: "import {Customer} from './customer.model';",
+        kind: 'class',
+        declaration:
+          "{\n  id: number;\n  'first-name'?: string;\n  'last-name'?: Name;\n}",
+        signature: 'Customer',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
The PR adds `lb4 openapi` command to generate controllers from openapi specs (Swagger 2.0 and OpenAPI 3.0). 

- Supports swagger 2.0 and openapi 3.0
- Maps tagged operations to controllers
- Maps schemas to TypeScript classes/types
- Supports circular references
- Supports `enum`
- Supports `default`
- Supports `required`

Smoke test against https://api.apis.guru/v2/list.json.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
