### PR TITLE
fix: path to test folder

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "args": [
         "--opts",
         "${workspaceRoot}/test/mocha.opts",
-        "packages/*/dist/test/**/*.js",
+        "packages/*/dist*/test/**/*.js",
         "-t",
         "0"
       ]


### PR DESCRIPTION
### Description

The generated dist folder is `dist<node_version>`. Fix the vscode config file to reflect it.