### PR TITLE
refactor: move https/travis helper functions to testlab

### DIFF
--- a/packages/testlab/README.md
+++ b/packages/testlab/README.md
@@ -47,6 +47,10 @@ Table of contents:
 - [sinon](#sinon) - Mocks, stubs and more.
 - [shot](#shot) - HTTP Request/Response stubs.
 - [validateApiSpec](#validateapispec) - Open API Spec validator.
+- [itSkippedOnTravis](#itskippedontravis) - Skip tests on Travis env.
+- [givenHttpServerConfig](#givenhttpserverconfig) - Generate HTTP server config.
+- [httpGetAsync](#httpgetasync) - Async wrapper for HTTP GET requests.
+- [httpsGetAsync](#httpsgetasync) - Async wrapper for HTTPS GET requests.
 
 ### `expect`
 
@@ -72,6 +76,34 @@ by Shot in your unit tests:
 - Code parsing core HTTP Request
 - Code modifying core HTTP Response, including full request/response handlers
 - Code parsing Express HTTP Request or modifying Express HTTP Response
+
+### `itSkippedOnTravis`
+
+Helper function for skipping tests on Travis environment. If you need to skip
+testing on Travis for any reason, use this instead of Mocha's `it`.
+
+### `givenhttpserverconfig`
+
+Helper function for generating Travis-friendly host (127.0.0.1). This is
+required because Travis is not able to handle IPv6 addresses.
+
+### `httpgetasync`
+
+Async wrapper for making HTTP GET requests.
+
+```ts
+import {httpGetAsync} from '@loopback/testlab';
+const response = await httpGetAsync('http://example.com');
+```
+
+### `httpsgetasync`
+
+Async wrapper for making HTTPS GET requests.
+
+```ts
+import {httpsGetAsync} from '@loopback/testlab';
+const response = await httpsGetAsync('https://example.com');
+```
 
 #### Test request parsing
 

--- a/packages/testlab/src/http-server-config.ts
+++ b/packages/testlab/src/http-server-config.ts
@@ -1,0 +1,13 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * Helper function for generating Travis-friendly host (127.0.0.1)
+ * @param options Optional defaults
+ */
+export function givenHttpServerConfig<T>(options?: T): T & {host?: string} {
+  const defaults = process.env.TRAVIS ? {host: '127.0.0.1'} : {};
+  return Object.assign(defaults, options);
+}

--- a/packages/testlab/src/index.ts
+++ b/packages/testlab/src/index.ts
@@ -9,3 +9,6 @@ export * from './client';
 export * from './shot';
 export * from './validate-api-spec';
 export * from './test-sandbox';
+export * from './skip-travis';
+export * from './request';
+export * from './http-server-config';

--- a/packages/testlab/src/request.ts
+++ b/packages/testlab/src/request.ts
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {IncomingMessage} from 'http';
+import * as http from 'http';
+import * as https from 'https';
+import * as url from 'url';
+
+/**
+ * Async wrapper for making HTTP GET requests
+ * @param urlString
+ */
+export function httpGetAsync(urlString: string): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    http.get(urlString, resolve).on('error', reject);
+  });
+}
+
+/**
+ * Async wrapper for making HTTPS GET requests
+ * @param urlString
+ */
+export function httpsGetAsync(urlString: string): Promise<IncomingMessage> {
+  const agent = new https.Agent({
+    rejectUnauthorized: false,
+  });
+
+  const urlOptions = url.parse(urlString);
+  const options = {agent, ...urlOptions};
+
+  return new Promise((resolve, reject) => {
+    https.get(options, resolve).on('error', reject);
+  });
+}

--- a/packages/testlab/src/skip-travis.ts
+++ b/packages/testlab/src/skip-travis.ts
@@ -1,0 +1,26 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+// tslint:disable-next-line:no-any
+export type TestCallbackRetval = void | PromiseLike<any>;
+
+/**
+ * Helper function for skipping tests on Travis env
+ * @param expectation
+ * @param callback
+ */
+export function itSkippedOnTravis(
+  expectation: string,
+  callback?: (
+    this: Mocha.ITestCallbackContext,
+    done: MochaDone,
+  ) => TestCallbackRetval,
+): void {
+  if (process.env.TRAVIS) {
+    it.skip(`[SKIPPED ON TRAVIS] ${expectation}`, callback);
+  } else {
+    it(expectation, callback);
+  }
+}


### PR DESCRIPTION
Move https/travis helper functions to testlab

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
