### PR TITLE
fix(repository): make models strict by default

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -121,6 +121,29 @@ export class Product extends Entity {
 }
 ```
 
+As you can see, models are defined primarily by their TypeScript class. By
+default, classes forbid additional properties not specified in the type
+definition. The persistence layer is respecting this constraint and configures
+underlying PersistedModel classes to enforce `strict` mode.
+
+To create a model that allows both well-defined but also arbitrary extra
+properties, you need to disable `strict` mode in model settings and tell
+TypeScript to allow arbitrary additional properties to be set on model
+instances.
+
+```ts
+@model({settings: {strict: false}})
+class MyFlexibleModel extends Entity {
+  @property({id: true})
+  id: number;
+
+  // Define well-known properties here
+
+  // Add an indexer property to allow additional data
+  [prop: string]: any;
+}
+```
+
 ### Model Decorator
 
 The model decorator can be used without any additional parameters, or can be

--- a/packages/repository/src/repositories/constraint-utils.ts
+++ b/packages/repository/src/repositories/constraint-utils.ts
@@ -57,7 +57,7 @@ export function constrainDataObject<T extends Entity>(
   for (const c in constraint) {
     if (constrainedData.hasOwnProperty(c))
       throw new Error(`Property "${c}" cannot be changed!`);
-    constrainedData[c] = constraint[c];
+    (constrainedData as AnyObject)[c] = constraint[c];
   }
   return constrainedData;
 }
@@ -76,7 +76,7 @@ export function constrainDataObjects<T extends Entity>(
   const constrainedData = cloneDeep(originalData);
   for (let obj of constrainedData) {
     for (let prop in constraint) {
-      obj[prop] = constraint[prop];
+      (obj as AnyObject)[prop] = constraint[prop];
     }
   }
   return constrainedData;

--- a/packages/repository/src/repositories/relation.factory.ts
+++ b/packages/repository/src/repositories/relation.factory.ts
@@ -28,21 +28,25 @@ export type HasManyRepositoryFactory<T extends Entity, ID> = (
  * @returns The factory function which accepts a foreign key value to constrain
  * the given target repository
  */
-export function createHasManyRepositoryFactory<T extends Entity, ID>(
-  relationMeta: HasManyDefinition,
-  targetRepo: EntityCrudRepository<T, ID>,
-): HasManyRepositoryFactory<T, ID> {
-  return function(fkValue: ID) {
-    const fkName = relationMeta.keyTo;
+export function createHasManyRepositoryFactory<
+  SourceID,
+  Target extends Entity,
+  TargetID
+>(
+  relationMetadata: HasManyDefinition,
+  targetRepository: EntityCrudRepository<Target, TargetID>,
+): HasManyRepositoryFactory<Target, SourceID> {
+  return function(fkValue: SourceID) {
+    const fkName = relationMetadata.keyTo;
     if (!fkName) {
       throw new Error(
         'The foreign key property name (keyTo) must be specified',
       );
     }
     return new DefaultHasManyEntityCrudRepository<
-      T,
-      ID,
-      EntityCrudRepository<T, ID>
-    >(targetRepo, {[fkName]: fkValue});
+      Target,
+      TargetID,
+      EntityCrudRepository<Target, TargetID>
+    >(targetRepository, {[fkName]: fkValue});
   };
 }

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -232,8 +232,9 @@ export class CrudRepositoryImpl<T extends Entity, ID>
     if (typeof this.connector.save === 'function') {
       return this.toModel(this.connector.save(this.model, entity, options));
     } else {
-      if (entity.getId() != null) {
-        return this.replaceById(entity.getId(), entity, options).then(
+      const id = this.model.getIdOf(entity);
+      if (id != null) {
+        return this.replaceById(id, entity, options).then(
           (result: boolean) =>
             result
               ? this.toModel(Promise.resolve(entity))
@@ -262,11 +263,11 @@ export class CrudRepositoryImpl<T extends Entity, ID>
   }
 
   update(entity: DataObject<T>, options?: Options): Promise<boolean> {
-    return this.updateById(entity.getId(), entity, options);
+    return this.updateById(this.model.getIdOf(entity), entity, options);
   }
 
   delete(entity: DataObject<T>, options?: Options): Promise<boolean> {
-    return this.deleteById(entity.getId(), options);
+    return this.deleteById(this.model.getIdOf(entity), options);
   }
 
   updateAll(

--- a/packages/repository/test/integration/repositories/relation.factory.integration.ts
+++ b/packages/repository/test/integration/repositories/relation.factory.integration.ts
@@ -209,8 +209,9 @@ describe('HasMany relation', () => {
 
   function givenConstrainedRepositories() {
     const orderFactoryFn = createHasManyRepositoryFactory<
+      typeof Customer.prototype.id,
       Order,
-      typeof Customer.prototype.id
+      typeof Order.prototype.id
     >(Customer.definition.relations.orders as HasManyDefinition, orderRepo);
 
     customerOrderRepo = orderFactoryFn(existingCustomerId);

--- a/packages/repository/test/unit/model/model.unit.ts
+++ b/packages/repository/test/unit/model/model.unit.ts
@@ -31,17 +31,55 @@ describe('model', () => {
     .addProperty('firstName', String)
     .addProperty('lastName', STRING);
 
+  const flexibleDef = new ModelDefinition('Flexible');
+  flexibleDef
+    .addProperty('id', {type: 'string', id: true})
+    .addSetting('strict', false);
+
   class Customer extends Entity {
     static definition = customerDef;
+    id: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+
+    constructor(data?: Partial<Customer>) {
+      super(data);
+    }
   }
 
   class RealmCustomer extends Entity {
     static definition = realmCustomerDef;
+    realm: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+
+    constructor(data?: Partial<RealmCustomer>) {
+      super(data);
+    }
   }
 
   // tslint:disable-next-line:no-unused-variable
   class User extends Entity {
     static definition = userDef;
+    id: string;
+    email: string;
+    firstName: string;
+
+    constructor(data?: Partial<User>) {
+      super(data);
+    }
+  }
+
+  class Flexible extends Entity {
+    static definition = flexibleDef;
+
+    id: string;
+
+    constructor(data?: Partial<Flexible>) {
+      super(data);
+    }
   }
 
   function createCustomer() {
@@ -81,12 +119,21 @@ describe('model', () => {
 
   it('converts to json', () => {
     const customer = createCustomer();
+    Object.assign(customer, {extra: 'additional data'});
     expect(customer.toJSON()).to.eql({id: '123', email: 'xyz@example.com'});
+    // notice that "extra" property was discarded from the output
+  });
+
+  it('supports non-strict model in toJSON()', () => {
+    const DATA = {id: 'uid', extra: 'additional data'};
+    const instance = new Flexible(DATA);
+    const actual = instance.toJSON();
+    expect(actual).to.deepEqual(DATA);
   });
 
   it('converts to plain object', () => {
     const customer = createCustomer();
-    customer.unknown = 'abc';
+    Object.assign(customer, {unknown: 'abc'});
     expect(customer.toObject()).to.eql({id: '123', email: 'xyz@example.com'});
     expect(customer.toObject({ignoreUnknownProperties: false})).to.eql({
       id: '123',

--- a/packages/repository/test/unit/repositories/constraint-utils.unit.ts
+++ b/packages/repository/test/unit/repositories/constraint-utils.unit.ts
@@ -139,5 +139,9 @@ describe('constraint utility functions', () => {
     id: number;
     description: string;
     customerId: number;
+
+    constructor(data?: Partial<Order>) {
+      super(data);
+    }
   }
 });

--- a/packages/repository/test/unit/repositories/crud.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/crud.repository.unit.ts
@@ -16,6 +16,7 @@ import {
   Where,
   Options,
   CrudConnector,
+  AnyObject,
 } from '../../..';
 
 /**
@@ -62,7 +63,7 @@ class CrudConnectorStub implements CrudConnector {
   ): Promise<number> {
     for (const p in data) {
       for (const e of this.entities) {
-        e[p] = data[p];
+        (e as AnyObject)[p] = (data as AnyObject)[p];
       }
     }
     return Promise.resolve(this.entities.length);
@@ -93,7 +94,7 @@ class Customer extends Entity {
   id: number;
   email: string;
 
-  constructor(data: EntityData) {
+  constructor(data: Partial<Customer>) {
     super();
     if (data && typeof data.id === 'number') {
       this.id = data.id;

--- a/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -52,6 +52,14 @@ describe('DefaultCrudRepository', () => {
         id: {name: 'id', type: 'number', id: true},
       },
     });
+
+    title?: string;
+    content?: string;
+    id: number;
+
+    constructor(data: Partial<Note>) {
+      super(data);
+    }
   }
 
   beforeEach(() => {

--- a/packages/repository/test/unit/repositories/relation.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/relation.repository.unit.ts
@@ -19,7 +19,7 @@ import {
 } from '../../..';
 
 describe('relation repository', () => {
-  context('hasManyEntityCrudRepository interface', () => {
+  context('HasManyRepository interface', () => {
     /**
      * The class below is declared as test for the HasManyEntityCrudRepository
      * interface. The TS Compiler will complain if the interface changes.
@@ -114,6 +114,7 @@ describe('relation repository', () => {
     id: number;
     name: string;
     age: number;
+    country: string;
   }
 
   class CustomerRepository extends DefaultCrudRepository<


### PR DESCRIPTION
Modify the code building legacy PersistedModel definition to enable strict mode by default. This means only properties described in model definitions are allowed, requests adding extra properties are rejected with an error.

Fix `Model.toJSON()` to correctly handle strict/non-strict mode:
 - in strict mode, only defined properties are returned
 - in non-strict mode, all instance properties are returned

My reasoning for this change: in LB4, we are using TypeScript classes and decorators to define models. By default, TS classes forbid additional properties not specified in the type definition. IMO, our persistence implementation should mirror that behavior.

One can disable the strict mode via model setting at juggler level and an indexer property at TypeScript level. Do we want to describe this usage in our docs? What would be the best place to do so?

```ts
@model({settings: {strict: false}})
class MyFlexibleModel extends Entity {
  @property({id: true})
  id: number;

  [prop: string]: any;
}
```

This pull request requires https://github.com/strongloop/loopback-datasource-juggler/pull/1599 to be landed first.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated