### PR TITLE
fix(example-todo): correct todo-overview image link

### DIFF
--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -7,7 +7,7 @@ This is the basic tutorial for getting started with Loopback 4!
 This tutorial demonstrates how to create a basic API for a todo list using
 LoopBack 4.
 
-![todo-tutorial-overview](https://loopback.io/doc/en/lb4/imgs/todo-overview.png)
+![todo-tutorial-overview](https://loopback.io/pages/en/lb4/imgs/todo-overview.png)
 
 ## Setup
 


### PR DESCRIPTION
images in /pages folder aren't generated under `/doc` URL.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
