### PR TITLE
feat(cli): `lb4 model` to scaffold model files

### DIFF
--- a/examples/todo/src/models/todo.model.ts
+++ b/examples/todo/src/models/todo.model.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, property, model} from '@loopback/repository';
+import {Entity, model, property} from '@loopback/repository';
 
 @model()
 export class Todo extends Entity {
@@ -27,22 +27,18 @@ export class Todo extends Entity {
   @property({
     type: 'boolean',
   })
-  isComplete: boolean;
+  isComplete?: boolean;
 
   @property({
     type: 'string',
   })
-  remindAtAddress: string; // address,city,zipcode
+  remindAtAddress?: string; // address,city,zipcode
 
   // TODO(bajtos) Use LoopBack's GeoPoint type here
   @property({
     type: 'string',
   })
-  remindAtGeo: string; // latitude,longitude
-
-  getId() {
-    return this.id;
-  }
+  remindAtGeo?: string; // latitude,longitude
 
   constructor(data?: Partial<Todo>) {
     super(data);

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -65,6 +65,7 @@ function setupGenerators() {
     path.join(__dirname, '../generators/datasource'),
     PREFIX + 'datasource',
   );
+  env.register(path.join(__dirname, '../generators/model'), PREFIX + 'model');
   env.register(
     path.join(__dirname, '../generators/example'),
     PREFIX + 'example',

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -197,6 +197,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
     if (debug.enabled) {
       debug(`Artifact output filename set to: ${this.artifactInfo.outFile}`);
     }
+
     // renames the file
     let template = 'controller-template.ts.ejs';
     switch (this.artifactInfo.controllerType) {

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -1,0 +1,241 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const ArtifactGenerator = require('../../lib/artifact-generator');
+const debug = require('../../lib/debug')('model-generator');
+const utils = require('../../lib/utils');
+const chalk = require('chalk');
+const path = require('path');
+
+/**
+ * Model Generator
+ *
+ * Prompts for a Model name, Model Base Class (currently defaults to 'Entity').
+ * Creates the Model Class -- currently a one time process only.
+ *
+ * Will prompt for properties to add to the Model till a blank property name is
+ * entered. Will also ask if a property is required, the default value for the
+ * property, if it's the ID (unless one has been selected), etc.
+ */
+module.exports = class ModelGenerator extends ArtifactGenerator {
+  constructor(args, opts) {
+    super(args, opts);
+  }
+
+  _setupGenerator() {
+    this.artifactInfo = {
+      type: 'model',
+      rootDir: 'src',
+    };
+
+    this.artifactInfo.outDir = path.resolve(
+      this.artifactInfo.rootDir,
+      'models',
+    );
+
+    // Model Property Types
+    this.typeChoices = [
+      'string',
+      'number',
+      'boolean',
+      'object',
+      'array',
+      'date',
+      'buffer',
+      'geopoint',
+      'any',
+    ];
+
+    this.artifactInfo.properties = {};
+    this.propCounter = 0;
+
+    return super._setupGenerator();
+  }
+
+  setOptions() {
+    return super.setOptions();
+  }
+
+  checkLoopBackProject() {
+    return super.checkLoopBackProject();
+  }
+
+  async promptArtifactName() {
+    await super.promptArtifactName();
+    this.artifactInfo.className = utils.toClassName(this.artifactInfo.name);
+    this.log(
+      `Let's add a property to ${chalk.yellow(this.artifactInfo.className)}`,
+    );
+  }
+
+  // Prompt for a property name
+  async promptPropertyName() {
+    this.log(`Enter an empty property name when done`);
+
+    delete this.propName;
+
+    const prompts = [
+      {
+        name: 'propName',
+        message: 'Enter the property name:',
+        validate: function(val) {
+          if (val) {
+            return utils.checkPropertyName(val);
+          } else {
+            return true;
+          }
+        },
+      },
+    ];
+
+    const answers = await this.prompt(prompts);
+    debug(`propName => ${JSON.stringify(answers)}`);
+    if (answers.propName) {
+      this.artifactInfo.properties[answers.propName] = {};
+      this.propName = answers.propName;
+    }
+    return this._promptPropertyInfo();
+  }
+
+  // Internal Method. Called when a new property is entered.
+  // Prompts the user for more information about the property to be added.
+  async _promptPropertyInfo() {
+    if (!this.propName) {
+      return true;
+    } else {
+      const prompts = [
+        {
+          name: 'type',
+          message: 'Property type:',
+          type: 'list',
+          choices: this.typeChoices,
+        },
+        {
+          name: 'arrayType',
+          message: 'Type of array items:',
+          type: 'list',
+          choices: this.typeChoices.filter(choice => {
+            return choice !== 'array';
+          }),
+          when: answers => {
+            return answers.type === 'array';
+          },
+        },
+        {
+          name: 'id',
+          message: 'Is ID field?',
+          type: 'confirm',
+          default: false,
+          when: answers => {
+            return (
+              !this.idFieldSet &&
+              !['array', 'object', 'buffer'].includes(answers.type)
+            );
+          },
+        },
+        {
+          name: 'required',
+          message: 'Required?:',
+          type: 'confirm',
+          default: false,
+        },
+        {
+          name: 'default',
+          message: `Default value ${chalk.yellow('[leave blank for none]')}:`,
+          when: answers => {
+            return ![null, 'buffer', 'any'].includes(answers.type);
+          },
+        },
+      ];
+
+      const answers = await this.prompt(prompts);
+      debug(`propertyInfo => ${JSON.stringify(answers)}`);
+      if (answers.default === '') {
+        delete answers.default;
+      }
+
+      Object.assign(this.artifactInfo.properties[this.propName], answers);
+      if (answers.id) {
+        this.idFieldSet = true;
+      }
+
+      this.log(
+        `Let's add another property to ${chalk.yellow(
+          this.artifactInfo.className,
+        )}`,
+      );
+      return this.promptPropertyName();
+    }
+  }
+
+  scaffold() {
+    if (this.shouldExit()) return false;
+
+    debug('scaffolding');
+
+    // Data for templates
+    this.artifactInfo.fileName = utils.kebabCase(this.artifactInfo.name);
+    this.artifactInfo.outFile = `${this.artifactInfo.fileName}.model.ts`;
+
+    // Resolved Output Path
+    const tsPath = this.destinationPath(
+      this.artifactInfo.outDir,
+      this.artifactInfo.outFile,
+    );
+
+    const modelTemplatePath = this.templatePath('model.ts.ejs');
+
+    // Set up types for Templating
+    const TS_TYPES = ['string', 'number', 'object', 'boolean', 'any'];
+    const NON_TS_TYPES = ['geopoint', 'date'];
+    Object.entries(this.artifactInfo.properties).forEach(([key, val]) => {
+      // Default tsType is the type property
+      val.tsType = val.type;
+
+      // Override tsType based on certain type values
+      if (val.type === 'array') {
+        if (TS_TYPES.includes(val.arrayType)) {
+          val.tsType = `${val.arrayType}[]`;
+        } else if (val.type === 'buffer') {
+          val.tsType = `Buffer[]`;
+        } else {
+          val.tsType = `string[]`;
+        }
+      } else if (val.type === 'buffer') {
+        val.tsType = 'Buffer';
+      }
+
+      if (NON_TS_TYPES.includes(val.tsType)) {
+        val.tsType = 'string';
+      }
+
+      if (
+        val.defaultValue &&
+        NON_TS_TYPES.concat(['string', 'any']).includes(val.type)
+      ) {
+        val.defaultValue = `'${val.defaultValue}'`;
+      }
+
+      // Convert Type to include '' for template
+      val.type = `'${val.type}'`;
+
+      if (!val.required) {
+        delete val.required;
+      }
+
+      if (!val.id) {
+        delete val.id;
+      }
+    });
+
+    this.fs.copyTpl(modelTemplatePath, tsPath, this.artifactInfo);
+  }
+
+  async end() {
+    await super.end();
+  }
+};

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -1,0 +1,14 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class <%= className %> extends Entity {
+  <% Object.entries(properties).forEach(([key, val]) => { %>
+  @property({<% Object.entries(val).forEach(([propKey, propVal]) => {%>
+    <%if (propKey !== 'tsType') {%><%= propKey %>: <%- propVal %>,<% } %><% }) %>
+  })
+  <%= key %><%if (!val.required) {%>?<% } %>: <%= val.tsType %>;
+  <% }) %>
+  constructor(data?: Partial<<%= className %>>) {
+    super(data);
+  }
+}

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -25,6 +25,8 @@ const Conflicter = require('yeoman-generator/lib/util/conflicter');
 
 const readdirAsync = promisify(fs.readdir);
 
+const RESERVED_PROPERTY_NAMES = ['constructor'];
+
 /**
  * Either a reference to util.promisify or its polyfill, depending on
  * your version of Node.
@@ -328,3 +330,43 @@ exports.readTextFromStdin = function() {
       });
   });
 };
+
+/*
+ * Validate property name
+ * @param {String} name The user input
+ * @returns {String|Boolean}
+ */
+exports.checkPropertyName = function(name) {
+  var result = exports.validateRequiredName(name);
+  if (result !== true) return result;
+  if (RESERVED_PROPERTY_NAMES.includes(name)) {
+    return `${name} is a reserved keyword. Please use another name`;
+  }
+  return true;
+};
+
+/**
+ * Validate required name for properties, data sources, or connectors
+ * Empty name could not pass
+ * @param {String} name The user input
+ * @returns {String|Boolean}
+ */
+exports.validateRequiredName = function(name) {
+  if (!name) {
+    return 'Name is required';
+  }
+  return validateValue(name, /[\/@\s\+%:\.]/);
+};
+
+function validateValue(name, unallowedCharacters) {
+  if (!unallowedCharacters) {
+    unallowedCharacters = /[\/@\s\+%:\.]/;
+  }
+  if (name.match(unallowedCharacters)) {
+    return `Name cannot contain special characters ${unallowedCharacters}: ${name}`;
+  }
+  if (name !== encodeURIComponent(name)) {
+    return `Name cannot contain special characters escaped by encodeURIComponent: ${name}`;
+  }
+  return true;
+}

--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -24,7 +24,7 @@ describe('cli', () => {
     expect(entries).to.eql([
       'Available commands: ',
       '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
-        'lb4 example\n  lb4 openapi',
+        'lb4 model\n  lb4 example\n  lb4 openapi',
     ]);
   });
 
@@ -42,7 +42,7 @@ describe('cli', () => {
     expect(entries).to.containEql('Available commands: ');
     expect(entries).to.containEql(
       '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
-        'lb4 example\n  lb4 openapi',
+        'lb4 model\n  lb4 example\n  lb4 openapi',
     );
   });
 

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -1,0 +1,110 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+('use strict');
+
+// Imports
+const path = require('path');
+const assert = require('yeoman-assert');
+const testlab = require('@loopback/testlab');
+
+const expect = testlab.expect;
+const TestSandbox = testlab.TestSandbox;
+
+const generator = path.join(__dirname, '../../../generators/model');
+const tests = require('../lib/artifact-generator')(generator);
+const baseTests = require('../lib/base-generator')(generator);
+const testUtils = require('../../test-utils');
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+
+// Basic CLI Input
+const basicCLIInput = {
+  name: 'test',
+};
+
+// Expected File Paths & File Contents
+const expectedIndexFile = path.join(SANDBOX_PATH, 'src/models/index.ts');
+const expectedModelFile = path.join(SANDBOX_PATH, 'src/models/test.model.ts');
+
+// Base Tests
+describe('model-generator extending BaseGenerator', baseTests);
+describe('generator-loopback4:model', tests);
+
+describe('lb4 model integration', () => {
+  beforeEach('reset sandbox', () => sandbox.reset());
+
+  it('does not run without package.json', () => {
+    return expect(
+      testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {excludePackageJSON: true}),
+        )
+        .withPrompts(basicCLIInput),
+    ).to.be.rejectedWith(/No package.json found in/);
+  });
+
+  it('does not run without the loopback keyword', () => {
+    return expect(
+      testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: true}),
+        )
+        .withPrompts(basicCLIInput),
+    ).to.be.rejectedWith(/No `loopback` keyword found in/);
+  });
+
+  describe('model generator', () => {
+    it('scaffolds correct files with input', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withPrompts({
+          name: 'test',
+          propName: null,
+        });
+
+      basicModelFileChecks();
+    });
+
+    it('scaffolds correct files with args', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withArguments('test')
+        .withPrompts({
+          propName: null,
+        });
+
+      basicModelFileChecks();
+    });
+  });
+});
+
+// Checks to ensure expected files exist with the current file contents
+function basicModelFileChecks() {
+  assert.file(expectedModelFile);
+  assert.file(expectedIndexFile);
+
+  // Actual Model File
+  assert.fileContent(
+    expectedModelFile,
+    /import {Entity, model, property} from '@loopback\/repository';/,
+  );
+  assert.fileContent(expectedModelFile, /@model()/);
+  assert.fileContent(expectedModelFile, /export class Test extends Entity {/);
+  assert.fileContent(
+    expectedModelFile,
+    /constructor\(data\?\: Partial<Test>\) {/,
+  );
+  assert.fileContent(expectedModelFile, /super\(data\)/);
+
+  // Actual Index File
+  assert.fileContent(expectedIndexFile, /export \* from '.\/test.model';/);
+}

--- a/packages/cli/test/integration/lib/artifact-generator.js
+++ b/packages/cli/test/integration/lib/artifact-generator.js
@@ -116,10 +116,14 @@ module.exports = function(artiGenerator) {
       beforeEach(() => {
         gen = testUtils.testSetUpGen(artiGenerator);
         gen.prompt = sinon.stub(gen, 'prompt');
+        gen.log = sinon.stub(gen, 'log');
       });
 
       afterEach(() => {
-        if (gen) gen.prompt.restore();
+        if (gen) {
+          gen.prompt.restore();
+          gen.log.restore();
+        }
       });
 
       it('incorporates user input into artifactInfo', () => {


### PR DESCRIPTION
implements #1221 

- Associated documentation changes will be in a follow up PR once this lands.

Commit Summary:
- First commit fixes CLI so the base ArtifactGenerator supports updating multiple `index.ts` files
- Second commit implemented `lb4 model` command
- Third commit updates `example-todo` to match output from `lb4 model` command

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
