### PR TITLE
fix(http-server): correctly format IPv6 host in url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,10 @@ matrix:
 branches:
   only:
     - master
+
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -100,7 +100,11 @@ export class HttpServer {
    * URL of the HTTP / HTTPS server
    */
   public get url(): string {
-    return `${this._protocol}://${this.host}:${this.port}`;
+    let host = this.host;
+    if (this._address.family === 'IPv6') {
+      host = `[${host}]`;
+    }
+    return `${this._protocol}://${host}:${this.port}`;
   }
 
   /**


### PR DESCRIPTION
Format IPv6 local address correctly in the `url` property.

Fixes https://github.com/strongloop/loopback-next/issues/1453.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
