### PR TITLE
chore(build): pin typescript version to 2.8.x

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -26,7 +26,7 @@
     "source-map-support": "^0.5.5",
     "strong-docs": "^3.0.1",
     "tslint": "^5.9.1",
-    "typescript": "^2.9.1"
+    "typescript": "~2.8.4"
   },
   "bin": {
     "lb-tsc": "./bin/compile-package.js",


### PR DESCRIPTION
TypeScript 2.9 transpiles code with relative import to reference
external types and the path can be invalid if a depenednecy is
symbol-linked.

See https://github.com/strongloop/loopback-next/issues/1405

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
