### PR TITLE
fix(service-proxy): await datasource until it connects to the service

### DIFF
--- a/docs/site/Calling-other-APIs-and-Web-Services.md
+++ b/docs/site/Calling-other-APIs-and-Web-Services.md
@@ -156,7 +156,7 @@ export class GeoServiceProvider implements Provider<GeoService> {
     protected datasource: juggler.DataSource = new GeocoderDataSource(),
   ) {}
 
-  value(): GeocoderService {
+  value(): Promise<GeocoderService> {
     return getService(this.datasource);
   }
 }

--- a/examples/todo/src/services/geocoder.service.ts
+++ b/examples/todo/src/services/geocoder.service.ts
@@ -29,7 +29,7 @@ export class GeocoderServiceProvider implements Provider<GeocoderService> {
     protected datasource: juggler.DataSource = new GeocoderDataSource(),
   ) {}
 
-  value(): GeocoderService {
+  value(): Promise<GeocoderService> {
     return getService(this.datasource);
   }
 }

--- a/examples/todo/test/integration/services/geocoder.service.integration.ts
+++ b/examples/todo/test/integration/services/geocoder.service.integration.ts
@@ -34,9 +34,9 @@ describe('GeoLookupService', function() {
     ]);
   });
 
-  function givenGeoService() {
+  async function givenGeoService() {
     const config = getProxiedGeoCoderConfig(cachingProxy);
     const dataSource = new GeocoderDataSource(config);
-    service = new GeocoderServiceProvider(dataSource).value();
+    service = await new GeocoderServiceProvider(dataSource).value();
   }
 });

--- a/packages/service-proxy/src/legacy-juggler-bridge.ts
+++ b/packages/service-proxy/src/legacy-juggler-bridge.ts
@@ -24,7 +24,10 @@ export interface GenericService {
  * @param ds A legacy data source
  * @typeparam T The generic type of service interface
  */
-export function getService<T = GenericService>(ds: legacy.DataSource): T {
+export async function getService<T = GenericService>(
+  ds: legacy.DataSource,
+): Promise<T> {
+  await ds.connect();
   // tslint:disable-next-line:no-any
   return ds.DataAccessObject as any;
 }

--- a/packages/service-proxy/test/integration/service-proxy.integration.ts
+++ b/packages/service-proxy/test/integration/service-proxy.integration.ts
@@ -35,7 +35,7 @@ describe('service-proxy', () => {
       zipcode: '94401',
     };
 
-    const geoService = getService<GeoService>(ds);
+    const geoService = await getService<GeoService>(ds);
     const result = await geoService.geocode(loc.street, loc.city, loc.zipcode);
 
     // { lat: 37.5669986, lng: -122.3237495 }
@@ -50,7 +50,7 @@ describe('service-proxy', () => {
       zipcode: '94401',
     };
 
-    const geoService: GenericService = getService(ds);
+    const geoService: GenericService = await getService(ds);
     const result = await geoService.geocode(loc.street, loc.city, loc.zipcode);
 
     // { lat: 37.5669986, lng: -122.3237495 }

--- a/packages/service-proxy/test/mock-service.connector.ts
+++ b/packages/service-proxy/test/mock-service.connector.ts
@@ -51,6 +51,13 @@ export class MockConnector {
   }
 
   get DataAccessObject() {
+    if (!this.connected) {
+      // this simulates call to the connector.DataAccessObject when the
+      // connector has not been connected and its DAO methods has not been
+      // fully built
+      return {};
+    }
+
     return {
       geocode: async function(street: string, city: string, zipcode: string) {
         return {


### PR DESCRIPTION
When `getService` returns a service, it does not wait until the service has been completely set up. The PR now calls `datasource.connect()` before the service is returned.

- related to #1553
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
