### PR TITLE
fix(docs): fix Parsing-requests.html sidebar entry

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -93,11 +93,11 @@ children:
   - title: 'Sequence'
     url: Sequence.html
     output: 'web, pdf'
-
     children:
-      - title: 'Parsing requests'
-      - url: Parsing-request.html
-      - output: 'web, pdf'
+
+    - title: 'Parsing requests'
+      url: Parsing-requests.html
+      output: 'web, pdf'
 
   - title: 'Model'
     url: Model.html


### PR DESCRIPTION
The sidebar formatting was off for `Parsing-requests.html`

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
