### PR TITLE
fix: update todo juggler page

### DIFF
--- a/docs/site/todo-tutorial-juggler.md
+++ b/docs/site/todo-tutorial-juggler.md
@@ -32,7 +32,6 @@ the `RepositoryMixin`:
 import {ApplicationConfig} from '@loopback/core';
 import {RestApplication} from '@loopback/rest';
 import {MySequence} from './sequence';
-import {db} from './datasources/db.datasource';
 
 /* tslint:disable:no-unused-variable */
 // Binding and Booter imports are required to infer types for BootMixin!
@@ -66,18 +65,6 @@ export class TodoListApplication extends BootMixin(
         nested: true,
       },
     };
-
-    this.setupDatasources();
-  }
-
-  setupDatasources() {
-    // This will allow you to test your application without needing to
-    // use a "real" datasource!
-    const datasource =
-      this.options && this.options.datasource
-        ? new juggler.DataSource(this.options.datasource)
-        : db;
-    this.dataSource(datasource);
   }
 }
 ```


### PR DESCRIPTION
The content on `todo-tutorial-juggler.md` was outdated.
fixes #1566 


## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
