### PR TITLE
chore: specify node requirement to 8.9 and above 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ by using it for your next project. Start by having a look at
 
 Make sure you have the following installed:
 
-- [Node.js](https://nodejs.org/en/download/) >= 8.0.0
+- [Node.js](https://nodejs.org/en/download/) >= 8.9.0
 
 Install LoopBack 4 CLI to help create new projects as follows:
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "name": "IBM"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "files": [
     "**/*"

--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -9,7 +9,7 @@ summary: Write and run a LoopBack 4 "Hello World" project in TypeScript.
 
 ## Prerequisites
 
-Install [Node.js](https://nodejs.org/en/download/) (version 8.x.x or higher) if
+Install [Node.js](https://nodejs.org/en/download/) (version 8.9 or higher) if
 not already installed on your machine.
 
 ## Install LoopBack 4 CLI

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -12,7 +12,7 @@ our application to always respond with "Hello World!".
 
 Before we can begin, you'll need to make sure you have some things installed:
 
-- [Node.js](https://nodejs.org/en/) at v8.x or greater
+- [Node.js](https://nodejs.org/en/) at v8.9 or greater
 
 Additionally, this tutorial assumes that you are comfortable with certain
 technologies, languages and concepts.

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -4,7 +4,7 @@
   "description": "A simple hello-world Application using LoopBack 4",
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -4,7 +4,7 @@
   "description": "An example extension project for LoopBack 4",
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -7,7 +7,7 @@
     "loopback"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/examples/todo-list/README.md
+++ b/examples/todo-list/README.md
@@ -18,7 +18,7 @@ straight to our first step:
 If not, you'll need to make sure you have a couple of things installed before we
 get started:
 
-- [Node.js](https://nodejs.org/en/) at v8.x or greater
+- [Node.js](https://nodejs.org/en/) at v8.9 or greater
 
 Next, you'll need to install the LoopBack 4 CLI toolkit:
 

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -4,7 +4,7 @@
   "description": "Continuation of the todo example using relations in LoopBack 4.",
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -13,7 +13,7 @@ LoopBack 4.
 
 You'll need to make sure you have some things installed:
 
-- [Node.js](https://nodejs.org/en/) at v8.x or greater
+- [Node.js](https://nodejs.org/en/) at v8.9 or greater
 
 Additionally, this tutorial assumes that you are comfortable with certain
 technologies, languages and concepts.

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -4,7 +4,7 @@
   "description": "Tutorial example on how to build an application with LoopBack 4.",
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "version": "0.1.0",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -3,7 +3,7 @@
   "version": "0.11.2",
   "description": "A LoopBack component for authentication support.",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.2",
   "description": "A collection of Booters for LoopBack 4 Applications",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -7,7 +7,7 @@
   },
   "version": "0.6.13",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "main": "index.js",
   "copyright.owner": "IBM Corp.",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -8,7 +8,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -8,7 +8,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build": "tsc --outDir dist --target es2017",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
     "name": "IBM"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "files": [
     "bin",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.2",
   "description": "LoopBack's container for Inversion of Control",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.11.2",
   "description": "",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",

--- a/packages/dist-util/index.js
+++ b/packages/dist-util/index.js
@@ -12,7 +12,7 @@ function getDist() {
   if (nodeMajorVersion < 8) {
     throw new Error(
       `Node.js version ${process.versions.node} is not supported.` +
-        'Please use Node.js 8.x or newer.',
+        'Please use Node.js 8.9 or newer.',
     );
   }
   return nodeMajorVersion >= 10 ? './dist10' : './dist8';

--- a/packages/dist-util/package.json
+++ b/packages/dist-util/package.json
@@ -7,7 +7,7 @@
     "name": "IBM"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "files": [
     "index.js"

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.2",
   "description": "A caching HTTP proxy for integration tests. NOT SUITABLE FOR PRODUCTION USE!",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.2",
   "description": "A wrapper for creating HTTP/HTTPS servers",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.2",
   "description": "LoopBack's metadata utilities for reflection and decoration",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.2",
   "description": "Make it easy to create OpenAPI (Swagger) specification documents in your tests using the builder pattern.",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/packages/openapi-v3-types/package.json
+++ b/packages/openapi-v3-types/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.2",
   "description": "TypeScript type definitions for OpenAPI Specifications.",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "dependencies": {
     "@loopback/dist-util": "^0.3.5",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.2",
   "description": "Processes openapi v3 related metadata",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "devDependencies": {
     "@loopback/build": "^0.6.13",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -3,7 +3,7 @@
   "version": "0.10.2",
   "description": "Converts TS classes into JSON Schemas using TypeScript's reflection API",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -3,7 +3,7 @@
   "version": "0.14.2",
   "description": "Repository based persistence for LoopBack 4",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "main": "index",
   "scripts": {

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.2",
   "description": "",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.2",
   "description": "Service integration for LoopBack 4",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "main": "index",
   "scripts": {

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -3,7 +3,7 @@
   "version": "0.11.2",
   "description": "A collection of test utilities we use to write LoopBack tests.",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "scripts": {
     "build:all-dist": "npm run build:dist8 && npm run build:dist10",


### PR DESCRIPTION
~`...` operator used on an object is not supported until node v8.3
To mitigate this, the PR replaces the spread operators used in JS files with `Object.assign`
related to https://github.com/strongloop/loopback-next/issues/1405#issuecomment-408063882~

I've repurposed the PR to update our docs on the minimum required node version for developing with LoopBack 4

related to https://github.com/strongloop/loopback-next/issues/1405#issuecomment-408063882
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
