### PR TITLE
chore: increase timeout to allow slow geocode response

### DIFF
--- a/examples/todo/test/acceptance/application.acceptance.ts
+++ b/examples/todo/test/acceptance/application.acceptance.ts
@@ -32,7 +32,11 @@ describe('Application', () => {
     client = createClientForHandler(app.requestHandler);
   });
 
-  it('creates a todo', async () => {
+  it('creates a todo', async function() {
+    // Set timeout to 30 seconds as `post /todos` triggers geocode look up
+    // over the internet and it takes more than 2 seconds
+    // tslint:disable-next-line:no-invalid-this
+    this.timeout(30000);
     const todo = givenTodo();
     const response = await client
       .post('/todos')
@@ -44,7 +48,7 @@ describe('Application', () => {
   });
 
   it('creates an address-based reminder', async function() {
-    // Increase the timeout to accomodate slow network connections
+    // Increase the timeout to accommodate slow network connections
     // tslint:disable-next-line:no-invalid-this
     this.timeout(30000);
 


### PR DESCRIPTION
`npm test` consistently fails for me due to the following timeout:
```
1) Application
       creates a todo:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/rfeng/Projects/loopback4/loopback-next/examples/todo/dist8/test/acceptance/application.acceptance.js)
```

Instrumentation shows the geocode lookup takes more than 3.5 seconds.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
