### PR TITLE
docs(cli): add docs on how the CLI detects artifacts

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -69,6 +69,20 @@ to select:
 - The repository for this model that provides datasource connectivity
 - The REST path name to host the endpoints on
 
+The prompts that list out the models and repositories to choose from to build
+the controller with are chosen from the existing model/repository files on disc.
+From the LoopBack 4 project that the CLI is run, the CLI tool will search for
+file names ending with the following strings under `src/models` and
+`src/repositories`: `model.ts`/`model.js` and `repository.ts`/`repository.ts`.
+Files that match these patterns will then be identified based on the string
+before the first `.` separator.
+
+{% include note.html content="
+Please note that the model and repository typing information will be based on
+how the model/repository files are named; the CLI tooling does not read the
+actual artifact class names inside the files.
+" %}
+
 {% include warning.html content="
 If you do not have a model and repository to select,
 then you will receive an error!

--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -71,11 +71,17 @@ to select:
 
 The prompts that list out the models and repositories to choose from to build
 the controller with are chosen from the existing model/repository files on disc.
-From the LoopBack 4 project that the CLI is run, the CLI tool will search for
-file names ending with the following strings under `src/models` and
-`src/repositories`: `model.ts`/`model.js` and `repository.ts`/`repository.ts`.
+From the LoopBack 4 project that the CLI is run in, the CLI tool will search for
+the following files in the LoopBack 4 project it runs in:
+
+- `src/repositories/*.repository.ts`
+- `src/repositores/*.repository.js`
+- `src/models/*.model.ts`
+- `src/models/*.model.js`
+
 Files that match these patterns will then be identified based on the string
-before the first `.` separator.
+before the first `.` separator. For example, file `models/product.model.ts` is
+identified as a source of `Product` model.
 
 {% include note.html content="
 Please note that the model and repository typing information will be based on

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -89,8 +89,6 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
   }
 
   async promptArtifactCrudVars() {
-    // let modelList = [];
-    // let repositoryList = [];
     if (
       !this.artifactInfo.controllerType ||
       this.artifactInfo.controllerType === ControllerGenerator.BASIC
@@ -108,16 +106,18 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
     );
     if (_.isEmpty(modelList)) {
       throw new Error(
-        `No models found in ${
-          this.artifactInfo.modelDir
-        }. Please visit htpp://loopback.io/doc/en/lb4/Controller-generator.html for information on how models are discovered`,
+        `No models found in ${this.artifactInfo.modelDir}.
+        ${chalk.yellow(
+          'Please visit http://loopback.io/doc/en/lb4/Controller-generator.html for information on how models are discovered',
+        )}`,
       );
     }
     if (_.isEmpty(repositoryList)) {
       throw new Error(
-        `No repositories found in ${
-          this.artifactInfo.repositoryDir
-        }. Please visit htpp://loopback.io/doc/en/lb4/Controller-generator.html for information on how repositories are discovered`,
+        `No repositories found in ${this.artifactInfo.repositoryDir}.
+        ${chalk.yellow(
+          'Please visit http://loopback.io/doc/en/lb4/Controller-generator.html for information on how repositories are discovered',
+        )}`,
       );
     }
     return this.prompt([

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -180,17 +180,16 @@ exports.StatusConflicter = class StatusConflicter extends Conflicter {
  * paths. Must return a Promise.
  * @returns {Promise<string[]>} The filtered list of paths.
  */
-exports.findArtifactPaths = function(path, artifactType, reader) {
+exports.findArtifactPaths = async function(path, artifactType, reader) {
   const readdir = reader || readdirAsync;
   debug(`Finding artifact paths at: ${path}`);
+
   // Wrapping readdir in case it's not a promise.
-  return Promise.resolve(readdir(path)).then(files => {
-    return _.filter(files, f => {
-      return (
-        _.endsWith(f, `${artifactType}.js`) ||
-        _.endsWith(f, `${artifactType}.ts`)
-      );
-    });
+  const files = await readdir(path);
+  return _.filter(files, f => {
+    return (
+      _.endsWith(f, `${artifactType}.js`) || _.endsWith(f, `${artifactType}.ts`)
+    );
   });
 };
 /**
@@ -204,16 +203,15 @@ exports.findArtifactPaths = function(path, artifactType, reader) {
  * @param {Function} reader An alternate function to replace the promisified
  * fs.readdir (useful for testing and for custom overrides).
  */
-exports.getArtifactList = function(dir, artifactType, addSuffix, reader) {
-  return exports.findArtifactPaths(dir, artifactType, reader).then(paths => {
-    debug(`Filtering artifact paths: ${paths}`);
-    return paths.map(p => {
-      const result = _.first(_.split(_.last(_.split(p, path.sep)), '.'));
-      //
-      return addSuffix
-        ? exports.toClassName(result) + exports.toClassName(artifactType)
-        : exports.toClassName(result);
-    });
+exports.getArtifactList = async function(dir, artifactType, addSuffix, reader) {
+  const paths = await exports.findArtifactPaths(dir, artifactType, reader);
+  debug(`Filtering artifact paths: ${paths}`);
+  return paths.map(p => {
+    const result = _.first(_.split(_.last(_.split(p, path.sep)), '.'));
+    //
+    return addSuffix
+      ? exports.toClassName(result) + exports.toClassName(artifactType)
+      : exports.toClassName(result);
   });
 };
 

--- a/packages/cli/test/unit/utils.unit.js
+++ b/packages/cli/test/unit/utils.unit.js
@@ -197,7 +197,7 @@ describe('Utils', () => {
   });
 
   describe('findArtifactPaths', () => {
-    it('returns all matching paths of type', () => {
+    it('returns all matching paths of type', async () => {
       const expected = [
         path.join('tmp', 'app', 'models', 'foo.model.js'),
         path.join('tmp', 'app', 'models', 'baz.model.js'),
@@ -211,74 +211,67 @@ describe('Utils', () => {
         ].concat(expected);
       };
 
-      return utils
-        .findArtifactPaths(path.join('fake', 'path'), 'model', reader)
-        .then(results => {
-          expect(results).to.eql(expected);
-        });
+      const results = await utils.findArtifactPaths(
+        path.join('fake', 'path'),
+        'model',
+        reader,
+      );
+      expect(results).to.eql(expected);
     });
   });
   describe('getArtifactList', () => {
     const expectedModels = ['Foo', 'Bar'];
     const expectedRepos = ['FooRepository', 'BarRepository'];
-    it('finds JS models', () => {
+    it('finds JS models', async () => {
       const files = [
         path.join('tmp', 'app', 'foo.model.js'),
         path.join('tmp', 'app', 'bar.model.js'),
         path.join('tmp', 'app', 'README.md'),
       ];
-      return verifyArtifactList('model', 'models', false, files).then(
-        results => {
-          expect(results).to.eql(expectedModels);
-        },
-      );
+      const results = await verifyArtifactList('model', 'models', false, files);
+      expect(results).to.eql(expectedModels);
     });
 
-    it('finds TS models', () => {
+    it('finds TS models', async () => {
       const files = [
         path.join('tmp', 'app', 'foo.model.ts'),
         path.join('tmp', 'app', 'bar.model.ts'),
         path.join('tmp', 'app', 'README.md'),
       ];
-      return verifyArtifactList('model', 'models', false, files).then(
-        results => {
-          expect(results).to.eql(expectedModels);
-        },
-      );
+      const results = await verifyArtifactList('model', 'models', false, files);
+      expect(results).to.eql(expectedModels);
     });
 
-    it('finds JS repositories', () => {
+    it('finds JS repositories', async () => {
       const files = [
         path.join('tmp', 'app', 'foo.repository.js'),
         path.join('tmp', 'app', 'bar.repository.js'),
         path.join('tmp', 'app', 'foo.model.js'),
       ];
-      return verifyArtifactList(
+      const results = await verifyArtifactList(
         'repository',
         'repositories',
         true,
         files,
         expectedRepos,
-      ).then(results => {
-        expect(results).to.eql(expectedRepos);
-      });
+      );
+      expect(results).to.eql(expectedRepos);
     });
 
-    it('finds TS repositories', () => {
+    it('finds TS repositories', async () => {
       const files = [
         path.join('tmp', 'app', 'foo.repository.ts'),
         path.join('tmp', 'app', 'bar.repository.ts'),
         path.join('tmp', 'app', 'foo.model.ts'),
       ];
-      return verifyArtifactList(
+      const results = await verifyArtifactList(
         'repository',
         'repositories',
         true,
         files,
         expectedRepos,
-      ).then(results => {
-        expect(results).to.eql(expectedRepos);
-      });
+      );
+      expect(results).to.eql(expectedRepos);
     });
 
     /**
@@ -292,12 +285,17 @@ describe('Utils', () => {
      * (ex. the "foo" repository is FooRepository)
      * @param {string[]} files An array of fake filepaths to test with
      */
-    function verifyArtifactList(artifactType, folder, suffix, files) {
+    async function verifyArtifactList(artifactType, folder, suffix, files) {
       const reader = () => {
         return files;
       };
       const artifactPath = path.join('tmp', 'app', folder);
-      return utils.getArtifactList(artifactPath, artifactType, suffix, reader);
+      return await utils.getArtifactList(
+        artifactPath,
+        artifactType,
+        suffix,
+        reader,
+      );
     }
   });
 


### PR DESCRIPTION
Divided into two commits:
- the first includes the link to the documentation on CLI to the error thrown when no models/repositories are detected AND switches promises to use es7's async/await
- the second is the actual docs

Closes #1085

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
