### PR TITLE
feat: coercion for other types

### DIFF
--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -143,9 +143,6 @@ export class TodoController {
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
   ): Promise<boolean> {
-    // REST adapter does not coerce parameter values coming from string sources
-    // like path & query, so we cast the value to a number ourselves.
-    id = +id;
     return await this.todoRepo.replaceById(id, todo);
   }
 
@@ -154,7 +151,6 @@ export class TodoController {
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
   ): Promise<boolean> {
-    id = +id;
     return await this.todoRepo.updateById(id, todo);
   }
 

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -38,7 +38,8 @@
     "http-errors": "^1.6.3",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.5",
-    "path-to-regexp": "^2.2.0"
+    "path-to-regexp": "^2.2.0",
+    "validator": "^10.4.0"
   },
   "devDependencies": {
     "@loopback/build": "^0.6.9",

--- a/packages/rest/src/coercion/rest-http-error.ts
+++ b/packages/rest/src/coercion/rest-http-error.ts
@@ -9,8 +9,7 @@ export namespace RestHttpErrors {
     return new HttpErrors.BadRequest(msg);
   }
   export function invalidParamLocation(location: string): HttpErrors.HttpError {
-    return new HttpErrors.NotImplemented(
-      'Parameters with "in: ' + location + '" are not supported yet.',
-    );
+    const msg = `Parameters with "in: ${location}" are not supported yet.`;
+    return new HttpErrors.NotImplemented(msg);
   }
 }

--- a/packages/rest/src/coercion/utils.ts
+++ b/packages/rest/src/coercion/utils.ts
@@ -1,0 +1,102 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as debugModule from 'debug';
+const debug = debugModule('loopback:rest:coercion');
+
+/**
+ * Options for function coerceDatetime
+ */
+export type DateCoercionOptions = {
+  dateOnly?: boolean;
+};
+
+/**
+ * Options for function coerceInteger
+ */
+export type IntegerCoercionOptions = {
+  isLong?: boolean;
+};
+
+export function isEmpty(data: string) {
+  debug('isEmpty %s', data);
+  return data === '';
+}
+/**
+ * A set of truthy values. A data in this set will be coerced to `true`.
+ *
+ * @param data The raw data get from http request
+ * @returns The corresponding coerced boolean type
+ */
+export function isTrue(data: string): boolean {
+  return ['TRUE', '1'].includes(data.toUpperCase());
+}
+
+/**
+ * A set of falsy values. A data in this set will be coerced to `false`.
+ * @param data The raw data get from http request
+ * @returns The corresponding coerced boolean type
+ */
+export function isFalse(data: string): boolean {
+  return ['FALSE', '0'].includes(data.toUpperCase());
+}
+
+/**
+ * Return false for invalid date
+ */
+export function isValidDateTime(data: Date) {
+  return isNaN(data.getTime()) ? false : true;
+}
+
+const REGEX_RFC3339_DATE = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])$/;
+
+/**
+ * Return true when a date follows the RFC3339 standard
+ *
+ * @param date The date to verify
+ */
+export function matchDateFormat(date: string) {
+  const pattern = new RegExp(REGEX_RFC3339_DATE);
+  debug('matchDateFormat: %s', pattern.test(date));
+  return pattern.test(date);
+}
+
+/**
+ * Return the corresponding OpenAPI data type given an OpenAPI schema
+ *
+ * @param type The type in an OpenAPI schema specification
+ * @param format The format in an OpenAPI schema specification
+ */
+export function getOAIPrimitiveType(type?: string, format?: string) {
+  // serizlize will be supported in next PR
+  if (type === 'object' || type === 'array') return 'serialize';
+  if (type === 'string') {
+    switch (format) {
+      case 'byte':
+        return 'byte';
+      case 'binary':
+        return 'binary';
+      case 'date':
+        return 'date';
+      case 'date-time':
+        return 'date-time';
+      case 'password':
+        return 'password';
+      default:
+        return 'string';
+    }
+  }
+  if (type === 'boolean') return 'boolean';
+  if (type === 'number')
+    switch (format) {
+      case 'float':
+        return 'float';
+      case 'double':
+        return 'double';
+      default:
+        return 'number';
+    }
+  if (type === 'integer') return format === 'int64' ? 'long' : 'integer';
+}

--- a/packages/rest/test/unit/coercion/paramStringToBoolean.unit.ts
+++ b/packages/rest/test/unit/coercion/paramStringToBoolean.unit.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {test} from './utils';
+import {RestHttpErrors} from '../../../';
 import {ParameterLocation} from '@loopback/openapi-v3-types';
 
 const BOOLEAN_PARAM = {
@@ -12,8 +13,68 @@ const BOOLEAN_PARAM = {
   schema: {type: 'boolean'},
 };
 
-describe('coerce param from string to boolean', () => {
-  test(BOOLEAN_PARAM, 'false', false);
-  test(BOOLEAN_PARAM, 'true', true);
-  test(BOOLEAN_PARAM, undefined, undefined);
+const REQUIRED_BOOLEAN_PARAM = {
+  in: <ParameterLocation>'path',
+  name: 'aparameter',
+  schema: {type: 'boolean'},
+  required: true,
+};
+
+describe('coerce param from string to boolean - required', function() {
+  context('valid values', () => {
+    test(REQUIRED_BOOLEAN_PARAM, 'false', false);
+    test(REQUIRED_BOOLEAN_PARAM, 'true', true);
+    test(REQUIRED_BOOLEAN_PARAM, 'FALSE', false);
+    test(REQUIRED_BOOLEAN_PARAM, 'TRUE', true);
+    test(REQUIRED_BOOLEAN_PARAM, '0', false);
+    test(REQUIRED_BOOLEAN_PARAM, '1', true);
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(
+      REQUIRED_BOOLEAN_PARAM,
+      '',
+      RestHttpErrors.missingRequired(REQUIRED_BOOLEAN_PARAM.name),
+    );
+  });
+});
+
+describe('coerce param from string to boolean - optional', function() {
+  context('valid values', () => {
+    test(BOOLEAN_PARAM, 'false', false);
+    test(BOOLEAN_PARAM, 'true', true);
+    test(BOOLEAN_PARAM, 'FALSE', false);
+    test(BOOLEAN_PARAM, 'TRUE', true);
+    test(BOOLEAN_PARAM, '0', false);
+    test(BOOLEAN_PARAM, '1', true);
+  });
+
+  context('invalid values should trigger ERROR_BAD_REQUEST', () => {
+    test(
+      BOOLEAN_PARAM,
+      'text',
+      RestHttpErrors.invalidData('text', BOOLEAN_PARAM.name),
+    );
+    test(
+      BOOLEAN_PARAM,
+      'null',
+      RestHttpErrors.invalidData('null', BOOLEAN_PARAM.name),
+    );
+    // {a: true}, [1,2] are converted to object
+    test(
+      BOOLEAN_PARAM,
+      {a: true},
+      RestHttpErrors.invalidData({a: true}, BOOLEAN_PARAM.name),
+    );
+  });
+
+  context('empty collection converts to undefined', () => {
+    test(BOOLEAN_PARAM, undefined, undefined);
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(BOOLEAN_PARAM, '', RestHttpErrors.invalidData('', BOOLEAN_PARAM.name));
+  });
 });

--- a/packages/rest/test/unit/coercion/paramStringToBuffer.unit.ts
+++ b/packages/rest/test/unit/coercion/paramStringToBuffer.unit.ts
@@ -5,6 +5,7 @@
 
 import {test} from './utils';
 import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {RestHttpErrors} from '../../..';
 
 const BUFFER_PARAM = {
   in: <ParameterLocation>'path',
@@ -12,14 +13,51 @@ const BUFFER_PARAM = {
   schema: {type: 'string', format: 'byte'},
 };
 
-describe('coerce param from string to buffer', () => {
-  const testValues = {
-    base64: Buffer.from('Hello World').toString('base64'),
-  };
+const REQUIRED_BUFFER_PARAM = {
+  in: <ParameterLocation>'path',
+  name: 'aparameter',
+  schema: {type: 'string', format: 'byte'},
+  required: true,
+};
 
-  test(
-    BUFFER_PARAM,
-    testValues.base64,
-    Buffer.from(testValues.base64, 'base64'),
-  );
+describe('coerce param from string to buffer - required', () => {
+  context('valid value', () => {
+    const testValues = {
+      base64: Buffer.from('Hello World').toString('base64'),
+    };
+
+    test(
+      BUFFER_PARAM,
+      testValues.base64,
+      Buffer.from(testValues.base64, 'base64'),
+    );
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(
+      REQUIRED_BUFFER_PARAM,
+      '',
+      RestHttpErrors.missingRequired(REQUIRED_BUFFER_PARAM.name),
+    );
+  });
+});
+
+describe('coerce param from string to buffer - optional', () => {
+  context('valid values', () => {
+    const testValues = {
+      base64: Buffer.from('Hello World').toString('base64'),
+    };
+
+    test(
+      BUFFER_PARAM,
+      testValues.base64,
+      Buffer.from(testValues.base64, 'base64'),
+    );
+  });
+
+  context('empty collection converts to undefined', () => {
+    // [], {} sent from request are converted to raw value undefined
+    test(BUFFER_PARAM, undefined, undefined);
+  });
 });

--- a/packages/rest/test/unit/coercion/paramStringToDate.unit.ts
+++ b/packages/rest/test/unit/coercion/paramStringToDate.unit.ts
@@ -5,6 +5,7 @@
 
 import {test} from './utils';
 import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {RestHttpErrors} from '../../../';
 
 const DATE_PARAM = {
   in: <ParameterLocation>'path',
@@ -12,6 +13,68 @@ const DATE_PARAM = {
   schema: {type: 'string', format: 'date'},
 };
 
-describe('coerce param from string to date', () => {
-  test(DATE_PARAM, '2015-03-01', new Date('2015-03-01'));
+const REQUIRED_DATETIME_PARAM = {
+  in: <ParameterLocation>'path',
+  name: 'aparameter',
+  schema: {type: 'string', format: 'date'},
+  required: true,
+};
+
+describe('coerce param from string to date - required', () => {
+  context('valid values', () => {
+    test(REQUIRED_DATETIME_PARAM, '2016-05-19', new Date('2016-05-19'));
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(
+      REQUIRED_DATETIME_PARAM,
+      '',
+      RestHttpErrors.missingRequired(REQUIRED_DATETIME_PARAM.name),
+    );
+  });
+});
+
+describe('coerce param from string to date - optional', () => {
+  context('valid values', () => {
+    test(DATE_PARAM, '2015-03-01', new Date('2015-03-01'));
+  });
+
+  context('invalid values trigger ERROR_BAD_REQUEST', () => {
+    test(
+      DATE_PARAM,
+      '2015-04-32',
+      RestHttpErrors.invalidData('2015-04-32', DATE_PARAM.name),
+    );
+    test(
+      DATE_PARAM,
+      '2015-03-01T11:20:20.001Z',
+      RestHttpErrors.invalidData('2015-03-01T11:20:20.001Z', DATE_PARAM.name),
+    );
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(DATE_PARAM, '', RestHttpErrors.invalidData('', DATE_PARAM.name));
+  });
+
+  context('empty collection converts to undefined', () => {
+    // [], {} sent from request are converted to raw value undefined
+    test(DATE_PARAM, undefined, undefined);
+  });
+
+  context('All other non-date values trigger ERROR_BAD_REQUEST', () => {
+    // 'false', false, 'true', true, 'text' sent from request are converted to a string
+    test(
+      DATE_PARAM,
+      'text',
+      RestHttpErrors.invalidData('text', DATE_PARAM.name),
+    );
+    // {a: true}, [1,2] are converted to object
+    test(
+      DATE_PARAM,
+      {a: true},
+      RestHttpErrors.invalidData({a: true}, DATE_PARAM.name),
+    );
+  });
 });

--- a/packages/rest/test/unit/coercion/paramStringToInteger.unit.ts
+++ b/packages/rest/test/unit/coercion/paramStringToInteger.unit.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {test} from './utils';
+import {RestHttpErrors} from '../../../';
 import {ParameterLocation} from '@loopback/openapi-v3-types';
 
 const INT32_PARAM = {
@@ -18,7 +19,123 @@ const INT64_PARAM = {
   schema: {type: 'integer', format: 'int64'},
 };
 
+const REQUIRED_INTEGER_PARAM = {
+  in: <ParameterLocation>'path',
+  name: 'aparameter',
+  schema: {type: 'integer'},
+  required: true,
+};
+
+const INTEGER_PARAM = {
+  in: <ParameterLocation>'path',
+  name: 'aparameter',
+  schema: {type: 'integer'},
+};
+
 describe('coerce param from string to integer', () => {
   test(INT32_PARAM, '100', 100);
   test(INT64_PARAM, '9223372036854775807', 9223372036854775807);
+});
+
+describe('coerce param from string to integer - required', function() {
+  context('valid values', () => {
+    test(REQUIRED_INTEGER_PARAM, '0', 0);
+    test(REQUIRED_INTEGER_PARAM, '1', 1);
+    test(REQUIRED_INTEGER_PARAM, '-1', -1);
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(
+      REQUIRED_INTEGER_PARAM,
+      '',
+      RestHttpErrors.missingRequired(REQUIRED_INTEGER_PARAM.name),
+    );
+  });
+});
+
+describe('coerce param from string to integer - optional', function() {
+  context('valid values', () => {
+    test(INTEGER_PARAM, '0', 0);
+    test(INTEGER_PARAM, '1', 1);
+    test(INTEGER_PARAM, '-1', -1);
+  });
+
+  context(
+    'integers larger than MAX_SAFE_INTEGER should trigger ERROR_BAD_REQUEST',
+    () => {
+      test(
+        INTEGER_PARAM,
+        '2343546576878989879789',
+        RestHttpErrors.invalidData(
+          '2343546576878989879789',
+          REQUIRED_INTEGER_PARAM.name,
+        ),
+      );
+      test(
+        INTEGER_PARAM,
+        '-2343546576878989879789',
+        RestHttpErrors.invalidData(
+          '-2343546576878989879789',
+          REQUIRED_INTEGER_PARAM.name,
+        ),
+      );
+      test(
+        INTEGER_PARAM,
+        '1.234e+30',
+        RestHttpErrors.invalidData('1.234e+30', REQUIRED_INTEGER_PARAM.name),
+      );
+      test(
+        INTEGER_PARAM,
+        '-1.234e+30',
+        RestHttpErrors.invalidData('-1.234e+30', REQUIRED_INTEGER_PARAM.name),
+      );
+    },
+  );
+
+  context('scientific notations', () => {
+    test(INTEGER_PARAM, '1.234e+3', 1.234e3);
+    test(INTEGER_PARAM, '-1.234e+3', -1.234e3);
+  });
+
+  context('integer-like string values should trigger ERROR_BAD_REQUEST', () => {
+    test(
+      INTEGER_PARAM,
+      '1.2',
+      RestHttpErrors.invalidData('1.2', INTEGER_PARAM.name),
+    );
+    test(
+      INTEGER_PARAM,
+      '-1.2',
+      RestHttpErrors.invalidData('-1.2', INTEGER_PARAM.name),
+    );
+  });
+
+  context('empty collection converts to undefined', () => {
+    // [], {} sent from request are converted to raw value undefined
+    test(INTEGER_PARAM, undefined, undefined);
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(INTEGER_PARAM, '', RestHttpErrors.invalidData('', INTEGER_PARAM.name));
+  });
+
+  context(
+    'all other non-integer values should trigger ERROR_BAD_REQUEST',
+    () => {
+      // 'false', false, 'true', true, 'text' sent from request are converted to a string
+      test(
+        INTEGER_PARAM,
+        'text',
+        RestHttpErrors.invalidData('text', INTEGER_PARAM.name),
+      );
+      // {a: true}, [1,2] are converted to object
+      test(
+        INTEGER_PARAM,
+        {a: true},
+        RestHttpErrors.invalidData({a: true}, INTEGER_PARAM.name),
+      );
+    },
+  );
 });

--- a/packages/rest/test/unit/coercion/paramStringToNumber.unit.ts
+++ b/packages/rest/test/unit/coercion/paramStringToNumber.unit.ts
@@ -5,7 +5,7 @@
 
 import {test} from './utils';
 import {ParameterLocation} from '@loopback/openapi-v3-types';
-import {RestHttpErrors} from './../../../';
+import {RestHttpErrors} from '../../../';
 
 const NUMBER_PARAM = {
   in: <ParameterLocation>'path',
@@ -74,9 +74,15 @@ describe('coerce param from string to number - optional', () => {
     test(NUMBER_PARAM, '-1.234e+30', -1.234e30);
   });
 
-  context('empty value converts to undefined', () => {
+  context('empty collection converts to undefined', () => {
     // [], {} sent from request are converted to raw value undefined
     test(NUMBER_PARAM, undefined, undefined);
+  });
+
+  // @jannyhou For review: shall we convert empty value to 0 or throw error?
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(NUMBER_PARAM, '', RestHttpErrors.invalidData('', NUMBER_PARAM.name));
   });
 
   context('All other non-number values trigger ERROR_BAD_REQUEST', () => {

--- a/packages/rest/test/unit/coercion/parseStringToDatetime.unit.ts
+++ b/packages/rest/test/unit/coercion/parseStringToDatetime.unit.ts
@@ -1,0 +1,112 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {test} from './utils';
+import {RestHttpErrors} from '../../../';
+import {ParameterLocation} from '@loopback/openapi-v3-types';
+
+const DATETIME_PARAM = {
+  in: <ParameterLocation>'path',
+  name: 'aparameter',
+  schema: {type: 'string', format: 'date-time'},
+};
+
+const REQUIRED_DATETIME_PARAM = {
+  in: <ParameterLocation>'path',
+  name: 'aparameter',
+  schema: {type: 'string', format: 'date-time'},
+  required: true,
+};
+
+describe('coerce param from string to date - required', function() {
+  context('valid values', () => {
+    test(
+      REQUIRED_DATETIME_PARAM,
+      '2016-05-19T13:28:51Z',
+      new Date('2016-05-19T13:28:51Z'),
+    );
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(
+      REQUIRED_DATETIME_PARAM,
+      '',
+      RestHttpErrors.missingRequired(REQUIRED_DATETIME_PARAM.name),
+    );
+  });
+});
+
+describe('coerce param from string to date - optional', function() {
+  context('valid values', () => {
+    test(
+      DATETIME_PARAM,
+      '2016-05-19T13:28:51Z',
+      new Date('2016-05-19T13:28:51Z'),
+    );
+    test(
+      DATETIME_PARAM,
+      '2016-05-19t13:28:51z',
+      new Date('2016-05-19t13:28:51z'),
+    );
+    test(
+      DATETIME_PARAM,
+      '2016-05-19T13:28:51.299Z',
+      new Date('2016-05-19T13:28:51.299Z'),
+    );
+    test(
+      DATETIME_PARAM,
+      '2016-05-19T13:28:51-08:00',
+      new Date('2016-05-19T13:28:51-08:00'),
+    );
+    test(
+      DATETIME_PARAM,
+      '2016-05-19T13:28:51.299-08:00',
+      new Date('2016-05-19T13:28:51.299-08:00'),
+    );
+  });
+
+  context('invalid values should trigger ERROR_BAD_REQUEST', () => {
+    test(
+      DATETIME_PARAM,
+      '2016-01-01',
+      RestHttpErrors.invalidData('2016-01-01', DATETIME_PARAM.name),
+    );
+    test(
+      DATETIME_PARAM,
+      '2016-04-32T13:28:51Z',
+      RestHttpErrors.invalidData('2016-04-32T13:28:51Z', DATETIME_PARAM.name),
+    );
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(
+      DATETIME_PARAM,
+      '',
+      RestHttpErrors.invalidData('', DATETIME_PARAM.name),
+    );
+  });
+
+  context('empty collection converts to undefined', () => {
+    // [], {} sent from request are converted to raw value undefined
+    test(DATETIME_PARAM, undefined, undefined);
+  });
+
+  context('All other non-date values trigger ERROR_BAD_REQUEST', () => {
+    // 'false', false, 'true', true, 'text' sent from request are converted to a string
+    test(
+      DATETIME_PARAM,
+      'text',
+      RestHttpErrors.invalidData('text', DATETIME_PARAM.name),
+    );
+    // {a: true}, [1,2] are converted to object
+    test(
+      DATETIME_PARAM,
+      {a: true},
+      RestHttpErrors.invalidData({a: true}, DATETIME_PARAM.name),
+    );
+  });
+});


### PR DESCRIPTION
connect to #750 

coercion for **integer** and **boolean** is good for review
coercion for date-time is missing some invalid value check, but earlier feedback are welcomed.

- [x] integer
- [x] boolean
- [x] date
- [x] date-time
- [x] buffer
- [x] float
- [x] double
- [x] long
(@bajtos you left some feedback for date and date-time, I applied under the original PR, see [comment](https://github.com/strongloop/loopback-next/pull/1370#discussion_r192674150), PTAL, thanks!)

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] TBD after code is good: Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
