### PR TITLE
feat(rest): add url property

### DIFF
--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -136,6 +136,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
     return this._httpServer ? this._httpServer.listening : false;
   }
 
+  get url(): string | undefined {
+    return this._httpServer && this._httpServer.url;
+  }
+
   /**
    * @memberof RestServer
    * Creates an instance of RestServer.

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -4,11 +4,30 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Application, ApplicationConfig} from '@loopback/core';
-import {expect, createClientForHandler} from '@loopback/testlab';
+import {supertest, expect, createClientForHandler} from '@loopback/testlab';
 import {Route, RestBindings, RestServer, RestComponent} from '../..';
 import * as yaml from 'js-yaml';
 
 describe('RestServer (integration)', () => {
+  it('exports url property', async () => {
+    const server = await givenAServer({rest: {port: 0}});
+    server.handler(({response}, sequence) => {
+      response.write('ok');
+      response.end();
+    });
+    expect(server.url).to.be.undefined();
+    await server.start();
+    expect(server)
+      .to.have.property('url')
+      .which.is.a.String()
+      .match(/http|https\:\/\//);
+    await supertest(server.url)
+      .get('/')
+      .expect(200, 'ok');
+    await server.stop();
+    expect(server.url).to.be.undefined();
+  });
+
   it('updates rest.port binding when listening on ephemeral port', async () => {
     const server = await givenAServer({rest: {port: 0}});
     await server.start();


### PR DESCRIPTION
Add `url` property to Rest server.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
