### PR TITLE
Juggler array

### DIFF
--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -121,7 +121,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
           choices: this.typeChoices,
         },
         {
-          name: 'arrayType',
+          name: 'itemType',
           message: 'Type of array items:',
           type: 'list',
           choices: this.typeChoices.filter(choice => {
@@ -204,18 +204,18 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
     // Set up types for Templating
     const TS_TYPES = ['string', 'number', 'object', 'boolean', 'any'];
     const NON_TS_TYPES = ['geopoint', 'date'];
-    Object.entries(this.artifactInfo.properties).forEach(([key, val]) => {
+    Object.values(this.artifactInfo.properties).forEach(val => {
       // Default tsType is the type property
       val.tsType = val.type;
 
       // Override tsType based on certain type values
       if (val.type === 'array') {
-        if (TS_TYPES.includes(val.arrayType)) {
-          val.tsType = `${val.arrayType}[]`;
+        if (TS_TYPES.includes(val.itemType)) {
+          val.tsType = `${val.itemType}[]`;
         } else if (val.type === 'buffer') {
-          val.tsType = `Buffer[]`;
+          val.tsType = 'Buffer[]';
         } else {
-          val.tsType = `string[]`;
+          val.tsType = 'string[]';
         }
       } else if (val.type === 'buffer') {
         val.tsType = 'Buffer';
@@ -234,8 +234,8 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
       // Convert Type to include '' for template
       val.type = `'${val.type}'`;
-      if (val.arrayType) {
-        val.arrayType = `'${val.arrayType}'`;
+      if (val.itemType) {
+        val.itemType = `'${val.itemType}'`;
       }
 
       // If required is false, we can delete it as that's the default assumption

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -5,7 +5,7 @@ export class <%= className %> extends Entity {
 <% Object.entries(properties).forEach(([key, val]) => { -%>
   @property({
   <%_ Object.entries(val).forEach(([propKey, propVal]) => { -%>
-    <%_ if (propKey !== 'tsType') { -%>
+    <%_ if (!['tsType'].includes(propKey)) { -%>
     <%= propKey %>: <%- propVal %>,
     <%_ } -%>
   <%_ }) -%>

--- a/packages/repository-json-schema/test/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/test/unit/build-schema.unit.ts
@@ -8,10 +8,34 @@ import {isComplexType, stringTypeToWrapper, metaToJsonProperty} from '../..';
 
 describe('build-schema', () => {
   describe('stringTypeToWrapper', () => {
-    it('returns respective wrapper of number, string and boolean', () => {
-      expect(stringTypeToWrapper('string')).to.eql(String);
-      expect(stringTypeToWrapper('number')).to.eql(Number);
-      expect(stringTypeToWrapper('boolean')).to.eql(Boolean);
+    context('when given primitive types in string', () => {
+      it('returns String for "string"', () => {
+        expect(stringTypeToWrapper('string')).to.eql(String);
+      });
+
+      it('returns Number for "number"', () => {
+        expect(stringTypeToWrapper('number')).to.eql(Number);
+      });
+
+      it('returns Boolean for "boolean"', () => {
+        expect(stringTypeToWrapper('boolean')).to.eql(Boolean);
+      });
+
+      it('returns Array for "array"', () => {
+        expect(stringTypeToWrapper('array')).to.eql(Array);
+      });
+
+      it('returns Buffer for "buffer"', () => {
+        expect(stringTypeToWrapper('buffer')).to.eql(Buffer);
+      });
+
+      it('returns Date for "date"', () => {
+        expect(stringTypeToWrapper('date')).to.eql(Date);
+      });
+
+      it('returns Object for "object"', () => {
+        expect(stringTypeToWrapper('object')).to.eql(Object);
+      });
     });
 
     it('errors out if other types are given', () => {
@@ -21,19 +45,34 @@ describe('build-schema', () => {
       expect(() => {
         stringTypeToWrapper('function');
       }).to.throw(/Unsupported type/);
-      expect(() => {
-        stringTypeToWrapper('object');
-      }).to.throw(/Unsupported type/);
     });
   });
 
   describe('isComplextype', () => {
-    it('returns false if primitive or object wrappers are passed in', () => {
-      expect(isComplexType(Number)).to.eql(false);
-      expect(isComplexType(String)).to.eql(false);
-      expect(isComplexType(Boolean)).to.eql(false);
-      expect(isComplexType(Object)).to.eql(false);
-      expect(isComplexType(Function)).to.eql(false);
+    context('when given primitive wrappers', () => {
+      it('returns false for Number', () => {
+        expect(isComplexType(Number)).to.eql(false);
+      });
+
+      it('returns false for String', () => {
+        expect(isComplexType(String)).to.eql(false);
+      });
+
+      it('returns false for Boolean', () => {
+        expect(isComplexType(Boolean)).to.eql(false);
+      });
+
+      it('returns false for Object', () => {
+        expect(isComplexType(Object)).to.eql(false);
+      });
+
+      it('returns false for Function', () => {
+        expect(isComplexType(Function)).to.eql(false);
+      });
+
+      it('returns false for Array', () => {
+        expect(isComplexType(Array)).to.eql(false);
+      });
     });
 
     it('returns true if any other wrappers are passed in', () => {
@@ -43,9 +82,9 @@ describe('build-schema', () => {
   });
 
   describe('metaToJsonSchema', () => {
-    it('errors out if "type" property is Array', () => {
-      expect(() => metaToJsonProperty({type: Array})).to.throw(
-        /type is defined as an array/,
+    it('errors out if "itemType" is an array', () => {
+      expect(() => metaToJsonProperty({type: Array, itemType: []})).to.throw(
+        /itemType as an array is not supported/,
       );
     });
 
@@ -61,6 +100,12 @@ describe('build-schema', () => {
       });
     });
 
+    it('converts arrays', () => {
+      expect(metaToJsonProperty({type: Array})).to.eql({
+        type: 'array',
+      });
+    });
+
     it('converts complex types', () => {
       class CustomType {}
       expect(metaToJsonProperty({type: CustomType})).to.eql({
@@ -69,7 +114,7 @@ describe('build-schema', () => {
     });
 
     it('converts primitive arrays', () => {
-      expect(metaToJsonProperty({array: true, type: Number})).to.eql({
+      expect(metaToJsonProperty({type: Array, itemType: Number})).to.eql({
         type: 'array',
         items: {type: 'number'},
       });
@@ -77,7 +122,7 @@ describe('build-schema', () => {
 
     it('converts arrays of custom types', () => {
       class CustomType {}
-      expect(metaToJsonProperty({array: true, type: CustomType})).to.eql({
+      expect(metaToJsonProperty({type: Array, itemType: CustomType})).to.eql({
         type: 'array',
         items: {$ref: '#/definitions/CustomType'},
       });

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -121,9 +121,10 @@ export namespace property {
         throw new Error(ERR_PROP_NOT_ARRAY);
       } else {
         property(
-          Object.assign({array: true}, definition, {
-            type: itemType,
-          }),
+          Object.assign(
+            {type: Array, itemType} as Partial<PropertyDefinition>,
+            definition,
+          ),
         )(target, propertyName);
       }
     };

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -25,6 +25,7 @@ export interface PropertyDefinition {
   id?: boolean;
   json?: PropertyForm;
   store?: PropertyForm;
+  itemType?: PropertyType; // type of array
   [attribute: string]: any; // Other attributes
 }
 

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -112,9 +112,16 @@ export class DefaultCrudRepository<T extends Entity, ID>
     // We need to convert property definitions from PropertyDefinition
     // to plain data object because of a juggler limitation
     const properties: {[name: string]: object} = {};
-    for (const p in definition.properties) {
-      properties[p] = Object.assign({}, definition.properties[p]);
-    }
+
+    // We need to convert PropertyDefinition into the definition that
+    // the juggler understands
+    Object.entries(definition.properties).forEach(([key, value]) => {
+      if (value.type === 'array' || value.type === Array) {
+        value = Object.assign({}, value, {type: [value.itemType]});
+        delete value.itemType;
+      }
+      properties[key] = Object.assign({}, value);
+    });
 
     this.modelClass = dataSource.createModel<juggler.PersistedModelClass>(
       definition.name,

--- a/packages/repository/test/unit/decorator/metadata.unit.ts
+++ b/packages/repository/test/unit/decorator/metadata.unit.ts
@@ -76,8 +76,8 @@ describe('Repository', () => {
               type: Number,
             },
             colours: {
-              array: true,
-              type: Colour,
+              type: Array,
+              itemType: Colour,
             },
           },
           settings: new Map(),

--- a/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
@@ -192,6 +192,21 @@ describe('model decorator', () => {
     expect(meta.isShipped).to.eql({type: Boolean});
   });
 
+  it('adds explicitly declared array property metadata', () => {
+    @model()
+    class ArrayModel {
+      @property({type: Array})
+      strArr: string[];
+    }
+
+    const meta =
+      MetadataInspector.getAllPropertyMetadata(
+        MODEL_PROPERTIES_KEY,
+        ArrayModel.prototype,
+      ) || /* istanbul ignore next */ {};
+    expect(meta.strArr).to.eql({type: Array});
+  });
+
   it('adds embedsOne metadata', () => {
     const meta =
       MetadataInspector.getAllPropertyMetadata(
@@ -316,7 +331,7 @@ describe('model decorator', () => {
             MODEL_PROPERTIES_KEY,
             TestModel.prototype,
           ) || /* istanbul ignore next */ {};
-        expect(meta.items).to.eql({type: Product, array: true});
+        expect(meta.items).to.eql({type: Array, itemType: Product});
       });
 
       it('throws when @property.array is used on a non-array property', () => {

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -61,12 +61,12 @@ describe('relation decorator', () => {
         keyTo: 'addressBookId',
       });
       expect(jugglerMeta).to.eql({
-        type: Address,
-        array: true,
+        type: Array,
+        itemType: Address,
       });
     });
 
-    it('takes in both complex property type and asMany metadata', () => {
+    it('takes in both complex property type and hasMany metadata', () => {
       class Address extends Entity {
         addressId: number;
         street: string;
@@ -95,8 +95,8 @@ describe('relation decorator', () => {
         keyTo: 'someForeignKey',
       });
       expect(jugglerMeta).to.eql({
-        type: Address,
-        array: true,
+        type: Array,
+        itemType: Address,
       });
     });
 

--- a/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -75,6 +75,55 @@ describe('DefaultCrudRepository', () => {
     await model.deleteAll();
   });
 
+  context('constructor', () => {
+    class ShoppingList extends Entity {
+      static definition = new ModelDefinition({
+        name: 'ShoppingList',
+        properties: {
+          id: {
+            type: 'number',
+            id: true,
+          },
+          toBuy: {
+            type: 'array',
+            itemType: 'string',
+          },
+          toVisit: {
+            type: Array,
+            itemType: String,
+          },
+        },
+      });
+
+      toBuy: String[];
+      toVisit: String[];
+    }
+
+    it('converts PropertyDefinition with array type', () => {
+      const originalPropertyDefinition = Object.assign(
+        {},
+        ShoppingList.definition.properties,
+      );
+      const listDefinition = new DefaultCrudRepository(ShoppingList, ds)
+        .modelClass.definition;
+      const jugglerPropertyDefinition = {
+        toBuy: {
+          type: [String],
+        },
+        toVisit: {
+          type: [String],
+        },
+      };
+
+      expect(listDefinition.properties).to.containDeep(
+        jugglerPropertyDefinition,
+      );
+      expect(ShoppingList.definition.properties).to.containDeep(
+        originalPropertyDefinition,
+      );
+    });
+  });
+
   it('shares the backing PersistedModel across repo instances', () => {
     const model1 = new DefaultCrudRepository(Note, ds).modelClass;
     const model2 = new DefaultCrudRepository(Note, ds).modelClass;


### PR DESCRIPTION
The property definition for arrays used to be defined this way:
```ts
{type: 'string', array: true}
// or
{type: String, array: true}
```

This does not match with the property definition of an array as the legacy juggler would define it. The property definition created by the `@property.array(String)` decorator can now look like this:
```ts
{type: 'array', itemType: String}
// @repository-json-schema also supports
{type: 'array', itemType: 'string'}
```

Related to #1508
Fixes #1562
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
