### PR TITLE
ci: skip IPv6 tests on Travis and remove sudo script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,3 @@ matrix:
 branches:
   only:
     - master
-
-before_script:
-  # Add an IPv6 config - see the corresponding Travis issue
-  # https://github.com/travis-ci/travis-ci/issues/8361
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
-    fi

--- a/packages/http-server/test/integration/http-server.integration.ts
+++ b/packages/http-server/test/integration/http-server.integration.ts
@@ -12,13 +12,16 @@ describe('HttpServer (integration)', () => {
 
   afterEach(stopServer);
 
-  it('formats IPv6 url correctly', async () => {
-    server = new HttpServer(dummyRequestHandler, {host: '::1'});
-    await server.start();
-    expect(server.address!.family).to.equal('IPv6');
-    const response = await getAsync(server.url);
-    expect(response.statusCode).to.equal(200);
-  });
+  process.env.TRAVIS
+    ? // tslint:disable-next-line:no-unused-expression
+      it.skip
+    : it('formats IPv6 url correctly', async () => {
+        server = new HttpServer(dummyRequestHandler, {host: '::1'});
+        await server.start();
+        expect(server.address!.family).to.equal('IPv6');
+        const response = await getAsync(server.url);
+        expect(response.statusCode).to.equal(200);
+      });
 
   it('starts server', async () => {
     server = new HttpServer(dummyRequestHandler);
@@ -29,7 +32,8 @@ describe('HttpServer (integration)', () => {
   });
 
   it('stops server', async () => {
-    server = new HttpServer(dummyRequestHandler);
+    // Explicitly setting host to IPv4 address so test runs on Travis
+    server = new HttpServer(dummyRequestHandler, {host: '127.0.0.1'});
     await server.start();
     await server.stop();
     await expect(

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -10,7 +10,8 @@ import * as yaml from 'js-yaml';
 
 describe('RestServer (integration)', () => {
   it('exports url property', async () => {
-    const server = await givenAServer({rest: {port: 0}});
+    // Explicitly setting host to IPv4 address so test runs on Travis
+    const server = await givenAServer({rest: {port: 0, host: '127.0.0.1'}});
     server.handler(({response}, sequence) => {
       response.write('ok');
       response.end();


### PR DESCRIPTION
Builds on Travis (Linux) are failing as we use `sudo` in the `before_script` BUT we had `sudo: false` in `.travis.yml`. 

Not sure how it worked before but it looks like something changes with Travis causing the builds to now fail.

Since only one test requires IPv6 - this PR removes the `before_script` and skips the one test on Travis (and other tests failing are updated to explicitly use IPv4 address). 

Example of a failing build: https://travis-ci.org/strongloop/loopback-next/jobs/403098729

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
