### PR TITLE
build: remove test files from code coverage data

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,7 +1,12 @@
 {
     "include": [
-      "packages/*/dist*/*",
-      "examples/*/dist*/*"
+      "packages/*/dist*/",
+      "examples/*/dist*/"
+    ],
+    "exclude": [
+      "packages/*/dist*/test/",
+      "examples/*/dist*/test/",
+      "**/.sandbox/"
     ],
     "extension": [
       ".js",


### PR DESCRIPTION
Right now, we are including all test files (e.g. `packages/core/test/acceptance/application.acceptance.ts`) in the code coverage data. Because most (if not all) test files have 100% coverage by their nature, by including them in code coverage data we are artificially inflating the reported percentage number.

I am proposing to configure `nyc` to exclude all test files.

A downside I am aware of: when test file coverage is measured, we can detect changes that are skipping tests (e.g. via `it.skip` - but this can be caught by a linter too) and find test code that's no longer executed (e.g. test helpers).

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated