### PR TITLE
feat(repository): hasmany relation decorator inference

### DIFF
--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -25,13 +25,13 @@
     "@loopback/build": "^0.6.11",
     "@loopback/testlab": "^0.10.10",
     "@types/lodash": "^4.14.108",
-    "@types/node": "^10.1.1",
-    "lodash": "^4.17.10"
+    "@types/node": "^10.1.1"
   },
   "dependencies": {
     "@loopback/context": "^0.11.9",
     "@loopback/core": "^0.10.1",
     "@loopback/dist-util": "^0.3.3",
+    "lodash": "^4.17.10",
     "loopback-datasource-juggler": "^3.20.2"
   },
   "files": [

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -15,6 +15,7 @@ import {
   ModelDefinitionSyntax,
   PropertyDefinition,
 } from '../model';
+import {RELATIONS_KEY, RelationDefinitionBase} from './relation.decorator';
 
 export const MODEL_KEY = MetadataAccessor.create<
   Partial<ModelDefinitionSyntax>,
@@ -30,6 +31,7 @@ export const MODEL_WITH_PROPERTIES_KEY = MetadataAccessor.create<
 >('loopback:model-and-properties');
 
 export type PropertyMap = MetadataMap<PropertyDefinition>;
+export type RelationMap = MetadataMap<RelationDefinitionBase>;
 
 // tslint:disable:no-any
 
@@ -73,6 +75,13 @@ export function model(definition?: Partial<ModelDefinitionSyntax>) {
     }
 
     target.definition = modelDef;
+
+    const relationMap: RelationMap =
+      MetadataInspector.getAllPropertyMetadata(
+        RELATIONS_KEY,
+        target.prototype,
+      ) || {};
+    target.definition.relations = relationMap;
   };
 }
 

--- a/packages/repository/src/decorators/relation.decorator.ts
+++ b/packages/repository/src/decorators/relation.decorator.ts
@@ -5,8 +5,9 @@
 
 import {Class} from '../common-types';
 import {Entity} from '../model';
-
 import {PropertyDecoratorFactory} from '@loopback/context';
+import {property} from './model.decorator';
+import {camelCase} from 'lodash';
 
 // tslint:disable:no-any
 
@@ -26,6 +27,15 @@ export class RelationMetadata {
   type: RelationType;
   target: string | Class<Entity>;
   as: string;
+}
+
+export interface RelationDefinitionBase {
+  type: RelationType;
+}
+
+export interface HasManyDefinition extends RelationDefinitionBase {
+  type: RelationType.hasMany;
+  keyTo: string;
 }
 
 /**
@@ -61,12 +71,44 @@ export function hasOne(definition?: Object) {
 
 /**
  * Decorator for hasMany
- * @param definition
+ * Calls property.array decorator underneath the hood and infers foreign key
+ * name from target model name unless explicitly specified
+ * @param targetModel Target model for hasMany relation
+ * @param definition Optional metadata for setting up hasMany relation
  * @returns {(target:any, key:string)}
  */
-export function hasMany(definition?: Object) {
-  const rel = Object.assign({type: RelationType.hasMany}, definition);
-  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel);
+export function hasMany<T extends typeof Entity>(
+  targetModel: T,
+  definition?: Partial<HasManyDefinition>,
+) {
+  // todo(shimks): extract out common logic (such as @property.array) to
+  // @relation
+  return function(target: Object, key: string) {
+    property.array(targetModel)(target, key);
+
+    const defaultFkName = camelCase(target.constructor.name + '_id');
+    const hasKeyTo = definition && definition.keyTo;
+    const hasDefaultFkProperty =
+      targetModel.definition &&
+      targetModel.definition.properties &&
+      targetModel.definition.properties[defaultFkName];
+    if (!(hasKeyTo || hasDefaultFkProperty)) {
+      // note(shimks): should we also check for the existence of explicitly
+      // given foreign key name on the juggler definition?
+      throw new Error(
+        `foreign key ${defaultFkName} not found on ${
+          targetModel.name
+        } model's juggler definition`,
+      );
+    }
+    const meta = {keyTo: defaultFkName};
+    Object.assign(meta, definition, {type: RelationType.hasMany});
+
+    PropertyDecoratorFactory.createDecorator(
+      RELATIONS_KEY,
+      meta as HasManyDefinition,
+    )(target, key);
+  };
 }
 
 /**

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -5,6 +5,7 @@
 
 import {Options, AnyObject, DataObject} from './common-types';
 import {Type} from './types';
+import {RelationDefinitionBase} from './decorators/relation.decorator';
 
 /**
  * This module defines the key classes representing building blocks for Domain
@@ -45,6 +46,7 @@ export interface ModelDefinitionSyntax {
   name: string;
   properties?: {[name: string]: PropertyDefinition | PropertyType};
   settings?: {[name: string]: any};
+  relations?: {[name: string]: RelationDefinitionBase};
   [attribute: string]: any;
 }
 
@@ -55,6 +57,7 @@ export class ModelDefinition {
   readonly name: string;
   properties: {[name: string]: PropertyDefinition};
   settings: {[name: string]: any};
+  relations: {[name: string]: RelationDefinitionBase};
   // indexes: Map<string, any>;
   [attribute: string]: any; // Other attributes
 
@@ -62,7 +65,7 @@ export class ModelDefinition {
     if (typeof nameOrDef === 'string') {
       nameOrDef = {name: nameOrDef};
     }
-    const {name, properties, settings} = nameOrDef;
+    const {name, properties, settings, relations} = nameOrDef;
 
     this.name = name;
 
@@ -74,6 +77,7 @@ export class ModelDefinition {
     }
 
     this.settings = settings || new Map();
+    this.relations = relations || {};
   }
 
   /**

--- a/packages/repository/src/repositories/relation.factory.ts
+++ b/packages/repository/src/repositories/relation.factory.ts
@@ -4,49 +4,45 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {EntityCrudRepository} from './repository';
-import {RelationType} from '../decorators/relation.decorator';
+import {HasManyDefinition} from '../decorators/relation.decorator';
 import {Entity} from '../model';
 import {
-  HasManyEntityCrudRepository,
+  HasManyRepository,
   DefaultHasManyEntityCrudRepository,
 } from './relation.repository';
 
-export interface RelationDefinitionBase {
-  type: RelationType;
-  keyTo: string;
-}
+export type HasManyRepositoryFactory<T extends Entity, ID> = (
+  fkValue: ID,
+) => HasManyRepository<T>;
 
-export interface HasManyDefinition extends RelationDefinitionBase {
-  type: RelationType.hasMany;
-}
 /**
  * Enforces a constraint on a repository based on a relationship contract
- * between models. Returns a relational repository that exposes applicable CRUD
- * method APIs for the related target repository. For example, if a Customer model is
- * related to an Order model via a HasMany relation, then, the relational
- * repository returned by this method would be constrained by a Customer model
- * instance's id(s).
+ * between models. For example, if a Customer model is related to an Order model
+ * via a HasMany relation, then, the relational repository returned by the
+ * factory function would be constrained by a Customer model instance's id(s).
  *
- * @param constraint The constraint to apply to the target repository. For
- * example, {id: '5'}.
- * @param relationMetadata The relation metadata used to used to describe the
+ * @param relationMeta The relation metadata used to describe the
  * relationship and determine how to apply the constraint.
- * @param targetRepository The repository which represents the target model of a
+ * @param targetRepo The repository which represents the target model of a
  * relation attached to a datasource.
- *
+ * @returns The factory function which accepts a foreign key value to constrain
+ * the given target repository
  */
-export function hasManyRepositoryFactory<SourceID, T extends Entity, ID>(
-  sourceModelId: SourceID,
-  relationMetadata: HasManyDefinition,
-  targetRepository: EntityCrudRepository<T, ID>,
-): HasManyEntityCrudRepository<T> {
-  switch (relationMetadata.type) {
-    case RelationType.hasMany:
-      const fkConstraint = {[relationMetadata.keyTo]: sourceModelId};
-
-      return new DefaultHasManyEntityCrudRepository<
-        T,
-        EntityCrudRepository<T, ID>
-      >(targetRepository, fkConstraint);
-  }
+export function createHasManyRepositoryFactory<T extends Entity, ID>(
+  relationMeta: HasManyDefinition,
+  targetRepo: EntityCrudRepository<T, ID>,
+): HasManyRepositoryFactory<T, ID> {
+  return function(fkValue: ID) {
+    const fkName = relationMeta.keyTo;
+    if (!fkName) {
+      throw new Error(
+        'The foreign key property name (keyTo) must be specified',
+      );
+    }
+    return new DefaultHasManyEntityCrudRepository<
+      T,
+      ID,
+      EntityCrudRepository<T, ID>
+    >(targetRepo, {[fkName]: fkValue});
+  };
 }

--- a/packages/repository/src/repositories/relation.repository.ts
+++ b/packages/repository/src/repositories/relation.repository.ts
@@ -16,7 +16,7 @@ import {Filter, Where} from '../query';
 /**
  * CRUD operations for a target repository of a HasMany relation
  */
-export interface HasManyEntityCrudRepository<T extends Entity> {
+export interface HasManyRepository<T extends Entity> {
   /**
    * Create a target model instance
    * @param targetModelData The target model data
@@ -54,8 +54,9 @@ export interface HasManyEntityCrudRepository<T extends Entity> {
 
 export class DefaultHasManyEntityCrudRepository<
   T extends Entity,
-  TargetRepository extends EntityCrudRepository<T, typeof Entity.prototype.id>
-> implements HasManyEntityCrudRepository<T> {
+  ID,
+  TargetRepository extends EntityCrudRepository<T, ID>
+> implements HasManyRepository<T> {
   /**
    * Constructor of DefaultHasManyEntityCrudRepository
    * @param targetRepository the related target model repository instance

--- a/packages/repository/test/acceptance/has-many-without-di.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many-without-di.relation.acceptance.ts
@@ -1,0 +1,164 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  model,
+  property,
+  Entity,
+  DefaultCrudRepository,
+  juggler,
+  hasMany,
+  HasManyRepositoryFactory,
+  EntityCrudRepository,
+} from '../..';
+import {expect} from '@loopback/testlab';
+
+describe('HasMany relation', () => {
+  // Given a Customer and Order models - see definitions at the bottom
+
+  let existingCustomerId: number;
+  let ds: juggler.DataSource;
+  let customerRepo: CustomerRepository;
+  let orderRepo: OrderRepository;
+
+  before(givenDataSource);
+  before(givenOrderRepository);
+  before(givenCustomerRepository);
+  beforeEach(async () => {
+    existingCustomerId = (await givenPersistedCustomerInstance()).id;
+  });
+  afterEach(async () => {
+    await orderRepo.deleteAll();
+  });
+
+  it('can create an instance of the related model', async () => {
+    async function createCustomerOrders(
+      customerId: number,
+      orderData: Partial<Order>,
+    ): Promise<Order> {
+      return await customerRepo.orders(customerId).create(orderData);
+    }
+    const order = await createCustomerOrders(existingCustomerId, {
+      description: 'order 1',
+    });
+    expect(order.toObject()).to.containDeep({
+      customerId: existingCustomerId,
+      description: 'order 1',
+    });
+
+    const persisted = await orderRepo.findById(order.id);
+    expect(persisted.toObject()).to.deepEqual(order.toObject());
+  });
+
+  it('can find instances of the related model', async () => {
+    async function createCustomerOrders(
+      customerId: number,
+      orderData: Partial<Order>,
+    ): Promise<Order> {
+      return await customerRepo.orders(customerId).create(orderData);
+    }
+    async function findCustomerOrders(customerId: number) {
+      return await customerRepo.orders(customerId).find();
+    }
+
+    const order = await createCustomerOrders(existingCustomerId, {
+      description: 'order 1',
+    });
+    const notMyOrder = await createCustomerOrders(existingCustomerId + 1, {
+      description: 'order 2',
+    });
+    const orders = await findCustomerOrders(existingCustomerId);
+
+    expect(orders).to.containEql(order);
+    expect(orders).to.not.containEql(notMyOrder);
+
+    const persisted = await orderRepo.find({
+      where: {customerId: existingCustomerId},
+    });
+    expect(persisted).to.deepEqual(orders);
+  });
+
+  //--- HELPERS ---//
+
+  @model()
+  class Order extends Entity {
+    @property({
+      type: 'number',
+      id: true,
+    })
+    id: number;
+
+    @property({
+      type: 'string',
+      required: true,
+    })
+    description: string;
+
+    @property({
+      type: 'number',
+      required: true,
+    })
+    customerId: number;
+  }
+
+  @model()
+  class Customer extends Entity {
+    @property({
+      type: 'number',
+      id: true,
+    })
+    id: number;
+
+    @property({
+      type: 'string',
+    })
+    name: string;
+
+    @hasMany(Order) orders: Order[];
+  }
+
+  class OrderRepository extends DefaultCrudRepository<
+    Order,
+    typeof Order.prototype.id
+  > {
+    constructor(db: juggler.DataSource) {
+      super(Order, db);
+    }
+  }
+
+  class CustomerRepository extends DefaultCrudRepository<
+    Customer,
+    typeof Customer.prototype.id
+  > {
+    public orders: HasManyRepositoryFactory<Order, typeof Order.prototype.id>;
+
+    constructor(
+      protected db: juggler.DataSource,
+      orderRepository: EntityCrudRepository<Order, typeof Order.prototype.id>,
+    ) {
+      super(Customer, db);
+      this.orders = this._createHasManyRepositoryFactoryFor(
+        'orders',
+        orderRepository,
+      );
+    }
+  }
+
+  function givenDataSource() {
+    ds = new juggler.DataSource({connector: 'memory'});
+  }
+
+  function givenOrderRepository() {
+    orderRepo = new OrderRepository(ds);
+  }
+
+  function givenCustomerRepository() {
+    customerRepo = new CustomerRepository(ds, orderRepo);
+  }
+
+  async function givenPersistedCustomerInstance() {
+    return customerRepo.create({name: 'a customer'});
+  }
+});

--- a/packages/repository/test/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many.relation.acceptance.ts
@@ -9,61 +9,88 @@ import {
   Entity,
   DefaultCrudRepository,
   juggler,
-  EntityCrudRepository,
-  hasManyRepositoryFactory,
-  HasManyDefinition,
-  RelationType,
-  HasManyEntityCrudRepository,
+  hasMany,
+  repository,
+  RepositoryMixin,
+  AppWithRepository,
+  HasManyRepositoryFactory,
 } from '../..';
 import {expect} from '@loopback/testlab';
 import * as _ from 'lodash';
+import {inject} from '@loopback/context';
+import {Application} from '@loopback/core';
 
 describe('HasMany relation', () => {
   // Given a Customer and Order models - see definitions at the bottom
 
-  beforeEach(givenCrudRepositoriesForCustomerAndOrder);
-
+  let app: AppWithRepository;
+  let controller: CustomerController;
+  let customerRepo: CustomerRepository;
+  let orderRepo: OrderRepository;
   let existingCustomerId: number;
-  //FIXME: this should be inferred from relational decorators
-  let customerHasManyOrdersRelationMeta: HasManyDefinition;
-  let customerOrders: HasManyEntityCrudRepository<Order>;
+
+  before(givenApplicationWithMemoryDB);
+  before(givenBoundCrudRepositoriesForCustomerAndOrder);
+  before(givenCustomerController);
 
   beforeEach(async () => {
     existingCustomerId = (await givenPersistedCustomerInstance()).id;
-    customerHasManyOrdersRelationMeta = givenHasManyRelationMetadata();
-    // Ideally, we would like to write
-    // customerRepo.orders.create(customerId, orderData);
-    // or customerRepo.orders({id: customerId}).*
-    // The initial "involved" implementation is below
-
-    //FIXME: should be automagically instantiated via DI or other means
-    customerOrders = hasManyRepositoryFactory(
-      existingCustomerId,
-      customerHasManyOrdersRelationMeta,
-      orderRepo,
-    );
+  });
+  afterEach(async () => {
+    await orderRepo.deleteAll();
   });
 
   it('can create an instance of the related model', async () => {
-    const description = 'an order desc';
-    const order = await customerOrders.create({description});
-
+    const order = await controller.createCustomerOrders(existingCustomerId, {
+      description: 'order 1',
+    });
     expect(order.toObject()).to.containDeep({
       customerId: existingCustomerId,
-      description,
+      description: 'order 1',
     });
+
     const persisted = await orderRepo.findById(order.id);
     expect(persisted.toObject()).to.deepEqual(order.toObject());
   });
 
+  it('can find instances of the related model', async () => {
+    const order = await controller.createCustomerOrders(existingCustomerId, {
+      description: 'order 1',
+    });
+    const notMyOrder = await controller.createCustomerOrders(
+      existingCustomerId + 1,
+      {
+        description: 'order 2',
+      },
+    );
+    const foundOrders = await controller.findCustomerOrders(existingCustomerId);
+    expect(foundOrders).to.containEql(order);
+    expect(foundOrders).to.not.containEql(notMyOrder);
+
+    const persisted = await orderRepo.find({
+      where: {customerId: existingCustomerId},
+    });
+    expect(persisted).to.deepEqual(foundOrders);
+  });
+
   it('can patch many instances', async () => {
-    await givenCustomerOrder({description: 'order 1', isDelivered: false});
-    await givenCustomerOrder({description: 'order 2', isDelivered: false});
+    await controller.createCustomerOrders(existingCustomerId, {
+      description: 'order 1',
+      isDelivered: false,
+    });
+    await controller.createCustomerOrders(existingCustomerId, {
+      description: 'order 2',
+      isDelivered: false,
+    });
     const patchObject = {isDelivered: true};
-    const arePatched = await customerOrders.patch(patchObject);
+    const arePatched = await controller.patchCustomerOrders(
+      existingCustomerId,
+      patchObject,
+    );
     expect(arePatched).to.equal(2);
-    const patchedData = _.map(await customerOrders.find(), d =>
-      _.pick(d, ['customerId', 'description', 'isDelivered']),
+    const patchedData = _.map(
+      await controller.findCustomerOrders(existingCustomerId),
+      d => _.pick(d, ['customerId', 'description', 'isDelivered']),
     );
     expect(patchedData).to.eql([
       {
@@ -81,16 +108,26 @@ describe('HasMany relation', () => {
 
   it('throws error when query tries to change the foreignKey', async () => {
     await expect(
-      customerOrders.patch({customerId: existingCustomerId + 1}),
+      controller.patchCustomerOrders(existingCustomerId, {
+        customerId: existingCustomerId + 1,
+      }),
     ).to.be.rejectedWith(/Property "customerId" cannot be changed!/);
   });
 
   it('can delete many instances', async () => {
-    await givenCustomerOrder({description: 'order 1'});
-    await givenCustomerOrder({description: 'order 2'});
-    const deletedOrders = await customerOrders.delete();
+    await controller.createCustomerOrders(existingCustomerId, {
+      description: 'order 1',
+    });
+    await controller.createCustomerOrders(existingCustomerId, {
+      description: 'order 2',
+    });
+    const deletedOrders = await controller.deleteCustomerOrders(
+      existingCustomerId,
+    );
     expect(deletedOrders).to.equal(2);
-    const relatedOrders = await customerOrders.find();
+    const relatedOrders = await controller.findCustomerOrders(
+      existingCustomerId,
+    );
     expect(relatedOrders).to.be.empty();
   });
 
@@ -100,33 +137,16 @@ describe('HasMany relation', () => {
       description: 'another order',
     };
     await orderRepo.create(newOrder);
-    await customerOrders.delete();
+    await controller.deleteCustomerOrders(existingCustomerId);
     const orders = await orderRepo.find();
     expect(orders).to.have.length(1);
     expect(_.pick(orders[0], ['customerId', 'description'])).to.eql(newOrder);
   });
 
-  async function givenCustomerOrder(dataObject: Partial<Order>) {
-    await customerOrders.create(dataObject);
-  }
   // This should be enforced by the database to avoid race conditions
   it.skip('reject create request when the customer does not exist');
 
   //--- HELPERS ---//
-
-  @model()
-  class Customer extends Entity {
-    @property({
-      type: 'number',
-      id: true,
-    })
-    id: number;
-
-    @property({
-      type: 'string',
-    })
-    name: string;
-  }
 
   @model()
   class Order extends Entity {
@@ -155,26 +175,95 @@ describe('HasMany relation', () => {
     customerId: number;
   }
 
-  let customerRepo: EntityCrudRepository<
+  @model()
+  class Customer extends Entity {
+    @property({
+      type: 'number',
+      id: true,
+    })
+    id: number;
+
+    @property({
+      type: 'string',
+    })
+    name: string;
+
+    @hasMany(Order) orders: Order[];
+  }
+
+  class OrderRepository extends DefaultCrudRepository<
+    Order,
+    typeof Order.prototype.id
+  > {
+    constructor(@inject('datasources.db') protected db: juggler.DataSource) {
+      super(Order, db);
+    }
+  }
+
+  class CustomerRepository extends DefaultCrudRepository<
     Customer,
     typeof Customer.prototype.id
-  >;
-  let orderRepo: EntityCrudRepository<Order, typeof Order.prototype.id>;
-  function givenCrudRepositoriesForCustomerAndOrder() {
-    const db = new juggler.DataSource({connector: 'memory'});
+  > {
+    public orders: HasManyRepositoryFactory<Order, typeof Order.prototype.id>;
+    constructor(
+      @inject('datasources.db') protected db: juggler.DataSource,
+      @repository(OrderRepository) orderRepository: OrderRepository,
+    ) {
+      super(Customer, db);
+      this.orders = this._createHasManyRepositoryFactoryFor(
+        'orders',
+        orderRepository,
+      );
+    }
+  }
 
-    customerRepo = new DefaultCrudRepository(Customer, db);
-    orderRepo = new DefaultCrudRepository(Order, db);
+  class CustomerController {
+    constructor(
+      @repository(CustomerRepository)
+      protected customerRepository: CustomerRepository,
+    ) {}
+
+    async createCustomerOrders(
+      customerId: number,
+      orderData: Partial<Order>,
+    ): Promise<Order> {
+      return await this.customerRepository.orders(customerId).create(orderData);
+    }
+
+    async findCustomerOrders(customerId: number) {
+      return await this.customerRepository.orders(customerId).find();
+    }
+
+    async patchCustomerOrders(customerId: number, order: Partial<Order>) {
+      return await this.customerRepository.orders(customerId).patch(order);
+    }
+
+    async deleteCustomerOrders(customerId: number) {
+      return await this.customerRepository.orders(customerId).delete();
+    }
+  }
+
+  function givenApplicationWithMemoryDB() {
+    class TestApp extends RepositoryMixin(Application) {}
+    app = new TestApp();
+    app.dataSource(new juggler.DataSource({name: 'db', connector: 'memory'}));
+  }
+
+  async function givenBoundCrudRepositoriesForCustomerAndOrder() {
+    app.repository(CustomerRepository);
+    app.repository(OrderRepository);
+    customerRepo = await app.getRepository(CustomerRepository);
+    orderRepo = await app.getRepository(OrderRepository);
+  }
+
+  async function givenCustomerController() {
+    app.controller(CustomerController);
+    controller = await app.get<CustomerController>(
+      'controllers.CustomerController',
+    );
   }
 
   async function givenPersistedCustomerInstance() {
     return customerRepo.create({name: 'a customer'});
-  }
-
-  function givenHasManyRelationMetadata(): HasManyDefinition {
-    return {
-      keyTo: 'customerId',
-      type: RelationType.hasMany,
-    };
   }
 });

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -1,0 +1,123 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Entity, hasMany, RELATIONS_KEY, RelationType, property} from '../../..';
+import {MetadataInspector} from '@loopback/context';
+import {MODEL_PROPERTIES_KEY, model} from '../../../src';
+
+describe('relation decorator', () => {
+  context('hasMany', () => {
+    it('throws when foreign key is not defined in the target TypeScript model', () => {
+      expect(() => {
+        @model()
+        class Address extends Entity {
+          addressId: number;
+          street: string;
+          province: string;
+        }
+
+        // tslint:disable-next-line:no-unused-variable
+        class AddressBook extends Entity {
+          id: number;
+
+          @hasMany(Address) addresses: Address[];
+        }
+      }).throw(/addressBookId not found on Address/);
+    });
+
+    it('takes in complex property type and infers foreign key via source model name', () => {
+      @model()
+      class Address extends Entity {
+        addressId: number;
+        street: string;
+        province: string;
+        @property() addressBookId: number;
+      }
+
+      class AddressBook extends Entity {
+        id: number;
+
+        @hasMany(Address) addresses: Address[];
+      }
+
+      const meta = MetadataInspector.getPropertyMetadata(
+        RELATIONS_KEY,
+        AddressBook.prototype,
+        'addresses',
+      );
+      const jugglerMeta = MetadataInspector.getPropertyMetadata(
+        MODEL_PROPERTIES_KEY,
+        AddressBook.prototype,
+        'addresses',
+      );
+      expect(meta).to.eql({
+        type: RelationType.hasMany,
+        keyTo: 'addressBookId',
+      });
+      expect(jugglerMeta).to.eql({
+        type: Address,
+        array: true,
+      });
+    });
+
+    it('takes in both complex property type and asMany metadata', () => {
+      class Address extends Entity {
+        addressId: number;
+        street: string;
+        province: string;
+      }
+
+      class AddressBook extends Entity {
+        id: number;
+
+        @hasMany(Address, {keyTo: 'someForeignKey'})
+        addresses: Address[];
+      }
+
+      const meta = MetadataInspector.getPropertyMetadata(
+        RELATIONS_KEY,
+        AddressBook.prototype,
+        'addresses',
+      );
+      const jugglerMeta = MetadataInspector.getPropertyMetadata(
+        MODEL_PROPERTIES_KEY,
+        AddressBook.prototype,
+        'addresses',
+      );
+      expect(meta).to.eql({
+        type: RelationType.hasMany,
+        keyTo: 'someForeignKey',
+      });
+      expect(jugglerMeta).to.eql({
+        type: Address,
+        array: true,
+      });
+    });
+
+    context('when interacting with @property.array', () => {
+      // Do you think this test case is necessary?
+      it('does not get its property metadata overwritten by @property.array', () => {
+        expect(() => {
+          class Address extends Entity {
+            addressId: number;
+            street: string;
+            province: string;
+          }
+
+          // tslint:disable-next-line:no-unused-variable
+          class AddressBook extends Entity {
+            id: number;
+            @property.array(Entity)
+            @hasMany(Address, {
+              keyTo: 'someForeignKey',
+            })
+            addresses: Address[];
+          }
+        }).to.throw(/Decorator cannot be applied more than once/);
+      });
+    });
+  });
+});

--- a/packages/repository/test/unit/repositories/relation.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/relation.repository.unit.ts
@@ -6,7 +6,7 @@
 import {sinon, expect} from '@loopback/testlab';
 import {
   EntityCrudRepository,
-  HasManyEntityCrudRepository,
+  HasManyRepository,
   DefaultCrudRepository,
   juggler,
   DefaultHasManyEntityCrudRepository,
@@ -28,11 +28,9 @@ describe('relation repository', () => {
     // tslint:disable-next-line:no-unused-variable
     class testHasManyEntityCrudRepository<
       T extends Entity,
-      TargetRepository extends EntityCrudRepository<
-        T,
-        typeof Entity.prototype.id
-      >
-    > implements HasManyEntityCrudRepository<T> {
+      ID,
+      TargetRepository extends EntityCrudRepository<T, ID>
+    > implements HasManyRepository<T> {
       create(
         targetModelData: Partial<T>,
         options?: AnyObject | undefined,
@@ -131,6 +129,10 @@ describe('relation repository', () => {
 
   function givenDefaultHasManyCrudInstance(constraint: AnyObject) {
     repo = sinon.createStubInstance(CustomerRepository);
-    return new DefaultHasManyEntityCrudRepository(repo, constraint);
+    return new DefaultHasManyEntityCrudRepository<
+      Customer,
+      typeof Customer.prototype.id,
+      CustomerRepository
+    >(repo, constraint);
   }
 });


### PR DESCRIPTION
- Implement `hasMany` decorator which takes the target model class and infers the relation metadata and return type as an array of the target model instances
- store relation metadata on model definition
- modify the function returned by `hasManyRepositoryFactory` function to only take in value of the PK/FK constraint instead of a key value pair for the PK (`{id: 5}` -> `5`}
- create a protected function in DefaultEntityCrudRepository which calls `hasManyRepositoryFactory` using the metadata stored by `hasMany` decorator on the source model definition and returns a constrained version of the target repository

Connect to #1372.
## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
