### PR TITLE
fix(cli): reorder where and body in CLI template for updateAll

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -99,7 +99,7 @@ Here's an example of what the template will produce given a `Todo` model and a
 
 ```ts
 import {Filter, Where, repository} from '@loopback/repository';
-import {post, param, get, put, patch, del, requestBody} from '@loopback/rest';
+import {post, param, get, patch, del, requestBody} from '@loopback/rest';
 import {Todo} from '../models';
 import {TodoRepository} from '../repositories';
 
@@ -114,25 +114,25 @@ export class TodoController {
   }
 
   @get('/todos/count')
-  async count(@param.query.string('where') where: Where): Promise<number> {
+  async count(@param.query.string('where') where?: Where): Promise<number> {
     return await this.todoRepository.count(where);
   }
 
   @get('/todos')
-  async find(@param.query.string('filter') filter: Filter): Promise<Todo[]> {
+  async find(@param.query.string('filter') filter?: Filter): Promise<Todo[]> {
     return await this.todoRepository.find(filter);
   }
 
   @patch('/todos')
   async updateAll(
-    @param.query.string('where') where: Where,
     @requestBody() obj: Todo,
+    @param.query.string('where') where?: Where,
   ): Promise<number> {
-    return await this.todoRepository.updateAll(where, obj);
+    return await this.todoRepository.updateAll(obj, where);
   }
 
   @del('/todos')
-  async deleteAll(@param.query.string('where') where: Where): Promise<number> {
+  async deleteAll(@param.query.string('where') where?: Where): Promise<number> {
     return await this.todoRepository.deleteAll(where);
   }
 

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -3,7 +3,6 @@ import {
   post,
   param,
   get,
-  put,
   patch,
   del,
   requestBody
@@ -24,26 +23,26 @@ export class <%= className %>Controller {
   }
 
   @get('<%= httpPathName %>/count')
-  async count(@param.query.string('where') where: Where): Promise<number> {
+  async count(@param.query.string('where') where?: Where): Promise<number> {
     return await this.<%= repositoryNameCamel %>.count(where);
   }
 
   @get('<%= httpPathName %>')
-  async find(@param.query.string('filter') filter: Filter)
+  async find(@param.query.string('filter') filter?: Filter)
     : Promise<<%= modelName %>[]> {
     return await this.<%= repositoryNameCamel %>.find(filter);
   }
 
   @patch('<%= httpPathName %>')
   async updateAll(
-    @param.query.string('where') where: Where,
     @requestBody() obj: <%= modelName %>
+    @param.query.string('where') where?: Where,
   ): Promise<number> {
-    return await this.<%= repositoryNameCamel %>.updateAll(where, obj);
+    return await this.<%= repositoryNameCamel %>.updateAll(obj, where);
   }
 
   @del('<%= httpPathName %>')
-  async deleteAll(@param.query.string('where') where: Where): Promise<number> {
+  async deleteAll(@param.query.string('where') where?: Where): Promise<number> {
     return await this.<%= repositoryNameCamel %>.deleteAll(where);
   }
 

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -256,7 +256,7 @@ function checkRestCrudContents() {
   );
   assert.fileContent(
     expectedFile,
-    /\@patch\('\/product-reviews'\)\s{1,}async updateAll\(\s{1,}\@param.query.string\('where'\) where: Where,\s{1,}\@requestBody\(\)/,
+    /\@patch\('\/product-reviews'\)\s{1,}async updateAll\(\s{1,}\@requestBody\(\).*\s{1,}\@param.query.string\('where'\) where\?: Where,/,
   );
   assert.fileContent(
     expectedFile,


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Current way the call is made with updateAll in the CRUD CLI template:
`return await this.<%= repositoryNameCamel %>.updateAll(where, obj);`

Signature of `updateAll`:
```ts
  updateAll(
    data: Partial<T>,
    where?: Where,
    options?: Options,
  ): Promise<number>
```

The where object and the body need to be switched around

fixes #1521 

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
