### PR TITLE
Fix CI: update yeoman-generator to 3.x, apply latest prettier formatting

### DIFF
--- a/docs/site/Application-generator.md
+++ b/docs/site/Application-generator.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Application generator'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Application-generator.html
-summary:
 ---
 
 ### Synopsis

--- a/docs/site/Application.md
+++ b/docs/site/Application.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Application'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Application.html
-summary:
 ---
 
 ## What is an Application?

--- a/docs/site/Best-practices.md
+++ b/docs/site/Best-practices.md
@@ -2,12 +2,10 @@
 lang: en
 title: 'Best practices with Loopback 4'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Best-practices.html
 redirect_from:
   - /doc/en/lb4/Best-practices-with-Loopback-4.html
-summary:
 ---
 
 LoopBack 4 is more than just a framework: It’s an ecosystem that encourages

--- a/docs/site/Booting-an-Application.md
+++ b/docs/site/Booting-an-Application.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Booting an Application'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Booting-an-Application.html
-summary:
 ---
 
 ## What does Booting an Application mean?

--- a/docs/site/Calling-other-APIs-and-Web-Services.md
+++ b/docs/site/Calling-other-APIs-and-Web-Services.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Calling other APIs and web services'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Calling-other-APIs-and-web-services.html
-summary:
 ---
 
 Your API implementation often needs to interact with REST APIs, SOAP Web
@@ -122,7 +120,8 @@ properties of the controller class.
 import {serviceProxy} from '@loopback/service-proxy';
 
 export class MyController {
-  @serviceProxy('geoService') private geoService: GeoService;
+  @serviceProxy('geoService')
+  private geoService: GeoService;
 }
 ```
 
@@ -174,7 +173,8 @@ constructor:
 
 ```ts
 export class MyController {
-  @inject('services.geo') private geoService: GeoService;
+  @inject('services.geo')
+  private geoService: GeoService;
 }
 ```
 

--- a/docs/site/Command-line-interface.md
+++ b/docs/site/Command-line-interface.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Command-line interface'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Command-line-interface.html
-summary:
 ---
 
 LoopBack 4 provides command-line tools to help you get started quickly. The

--- a/docs/site/Concepts.md
+++ b/docs/site/Concepts.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Key concepts'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Concepts.html
-summary:
 ---
 
 LoopBack 4 introduces some new concepts that are important to understand:

--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Context'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Context.html
-summary:
 ---
 
 ## What is Context?

--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Controller generator'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Controller-generator.html
-summary:
 ---
 
 {% include content/generator-create-app.html lang=page.lang %}

--- a/docs/site/Controllers.md
+++ b/docs/site/Controllers.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Controllers'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Controllers.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Crafting-LoopBack-4.md
+++ b/docs/site/Crafting-LoopBack-4.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Crafting LoopBack 4'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Crafting-LoopBack-4.html
-summary:
 ---
 
 ## Background

--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Creating components'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-components.html
-summary:
 ---
 
 As explained in [Using Components](Using-components.md), a typical LoopBack

--- a/docs/site/Creating-decorators.md
+++ b/docs/site/Creating-decorators.md
@@ -5,7 +5,6 @@ keywords: LoopBack 4.0, LoopBack 4
 layout: readme
 source: loopback-next
 file: packages/metadata/README.md
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-decorators.html
 summary: A tutorial to use `@loopback/metadata` module to create new decorators

--- a/docs/site/Creating-servers.md
+++ b/docs/site/Creating-servers.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Creating servers'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-servers.html
-summary:
 ---
 
 ## Creating your own servers

--- a/docs/site/DataSource-generator.md
+++ b/docs/site/DataSource-generator.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'DataSource generator'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/DataSource-generator.html
-summary:
 ---
 
 {% include content/generator-create-app.html lang=page.lang %}

--- a/docs/site/DataSources.md
+++ b/docs/site/DataSources.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'DataSources'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/DataSources.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Decorators.md
+++ b/docs/site/Decorators.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Decorators'
 keywords: LoopBack 4.0, LoopBack-Next
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Decorators.html
-summary:
 ---
 
 A decorator allows you to annotate or modify your class declarations and members
@@ -248,9 +246,12 @@ import {Address} from './address.model';
 
 @model()
 class User {
-  @property() firstname: string;
-  @property() lastname: string;
-  @property() address: Address;
+  @property()
+  firstname: string;
+  @property()
+  lastname: string;
+  @property()
+  address: Address;
 }
 ```
 
@@ -383,7 +384,8 @@ import {inject} from '@loopback/context';
 
 export class WidgetController {
   // injection for property
-  @inject('logger.widget') private logger: Function;
+  @inject('logger.widget')
+  private logger: Function;
 
   // injection for constructor parameter
   constructor(

--- a/docs/site/Defining-the-API-using-code-first-approach.md
+++ b/docs/site/Defining-the-API-using-code-first-approach.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Defining the API using code-first approach'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Defining-the-API-using-code-first-approach.html
-summary:
 ---
 
 ## Define the API from code-first approach
@@ -85,13 +83,16 @@ import {model, property} from '@loopback/repository';
 
 @model()
 export class Todo {
-  @property() id?: number;
+  @property()
+  id?: number;
   @property({
     required: true,
   })
   title: string;
-  @property() desc?: string;
-  @property() isComplete: boolean;
+  @property()
+  desc?: string;
+  @property()
+  isComplete: boolean;
 }
 ```
 

--- a/docs/site/Defining-the-API-using-design-first-approach.shelved.md
+++ b/docs/site/Defining-the-API-using-design-first-approach.shelved.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Defining the API using design-first approach'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Defining-the-API-using-design-first-approach.html
-summary:
 ---
 
 {% include important.html content="The top-down approach for building LoopBack

--- a/docs/site/Defining-your-testing-strategy.md
+++ b/docs/site/Defining-your-testing-strategy.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Defining your testing strategy'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Defining-your-testing-strategy.html
-summary:
 ---
 
 {% include previous.html content=" This article continues from

--- a/docs/site/Dependency-injection.md
+++ b/docs/site/Dependency-injection.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Dependency injection'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Dependency-injection.html
-summary:
 ---
 
 ## Introduction
@@ -225,8 +223,7 @@ export class LoggerProvider implements Provider<Logger> {
     @inject('log.writer', {optional: true})
     private logWriter: LogWriterFn = logToConsole,
     // Log level is an optional dependency with a default value `WARN`
-    @inject('log.level', {optional: true})
-    private logLevel: string = 'WARN',
+    @inject('log.level', {optional: true}) private logLevel: string = 'WARN',
   ) {}
 }
 ```
@@ -236,10 +233,7 @@ optional:
 
 ```ts
 export class MyController {
-  greet(
-    @inject('hello.prefix', {optional: true})
-    prefix: string = 'Hello',
-  ) {
+  greet(@inject('hello.prefix', {optional: true}) prefix: string = 'Hello') {
     return `${prefix}, world!`;
   }
 }

--- a/docs/site/Deploy-for-GDPR-readiness.md
+++ b/docs/site/Deploy-for-GDPR-readiness.md
@@ -1,5 +1,5 @@
 ---
-title: "LoopBack considerations for GDPR readiness"
+title: 'LoopBack considerations for GDPR readiness'
 layout: page
 keywords: LoopBack, GDPR
 tags: gdpr

--- a/docs/site/Download-examples.md
+++ b/docs/site/Download-examples.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Download examples'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Download-examples.html
-summary:
 ---
 
 ### Synopsis

--- a/docs/site/Examples-and-tutorials.md
+++ b/docs/site/Examples-and-tutorials.md
@@ -2,10 +2,8 @@
 lang: en
 title: Examples and tutorials
 keywords: LoopBack 4.0
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Examples-and-tutorials.html
-summary:
 ---
 
 LoopBack 4 comes with the following example projects:

--- a/docs/site/Extending-LoopBack-4.md
+++ b/docs/site/Extending-LoopBack-4.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Extending LoopBack 4'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extending-LoopBack-4.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Extension-generator.md
+++ b/docs/site/Extension-generator.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Extension generator'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extension-generator.html
-summary:
 ---
 
 ### Synopsis

--- a/docs/site/FAQ.md
+++ b/docs/site/FAQ.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Frequently-asked questions'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/FAQ.html
 summary: LoopBack 4 is a completely new framework, also known as LoopBack-Next.

--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Getting started'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Getting-started.html
 summary: Write and run a LoopBack 4 "Hello World" project in TypeScript.

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Relations'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/HasMany-relation.html
-summary:
 ---
 
 ## Overview
@@ -58,7 +56,8 @@ export class Customer extends Entity {
   })
   name: string;
 
-  @hasMany(Order) orders?: Order[];
+  @hasMany(Order)
+  orders?: Order[];
 
   constructor(data: Partial<Customer>) {
     super(data);

--- a/docs/site/Implementing-features.shelved.md
+++ b/docs/site/Implementing-features.shelved.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Implementing features'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Implementing-features.html
-summary:
 ---
 
 {% include previous.html content=" This article continues from \[Defining your

--- a/docs/site/Introduction-to-LoopBack-Next-development.md
+++ b/docs/site/Introduction-to-LoopBack-Next-development.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Introduction to LoopBack 4 development'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Intro-to-LB4-development.html
-summary:
 ---
 
 MOVED TO strongloop.com.

--- a/docs/site/Language-related-concepts.md
+++ b/docs/site/Language-related-concepts.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Language-related concepts'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Language-related-concepts.html
-summary:
 ---
 
 A module that exports JavaScript/TypeScript concept related functions.

--- a/docs/site/LoopBack-3.x.md
+++ b/docs/site/LoopBack-3.x.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'For current LoopBack users'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/LoopBack-3.x.html
-summary:
 ---
 
 LoopBack 4 is the next generation of the LoopBack framework, with a completely

--- a/docs/site/Mixin.md
+++ b/docs/site/Mixin.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Mixin'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Mixin.html
-summary:
 ---
 
 It is a commonly used JavaScript/TypeScript strategy to extend a class with new

--- a/docs/site/Model-generator.md
+++ b/docs/site/Model-generator.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Model generator'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Model-generator.html
-summary:
 ---
 
 {% include content/generator-create-app.html lang=page.lang %}

--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Model'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Model.html
-summary:
 ---
 
 {% include content/tbd.html %}
@@ -89,9 +87,12 @@ import {model, property} from '@loopback/repository';
 
 @model()
 export class Customer {
-  @property() email: string;
-  @property() isMember: boolean;
-  @property() cart: ShoppingCart;
+  @property()
+  email: string;
+  @property()
+  isMember: boolean;
+  @property()
+  cart: ShoppingCart;
 }
 ```
 
@@ -111,9 +112,11 @@ export class Product extends Entity {
   })
   id: number;
 
-  @property() name: string;
+  @property()
+  name: string;
 
-  @property() slug: string;
+  @property()
+  slug: string;
 
   constructor(data?: Partial<Product>) {
     super(data);
@@ -215,7 +218,8 @@ to determine the type of a particular property.
 ```ts
 @model()
 class Product extends Entity {
-  @property() public name: string; // The type information for this property is String.
+  @property()
+  public name: string; // The type information for this property is String.
 }
 ```
 
@@ -235,13 +239,15 @@ adds the appropriate metadata for type inference of your array properties.
 ```ts
 @model()
 class Order extends Entity {
-  @property.array(Product) items: Product[];
+  @property.array(Product)
+  items: Product[];
 }
 
 @model()
 class Thread extends Entity {
   // Note that we still require it, even for primitive types!
-  @property.array(String) posts: string[];
+  @property.array(String)
+  posts: string[];
 }
 ```
 
@@ -274,14 +280,16 @@ import {getJsonSchema} from '@loopback/repository-json-schema';
 
 @model()
 class Category {
-  @property() name: string;
+  @property()
+  name: string;
 }
 
 @model()
 class Product {
   @property({required: true})
   name: string;
-  @property() type: Category;
+  @property()
+  type: Category;
 }
 
 const jsonSchema = getJsonSchema(Product);

--- a/docs/site/OpenAPI-generator.md
+++ b/docs/site/OpenAPI-generator.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'OpenAPI generator'
 keywords: LoopBack 4.0, LoopBack 4, OpenAPI, Swagger
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/OpenAPI-generator.html
-summary:
 ---
 
 {% include content/generator-create-app.html lang=page.lang %}
@@ -166,14 +164,10 @@ export class AccountController {
    */
   @operation('get', '/account.cart.list.json')
   async accountCartList(
-    @param({name: 'params', in: 'query'})
-    params: string,
-    @param({name: 'exclude', in: 'query'})
-    exclude: string,
-    @param({name: 'request_from_date', in: 'query'})
-    request_from_date: string,
-    @param({name: 'request_to_date', in: 'query'})
-    request_to_date: string,
+    @param({name: 'params', in: 'query'}) params: string,
+    @param({name: 'exclude', in: 'query'}) exclude: string,
+    @param({name: 'request_from_date', in: 'query'}) request_from_date: string,
+    @param({name: 'request_to_date', in: 'query'}) request_to_date: string,
   ): Promise<{
     result?: {
       carts?: {
@@ -196,16 +190,11 @@ export class AccountController {
    */
   @operation('put', '/account.config.update.json')
   async accountConfigUpdate(
-    @param({name: 'db_tables_prefix', in: 'query'})
-    db_tables_prefix: string,
-    @param({name: 'client_id', in: 'query'})
-    client_id: string,
-    @param({name: 'bridge_url', in: 'query'})
-    bridge_url: string,
-    @param({name: 'store_root', in: 'query'})
-    store_root: string,
-    @param({name: 'shared_secret', in: 'query'})
-    shared_secret: string,
+    @param({name: 'db_tables_prefix', in: 'query'}) db_tables_prefix: string,
+    @param({name: 'client_id', in: 'query'}) client_id: string,
+    @param({name: 'bridge_url', in: 'query'}) bridge_url: string,
+    @param({name: 'store_root', in: 'query'}) store_root: string,
+    @param({name: 'shared_secret', in: 'query'}) shared_secret: string,
   ): Promise<{
     result?: {
       updated_items?: number;
@@ -221,12 +210,9 @@ export class AccountController {
    */
   @operation('get', '/account.failed_webhooks.json')
   async accountFailedWebhooks(
-    @param({name: 'count', in: 'query'})
-    count: number,
-    @param({name: 'start', in: 'query'})
-    start: number,
-    @param({name: 'ids', in: 'query'})
-    ids: string,
+    @param({name: 'count', in: 'query'}) count: number,
+    @param({name: 'start', in: 'query'}) start: number,
+    @param({name: 'ids', in: 'query'}) ids: string,
   ): Promise<{
     result?: {
       all_failed_webhook?: string;

--- a/docs/site/Parsing-requests.md
+++ b/docs/site/Parsing-requests.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Parsing requests'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Parsing-requests.html
-summary:
 ---
 
 ## Parsing Requests

--- a/docs/site/Preparing-the-API-for-consumption.shelved.md
+++ b/docs/site/Preparing-the-API-for-consumption.shelved.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Preparing the API for consumption'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Preparing-the-API-for-consumption.html
-summary:
 ---
 
 {% include previous.html content=" This article continues

--- a/docs/site/Reference.md
+++ b/docs/site/Reference.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Reference'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Reference.html
-summary:
 ---
 
 {% include list-children.html in=site.data.sidebars.lb4_sidebar %}

--- a/docs/site/Relations.md
+++ b/docs/site/Relations.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Relations'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Relations.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Repositories'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Repositories.html
-summary:
 ---
 
 `Repository` represents a specialized `Service` interface that provides
@@ -374,7 +372,8 @@ Injection:
 
     ```ts
     export class AccountController {
-      @repository(NewRepository) private repository: NewRepository;
+      @repository(NewRepository)
+      private repository: NewRepository;
     }
     ```
 

--- a/docs/site/Reserved-binding-keys.md
+++ b/docs/site/Reserved-binding-keys.md
@@ -3,10 +3,8 @@ lang: en
 title: 'Reserved binding keys'
 keywords: LoopBack 4.0, LoopBack 4
 toc_level: 1
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Reserved-binding-keys.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Roadmap.md
+++ b/docs/site/Roadmap.md
@@ -2,7 +2,6 @@
 lang: en
 title: Roadmap
 keywords: LoopBack 4.0
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Roadmap.html
 summary: LoopBack 4.0 is the upcoming release.

--- a/docs/site/Routes.md
+++ b/docs/site/Routes.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Routes'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Routes.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Sequence'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Sequence.html
-summary:
 ---
 
 ## What is a Sequence?

--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Server'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Server.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Team.md
+++ b/docs/site/Team.md
@@ -2,7 +2,6 @@
 lang: en
 title: Team
 keywords: LoopBack 4.0
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Team.html
 summary: The people working on LoopBack 4

--- a/docs/site/Testing-Your-Extensions.md
+++ b/docs/site/Testing-Your-Extensions.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Testing your extension'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Testing-your-extension.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Testing-the-API.shelved.md
+++ b/docs/site/Testing-the-API.shelved.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Testing the API'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Testing-the-API.html
-summary:
 ---
 
 {% include previous.html content=" This article continues off

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Testing your application'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Testing-your-application.html
-summary:
 ---
 
 ## Overview

--- a/docs/site/Using-components.md
+++ b/docs/site/Using-components.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Using components'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Using-components.html
-summary:
 ---
 
 Components play an important part in the extensibility of LoopBack 4. A

--- a/docs/site/Using-decorators.md
+++ b/docs/site/Using-decorators.md
@@ -2,10 +2,8 @@
 lang: en
 title: 'Using decorators'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Using-decorators.html
-summary:
 ---
 
 {% include content/tbd.html %}

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -3,7 +3,6 @@ lang: en
 title: LoopBack 4
 toc: false
 keywords: LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/index.html
 summary: LoopBack is a platform for building APIs and microservices in Node.js

--- a/docs/site/todo-list-tutorial-controller.md
+++ b/docs/site/todo-list-tutorial-controller.md
@@ -2,10 +2,11 @@
 lang: en
 title: "Add TodoList and TodoList's Todo Controller"
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-controller.html
-summary: LoopBack 4 TodoList Application Tutorial - Add TodoList and TodoList's Todo Controller
+summary:
+  LoopBack 4 TodoList Application Tutorial - Add TodoList and TodoList's Todo
+  Controller
 ---
 
 ### Controllers with related models

--- a/docs/site/todo-list-tutorial-model.md
+++ b/docs/site/todo-list-tutorial-model.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Add TodoList Model'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-model.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Model
@@ -79,7 +78,8 @@ model. To `TodoList` model, add in the following property:
 export class TodoList extends Entity {
   // ...properties defined by the CLI...
 
-  @hasMany(Todo) todos?: Todo[];
+  @hasMany(Todo)
+  todos?: Todo[];
 
   // ...constructor def...
 }
@@ -99,7 +99,8 @@ property on `Todo` model to complete defining the relation on both ends:
 export class Todo extends Entity {
   // ...properties defined by the CLI...
 
-  @property() todoListId: number;
+  @property()
+  todoListId: number;
 
   // ...constructor def...
 }

--- a/docs/site/todo-list-tutorial-repository.md
+++ b/docs/site/todo-list-tutorial-repository.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Add TodoList Repository'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-repository.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Repository

--- a/docs/site/todo-list-tutorial.md
+++ b/docs/site/todo-list-tutorial.md
@@ -5,7 +5,6 @@ keywords: LoopBack 4.0, LoopBack 4
 layout: readme
 source: loopback-next
 file: examples/todo-list/README.md
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial.html
 summary: LoopBack 4 TodoList Application Tutorial

--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Add a Controller'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-controller.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Controller

--- a/docs/site/todo-tutorial-datasource.md
+++ b/docs/site/todo-tutorial-datasource.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Add a Datasource'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-datasource.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Datasource
@@ -52,14 +51,10 @@ Create a `data` folder in the applications root and add a new file called
   },
   "models": {
     "Todo": {
-      "1":
-        "{\"title\":\"Take over the galaxy\",\"desc\":\"MWAHAHAHAHAHAHAHAHAHAHAHAHAMWAHAHAHAHAHAHAHAHAHAHAHAHA\",\"id\":1}",
-      "2":
-        "{\"title\":\"destroy alderaan\",\"desc\":\"Make sure there are no survivors left!\",\"id\":2}",
-      "3":
-        "{\"title\":\"terrorize senate\",\"desc\":\"Tell them they're getting a budget cut.\",\"id\":3}",
-      "4":
-        "{\"title\":\"crush rebel scum\",\"desc\":\"Every.Last.One.\",\"id\":4}"
+      "1": "{\"title\":\"Take over the galaxy\",\"desc\":\"MWAHAHAHAHAHAHAHAHAHAHAHAHAMWAHAHAHAHAHAHAHAHAHAHAHAHA\",\"id\":1}",
+      "2": "{\"title\":\"destroy alderaan\",\"desc\":\"Make sure there are no survivors left!\",\"id\":2}",
+      "3": "{\"title\":\"terrorize senate\",\"desc\":\"Tell them they're getting a budget cut.\",\"id\":3}",
+      "4": "{\"title\":\"crush rebel scum\",\"desc\":\"Every.Last.One.\",\"id\":4}"
     }
   }
 }

--- a/docs/site/todo-tutorial-geocoding-service.md
+++ b/docs/site/todo-tutorial-geocoding-service.md
@@ -2,10 +2,10 @@
 lang: en
 title: 'Integrate with a geo-coding service'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-geocoding-service.html
-summary: LoopBack 4 Todo Application Tutorial - Integrate with a geo-coding service
+summary:
+  LoopBack 4 Todo Application Tutorial - Integrate with a geo-coding service
 ---
 
 ### Services
@@ -74,8 +74,7 @@ docs here: [REST connector](/doc/en/lb3/REST-connector.html).
     {
       "template": {
         "method": "GET",
-        "url":
-          "https://geocoding.geo.census.gov/geocoder/locations/onelineaddress",
+        "url": "https://geocoding.geo.census.gov/geocoder/locations/onelineaddress",
         "query": {
           "format": "{format=json}",
           "benchmark": "Public_AR_Current",

--- a/docs/site/todo-tutorial-juggler.md
+++ b/docs/site/todo-tutorial-juggler.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Adding legacy juggler'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-juggler.html
 summary: LoopBack 4 Todo Application Tutorial - Adding legacy juggler

--- a/docs/site/todo-tutorial-model.md
+++ b/docs/site/todo-tutorial-model.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Add Todo Model'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-model.html
 summary: LoopBack 4 Todo Application Tutorial - Add Todo Model

--- a/docs/site/todo-tutorial-putting-it-together.md
+++ b/docs/site/todo-tutorial-putting-it-together.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Putting it all together'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-putting-it-together.html
 summary: LoopBack 4 Todo Application Tutorial - Putting it all together

--- a/docs/site/todo-tutorial-repository.md
+++ b/docs/site/todo-tutorial-repository.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Add a Repository'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-repository.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Repository

--- a/docs/site/todo-tutorial-scaffolding.md
+++ b/docs/site/todo-tutorial-scaffolding.md
@@ -2,7 +2,6 @@
 lang: en
 title: 'Create your app scaffolding'
 keywords: LoopBack 4.0, LoopBack 4
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-scaffolding.html
 summary: LoopBack 4 Todo Application Tutorial - Create app scaffolding

--- a/docs/site/todo-tutorial.md
+++ b/docs/site/todo-tutorial.md
@@ -5,7 +5,6 @@ keywords: LoopBack 4.0, LoopBack 4
 layout: readme
 source: loopback-next
 file: examples/todo/README.md
-tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial.html
 summary: LoopBack 4 Todo Application Tutorial

--- a/examples/todo-list/src/models/todo-list.model.ts
+++ b/examples/todo-list/src/models/todo-list.model.ts
@@ -25,7 +25,8 @@ export class TodoList extends Entity {
   })
   color?: string;
 
-  @hasMany(Todo) todos: Todo[];
+  @hasMany(Todo)
+  todos: Todo[];
 
   constructor(data?: Partial<TodoList>) {
     super(data);

--- a/examples/todo-list/src/models/todo.model.ts
+++ b/examples/todo-list/src/models/todo.model.ts
@@ -29,7 +29,8 @@ export class Todo extends Entity {
   })
   isComplete: boolean;
 
-  @property() todoListId: number;
+  @property()
+  todoListId: number;
 
   getId() {
     return this.id;

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -98,17 +98,26 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
     ) {
       return;
     }
-    const modelList = await utils.getArtifactList(
-      this.artifactInfo.modelDir,
-      'model',
-    );
-    const repositoryList = await utils.getArtifactList(
-      this.artifactInfo.repositoryDir,
-      'repository',
-      true,
-    );
+
+    let modelList, repositoryList;
+
+    try {
+      modelList = await utils.getArtifactList(
+        this.artifactInfo.modelDir,
+        'model',
+      );
+
+      repositoryList = await utils.getArtifactList(
+        this.artifactInfo.repositoryDir,
+        'repository',
+        true,
+      );
+    } catch (err) {
+      return this.exit(err);
+    }
+
     if (_.isEmpty(modelList)) {
-      throw new Error(
+      return this.exit(
         `No models found in ${this.artifactInfo.modelDir}.
         ${chalk.yellow(
           'Please visit http://loopback.io/doc/en/lb4/Controller-generator.html for information on how models are discovered',
@@ -116,7 +125,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
       );
     }
     if (_.isEmpty(repositoryList)) {
-      throw new Error(
+      return this.exit(
         `No repositories found in ${this.artifactInfo.repositoryDir}.
         ${chalk.yellow(
           'Please visit http://loopback.io/doc/en/lb4/Controller-generator.html for information on how repositories are discovered',

--- a/packages/cli/generators/openapi/README.md
+++ b/packages/cli/generators/openapi/README.md
@@ -137,14 +137,10 @@ export class AccountController {
    */
   @operation('get', '/account.cart.list.json')
   async accountCartList(
-    @param({name: 'params', in: 'query'})
-    params: string,
-    @param({name: 'exclude', in: 'query'})
-    exclude: string,
-    @param({name: 'request_from_date', in: 'query'})
-    request_from_date: string,
-    @param({name: 'request_to_date', in: 'query'})
-    request_to_date: string,
+    @param({name: 'params', in: 'query'}) params: string,
+    @param({name: 'exclude', in: 'query'}) exclude: string,
+    @param({name: 'request_from_date', in: 'query'}) request_from_date: string,
+    @param({name: 'request_to_date', in: 'query'}) request_to_date: string,
   ): Promise<{
     result?: {
       carts?: {
@@ -167,16 +163,11 @@ export class AccountController {
    */
   @operation('put', '/account.config.update.json')
   async accountConfigUpdate(
-    @param({name: 'db_tables_prefix', in: 'query'})
-    db_tables_prefix: string,
-    @param({name: 'client_id', in: 'query'})
-    client_id: string,
-    @param({name: 'bridge_url', in: 'query'})
-    bridge_url: string,
-    @param({name: 'store_root', in: 'query'})
-    store_root: string,
-    @param({name: 'shared_secret', in: 'query'})
-    shared_secret: string,
+    @param({name: 'db_tables_prefix', in: 'query'}) db_tables_prefix: string,
+    @param({name: 'client_id', in: 'query'}) client_id: string,
+    @param({name: 'bridge_url', in: 'query'}) bridge_url: string,
+    @param({name: 'store_root', in: 'query'}) store_root: string,
+    @param({name: 'shared_secret', in: 'query'}) shared_secret: string,
   ): Promise<{
     result?: {
       updated_items?: number;
@@ -192,12 +183,9 @@ export class AccountController {
    */
   @operation('get', '/account.failed_webhooks.json')
   async accountFailedWebhooks(
-    @param({name: 'count', in: 'query'})
-    count: number,
-    @param({name: 'start', in: 'query'})
-    start: number,
-    @param({name: 'ids', in: 'query'})
-    ids: string,
+    @param({name: 'count', in: 'query'}) count: number,
+    @param({name: 'start', in: 'query'}) start: number,
+    @param({name: 'ids', in: 'query'}) ids: string,
   ): Promise<{
     result?: {
       all_failed_webhook?: string;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "unicode-10.0.0": "^0.7.4",
     "url-slug": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
-    "yeoman-generator": "^2.0.3"
+    "yeoman-generator": "^3.1.1"
   },
   "scripts": {
     "prepublishOnly": "nsp check",

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -12,7 +12,6 @@ const testlab = require('@loopback/testlab');
 const expect = testlab.expect;
 const TestSandbox = testlab.TestSandbox;
 
-const debug = require('../../../lib/debug')('lb4:controller:test');
 const ControllerGenerator = require('../../../generators/controller');
 const generator = path.join(__dirname, '../../../generators/controller');
 const tests = require('../lib/artifact-generator')(generator);

--- a/packages/context/test/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/test/acceptance/class-level-bindings.acceptance.ts
@@ -111,7 +111,8 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     });
 
     class InfoController {
-      @inject('authenticated') public isAuthenticated: boolean;
+      @inject('authenticated')
+      public isAuthenticated: boolean;
     }
     ctx.bind(INFO_CONTROLLER).toClass(InfoController);
 
@@ -126,7 +127,8 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     class InfoController {
       constructor(@inject('appName') public appName: string) {}
 
-      @inject('authenticated') public isAuthenticated: boolean;
+      @inject('authenticated')
+      public isAuthenticated: boolean;
     }
     const b = ctx.bind(INFO_CONTROLLER).toClass(InfoController);
 
@@ -214,10 +216,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
   it('injects values by tag regex', () => {
     class Store {
-      constructor(
-        @inject.tag(/.+:location:sj/)
-        public locations: string[],
-      ) {}
+      constructor(@inject.tag(/.+:location:sj/) public locations: string[]) {}
     }
 
     ctx.bind('store').toClass(Store);

--- a/packages/context/test/acceptance/class-level-bindings.feature.md
+++ b/packages/context/test/acceptance/class-level-bindings.feature.md
@@ -48,7 +48,8 @@ const ctx = new Context();
 ctx.bind('application.name').to('CodeHub');
 
 class InfoController {
-  @inject('application.name') appName: string;
+  @inject('application.name')
+  appName: string;
 }
 ctx.bind('controllers.info').toClass(InfoController);
 

--- a/packages/context/test/acceptance/method-level-bindings.acceptance.ts
+++ b/packages/context/test/acceptance/method-level-bindings.acceptance.ts
@@ -15,10 +15,7 @@ class InfoController {
     return msg;
   }
 
-  hello(
-    @inject('user', {optional: true})
-    user: string = 'Mary',
-  ): string {
+  hello(@inject('user', {optional: true}) user: string = 'Mary'): string {
     const msg = `Hello ${user}`;
     debug(msg);
     return msg;

--- a/packages/context/test/unit/inject.unit.ts
+++ b/packages/context/test/unit/inject.unit.ts
@@ -85,14 +85,16 @@ describe('property injection', () => {
   it('can decorate properties', () => {
     // tslint:disable-next-line:no-unused-variable
     class TestClass {
-      @inject('foo') foo: string;
+      @inject('foo')
+      foo: string;
     }
     // the test passes when TypeScript Compiler is happy
   });
 
   it('can retrieve information about injected properties', () => {
     class TestClass {
-      @inject('foo') foo: string;
+      @inject('foo')
+      foo: string;
     }
 
     const meta = describeInjectedProperties(TestClass.prototype);
@@ -112,7 +114,8 @@ describe('property injection', () => {
     expect(() => {
       // tslint:disable-next-line:no-unused-variable
       class TestClass {
-        @inject('foo') static foo: string;
+        @inject('foo')
+        static foo: string;
       }
     }).to.throw(/@inject is not supported for a static property/);
   });
@@ -129,7 +132,8 @@ describe('property injection', () => {
 
   it('supports inheritance without overriding property', () => {
     class TestClass {
-      @inject('foo') foo: string;
+      @inject('foo')
+      foo: string;
     }
 
     class SubTestClass extends TestClass {}
@@ -139,11 +143,13 @@ describe('property injection', () => {
 
   it('supports inheritance with overriding property', () => {
     class TestClass {
-      @inject('foo') foo: string;
+      @inject('foo')
+      foo: string;
     }
 
     class SubTestClass extends TestClass {
-      @inject('bar') foo: string;
+      @inject('bar')
+      foo: string;
     }
 
     const base = describeInjectedProperties(TestClass.prototype);
@@ -155,11 +161,13 @@ describe('property injection', () => {
 
   it('supports inherited and own properties', () => {
     class TestClass {
-      @inject('foo') foo: string;
+      @inject('foo')
+      foo: string;
     }
 
     class SubTestClass extends TestClass {
-      @inject('bar') bar: string;
+      @inject('bar')
+      bar: string;
     }
     const meta = describeInjectedProperties(SubTestClass.prototype);
     expect(meta.foo.bindingKey).to.eql('foo');

--- a/packages/context/test/unit/resolver.unit.ts
+++ b/packages/context/test/unit/resolver.unit.ts
@@ -34,10 +34,7 @@ describe('constructor injection', () => {
 
   it('can report error for missing binding key', () => {
     class TestClass {
-      constructor(
-        @inject('', {x: 'bar'})
-        public fooBar: string,
-      ) {}
+      constructor(@inject('', {x: 'bar'}) public fooBar: string) {}
     }
 
     expect(() => {
@@ -115,10 +112,7 @@ describe('constructor injection', () => {
 
   it('resolves constructor arguments with custom decorator', () => {
     class TestClass {
-      constructor(
-        @customDecorator({x: 'bar'})
-        public fooBar: string,
-      ) {}
+      constructor(@customDecorator({x: 'bar'}) public fooBar: string) {}
     }
 
     const t = instantiateClass(TestClass, ctx) as TestClass;
@@ -131,11 +125,13 @@ describe('constructor injection', () => {
     interface YInterface {}
 
     class XClass implements XInterface {
-      @inject('y') public y: YInterface;
+      @inject('y')
+      public y: YInterface;
     }
 
     class YClass implements YInterface {
-      @inject('x') public x: XInterface;
+      @inject('x')
+      public x: XInterface;
     }
 
     context.bind('x').toClass(XClass);
@@ -339,10 +335,7 @@ describe('async constructor injection', () => {
   // tslint:disable-next-line:max-line-length
   it('resolves constructor arguments with custom async decorator', async () => {
     class TestClass {
-      constructor(
-        @customAsyncDecorator({x: 'bar'})
-        public fooBar: string,
-      ) {}
+      constructor(@customAsyncDecorator({x: 'bar'}) public fooBar: string) {}
     }
 
     const t = await instantiateClass(TestClass, ctx);
@@ -361,7 +354,8 @@ describe('property injection', () => {
 
   it('resolves injected properties', () => {
     class TestClass {
-      @inject('foo') foo: string;
+      @inject('foo')
+      foo: string;
     }
     const t = instantiateClass(TestClass, ctx) as TestClass;
     expect(t.foo).to.eql('FOO');
@@ -430,7 +424,8 @@ describe('async property injection', () => {
 
   it('resolves injected properties', async () => {
     class TestClass {
-      @inject('foo') foo: string;
+      @inject('foo')
+      foo: string;
     }
     const t: TestClass = await instantiateClass(TestClass, ctx);
     expect(t.foo).to.eql('FOO');
@@ -458,7 +453,8 @@ describe('dependency injection', () => {
 
   it('resolves properties and constructor arguments', () => {
     class TestClass {
-      @inject('bar') bar: string;
+      @inject('bar')
+      bar: string;
 
       constructor(@inject('foo') public foo: string) {}
     }
@@ -480,7 +476,8 @@ describe('async dependency injection', () => {
 
   it('resolves properties and constructor arguments', async () => {
     class TestClass {
-      @inject('bar') bar: string;
+      @inject('bar')
+      bar: string;
 
       constructor(@inject('foo') public foo: string) {}
     }
@@ -502,7 +499,8 @@ describe('async constructor & sync property injection', () => {
 
   it('resolves properties and constructor arguments', async () => {
     class TestClass {
-      @inject('bar') bar: string;
+      @inject('bar')
+      bar: string;
 
       constructor(@inject('foo') public foo: string) {}
     }
@@ -551,7 +549,8 @@ describe('async property injection with errors', () => {
 
   it('resolves properties and constructor arguments', async () => {
     class TestClass {
-      @inject('bar') bar: string;
+      @inject('bar')
+      bar: string;
     }
 
     await expect(instantiateClass(TestClass, ctx)).to.be.rejectedWith(
@@ -571,7 +570,8 @@ describe('sync constructor & async property injection', () => {
 
   it('resolves properties and constructor arguments', async () => {
     class TestClass {
-      @inject('bar') bar: string;
+      @inject('bar')
+      bar: string;
 
       constructor(@inject('foo') public foo: string) {}
     }

--- a/packages/metadata/README.md
+++ b/packages/metadata/README.md
@@ -143,24 +143,18 @@ follows:
 ```ts
 class MyController {
   constructor(
-    @myParameterDecorator({name: 'logging-prefix'})
-    public prefix: string,
-    @myParameterDecorator({name: 'logging-level'})
-    public level: number,
+    @myParameterDecorator({name: 'logging-prefix'}) public prefix: string,
+    @myParameterDecorator({name: 'logging-level'}) public level: number,
   ) {}
 
   myMethod(
-    @myParameterDecorator({name: 'x'})
-    x: number,
-    @myParameterDecorator({name: 'y'})
-    y: number,
+    @myParameterDecorator({name: 'x'}) x: number,
+    @myParameterDecorator({name: 'y'}) y: number,
   ) {}
 
   static myStaticMethod(
-    @myParameterDecorator({name: 'a'})
-    a: string,
-    @myParameterDecorator({name: 'b'})
-    b: string,
+    @myParameterDecorator({name: 'a'}) a: string,
+    @myParameterDecorator({name: 'b'}) b: string,
   ) {}
 }
 ```

--- a/packages/metadata/test/unit/decorator-factory.unit.ts
+++ b/packages/metadata/test/unit/decorator-factory.unit.ts
@@ -518,19 +518,13 @@ describe('ParameterDecoratorFactory', () => {
   }
 
   class BaseController {
-    myMethod(
-      @parameterDecorator({x: 1})
-      a: string,
-      b: number,
-    ) {}
+    myMethod(@parameterDecorator({x: 1}) a: string, b: number) {}
   }
 
   class SubController extends BaseController {
     myMethod(
-      @parameterDecorator({y: 2})
-      a: string,
-      @parameterDecorator({x: 2})
-      b: number,
+      @parameterDecorator({y: 2}) a: string,
+      @parameterDecorator({x: 2}) b: number,
     ) {}
   }
 
@@ -575,19 +569,13 @@ describe('ParameterDecoratorFactory for a constructor', () => {
   }
 
   class BaseController {
-    constructor(
-      @parameterDecorator({x: 1})
-      a: string,
-      b: number,
-    ) {}
+    constructor(@parameterDecorator({x: 1}) a: string, b: number) {}
   }
 
   class SubController extends BaseController {
     constructor(
-      @parameterDecorator({y: 2})
-      a: string,
-      @parameterDecorator({x: 2})
-      b: number,
+      @parameterDecorator({y: 2}) a: string,
+      @parameterDecorator({x: 2}) b: number,
     ) {
       super(a, b);
     }
@@ -619,19 +607,13 @@ describe('ParameterDecoratorFactory for a static method', () => {
   }
 
   class BaseController {
-    static myMethod(
-      @parameterDecorator({x: 1})
-      a: string,
-      b: number,
-    ) {}
+    static myMethod(@parameterDecorator({x: 1}) a: string, b: number) {}
   }
 
   class SubController extends BaseController {
     static myMethod(
-      @parameterDecorator({y: 2})
-      a: string,
-      @parameterDecorator({x: 2})
-      b: number,
+      @parameterDecorator({y: 2}) a: string,
+      @parameterDecorator({x: 2}) b: number,
     ) {}
   }
 

--- a/packages/metadata/test/unit/inspector.unit.ts
+++ b/packages/metadata/test/unit/inspector.unit.ts
@@ -361,19 +361,13 @@ describe('Inspector for parameters of an instance method', () => {
   }
 
   class BaseController {
-    myMethod(
-      @parameterDecorator({x: 1})
-      a: string,
-      b: number,
-    ) {}
+    myMethod(@parameterDecorator({x: 1}) a: string, b: number) {}
   }
 
   class SubController extends BaseController {
     myMethod(
-      @parameterDecorator({y: 2})
-      a: string,
-      @parameterDecorator({x: 2})
-      b: number,
+      @parameterDecorator({y: 2}) a: string,
+      @parameterDecorator({x: 2}) b: number,
     ) {}
   }
 
@@ -445,19 +439,13 @@ describe('Inspector for parameters of a static method', () => {
   }
 
   class BaseController {
-    static myMethod(
-      @parameterDecorator({x: 1})
-      a: string,
-      b: number,
-    ) {}
+    static myMethod(@parameterDecorator({x: 1}) a: string, b: number) {}
   }
 
   class SubController extends BaseController {
     static myMethod(
-      @parameterDecorator({y: 2})
-      a: string,
-      @parameterDecorator({x: 2})
-      b: number,
+      @parameterDecorator({y: 2}) a: string,
+      @parameterDecorator({x: 2}) b: number,
     ) {}
   }
 
@@ -527,19 +515,13 @@ describe('Inspector for parameters of a constructor', () => {
   }
 
   class BaseController {
-    constructor(
-      @parameterDecorator({x: 1})
-      a: string,
-      b: number,
-    ) {}
+    constructor(@parameterDecorator({x: 1}) a: string, b: number) {}
   }
 
   class SubController extends BaseController {
     constructor(
-      @parameterDecorator({y: 2})
-      a: string,
-      @parameterDecorator({x: 2})
-      b: number,
+      @parameterDecorator({y: 2}) a: string,
+      @parameterDecorator({x: 2}) b: number,
     ) {
       super(a, b);
     }
@@ -589,26 +571,27 @@ describe('Inspector for design time metadata', () => {
   class MyClass {}
 
   class MyController {
-    constructor(
-      @parameterDecorator({x: 1})
-      a: string,
-      b: number,
-    ) {}
+    constructor(@parameterDecorator({x: 1}) a: string, b: number) {}
 
-    @propertyDecorator() myProp: string;
+    @propertyDecorator()
+    myProp: string;
 
-    @propertyDecorator() myType: MyClass;
+    @propertyDecorator()
+    myType: MyClass;
 
-    @propertyDecorator() myArray: string[];
+    @propertyDecorator()
+    myArray: string[];
 
-    @propertyDecorator() myUnionType: string | number;
+    @propertyDecorator()
+    myUnionType: string | number;
 
     @methodDecorator()
     myMethod(x: string, y: number): boolean {
       return false;
     }
 
-    @propertyDecorator() static myStaticProp = {};
+    @propertyDecorator()
+    static myStaticProp = {};
 
     @methodDecorator()
     static myStaticMethod(x: string, y: number): boolean {

--- a/packages/openapi-v3/test/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/test/integration/controller-spec.integration.ts
@@ -12,25 +12,28 @@ describe('controller spec', () => {
   it('adds property schemas in components.schemas', () => {
     @model()
     class Bar {
-      @property() name: string;
+      @property()
+      name: string;
     }
 
     @model()
     class Baz {
-      @property() name: string;
+      @property()
+      name: string;
     }
 
     @model()
     class Foo {
-      @property() bar: Bar;
-      @property() baz: Baz;
+      @property()
+      bar: Bar;
+      @property()
+      baz: Baz;
     }
 
     class FooController {
       @post('/foo')
       create(
-        @requestBody({description: 'a foo instance', required: true})
-        foo: Foo,
+        @requestBody({description: 'a foo instance', required: true}) foo: Foo,
       ): void {}
     }
 
@@ -79,13 +82,16 @@ describe('controller spec', () => {
 
     @model()
     class Foo {
-      @property() bar: number;
+      @property()
+      bar: number;
     }
 
     @model()
     class MyParam {
-      @property() name: string;
-      @property() foo: Foo;
+      @property()
+      name: string;
+      @property()
+      foo: Foo;
     }
 
     class MyController {
@@ -128,7 +134,8 @@ describe('controller spec', () => {
       in: 'query',
     };
     class MyParam {
-      @property() name: string;
+      @property()
+      name: string;
     }
     class MyController {
       @post('/foo')

--- a/packages/openapi-v3/test/integration/operation-spec.integration.ts
+++ b/packages/openapi-v3/test/integration/operation-spec.integration.ts
@@ -11,8 +11,10 @@ describe('operation arguments', () => {
   it('generate parameters and requestBody for operation', () => {
     @model()
     class User {
-      @property() name: string;
-      @property() password: number;
+      @property()
+      name: string;
+      @property()
+      password: number;
     }
 
     class MyController {

--- a/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
@@ -61,8 +61,7 @@ describe('Routing metadata for parameters', () => {
             in: 'query',
           })
           vip: boolean,
-          @param.array('tags', 'query', {type: 'string'})
-          tags: string[],
+          @param.array('tags', 'query', {type: 'string'}) tags: string[],
           @param({
             name: 'address',
             in: 'query',
@@ -164,8 +163,7 @@ describe('Routing metadata for parameters', () => {
           class MyController {
             @get('/greet')
             greet(
-              @param.array('names', 'query', {type: 'string'})
-              names: string,
+              @param.array('names', 'query', {type: 'string'}) names: string,
             ) {}
           }
         },

--- a/packages/openapi-v3/test/unit/decorators/request-body/request-body.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/request-body/request-body.decorator.unit.ts
@@ -53,14 +53,14 @@ describe('requestBody decorator', () => {
 
       @model()
       class MyModel {
-        @property() name: string;
+        @property()
+        name: string;
       }
 
       class MyController {
         @post('/MyModel')
         createMyModel(
-          @requestBody({content: {'application/text': {}}})
-          inst: MyModel,
+          @requestBody({content: {'application/text': {}}}) inst: MyModel,
         ) {}
       }
 
@@ -81,10 +81,7 @@ describe('requestBody decorator', () => {
 
       class MyController {
         @post('/MyModel')
-        createMyModel(
-          @requestBody({content: expectedContent})
-          inst: MyModel,
-        ) {}
+        createMyModel(@requestBody({content: expectedContent}) inst: MyModel) {}
       }
 
       const requestBodySpec = getControllerSpec(MyController).paths['/MyModel'][
@@ -105,8 +102,7 @@ describe('requestBody decorator', () => {
       class MyController {
         @post('/MyModel')
         createMyModel(
-          @requestBody({content: expectedContent})
-          inst: Partial<MyModel>,
+          @requestBody({content: expectedContent}) inst: Partial<MyModel>,
         ) {}
       }
 

--- a/packages/repository-json-schema/README.md
+++ b/packages/repository-json-schema/README.md
@@ -22,7 +22,8 @@ import {model, property} from '@loopback/repository';
 
 @model()
 class MyModel {
-  @property() name: string;
+  @property()
+  name: string;
 }
 
 const jsonSchema = getJsonSchema(MyModel);

--- a/packages/repository-json-schema/test/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/test/integration/build-schema.integration.ts
@@ -20,8 +20,10 @@ describe('build-schema', () => {
       it('does not convert null or undefined property', () => {
         @model()
         class TestModel {
-          @property() nul: null;
-          @property() undef: undefined;
+          @property()
+          nul: null;
+          @property()
+          undef: undefined;
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -36,7 +38,8 @@ describe('build-schema', () => {
         }
         @model()
         class OnePropertyDecorated {
-          @property() foo: string;
+          @property()
+          foo: string;
           bar: boolean;
           baz: number;
         }
@@ -56,7 +59,8 @@ describe('build-schema', () => {
       it('does not convert models that have not been decorated with @model()', () => {
         class Empty {}
         class NoModelMeta {
-          @property() foo: string;
+          @property()
+          foo: string;
           bar: number;
         }
 
@@ -71,7 +75,8 @@ describe('build-schema', () => {
       it('infers "title" property from constructor name', () => {
         @model()
         class TestModel {
-          @property() foo: string;
+          @property()
+          foo: string;
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -82,7 +87,8 @@ describe('build-schema', () => {
       it('overrides "title" property if explicitly given', () => {
         @model({title: 'NewName'})
         class TestModel {
-          @property() foo: string;
+          @property()
+          foo: string;
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -96,7 +102,8 @@ describe('build-schema', () => {
         };
         @model(topMeta)
         class TestModel {
-          @property() foo: string;
+          @property()
+          foo: string;
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -107,9 +114,12 @@ describe('build-schema', () => {
       it('properly converts string, number, and boolean properties', () => {
         @model()
         class TestModel {
-          @property() str: string;
-          @property() num: number;
-          @property() bool: boolean;
+          @property()
+          str: string;
+          @property()
+          num: number;
+          @property()
+          bool: boolean;
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -130,7 +140,8 @@ describe('build-schema', () => {
       it('properly converts object properties', () => {
         @model()
         class TestModel {
-          @property() obj: object;
+          @property()
+          obj: object;
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -150,7 +161,8 @@ describe('build-schema', () => {
 
           @model()
           class TestModel {
-            @property() cusType: CustomType;
+            @property()
+            cusType: CustomType;
           }
 
           const jsonSchema = modelToJsonSchema(TestModel);
@@ -166,12 +178,14 @@ describe('build-schema', () => {
         it('properly converts decorated custom type properties', () => {
           @model()
           class CustomType {
-            @property() prop: string;
+            @property()
+            prop: string;
           }
 
           @model()
           class TestModel {
-            @property() cusType: CustomType;
+            @property()
+            cusType: CustomType;
           }
 
           const jsonSchema = modelToJsonSchema(TestModel);
@@ -196,17 +210,20 @@ describe('build-schema', () => {
         it('creates definitions only at the root level of the schema', () => {
           @model()
           class CustomTypeFoo {
-            @property() prop: string;
+            @property()
+            prop: string;
           }
 
           @model()
           class CustomTypeBar {
-            @property.array(CustomTypeFoo) prop: CustomTypeFoo[];
+            @property.array(CustomTypeFoo)
+            prop: CustomTypeFoo[];
           }
 
           @model()
           class TestModel {
-            @property() cusBar: CustomTypeBar;
+            @property()
+            cusBar: CustomTypeBar;
           }
 
           const jsonSchema = modelToJsonSchema(TestModel);
@@ -245,7 +262,8 @@ describe('build-schema', () => {
       it('properly converts primitive arrays properties', () => {
         @model()
         class TestModel {
-          @property.array(Number) numArr: number[];
+          @property.array(Number)
+          numArr: number[];
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -267,7 +285,8 @@ describe('build-schema', () => {
 
         @model()
         class TestModel {
-          @property.array(CustomType) cusArr: CustomType[];
+          @property.array(CustomType)
+          cusArr: CustomType[];
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -315,7 +334,8 @@ describe('build-schema', () => {
           propOne: string;
           @property({required: true})
           propTwo: string;
-          @property() propThree: number;
+          @property()
+          propThree: number;
         }
 
         const jsonSchema = modelToJsonSchema(TestModel);
@@ -336,7 +356,8 @@ describe('build-schema', () => {
       it('errors out when "@property.array" is not used on an array', () => {
         @model()
         class BadArray {
-          @property() badArr: string[];
+          @property()
+          badArr: string[];
         }
 
         expect(() => {
@@ -347,7 +368,8 @@ describe('build-schema', () => {
       it('errors out if "@property.array" is given "Array" as parameter', () => {
         @model()
         class BadArray {
-          @property.array(Array) badArr: string[][];
+          @property.array(Array)
+          badArr: string[][];
         }
 
         expect(() => {
@@ -373,7 +395,8 @@ describe('build-schema', () => {
     it('gets cached JSON schema if one exists', () => {
       @model()
       class TestModel {
-        @property() foo: number;
+        @property()
+        foo: number;
       }
       const cachedSchema: JsonSchema = {
         properties: {
@@ -395,7 +418,8 @@ describe('build-schema', () => {
     it('creates JSON schema if one does not already exist', () => {
       @model()
       class NewModel {
-        @property() newProperty: string;
+        @property()
+        newProperty: string;
       }
 
       const jsonSchema = getJsonSchema(NewModel);

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -47,8 +47,10 @@ import {model, Entity, property} from '@loopback/repository';
 export class Note extends Entity {
   @property({id: true})
   id: string;
-  @property() title: string;
-  @property() content: string;
+  @property()
+  title: string;
+  @property()
+  content: string;
 }
 ```
 

--- a/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
@@ -15,7 +15,8 @@ import {
 } from '../../';
 
 class NoteController {
-  @repository('noteRepo') public noteRepo: EntityCrudRepository<Entity, number>;
+  @repository('noteRepo')
+  public noteRepo: EntityCrudRepository<Entity, number>;
 }
 
 const ds: juggler.DataSource = new juggler.DataSource({

--- a/packages/repository/examples/models/order.model.ts
+++ b/packages/repository/examples/models/order.model.ts
@@ -26,5 +26,6 @@ class Order extends Entity {
   id: string;
   customerId: string;
 
-  @belongsTo() customer: Customer;
+  @belongsTo()
+  customer: Customer;
 }

--- a/packages/repository/test/acceptance/has-many-without-di.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many-without-di.relation.acceptance.ts
@@ -116,7 +116,8 @@ describe('HasMany relation', () => {
     })
     name: string;
 
-    @hasMany(Order) orders: Order[];
+    @hasMany(Order)
+    orders: Order[];
   }
 
   class OrderRepository extends DefaultCrudRepository<

--- a/packages/repository/test/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many.relation.acceptance.ts
@@ -188,7 +188,8 @@ describe('HasMany relation', () => {
     })
     name: string;
 
-    @hasMany(Order) orders: Order[];
+    @hasMany(Order)
+    orders: Order[];
   }
 
   class OrderRepository extends DefaultCrudRepository<

--- a/packages/repository/test/unit/decorator/metadata.unit.ts
+++ b/packages/repository/test/unit/decorator/metadata.unit.ts
@@ -17,7 +17,8 @@ import {MetadataInspector} from '@loopback/context';
 describe('Repository', () => {
   describe('getAllClassMetadata', () => {
     class Oops {
-      @property() oopsie: string;
+      @property()
+      oopsie: string;
     }
 
     @model()
@@ -27,8 +28,10 @@ describe('Repository', () => {
     }
     @model()
     class Widget {
-      @property() id: number;
-      @property.array(Colour) colours: Colour[];
+      @property()
+      id: number;
+      @property.array(Colour)
+      colours: Colour[];
     }
 
     @model()
@@ -40,9 +43,12 @@ describe('Repository', () => {
 
     @model()
     class Phlange {
-      @property() id: number;
-      @property() canFlap: boolean;
-      @property.array(Colour) colours: Colour[];
+      @property()
+      id: number;
+      @property()
+      canFlap: boolean;
+      @property.array(Colour)
+      colours: Colour[];
     }
 
     it('returns empty object for classes without @model', () => {

--- a/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
@@ -72,11 +72,14 @@ describe('model decorator', () => {
 
   @model()
   class Product extends Entity {
-    @property() id: string;
+    @property()
+    id: string;
 
-    @property() name: string;
+    @property()
+    name: string;
 
-    @property() price: number;
+    @property()
+    price: number;
   }
 
   @model({name: 'order'})
@@ -90,14 +93,16 @@ describe('model decorator', () => {
 
     @property({type: 'string', id: true, generated: true})
     id: string;
-    @property() customerId: string;
+    @property()
+    customerId: string;
 
     @belongsTo({target: 'Customer'})
     // TypeScript does not allow me to reference Customer here
     customer: ICustomer;
 
     // Validates that property no longer requires a parameter
-    @property() isShipped: boolean;
+    @property()
+    isShipped: boolean;
   }
 
   @model()
@@ -107,17 +112,23 @@ describe('model decorator', () => {
     firstName: string;
     lastName: string;
 
-    @embedsOne() address: Address;
+    @embedsOne()
+    address: Address;
 
-    @embedsMany() phones: Phone[];
+    @embedsMany()
+    phones: Phone[];
 
-    @referencesMany() accounts: Account[];
+    @referencesMany()
+    accounts: Account[];
 
-    @referencesOne() profile: Profile;
+    @referencesOne()
+    profile: Profile;
 
-    @hasMany(Order) orders?: Order[];
+    @hasMany(Order)
+    orders?: Order[];
 
-    @hasOne() lastOrder?: Order;
+    @hasOne()
+    lastOrder?: Order;
 
     @relation({type: RelationType.hasMany})
     recentOrders?: Order[];
@@ -276,7 +287,8 @@ describe('model decorator', () => {
 
     @model()
     class House extends Entity {
-      @property() name: string;
+      @property()
+      name: string;
       @hasMany(Person, {keyTo: 'fk'})
       person: Person[];
     }
@@ -295,7 +307,8 @@ describe('model decorator', () => {
       it('"@property.array" adds array metadata', () => {
         @model()
         class TestModel {
-          @property.array(Product) items: Product[];
+          @property.array(Product)
+          items: Product[];
         }
 
         const meta =
@@ -311,7 +324,8 @@ describe('model decorator', () => {
           () => {
             // tslint:disable-next-line:no-unused-variable
             class Oops {
-              @property.array(Product) product: Product;
+              @property.array(Product)
+              product: Product;
             }
           },
           Error,

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -23,7 +23,8 @@ describe('relation decorator', () => {
         class AddressBook extends Entity {
           id: number;
 
-          @hasMany(Address) addresses: Address[];
+          @hasMany(Address)
+          addresses: Address[];
         }
       }).throw(/addressBookId not found on Address/);
     });
@@ -34,13 +35,15 @@ describe('relation decorator', () => {
         addressId: number;
         street: string;
         province: string;
-        @property() addressBookId: number;
+        @property()
+        addressBookId: number;
       }
 
       class AddressBook extends Entity {
         id: number;
 
-        @hasMany(Address) addresses: Address[];
+        @hasMany(Address)
+        addresses: Address[];
       }
 
       const meta = MetadataInspector.getPropertyMetadata(

--- a/packages/repository/test/unit/decorator/repository.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/repository.decorator.unit.ts
@@ -19,7 +19,8 @@ import {
 class MyController {
   constructor(@repository('noteRepo') public noteRepo: Repository<Entity>) {}
 
-  @repository('noteRepo') noteRepo2: Repository<Entity>;
+  @repository('noteRepo')
+  noteRepo2: Repository<Entity>;
 }
 
 describe('repository decorator', () => {
@@ -79,8 +80,7 @@ describe('repository decorator', () => {
   it('supports @repository(model, dataSource) by names', async () => {
     class Controller2 {
       constructor(
-        @repository('Note', 'memory')
-        public noteRepo: Repository<Note>,
+        @repository('Note', 'memory') public noteRepo: Repository<Note>,
       ) {}
     }
     ctx.bind('controllers.Controller2').toClass(Controller2);

--- a/packages/rest/test/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/test/acceptance/validation/validation.acceptance.ts
@@ -44,8 +44,7 @@ describe('Validation at REST level', () => {
     class ProductController {
       @post('/products')
       async create(
-        @requestBody({required: true})
-        data: Product,
+        @requestBody({required: true}) data: Product,
       ): Promise<Product> {
         return new Product(data);
       }
@@ -80,8 +79,7 @@ describe('Validation at REST level', () => {
     class ProductControllerWithFullSchema {
       @post('/products')
       async create(
-        @requestBody(aBodySpec(PRODUCT_SPEC))
-        data: object,
+        @requestBody(aBodySpec(PRODUCT_SPEC)) data: object,
         //    ^^^^^^
         // use "object" instead of "Product" to verify the situation when
         // body schema cannot be inferred from the argument type

--- a/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -159,7 +159,8 @@ describe('RestServer.getApiSpec()', () => {
   it('returns definitions inferred via app.controller()', () => {
     @model()
     class MyModel {
-      @property() bar: string;
+      @property()
+      bar: string;
     }
     class MyController {
       @post('/foo')


### PR DESCRIPTION
Make `master` go green again by:

**Commit 1**
- Updating `yeoman-generator` to 3.x
  - Updating CLI tests as needed
---

**Commit 2**
- Applying latest prettier formatting standards
  - Empty properties in `front-matter` have been removed.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
