### PR TITLE
[WIP] feat(repository): add KVRepository impl using legacy juggler

### DIFF
--- a/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
@@ -14,10 +14,6 @@ import {
   ModelDefinition,
 } from '../../';
 
-class NoteController {
-  @repository('noteRepo') public noteRepo: EntityCrudRepository<Entity, number>;
-}
-
 const ds: juggler.DataSource = new juggler.DataSource({
   name: 'db',
   connector: 'memory',
@@ -28,6 +24,13 @@ class Note extends Entity {
     name: 'note',
     properties: {title: 'string', content: 'string'},
   });
+
+  title: string;
+  content?: string;
+}
+
+class NoteController {
+  @repository('noteRepo') public noteRepo: EntityCrudRepository<Note, number>;
 }
 
 class MyNoteRepository extends DefaultCrudRepository<Note, string> {

--- a/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
@@ -16,22 +16,6 @@ import {
   ModelDefinition,
 } from '../../';
 
-// The Controller for Note
-class NoteController {
-  constructor(
-    @repository('noteRepo')
-    public noteRepo: EntityCrudRepository<Entity, number>,
-  ) {}
-
-  create(data: DataObject<Entity>, options?: Options) {
-    return this.noteRepo.create(data, options);
-  }
-
-  findByTitle(title: string, options?: Options) {
-    return this.noteRepo.find({where: {title}}, options);
-  }
-}
-
 const ds: juggler.DataSource = new juggler.DataSource({
   name: 'db',
   connector: 'memory',
@@ -42,6 +26,24 @@ class Note extends Entity {
     name: 'note',
     properties: {title: 'string', content: 'string'},
   });
+
+  title: string;
+  content?: string;
+}
+
+// The Controller for Note
+class NoteController {
+  constructor(
+    @repository('noteRepo') public noteRepo: EntityCrudRepository<Note, number>,
+  ) {}
+
+  create(data: DataObject<Note>, options?: Options) {
+    return this.noteRepo.create(data, options);
+  }
+
+  findByTitle(title: string, options?: Options) {
+    return this.noteRepo.find({where: {title}}, options);
+  }
 }
 
 async function main() {

--- a/packages/repository/src/common-types.ts
+++ b/packages/repository/src/common-types.ts
@@ -44,9 +44,15 @@ export interface AnyObject {
 }
 
 /**
- * Type alias for T or any object
+ * An extension of the built-in Partial<T> type which allows partial values
+ * in deeply nested properties too.
  */
-export type DataObject<T> = T | AnyObject;
+export type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
+
+/**
+ * Type alias for strongly or weakly typed objects of T
+ */
+export type DataObject<T> = T | DeepPartial<T>;
 
 /**
  * Type alias for Node.js options object

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -177,7 +177,7 @@ export abstract class Model {
     return obj;
   }
 
-  constructor(data?: Partial<Model>) {
+  constructor(data?: DataObject<Model>) {
     Object.assign(this, data);
   }
 }

--- a/packages/repository/src/repositories/constraint-utils.ts
+++ b/packages/repository/src/repositories/constraint-utils.ts
@@ -51,7 +51,7 @@ export function constrainWhere(
  */
 export function constrainDataObject<T extends Entity>(
   originalData: DataObject<T>,
-  constraint: Partial<T>,
+  constraint: DataObject<T>,
 ): DataObject<T> {
   const constrainedData = cloneDeep(originalData);
   for (const c in constraint) {

--- a/packages/repository/src/repositories/index.ts
+++ b/packages/repository/src/repositories/index.ts
@@ -5,6 +5,7 @@
 
 export * from './kv.repository';
 export * from './legacy-juggler-bridge';
+export * from './kv.repository.bridge';
 export * from './repository';
 export * from './relation.factory';
 export * from './relation.repository';

--- a/packages/repository/src/repositories/kv.repository.bridge.ts
+++ b/packages/repository/src/repositories/kv.repository.bridge.ts
@@ -1,0 +1,69 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as legacy from 'loopback-datasource-juggler';
+
+import {Options, DataObject} from '../common-types';
+import {Model} from '../model';
+
+import {KVRepository, AsyncIterator, KVFilter} from './kv.repository';
+
+import {juggler, ensurePromise} from './legacy-juggler-bridge';
+
+/**
+ * An implementation of KVRepository based on legacy loopback-datasource-juggler
+ */
+export class DefaultKVRepository<T extends Model> implements KVRepository<T> {
+  kvModelClass: typeof juggler.KeyValueModel;
+
+  constructor(kvModelClass: typeof juggler.KeyValueModel) {
+    this.kvModelClass = kvModelClass;
+  }
+
+  delete(key: string, options?: Options): Promise<void> {
+    return ensurePromise(this.kvModelClass.delete(key, options));
+  }
+
+  deleteAll(options?: Options): Promise<void> {
+    return ensurePromise(this.kvModelClass.deleteAll(options));
+  }
+
+  get(key: string, options?: Options): Promise<T> {
+    const val = this.kvModelClass.get(key, options) as legacy.PromiseOrVoid<T>;
+    return ensurePromise<T>(val);
+  }
+
+  set(key: string, value: DataObject<T>, options?: Options): Promise<void> {
+    return ensurePromise<void>(this.kvModelClass.set(key, value, options));
+  }
+
+  expire(key: string, ttl: number, options?: Options): Promise<void> {
+    return ensurePromise<void>(this.kvModelClass.expire(key, ttl, options));
+  }
+
+  ttl(key: string, options?: Options): Promise<number> {
+    return ensurePromise<number>(this.kvModelClass.ttl(key, options));
+  }
+
+  keys(filter?: KVFilter, options?: Options): Promise<string[]> {
+    return ensurePromise<string[]>(this.kvModelClass.keys(filter, options));
+  }
+
+  iterateKeys(filter?: KVFilter, options?: Options): AsyncIterator<string> {
+    return new AsyncKeyIteratorImpl(
+      this.kvModelClass.iterateKeys(filter, options),
+    );
+  }
+}
+
+class AsyncKeyIteratorImpl implements AsyncIterator<string> {
+  constructor(private keys: legacy.AsyncKeyIterator) {}
+  next() {
+    const key = ensurePromise<string | undefined>(this.keys.next());
+    return key.then(k => {
+      return {done: k === undefined, value: k || ''};
+    });
+  }
+}

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -13,6 +13,7 @@ import {
   Command,
   NamedParameters,
   PositionalParameters,
+  DataObject,
 } from '../common-types';
 import {Entity, ModelDefinition} from '../model';
 import {Filter, Where} from '../query';
@@ -31,6 +32,7 @@ export namespace juggler {
   export import ModelBase = legacy.ModelBase;
   export import ModelBaseClass = legacy.ModelBaseClass;
   export import PersistedModel = legacy.PersistedModel;
+  export import KeyValueModel = legacy.KeyValueModel;
   export import PersistedModelClass = legacy.PersistedModelClass;
 }
 
@@ -55,7 +57,7 @@ export function bindModel<T extends juggler.ModelBaseClass>(
  * @param p Promise or void
  */
 /* tslint:disable-next-line:no-any */
-function ensurePromise<T>(p: legacy.PromiseOrVoid<T>): Promise<T> {
+export function ensurePromise<T>(p: legacy.PromiseOrVoid<T>): Promise<T> {
   if (p && isPromiseLike(p)) {
     // Juggler uses promise-like Bluebird instead of native Promise
     // implementation. We need to convert the promise returned by juggler
@@ -161,12 +163,12 @@ export class DefaultCrudRepository<T extends Entity, ID>
     );
   }
 
-  async create(entity: Partial<T>, options?: Options): Promise<T> {
+  async create(entity: DataObject<T>, options?: Options): Promise<T> {
     const model = await ensurePromise(this.modelClass.create(entity, options));
     return this.toEntity(model);
   }
 
-  async createAll(entities: Partial<T>[], options?: Options): Promise<T[]> {
+  async createAll(entities: DataObject<T>[], options?: Options): Promise<T[]> {
     const models = await ensurePromise(
       this.modelClass.create(entities, options),
     );
@@ -215,7 +217,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
   }
 
   updateAll(
-    data: Partial<T>,
+    data: DataObject<T>,
     where?: Where,
     options?: Options,
   ): Promise<number> {
@@ -224,14 +226,18 @@ export class DefaultCrudRepository<T extends Entity, ID>
     );
   }
 
-  updateById(id: ID, data: Partial<T>, options?: Options): Promise<boolean> {
+  updateById(id: ID, data: DataObject<T>, options?: Options): Promise<boolean> {
     const idProp = this.modelClass.definition.idName();
     const where = {} as Where;
     where[idProp] = id;
     return this.updateAll(data, where, options).then(count => count > 0);
   }
 
-  replaceById(id: ID, data: Partial<T>, options?: Options): Promise<boolean> {
+  replaceById(
+    id: ID,
+    data: DataObject<T>,
+    options?: Options,
+  ): Promise<boolean> {
     return ensurePromise(this.modelClass.replaceById(id, data, options)).then(
       result => !!result,
     );

--- a/packages/repository/src/repositories/relation.factory.ts
+++ b/packages/repository/src/repositories/relation.factory.ts
@@ -10,6 +10,7 @@ import {
   HasManyRepository,
   DefaultHasManyEntityCrudRepository,
 } from './relation.repository';
+import {DataObject} from '..';
 
 export type HasManyRepositoryFactory<SourceID, Target extends Entity> = (
   fkValue: SourceID,
@@ -43,10 +44,12 @@ export function createHasManyRepositoryFactory<
         'The foreign key property name (keyTo) must be specified',
       );
     }
+    // tslint:disable-next-line:no-any
+    const constraint: any = {[fkName]: fkValue};
     return new DefaultHasManyEntityCrudRepository<
       Target,
       TargetID,
       EntityCrudRepository<Target, TargetID>
-    >(targetRepository, {[fkName]: fkValue});
+    >(targetRepository, constraint as DataObject<Target>);
   };
 }

--- a/packages/repository/src/repositories/relation.repository.ts
+++ b/packages/repository/src/repositories/relation.repository.ts
@@ -9,7 +9,7 @@ import {
   constrainFilter,
   constrainWhere,
 } from './constraint-utils';
-import {DataObject, AnyObject, Options} from '../common-types';
+import {DataObject, Options} from '../common-types';
 import {Entity} from '../model';
 import {Filter, Where} from '../query';
 
@@ -23,7 +23,10 @@ export interface HasManyRepository<Target extends Entity> {
    * @param options Options for the operation
    * @returns A promise which resolves to the newly created target model instance
    */
-  create(targetModelData: Partial<Target>, options?: Options): Promise<Target>;
+  create(
+    targetModelData: DataObject<Target>,
+    options?: Options,
+  ): Promise<Target>;
   /**
    * Find target model instance(s)
    * @param Filter A filter object for where, order, limit, etc.
@@ -65,11 +68,11 @@ export class DefaultHasManyEntityCrudRepository<
    */
   constructor(
     public targetRepository: TargetRepository,
-    public constraint: AnyObject,
+    public constraint: DataObject<TargetEntity>,
   ) {}
 
   async create(
-    targetModelData: Partial<TargetEntity>,
+    targetModelData: DataObject<TargetEntity>,
     options?: Options,
   ): Promise<TargetEntity> {
     return await this.targetRepository.create(
@@ -93,7 +96,7 @@ export class DefaultHasManyEntityCrudRepository<
   }
 
   async patch(
-    dataObject: Partial<TargetEntity>,
+    dataObject: DataObject<TargetEntity>,
     where?: Where,
     options?: Options,
   ): Promise<number> {

--- a/packages/repository/test/unit/repositories/kv.repository.bridge.unit.ts
+++ b/packages/repository/test/unit/repositories/kv.repository.bridge.unit.ts
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+
+import {
+  juggler,
+  DefaultKVRepository,
+  DataObject,
+  Model,
+  KVRepository,
+} from '../../../';
+
+describe('DefaultKVRepository', () => {
+  let ds: juggler.DataSource;
+  let kvNoteModel: typeof juggler.KeyValueModel;
+  let repo: KVRepository<Note>;
+
+  class Note extends Model {
+    title?: string;
+    content?: string;
+    id: number;
+
+    constructor(data: DataObject<Note>) {
+      super(data);
+    }
+  }
+
+  beforeEach(() => {
+    ds = new juggler.DataSource({
+      name: 'db',
+      connector: 'kv-memory',
+    });
+    kvNoteModel = ds.createModel<typeof juggler.KeyValueModel>('note');
+    repo = new DefaultKVRepository<Note>(kvNoteModel);
+  });
+
+  it('implements KVRepository.set()', async () => {
+    const note1 = {title: 't1', content: 'c1'};
+    await repo.set('note1', note1);
+    const result = await repo.get('note1');
+    expect(result).to.eql(note1);
+  });
+
+  it('implements KVRepository.get() for non-existent key', async () => {
+    const result = await repo.get('note1');
+    expect(result).be.null();
+  });
+
+  it('implements KVRepository.delete()', async () => {
+    const note1 = {title: 't1', content: 'c1'};
+    await repo.set('note1', note1);
+    await repo.delete('note1');
+    const result = await repo.get('note1');
+    expect(result).be.null();
+  });
+
+  it('implements KVRepository.deleteAll()', async () => {
+    await repo.set('note1', {title: 't1', content: 'c1'});
+    await repo.set('note2', {title: 't2', content: 'c2'});
+    await repo.deleteAll();
+    let result = await repo.get('note1');
+    expect(result).be.null();
+    result = await repo.get('note2');
+    expect(result).be.null();
+  });
+
+  it('implements KVRepository.ttl()', async () => {
+    await repo.set('note1', {title: 't1', content: 'c1'}, {ttl: 100});
+    const result = await repo.ttl!('note1');
+    expect(result).to.eql(100);
+  });
+
+  it('reports error from KVRepository.ttl()', async () => {
+    const p = repo.ttl!('note2');
+    return expect(p).to.be.rejectedWith(
+      'Cannot get TTL for unknown key "note2"',
+    );
+  });
+
+  it('implements KVRepository.expire()', async () => {
+    await repo.set('note1', {title: 't1', content: 'c1'}, {ttl: 100});
+    await repo.expire!('note1', 200);
+    const ttl = await repo.ttl!('note1');
+    expect(ttl).to.eql(200);
+  });
+
+  it('implements KVRepository.iterateKeys()', async () => {
+    await repo.set('note1', {title: 't1', content: 'c1'});
+    await repo.set('note2', {title: 't2', content: 'c2'});
+    const keys = repo.iterateKeys!();
+    const keyList: string[] = [];
+    while (true) {
+      const {done, value} = await keys.next();
+      if (!done) {
+        keyList.push(value);
+      } else {
+        break;
+      }
+    }
+    expect(keyList).to.eql(['note1', 'note2']);
+  });
+});

--- a/packages/repository/test/unit/repositories/relation.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/relation.repository.unit.ts
@@ -32,7 +32,7 @@ describe('relation repository', () => {
       TargetRepository extends EntityCrudRepository<T, ID>
     > implements HasManyRepository<T> {
       create(
-        targetModelData: Partial<T>,
+        targetModelData: DataObject<T>,
         options?: AnyObject | undefined,
       ): Promise<T> {
         /* istanbul ignore next */
@@ -128,7 +128,7 @@ describe('relation repository', () => {
 
   let repo: CustomerRepository;
 
-  function givenDefaultHasManyCrudInstance(constraint: AnyObject) {
+  function givenDefaultHasManyCrudInstance(constraint: DataObject<Customer>) {
     repo = sinon.createStubInstance(CustomerRepository);
     return new DefaultHasManyEntityCrudRepository<
       Customer,


### PR DESCRIPTION
The PR adds a default implementation of KVRepository with legacy juggler

Depends on https://github.com/strongloop/loopback-datasource-juggler/pull/1608

Connects to https://github.com/strongloop/loopback-next/issues/1448

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
