### PR TITLE
docs: fix todo-list tutorial command

### DIFF
--- a/examples/todo-list/README.md
+++ b/examples/todo-list/README.md
@@ -33,7 +33,7 @@ again, you can use the LoopBack 4 CLI tool to catch up to where this tutorial
 will continue from:
 
 ```sh
-lb4 example todo
+lb4 example todo-list
 ```
 
 It should be noted that this tutorial does not assume the


### PR DESCRIPTION
In ToDo List tutorial set up https://loopback.io/doc/en/lb4/todo-list-tutorial.html#setup, the command to download the tutorial should be:
```
lb4 example todo-list
```
instead of 
```
lb4 example todo
```