### PR TITLE
fix(cli): tweak getArtifactList to return pascalCased strings

### DIFF
--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -209,8 +209,8 @@ exports.getArtifactList = async function(dir, artifactType, addSuffix, reader) {
   const paths = await exports.findArtifactPaths(dir, artifactType, reader);
   debug(`Filtering artifact paths: ${paths}`);
   return paths.map(p => {
-    const result = _.first(_.split(_.last(_.split(p, path.sep)), '.'));
-    //
+    const firstWord = _.first(_.split(_.last(_.split(p, path.sep)), '.'));
+    const result = pascalCase(exports.toClassName(firstWord));
     return addSuffix
       ? exports.toClassName(result) + exports.toClassName(artifactType)
       : exports.toClassName(result);

--- a/packages/cli/test/unit/utils.unit.js
+++ b/packages/cli/test/unit/utils.unit.js
@@ -274,6 +274,16 @@ describe('Utils', () => {
       expect(results).to.eql(expectedRepos);
     });
 
+    it('finds artifacts with hyphens in their names', async () => {
+      const files = [
+        path.join('tmp', 'app', 'foo-bar.model.js'),
+        path.join('tmp', 'app', 'baz.model.js'),
+        path.join('tmp', 'app', 'README.md'),
+      ];
+      const results = await verifyArtifactList('model', 'models', false, files);
+      expect(results).to.eql(['FooBar', 'Baz']);
+    });
+
     /**
      * Testing function for evaluating the lists returned from
      * the getArtifactList function.


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Before, if you had `foo-bar.model.ts`, the CLI would show `Foo-Bar` as an option to choose for the Default CRUD controller generator. This fixes this

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
