### PR TITLE
Use `app.restServer.url` for console logs, improve the URL generated by http-server

### DIFF
--- a/examples/rpc-server/src/application.ts
+++ b/examples/rpc-server/src/application.ts
@@ -18,9 +18,4 @@ export class MyApplication extends Application {
     this.options.port = this.options.port || 3000;
     this.bind('rpcServer.config').to(this.options);
   }
-
-  async start() {
-    await super.start();
-    console.log(`Server is running on port ${this.options.port}`);
-  }
 }

--- a/examples/rpc-server/src/index.ts
+++ b/examples/rpc-server/src/index.ts
@@ -10,6 +10,7 @@ export async function main(options?: ApplicationConfig) {
   const app = new MyApplication(options);
 
   await app.start();
+  console.log(`Server is running on port ${app.options.port}`);
   return app;
 }
 

--- a/examples/todo-list/src/index.ts
+++ b/examples/todo-list/src/index.ts
@@ -5,15 +5,13 @@
 
 import {TodoListApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
-import {RestServer} from '@loopback/rest';
 
 export async function main(options?: ApplicationConfig) {
   const app = new TodoListApplication(options);
   await app.boot();
   await app.start();
 
-  const server = await app.getServer(RestServer);
-  const port = await server.get<number>('rest.port');
-  console.log(`Server is running at http://127.0.0.1:${port}`);
+  const url = app.restServer.url;
+  console.log(`Server is running at ${url}`);
   return app;
 }

--- a/examples/todo/src/index.ts
+++ b/examples/todo/src/index.ts
@@ -5,15 +5,13 @@
 
 import {TodoListApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
-import {RestServer} from '@loopback/rest';
 
 export async function main(options?: ApplicationConfig) {
   const app = new TodoListApplication(options);
   await app.boot();
   await app.start();
 
-  const server = await app.getServer(RestServer);
-  const port = await server.get<number>('rest.port');
-  console.log(`Server is running at http://127.0.0.1:${port}`);
+  const url = app.restServer.url;
+  console.log(`Server is running at ${url}`);
   return app;
 }

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -1,5 +1,5 @@
 import {ApplicationConfig} from '@loopback/core';
-import {RestApplication, RestServer, RestBindings} from '@loopback/rest';
+import {RestApplication} from '@loopback/rest';
 import {MySequence} from './sequence';
 
 /* tslint:disable:no-unused-variable */
@@ -24,14 +24,5 @@ export class <%= project.applicationName %> extends BootMixin(RestApplication) {
         nested: true,
       },
     };
-  }
-
-  async start() {
-    await super.start();
-
-    const server = await this.getServer(RestServer);
-    const port = await server.get(RestBindings.PORT);
-    console.log(`Server is running at http://127.0.0.1:${port}`);
-    console.log(`Try http://127.0.0.1:${port}/ping`);
   }
 }

--- a/packages/cli/generators/app/templates/src/index.ts.ejs
+++ b/packages/cli/generators/app/templates/src/index.ts.ejs
@@ -7,5 +7,10 @@ export async function main(options?: ApplicationConfig) {
   const app = new <%= project.applicationName %>(options);
   await app.boot();
   await app.start();
+
+  const url = app.restServer.url;
+  console.log(`Server is running at ${url}`);
+  console.log(`Try ${url}/ping`);
+
   return app;
 }

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -34,7 +34,6 @@ describe('app-generator specific files', () => {
       /class MyAppApplication extends BootMixin\(RestApplication/,
     );
     assert.fileContent('src/application.ts', /constructor\(/);
-    assert.fileContent('src/application.ts', /async start\(/);
     assert.fileContent('src/application.ts', /this.projectRoot = __dirname/);
 
     assert.file('src/index.ts');

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -145,7 +145,10 @@ export class HttpServer {
   public get url(): string {
     let host = this.host;
     if (this._address.family === 'IPv6') {
+      if (host === '::') host = '::1';
       host = `[${host}]`;
+    } else if (host === '0.0.0.0') {
+      host = '127.0.0.1';
     }
     return `${this._protocol}://${host}:${this.port}`;
   }

--- a/packages/http-server/test/integration/http-server.integration.ts
+++ b/packages/http-server/test/integration/http-server.integration.ts
@@ -177,6 +177,20 @@ describe('HttpServer (integration)', () => {
     expect(response.statusCode).to.equal(200);
   });
 
+  it('converts host from [::] to [::1] in url', async () => {
+    // Safari on MacOS does not support http://[::]:3000/
+    server = new HttpServer(dummyRequestHandler, {host: '::'});
+    await server.start();
+    expect(server.url).to.equal(`http://[::1]:${server.port}`);
+  });
+
+  it('converts host from 0.0.0.0 to 127.0.0.1 in url', async () => {
+    // Windows does not support http://0.0.0.0:3000/
+    server = new HttpServer(dummyRequestHandler, {host: '0.0.0.0'});
+    await server.start();
+    expect(server.url).to.equal(`http://127.0.0.1:${server.port}`);
+  });
+
   function dummyRequestHandler(req: ServerRequest, res: ServerResponse): void {
     res.end();
   }


### PR DESCRIPTION
**fix(http-server): use loopback instead of 0.0.0.0/[::] in URLs**

Host values `0.0.0.0` (IPv4) and `::` (IPv6), which mean "any host", are not supported by certain browsers and platforms, e.g. Windows and Safari on MacOS.

This commit fixes the `url` getter to convert these "any host" values into a loopback address (`127.0.0.1` for IPV4 or `::1` for IPv6).

**feat(cli): use `app.restServer.url` for console logs**

Rework and simplify the application project template:

 - Remove console logs from `Application.prototype.start()`, let the caller print any logs if they wish to.

 - Modify the `main` function to log the URL to the console, use `app.restServer.url` to obtain the URL where the app is listening on.

 - Update example projects to follow this new style.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated