### PR TITLE
refactor(repository): make generic arguments more descriptive

### DIFF
--- a/packages/repository/src/repositories/relation.factory.ts
+++ b/packages/repository/src/repositories/relation.factory.ts
@@ -11,9 +11,9 @@ import {
   DefaultHasManyEntityCrudRepository,
 } from './relation.repository';
 
-export type HasManyRepositoryFactory<T extends Entity, ID> = (
-  fkValue: ID,
-) => HasManyRepository<T>;
+export type HasManyRepositoryFactory<Target extends Entity, SourceID> = (
+  fkValue: SourceID,
+) => HasManyRepository<Target>;
 
 /**
  * Enforces a constraint on a repository based on a relationship contract

--- a/packages/repository/src/repositories/relation.repository.ts
+++ b/packages/repository/src/repositories/relation.repository.ts
@@ -16,21 +16,21 @@ import {Filter, Where} from '../query';
 /**
  * CRUD operations for a target repository of a HasMany relation
  */
-export interface HasManyRepository<T extends Entity> {
+export interface HasManyRepository<Target extends Entity> {
   /**
    * Create a target model instance
    * @param targetModelData The target model data
    * @param options Options for the operation
    * @returns A promise which resolves to the newly created target model instance
    */
-  create(targetModelData: Partial<T>, options?: Options): Promise<T>;
+  create(targetModelData: Partial<Target>, options?: Options): Promise<Target>;
   /**
    * Find target model instance(s)
    * @param Filter A filter object for where, order, limit, etc.
    * @param options Options for the operation
    * @returns A promise which resolves with the found target instance(s)
    */
-  find(filter?: Filter, options?: Options): Promise<T[]>;
+  find(filter?: Filter, options?: Options): Promise<Target[]>;
   /**
    * Delete multiple target model instances
    * @param where Instances within the where scope are deleted
@@ -46,17 +46,17 @@ export interface HasManyRepository<T extends Entity> {
    * @returns A promise which resolves the patched target model instances
    */
   patch(
-    dataObject: DataObject<T>,
+    dataObject: DataObject<Target>,
     where?: Where,
     options?: Options,
   ): Promise<number>;
 }
 
 export class DefaultHasManyEntityCrudRepository<
-  T extends Entity,
-  ID,
-  TargetRepository extends EntityCrudRepository<T, ID>
-> implements HasManyRepository<T> {
+  TargetEntity extends Entity,
+  TargetID,
+  TargetRepository extends EntityCrudRepository<TargetEntity, TargetID>
+> implements HasManyRepository<TargetEntity> {
   /**
    * Constructor of DefaultHasManyEntityCrudRepository
    * @param targetRepository the related target model repository instance
@@ -68,14 +68,17 @@ export class DefaultHasManyEntityCrudRepository<
     public constraint: AnyObject,
   ) {}
 
-  async create(targetModelData: Partial<T>, options?: Options): Promise<T> {
+  async create(
+    targetModelData: Partial<TargetEntity>,
+    options?: Options,
+  ): Promise<TargetEntity> {
     return await this.targetRepository.create(
       constrainDataObject(targetModelData, this.constraint),
       options,
     );
   }
 
-  async find(filter?: Filter, options?: Options): Promise<T[]> {
+  async find(filter?: Filter, options?: Options): Promise<TargetEntity[]> {
     return await this.targetRepository.find(
       constrainFilter(filter, this.constraint),
       options,
@@ -90,7 +93,7 @@ export class DefaultHasManyEntityCrudRepository<
   }
 
   async patch(
-    dataObject: Partial<T>,
+    dataObject: Partial<TargetEntity>,
     where?: Where,
     options?: Options,
   ): Promise<number> {


### PR DESCRIPTION
Rename generic arguments of various HasMany-related templates to use more descriptive names making it clear whether the type argument is related to source or target model (entity).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated
