### PR TITLE
feat: localize error in details

### DIFF
--- a/packages/rest/src/rest-http-error.ts
+++ b/packages/rest/src/rest-http-error.ts
@@ -1,4 +1,5 @@
 import * as HttpErrors from 'http-errors';
+
 export namespace RestHttpErrors {
   export function invalidData<T>(data: T, name: string) {
     const msg = `Invalid data ${JSON.stringify(data)} for parameter ${name}!`;
@@ -12,7 +13,33 @@ export namespace RestHttpErrors {
     const msg = `Parameters with "in: ${location}" are not supported yet.`;
     return new HttpErrors.NotImplemented(msg);
   }
-  export function invalidRequestBody(msg: string): HttpErrors.HttpError {
-    return new HttpErrors.UnprocessableEntity(msg);
+  export const INVALID_REQUEST_BODY_MESSAGE =
+    'The request body is invalid. See error object `details` property for more info.';
+  export function invalidRequestBody(): HttpErrors.HttpError {
+    return new HttpErrors.UnprocessableEntity(INVALID_REQUEST_BODY_MESSAGE);
+  }
+  /**
+   * An invalid request body error contains a `details` property as the machine-readable error.
+   * Each entry in `error.details` contains 4 attributes: `path`, `code`, `info` and `message`.
+   * `ValidationErrorDetails` defines the type of each entry, which is an object.
+   * The type of `error.details` is `ValidationErrorDetails[]`.
+   */
+  export interface ValidationErrorDetails {
+    /**
+     * A path to the invalid field.
+     */
+    path: string;
+    /**
+     * A single word code represents the error's type.
+     */
+    code: string;
+    /**
+     * A human readable description of the error.
+     */
+    message: string;
+    /**
+     * Some additional details that the 3 attributes above don't cover.
+     */
+    info: object;
   }
 }


### PR DESCRIPTION
### Description

connect to https://github.com/strongloop/loopback-next/pull/1489
Original [comment](https://github.com/strongloop/loopback-next/pull/1489#issuecomment-403525040) from @bajtos 

### Discussion

LB3 and AJV error details are in different flavours:

- LB3: organized by detail attribute like `codes`, `messages`, and details are stored per field. e.g.:

```js
// error.details
{
  codes: {
    field1: ['errCode1', 'errCode2'],
    field2: ['errCode1', 'errCode3'],
  },
  messages: {
    field1: ['errMsg1', 'errMsg2'],
    field2: ['errMsg3', 'errMsg4'],
  }
}
```

- AJV: organized per error, each error entry includes detail attributes like field('dataPath'), code('keyword'), message, etc...e.g.:

```js
// the corresponding ajv.errors of example above
[
  {dataPath: 'field1', keyword: 'code1', message: 'msg1', params: {...additionalInfo1}}
  {dataPath: 'field2', keyword: 'code1', message: 'msg3', params: {...additionalInfo3}}
  {dataPath: 'field1', keyword: 'code2', message: 'msg2', params: {...additionalInfo2}}
  {dataPath: 'field2', keyword: 'code3', message: 'msg4', params: {...additionalInfo4}}
]
```
 
For the purpose of **localizing error in details**, either of those 2 flavour seems good to me.
I tried to convert the ajv style to LB3 style and find it's quite complicated, because 

 - `dataPath` cannot always be used as the id for a field. 
   - See the first error entry in the following picture: a missing property is easy to localize from `message` but the `dataPath` is empty...
 - I need more time to investigate how many keywords ajv has, and how to parse the field id for each type
   - [a reference of keywords that ajv uses](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md)
   - given a quick look there are too many keywords...is it worth to try everything?

@bajtos thought? You may have more insights regarding different signatures.

<img width="820" alt="screen shot 2018-07-10 at 8 46 36 pm" src="https://user-images.githubusercontent.com/12554153/42585525-dd22c31a-8503-11e8-8f25-242485362954.png">
