### PR TITLE
Cli run lint fix

### DIFF
--- a/docs/site/includes/CLI-std-options.md
+++ b/docs/site/includes/CLI-std-options.md
@@ -14,6 +14,9 @@
 `-c, --config`
 : JSON file name or value to configure options
 
+`--format`
+: Format generated code using `npm run lint:fix`
+
 For example,
 ```sh
 lb4 app --config config.json

--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -82,8 +82,9 @@ module.exports = class AppGenerator extends ProjectGenerator {
     return super.install();
   }
 
-  end() {
-    if (!super.end()) return false;
+  async end() {
+    await super.end();
+    if (this.shouldExit()) return;
     this.log();
     this.log(
       'Application %s was created in %s.',

--- a/packages/cli/lib/artifact-generator.js
+++ b/packages/cli/lib/artifact-generator.js
@@ -81,8 +81,10 @@ module.exports = class ArtifactGenerator extends BaseGenerator {
   }
 
   async end() {
-    const success = await super.end();
-    if (!success) return false;
+    if (this.shouldExit()) {
+      await super.end();
+      return;
+    }
 
     let generationStatus = true;
     // Check all files being generated to ensure they succeeded
@@ -124,6 +126,6 @@ module.exports = class ArtifactGenerator extends BaseGenerator {
       this.log();
     }
 
-    return false;
+    await super.end();
   }
 };

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -47,7 +47,6 @@ module.exports = class BaseGenerator extends Generator {
 
     this.option('format', {
       type: Boolean,
-      alias: 'f',
       description: 'Format generated code using npm run lint:fix',
     });
 
@@ -310,6 +309,24 @@ module.exports = class BaseGenerator extends Generator {
     return !!this.exitGeneration;
   }
 
+  async _runLintFix() {
+    if (this.options.format) {
+      const pkg = this.packageJson || {};
+      if (pkg.scripts && pkg.scripts['lint:fix']) {
+        this.log("Running 'npm run lint:fix' to format the code...");
+        await this._runNpmScript(this.destinationRoot(), [
+          'run',
+          '-s',
+          'lint:fix',
+        ]);
+      } else {
+        this.log(
+          chalk.red("No 'lint:fix' script is configured in package.json."),
+        );
+      }
+    }
+  }
+
   /**
    * Print out the exit reason if this generator is told to exit before it ends
    */
@@ -321,9 +338,6 @@ module.exports = class BaseGenerator extends Generator {
       process.exitCode = 1;
       return;
     }
-    if (this.options.format) {
-      this.log('Running npm run lint:fix to format the code...');
-      await this._runNpmScript(this.destinationRoot(), ['run', 'lint:fix']);
-    }
+    await this._runLintFix();
   }
 };

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -249,6 +249,10 @@ module.exports = class ProjectGenerator extends BaseGenerator {
 
   install() {
     if (this.shouldExit()) return false;
-    this.npmInstall(null, {}, {cwd: this.destinationRoot()});
+    const opts = this.options.npmInstall || {};
+    const spawnOpts = Object.assign({}, this.options.spawn, {
+      cwd: this.destinationRoot(),
+    });
+    this.npmInstall(null, opts, spawnOpts);
   }
 };

--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -24,7 +24,7 @@ describe('app-generator (SLOW)', function() {
   };
 
   before('scaffold a new application', async function createAppProject() {
-    // Increase the timeout to 1 minute to accomodate slow CI build machines
+    // Increase the timeout to 1 minute to accommodate slow CI build machines
     this.timeout(60 * 1000);
     await helpers
       .run(generator)

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -74,3 +74,37 @@ describe('app-generator with --applicationName', () => {
     );
   });
 });
+
+// The test takes about 1 min to install dependencies
+function testFormat() {
+  before(function() {
+    this.timeout(60 * 1000);
+    return helpers
+      .run(generator)
+      .withOptions({
+        applicationName: 'MyApp',
+        format: true,
+        // Make sure `npm install` happens
+        skipInstall: false,
+        // Disable npm log and progress bar
+        npmInstall: {silent: true, progress: false},
+        // Disable npm stdio
+        spawn: {
+          stdio: 'ignore',
+        },
+      })
+      .withPrompts(props);
+  });
+  it('generates all the proper files', () => {
+    assert.file('src/application.ts');
+    assert.fileContent(
+      'src/application.ts',
+      /class MyApp extends BootMixin\(RestApplication/,
+    );
+  });
+}
+
+// Skip the test for CI
+process.env.CI && !process.env.DEBUG
+  ? describe.skip
+  : describe('app-generator with --format', testFormat);

--- a/packages/cli/test/integration/lib/artifact-generator.js
+++ b/packages/cli/test/integration/lib/artifact-generator.js
@@ -58,6 +58,17 @@ module.exports = function(artiGenerator) {
     });
 
     describe('checkLoopBackProject', () => {
+      let gen;
+
+      beforeEach(() => {
+        gen = testUtils.testSetUpGen(artiGenerator);
+        gen.fs.readJSON = sinon.stub(fs, 'readJSON');
+      });
+
+      afterEach(() => {
+        if (gen) gen.fs.readJSON.restore();
+      });
+
       testCheckLoopBack(
         'throws an error if no package.json is present',
         undefined,
@@ -75,23 +86,18 @@ module.exports = function(artiGenerator) {
       );
 
       it('passes if "keywords" maps to "loopback"', () => {
-        let gen = testUtils.testSetUpGen(artiGenerator);
-        gen.fs.readJSON = sinon.stub(fs, 'readJSON');
         gen.fs.readJSON.returns({keywords: ['test', 'loopback']});
         assert.doesNotThrow(() => {
           gen.checkLoopBackProject();
         }, Error);
-        gen.fs.readJSON.restore();
       });
 
       function testCheckLoopBack(testName, obj, expected) {
         it(testName, () => {
-          let gen = testUtils.testSetUpGen(artiGenerator);
           let logs = [];
           gen.log = function(...args) {
             logs = logs.concat(args);
           };
-          gen.fs.readJSON = sinon.stub(fs, 'readJSON');
           gen.fs.readJSON.returns(obj);
           gen.checkLoopBackProject();
           assert(gen.exitGeneration instanceof Error);
@@ -100,18 +106,25 @@ module.exports = function(artiGenerator) {
           assert.deepEqual(logs, [
             chalk.red('Generation is aborted:', gen.exitGeneration),
           ]);
-          gen.fs.readJSON.restore();
         });
       }
     });
 
     describe('promptArtifactName', () => {
-      it('incorporates user input into artifactInfo', () => {
-        let gen = testUtils.testSetUpGen(artiGenerator);
+      let gen;
+
+      beforeEach(() => {
+        gen = testUtils.testSetUpGen(artiGenerator);
         gen.prompt = sinon.stub(gen, 'prompt');
+      });
+
+      afterEach(() => {
+        if (gen) gen.prompt.restore();
+      });
+
+      it('incorporates user input into artifactInfo', () => {
         gen.prompt.resolves({name: 'foobar'});
         return gen.promptArtifactName().then(() => {
-          gen.prompt.restore();
           assert(gen.artifactInfo.name);
           assert(gen.artifactInfo.name === 'foobar');
         });


### PR DESCRIPTION
The PR adds `--format` option to run `npm lint:fix` to format generated code.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
