### PR TITLE
fix(cli): remove deleteAll endpoint from REST Controller template

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -129,11 +129,6 @@ export class TodoController {
     return await this.todoRepository.updateAll(obj, where);
   }
 
-  @del('/todos')
-  async deleteAll(@param.query.string('where') where?: Where): Promise<number> {
-    return await this.todoRepository.deleteAll(where);
-  }
-
   @get('/todos/{id}')
   async findById(@param.path.number('id') id: number): Promise<Todo> {
     return await this.todoRepository.findById(id);

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -39,11 +39,6 @@ export class TodoListController {
     return await this.todoListRepository.updateAll(obj, where);
   }
 
-  @del('/todo-lists')
-  async deleteAll(@param.query.string('where') where?: Where): Promise<number> {
-    return await this.todoListRepository.deleteAll(where);
-  }
-
   @get('/todo-lists/{id}')
   async findById(@param.path.number('id') id: number): Promise<TodoList> {
     return await this.todoListRepository.findById(id);

--- a/examples/todo-list/test/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list.acceptance.ts
@@ -72,14 +72,6 @@ describe('Application', () => {
         expect(todoList.color).to.eql(patchedColorTodo.color);
       }
     });
-
-    it('deletes all todoLists', async () => {
-      await client
-        .del('/todo-lists')
-        .send()
-        .expect(200);
-      expect(await todoListRepo.find()).to.be.empty();
-    });
   });
 
   context('when dealing with a single persisted todoList', () => {

--- a/examples/todo-list/test/unit/controllers/todo-list.controller.unit.ts
+++ b/examples/todo-list/test/unit/controllers/todo-list.controller.unit.ts
@@ -24,7 +24,6 @@ describe('TodoController', () => {
   let count: sinon.SinonStub;
   let find: sinon.SinonStub;
   let updateAll: sinon.SinonStub;
-  let deleteAll: sinon.SinonStub;
   let findById: sinon.SinonStub;
   let updateById: sinon.SinonStub;
   let deleteById: sinon.SinonStub;
@@ -86,14 +85,6 @@ describe('TodoController', () => {
       const where = {title: aTodoListWithId.title};
       expect(await controller.updateAll(aTodoListToPatchTo, where)).to.eql(1);
       sinon.assert.calledWith(updateAll, aTodoListToPatchTo, where);
-    });
-  });
-
-  describe('deleteAll()', () => {
-    it('successfully deletes existing items', async () => {
-      deleteAll.resolves(aListOfTodoLists.length);
-      expect(await controller.deleteAll()).to.eql(aListOfTodoLists.length);
-      sinon.assert.called(deleteAll);
     });
   });
 
@@ -160,7 +151,6 @@ describe('TodoController', () => {
     count = todoListRepo.count as sinon.SinonStub;
     find = todoListRepo.find as sinon.SinonStub;
     updateAll = todoListRepo.updateAll as sinon.SinonStub;
-    deleteAll = todoListRepo.deleteAll as sinon.SinonStub;
     findById = todoListRepo.findById as sinon.SinonStub;
     updateById = todoListRepo.updateById as sinon.SinonStub;
     deleteById = todoListRepo.deleteById as sinon.SinonStub;

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -41,11 +41,6 @@ export class <%= className %>Controller {
     return await this.<%= repositoryNameCamel %>.updateAll(obj, where);
   }
 
-  @del('<%= httpPathName %>')
-  async deleteAll(@param.query.string('where') where?: Where): Promise<number> {
-    return await this.<%= repositoryNameCamel %>.deleteAll(where);
-  }
-
   @get('<%= httpPathName %>/{id}')
   async findById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<<%= modelName %>> {
     return await this.<%= repositoryNameCamel %>.findById(id);

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -259,10 +259,6 @@ function checkRestCrudContents() {
   );
   assert.fileContent(
     expectedFile,
-    /\@del\('\/product-reviews'\)\s{1,}async deleteAll\(\@param.query.string\('where'\)/,
-  );
-  assert.fileContent(
-    expectedFile,
     /\@get\('\/product-reviews\/{id}'\)\s{1,}async findById\(\@param.path.number\('id'\)/,
   );
   assert.fileContent(
@@ -295,10 +291,6 @@ function checkRestPaths(restUrl) {
   assert.fileContent(
     expectedFile,
     new RegExp(/@patch\('/.source + restUrl + /'\)/.source),
-  );
-  assert.fileContent(
-    expectedFile,
-    new RegExp(/@del\('/.source + restUrl + /'\)/.source),
   );
   assert.fileContent(
     expectedFile,


### PR DESCRIPTION
The endpoint for deleting all model instances is dangerous - it makes it too easy to accidentally delete the entire table/collection. We have intentionally not exposed this endpoint by default in LoopBack 3.x.

This commits is removing deleteAll endpoint from the REST Controller template used by `lb4 controller` command.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
