### PR TITLE
chore: add a test case to examples/hello-world

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^0.6.6",
+    "@loopback/testlab": "^0.10.5",
     "@types/node": "^10.1.1"
   },
   "keywords": [

--- a/examples/hello-world/src/application.ts
+++ b/examples/hello-world/src/application.ts
@@ -3,11 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {ApplicationConfig} from '@loopback/core';
 import {RestApplication, RestServer} from '@loopback/rest';
 
 export class HelloWorldApplication extends RestApplication {
-  constructor() {
-    super();
+  constructor(options?: ApplicationConfig) {
+    super(options);
 
     // In this example project, we configure a sequence that always
     // returns the same HTTP response: Hello World!
@@ -21,7 +22,11 @@ export class HelloWorldApplication extends RestApplication {
   async start() {
     await super.start();
 
-    const rest = await this.getServer(RestServer);
-    console.log(`REST server running on port: ${await rest.get('rest.port')}`);
+    if (!(this.options && this.options.disableConsoleLog)) {
+      const rest = await this.getServer(RestServer);
+      console.log(
+        `REST server running on port: ${await rest.get('rest.port')}`,
+      );
+    }
   }
 }

--- a/examples/hello-world/test/acceptance/application.acceptance.ts
+++ b/examples/hello-world/test/acceptance/application.acceptance.ts
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {createClientForHandler, expect, supertest} from '@loopback/testlab';
+import {RestServer} from '@loopback/rest';
+import {HelloWorldApplication} from '../../src/application';
+
+describe('Application', () => {
+  let app: HelloWorldApplication;
+  let client: supertest.SuperTest<supertest.Test>;
+  let server: RestServer;
+
+  before(givenAnApplication);
+  before(async () => {
+    await app.start();
+    server = await app.getServer(RestServer);
+  });
+
+  before(() => {
+    client = createClientForHandler(server.requestHandler);
+  });
+  after(async () => {
+    await app.stop();
+  });
+
+  it('responds with hello world', async () => {
+    const response = await client.get('/').expect(200);
+    expect(response.text).to.eql('Hello World!');
+  });
+
+  function givenAnApplication() {
+    app = new HelloWorldApplication({
+      rest: {
+        port: 0,
+      },
+      disableConsoleLog: true,
+    });
+  }
+});

--- a/examples/hello-world/tsconfig.build.json
+++ b/examples/hello-world/tsconfig.build.json
@@ -4,5 +4,5 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["index.ts", "src"]
+  "include": ["index.ts", "src", "test"]
 }


### PR DESCRIPTION
Before this change, `npm test` under `examples/hello-world` fails as there is no test.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
