### PR TITLE
Allow openapi path level params

### DIFF
--- a/packages/cli/generators/openapi/utils.js
+++ b/packages/cli/generators/openapi/utils.js
@@ -145,7 +145,7 @@ function escapeIdentifier(name) {
     return '_' + name;
   }
   if (!name.match(SAFE_IDENTIFER)) {
-    return camelCase(name);
+    return _.camelCase(name);
   }
   return name;
 }

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -11,10 +11,17 @@ tags:
     description: Customer resource
 paths:
   /customers:
+    parameters:
+      - name: access-token
+        in: query
+        description: Access token
+        required: false
+        schema:
+          type: string
     get:
       tags:
         - Customer
-      description: Returna all customers
+      description: Returns all customers
       parameters:
         - name: if
           in: query

--- a/packages/cli/test/unit/openapi/controller-spec.unit.js
+++ b/packages/cli/test/unit/openapi/controller-spec.unit.js
@@ -23,17 +23,21 @@ describe('openapi to controllers/models', () => {
         imports: ["import {Customer} from '../models/customer.model';"],
         methods: [
           {
-            description: 'Returna all customers',
+            description: 'Returns all customers',
             decoration: "@operation('get', '/customers')",
             signature:
               "async ''(@param({name: 'if', in: 'query'}) _if: string[], " +
-              "@param({name: 'limit', in: 'query'}) limit: number): " +
+              "@param({name: 'limit', in: 'query'}) limit: number, " +
+              "@param({name: 'access-token', in: 'query'}) " +
+              'accessToken: string): ' +
               'Promise<Customer[]>',
           },
           {
             description: 'Creates a new customer',
             decoration: "@operation('post', '/customers')",
-            signature: 'async createCustomer(): Promise<Customer>',
+            signature:
+              "async createCustomer(@param({name: 'access-token', " +
+              "in: 'query'}) accessToken: string): Promise<Customer>",
           },
           {
             description: 'Returns a customer based on a single ID',


### PR DESCRIPTION
OpenAPI spec allows `parameters` at path level which apply to all operations of the given path. This PR adds the support.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
