### PR TITLE
fix(repository): default where object to an empty object

### DIFF
--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -219,6 +219,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
     where?: Where,
     options?: Options,
   ): Promise<number> {
+    where = where || {};
     return ensurePromise(this.modelClass.updateAll(where, data, options)).then(
       result => result.count,
     );

--- a/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -177,6 +177,17 @@ describe('DefaultCrudRepository', () => {
     expect(notes[0].content).to.eql('c5');
   });
 
+  it('implements Repository.updateAll() without a where object', async () => {
+    const repo = new DefaultCrudRepository(Note, ds);
+    await repo.create({title: 't3', content: 'c3'});
+    await repo.create({title: 't4', content: 'c4'});
+    const result = await repo.updateAll({content: 'c5'});
+    expect(result).to.eql(2);
+    const notes = await repo.find();
+    const titles = notes.map(n => `${n.title}:${n.content}`);
+    expect(titles).to.deepEqual(['t3:c5', 't4:c5']);
+  });
+
   it('implements Repository.count()', async () => {
     const repo = new DefaultCrudRepository(Note, ds);
     await repo.create({title: 't3', content: 'c3'});


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

When using `updateAll` if no `where` and `options` objects are given as arguments, we get:
```shell
AssertionError [ERR_ASSERTION]: The where argument must be an object
```
Refer to AssertionError [ERR_ASSERTION]: The where argument must be an object

@raymondfeng Is there a reason why `where = where || {}` does not exist in the juggler's updateAll implementation?

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
