### PR TITLE
refactor: clean up server.listening() implementation

### DIFF
--- a/examples/rpc-server/src/rpc.server.ts
+++ b/examples/rpc-server/src/rpc.server.ts
@@ -11,9 +11,10 @@ import * as pEvent from 'p-event';
 import {rpcRouter} from './rpc.router';
 
 export class RPCServer extends Context implements Server {
+  private _listening: boolean = false;
   _server: http.Server;
   expressServer: express.Application;
-  listening: boolean = false;
+
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) public app?: Application,
     @inject('rpcServer.config') public config?: RPCServerConfig,
@@ -24,16 +25,20 @@ export class RPCServer extends Context implements Server {
     rpcRouter(this);
   }
 
+  get listening() {
+    return this._listening;
+  }
+
   async start(): Promise<void> {
     this._server = this.expressServer.listen(
       (this.config && this.config.port) || 3000,
     );
-    this.listening = true;
+    this._listening = true;
     return await pEvent(this._server, 'listening');
   }
   async stop(): Promise<void> {
     this._server.close();
-    this.listening = false;
+    this._listening = false;
     return await pEvent(this._server, 'close');
   }
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -17,6 +17,11 @@
  */
 export interface Server {
   /**
+   * Tells whether the server is listening for connections or not
+   */
+  readonly listening: boolean;
+
+  /**
    * Start the server
    */
   start(): Promise<void>;
@@ -24,8 +29,4 @@ export interface Server {
    * Stop the server
    */
   stop(): Promise<void>;
-  /**
-   * Tells whether the server is listening for connections or not
-   */
-  listening: boolean;
 }

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -130,7 +130,9 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
   protected _expressApp: express.Application;
 
-  listening: boolean = false;
+  get listening(): boolean {
+    return this._httpServer ? this._httpServer.listening : false;
+  }
 
   /**
    * @memberof RestServer
@@ -591,7 +593,6 @@ export class RestServer extends Context implements Server, HttpServerLike {
     this.bind(RestBindings.PORT).to(this._httpServer.port);
     this.bind(RestBindings.HOST).to(this._httpServer.host);
     this.bind(RestBindings.URL).to(this._httpServer.url);
-    this.listening = true;
   }
 
   /**
@@ -605,7 +606,6 @@ export class RestServer extends Context implements Server, HttpServerLike {
     if (!this._httpServer) return;
     await this._httpServer.stop();
     this._httpServer = undefined;
-    this.listening = false;
   }
 
   protected _onUnhandledError(req: Request, res: Response, err: Error) {


### PR DESCRIPTION
In a follow-up for #1479, I'd like to propose a small clean-up.

 - Annotate `server.listening` property as readonly
 - Rework `restServer.listening` as a getter property delegating the actual work to underlying `httpServer.listening`

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated