### PR TITLE
fix(cli): use <idtype> on param.path

### DIFF
--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -48,20 +48,20 @@ export class <%= className %>Controller {
   }
 
   @get('<%= httpPathName %>/{id}')
-  async findById(@param.path.number('id') id: <%= idType %>): Promise<<%= modelName %>> {
+  async findById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<<%= modelName %>> {
     return await this.<%= repositoryNameCamel %>.findById(id);
   }
 
   @patch('<%= httpPathName %>/{id}')
   async updateById(
-    @param.path.number('id') id: <%= idType %>,
+    @param.path.<%= idType %>('id') id: <%= idType %>,
     @requestBody() obj: <%= modelName %>
   ): Promise<boolean> {
     return await this.<%= repositoryNameCamel %>.updateById(id, obj);
   }
 
   @del('<%= httpPathName %>/{id}')
-  async deleteById(@param.path.number('id') id: <%= idType %>): Promise<boolean> {
+  async deleteById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<boolean> {
     return await this.<%= repositoryNameCamel %>.deleteById(id);
   }
 }


### PR DESCRIPTION
…st controller template parsing

now it works on models that specify string as their id data type such as mongodb

## Checklist

- [x ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
