### PR TITLE
fix: fix cli rest controller generator template

### DIFF
--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -35,8 +35,8 @@ export class <%= className %>Controller {
 
   @patch('<%= httpPathName %>')
   async updateAll(
-    @requestBody() obj: <%= modelName %>
-    @param.query.string('where') where?: Where,
+    @requestBody() obj: <%= modelName %>,
+    @param.query.string('where') where?: Where
   ): Promise<number> {
     return await this.<%= repositoryNameCamel %>.updateAll(obj, where);
   }

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -256,7 +256,7 @@ function checkRestCrudContents() {
   );
   assert.fileContent(
     expectedFile,
-    /\@patch\('\/product-reviews'\)\s{1,}async updateAll\(\s{1,}\@requestBody\(\).*\s{1,}\@param.query.string\('where'\) where\?: Where,/,
+    /\@patch\('\/product-reviews'\)\s{1,}async updateAll\(\s{1,}\@requestBody\(\).*,\s{1,}\@param.query.string\('where'\) where\?: Where/,
   );
   assert.fileContent(
     expectedFile,


### PR DESCRIPTION
Fix commas on lines 38 and 39 of `packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs` to produce valid code that passes lint

Fixes #1551 
