### PR TITLE
fix(repository): fix return type of DefaultCrudRepository#_createHasManyRepositoryFactoryFor

### DIFF
--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -17,7 +17,10 @@ import {
 import {Entity, ModelDefinition} from '../model';
 import {Filter, Where} from '../query';
 import {EntityCrudRepository} from './repository';
-import {createHasManyRepositoryFactory} from './relation.factory';
+import {
+  createHasManyRepositoryFactory,
+  HasManyRepositoryFactory,
+} from './relation.factory';
 import {HasManyDefinition} from '../decorators/relation.decorator';
 // need the import for exporting of a return type
 // tslint:disable-next-line:no-unused-variable
@@ -150,9 +153,9 @@ export class DefaultCrudRepository<T extends Entity, ID>
   protected _createHasManyRepositoryFactoryFor<Target extends Entity, TargetID>(
     relationName: string,
     targetRepo: EntityCrudRepository<Target, TargetID>,
-  ) {
+  ): HasManyRepositoryFactory<Target, ID> {
     const meta = this.entityClass.definition.relations[relationName];
-    return createHasManyRepositoryFactory(
+    return createHasManyRepositoryFactory<ID, Target, TargetID>(
       meta as HasManyDefinition,
       targetRepo,
     );


### PR DESCRIPTION
Fix the type information and implementation of DefaultCrudRepository's method _createHasManyRepositoryFactoryFor to correctly distinguish between source and target model/ID types.

I discovered this problem why reviewing the blog post introducing HasMany relation.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
