### PR TITLE
fix(cli): change model template to properly render array types

### DIFF
--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -234,6 +234,9 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
       // Convert Type to include '' for template
       val.type = `'${val.type}'`;
+      if (val.arrayType) {
+        val.arrayType = `'${val.arrayType}'`;
+      }
 
       // If required is false, we can delete it as that's the default assumption
       // for this field if not present. This helps to avoid polluting the

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -2,12 +2,17 @@ import {Entity, model, property} from '@loopback/repository';
 
 @model()
 export class <%= className %> extends Entity {
-  <% Object.entries(properties).forEach(([key, val]) => { %>
-  @property({<% Object.entries(val).forEach(([propKey, propVal]) => {%>
-    <%if (propKey !== 'tsType') {%><%= propKey %>: <%- propVal %>,<% } %><% }) %>
+<% Object.entries(properties).forEach(([key, val]) => { -%>
+  @property({
+  <%_ Object.entries(val).forEach(([propKey, propVal]) => { -%>
+    <%_ if (propKey !== 'tsType') { -%>
+    <%= propKey %>: <%- propVal %>,
+    <%_ } -%>
+  <%_ }) -%>
   })
   <%= key %><%if (!val.required) {%>?<% } %>: <%= val.tsType %>;
-  <% }) %>
+
+<% }) -%>
   constructor(data?: Partial<<%= className %>>) {
     super(data);
   }


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

The CLI used to build the templates without the quotation marks around value for `arrayType`.
Also removes the ugly new lines generated through the template

The generated code before:
```ts
import {Entity, model, property} from '@loopback/repository';

@model()
export class Model extends Entity {
  
  @property({
    type: 'array',
    arrayType: string,
    
  })
  prop?: string[];
  
  @property({
    type: 'number',
    
  })
  propNumberTwo?: number;
  
  constructor(data?: Partial<Model>) {
    super(data);
  }
}
```

The generated code with this PR:
```ts
import {Entity, model, property} from '@loopback/repository';

@model()
export class Model extends Entity {
  @property({
    type: 'array',
    arrayType: 'string',
  })
  prop?: string[];

  @property({
    type: 'number',
  })
  propNumberTwo?: number;

  constructor(data?: Partial<Model>) {
    super(data);
  }
}
```

fixes #1562

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
