### PR TITLE
fix(http-server): reset addressInfo when server is stopped

### DIFF
--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -113,7 +113,7 @@ export class HttpServer {
   /**
    * Address of the HTTP / HTTPS server
    */
-  public get address(): AddressInfo {
-    return this._address;
+  public get address(): AddressInfo | undefined {
+    return this._started ? this._address : undefined;
   }
 }

--- a/packages/http-server/test/integration/http-server.integration.ts
+++ b/packages/http-server/test/integration/http-server.integration.ts
@@ -100,6 +100,16 @@ describe('HttpServer (integration)', () => {
       .which.is.an.Object();
   });
 
+  it('resets address when server is stopped', async () => {
+    server = new HttpServer(dummyRequestHandler);
+    await server.start();
+    expect(server)
+      .to.have.property('address')
+      .which.is.an.Object();
+    await server.stop();
+    expect(server.address).to.be.undefined();
+  });
+
   it('exports started', async () => {
     server = new HttpServer(dummyRequestHandler);
     await server.start();


### PR DESCRIPTION
Reset `addressInfo` when the server is stopped. Currently it returns the old address.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
