### PR TITLE
feat: add two simple benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ api-docs
 **/*.tgz
 packages/*/dist*
 examples/*/dist*
+benchmark/dist*
 **/package
 .sandbox
 packages/cli/generators/datasource/connectors.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ packages/cli/generators/*/templates
 **/.sandbox
 packages/*/dist*
 examples/*/dist*
+benchmark/dist*
 sandbox/**/*
 *.json
 CHANGELOG.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "**/CVS": true,
     ".nyc_output": true,
     "coverage": true,
+    "benchmark/dist*": true,
     "packages/*/dist*": true,
     "packages/*/api-docs": true,
     "examples/*/dist*": true,

--- a/benchmark/.npmrc
+++ b/benchmark/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/benchmark/LICENSE
+++ b/benchmark/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Node module: @loopback/benchmark
+This project is licensed under the MIT License, full text below.
+
+--------
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,59 @@
+# benchmark
+
+Benchmarks for LoopBack framework.
+
+## Results
+
+MacBookPro Mid 2015 Processor: 2.5 GHz Intel Core i7 Memory: 16 GB 1600 MHz DDR3
+
+### Requests per seconds
+
+_Average number of requests handled every second._
+
+| scenario          |  rps |
+| ----------------- | ---: |
+| find all todos    | 4569 |
+| create a new todo |  348 |
+
+### Latency
+
+_Average time to handle a request in milliseconds._
+
+| scenario          | latency |
+| ----------------- | ------: |
+| find all todos    |    1.68 |
+| create a new todo |   28.27 |
+
+## Basic use
+
+Install all dependencies.
+
+```
+$ npm install
+```
+
+Run the tests to verify the benchmarked scenarios are working correctly.
+
+```
+$ npm test
+```
+
+Run the benchmark.
+
+```
+$ npm start
+```
+
+## Contributions
+
+- [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md)
+- [Join the team](https://github.com/strongloop/loopback-next/issues/110)
+
+## Contributors
+
+See
+[all contributors](https://github.com/strongloop/loopback-next/graphs/contributors).
+
+## License
+
+MIT

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const bench = require('@loopback/dist-util').loadDist(__dirname);
+
+module.exports = bench;
+
+if (require.main === module) {
+  bench.main().then(
+    success => process.exit(0),
+    err => {
+      console.error('Cannot run the benchmark.', err);
+      process.exit(1);
+    },
+  );
+}

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './src';

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@loopback/benchmark",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Benchmarks measuring performance of our framework.",
+  "keywords": [
+    "loopback",
+    "performance",
+    "benchmark"
+  ],
+  "main": "index.js",
+  "engines": {
+    "node": ">=8.9"
+  },
+  "scripts": {
+    "build:all-dist": "npm run build:dist8 && npm run build:dist10",
+    "build": "lb-tsc",
+    "build:dist8": "lb-tsc es2017",
+    "build:dist10": "lb-tsc es2018",
+    "clean": "lb-clean dist*",
+    "pretest": "npm run clean && npm run build",
+    "test": "lb-mocha \"DIST/test\"",
+    "prestart": "npm run build",
+    "start": "node .",
+    "prepublishOnly": "npm run test"
+  },
+  "repository": {
+    "type": "git"
+  },
+  "author": "",
+  "license": "MIT",
+  "files": [
+    "README.md",
+    "index.js",
+    "index.d.ts",
+    "dist*/src",
+    "dist*/index*",
+    "src"
+  ],
+  "dependencies": {
+    "@loopback/dist-util": "^0.3.6",
+    "@loopback/example-todo": "^0.15.0",
+    "@types/byline": "^4.2.31",
+    "@types/debug": "0.0.30",
+    "@types/p-event": "^1.3.0",
+    "@types/request-promise-native": "^1.0.15",
+    "autocannon": "^2.4.1",
+    "byline": "^5.0.0",
+    "debug": "^3.1.0",
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.5"
+  },
+  "devDependencies": {
+    "@loopback/build": "^0.6.14",
+    "@loopback/testlab": "^0.11.3",
+    "@types/mocha": "^5.0.0",
+    "@types/node": "^10.1.1",
+    "mocha": "^5.1.1",
+    "p-event": "^2.1.0",
+    "source-map-support": "^0.5.5"
+  }
+}

--- a/benchmark/src/autocannon.ts
+++ b/benchmark/src/autocannon.ts
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as assert from 'assert';
+import {promisify} from 'util';
+const autocannon = promisify(require('autocannon'));
+
+export interface EndpointStats {
+  requestsPerSecond: number;
+  latency: number;
+}
+
+export class Autocannon {
+  constructor(protected url: string, protected duration: number) {}
+
+  async execute(
+    title: string,
+    urlPath: string,
+    options?: object,
+  ): Promise<EndpointStats> {
+    const defaults = {
+      url: this.buildUrl(urlPath),
+      duration: this.duration,
+      title,
+    };
+    const config = Object.assign(defaults, options);
+    const data = await autocannon(config);
+    assert.equal(
+      data.non2xx,
+      0,
+      'No request should have failed with non-2xx status code.',
+    );
+    const stats: EndpointStats = {
+      requestsPerSecond: data.requests.average,
+      latency: data.latency.average,
+    };
+    return stats;
+  }
+
+  protected buildUrl(urlPath: string) {
+    return this.url + urlPath;
+  }
+}

--- a/benchmark/src/benchmark.ts
+++ b/benchmark/src/benchmark.ts
@@ -1,0 +1,121 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as byline from 'byline';
+import {ChildProcess, spawn} from 'child_process';
+import * as pEvent from 'p-event';
+import {Autocannon, EndpointStats} from './autocannon';
+import {Client} from './client';
+import {scenarios} from './scenarios';
+
+const debug = require('debug')('loopback:benchmark');
+
+export interface Scenario {
+  setup(client: Client): Promise<void>;
+  execute(autocannon: Autocannon): Promise<EndpointStats>;
+}
+
+export type ScenarioFactory = new () => Scenario;
+
+export interface Options {
+  /**
+   * How long to run the benchmark - time in seconds.
+   * Default: 30 seconds.
+   */
+  duration: number;
+}
+
+export interface Result {
+  [scenario: string]: EndpointStats;
+}
+
+export type AutocannonFactory = (url: string) => Autocannon;
+
+export class Benchmark {
+  private options: Options;
+  private worker: ChildProcess;
+  private url: string;
+
+  // Customization points
+  public cannonFactory: AutocannonFactory;
+  public logger: (title: string, stats: EndpointStats) => void;
+
+  constructor(options?: Partial<Options>) {
+    this.options = Object.assign(
+      {
+        duration: 30 /* seconds */,
+      },
+      options,
+    );
+    this.logger = function() {};
+    this.cannonFactory = url => new Autocannon(url, this.options.duration);
+  }
+
+  async run(): Promise<Result> {
+    const result: Result = {};
+    for (const name in scenarios) {
+      result[name] = await this.runScenario(name, scenarios[name]);
+    }
+    return result;
+  }
+
+  async runScenario(
+    name: string,
+    scenarioFactory: ScenarioFactory,
+  ): Promise<EndpointStats> {
+    debug('Starting scenario %j', name);
+    const {worker, url} = await startWorker();
+    debug('Worker started - pid=%s url=%s', worker.pid, url);
+
+    const client = new Client(url);
+    const autocannon = this.cannonFactory(url);
+
+    const runner = new scenarioFactory();
+    debug('Setting up the scenario');
+    await runner.setup(client);
+    debug('Pinging the app');
+    await client.ping();
+    debug('Starting the stress test.');
+    const result = await runner.execute(autocannon);
+    debug('Stats: %j', result);
+
+    closeWorker(worker);
+    debug('Worker stopped, done.');
+
+    this.logger(name, result);
+
+    return result;
+  }
+}
+
+function startWorker() {
+  return new Promise<{worker: ChildProcess; url: string}>((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--expose-gc', require.resolve('./worker')],
+      {
+        stdio: ['pipe', 'pipe', 'inherit'],
+      },
+    );
+
+    child.once('error', reject);
+    child.once('exit', (code, signal) =>
+      reject(new Error(`Child exited with code ${code} signal ${signal}`)),
+    );
+
+    const reader = byline.createStream(child.stdout);
+    reader.once('data', line => resolve({worker: child, url: line.toString()}));
+    reader.on('data', line => debug('[worker] %s', line.toString()));
+  });
+}
+
+async function closeWorker(worker: ChildProcess) {
+  worker.kill();
+  await pEvent(worker, 'close');
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/benchmark/src/client.ts
+++ b/benchmark/src/client.ts
@@ -1,0 +1,22 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as request from 'request-promise-native';
+import {Todo} from '@loopback/example-todo';
+
+export class Client {
+  constructor(private url: string) {}
+
+  createTodo(data: Partial<Todo>) {
+    return request.post(`${this.url}/todos`, {
+      json: true,
+      body: data,
+    });
+  }
+
+  ping() {
+    return request.get(`${this.url}/todos`);
+  }
+}

--- a/benchmark/src/index.ts
+++ b/benchmark/src/index.ts
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Benchmark, Options} from './benchmark';
+
+export {Benchmark, Options};
+
+export async function main() {
+  const duration = process.env.DURATION || '30';
+  const options: Options = {
+    duration: +duration,
+  };
+  const bench = new Benchmark(options);
+  bench.logger = (title, stats) => console.log('%s:', title, stats);
+  await bench.run();
+}

--- a/benchmark/src/scenarios/create-todo.scenario.ts
+++ b/benchmark/src/scenarios/create-todo.scenario.ts
@@ -1,0 +1,24 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Autocannon, EndpointStats} from '../autocannon';
+import {Scenario} from '../benchmark';
+import {Client} from '../client';
+
+export class CreateTodo implements Scenario {
+  async setup(client: Client) {
+    // no-op
+  }
+
+  execute(autocannon: Autocannon): Promise<EndpointStats> {
+    return autocannon.execute('createTodo', '/todos', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: 'Finish this',
+        desc: 'Finish running this benchmark.',
+      }),
+    });
+  }
+}

--- a/benchmark/src/scenarios/find-todos.scenario.ts
+++ b/benchmark/src/scenarios/find-todos.scenario.ts
@@ -1,0 +1,23 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Autocannon, EndpointStats} from '../autocannon';
+import {Scenario} from '../benchmark';
+import {Client} from '../client';
+
+export class FindTodos implements Scenario {
+  async setup(client: Client) {
+    await client.createTodo({
+      title: 'first item',
+      desc: 'Do something first',
+    });
+
+    await client.createTodo({title: 'Second item'});
+  }
+
+  execute(autocannon: Autocannon): Promise<EndpointStats> {
+    return autocannon.execute('findTodos', '/todos');
+  }
+}

--- a/benchmark/src/scenarios/index.ts
+++ b/benchmark/src/scenarios/index.ts
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ScenarioFactory} from '../benchmark';
+import {CreateTodo} from './create-todo.scenario';
+import {FindTodos} from './find-todos.scenario';
+
+export interface ScenarioMap {
+  [name: string]: ScenarioFactory;
+}
+
+export const scenarios: ScenarioMap = {
+  'find all todos': FindTodos,
+  // IMPORTANT NOTE(bajtos) the find scenario must run before create.
+  // Otherwise weird data is reported. I was not able to find the cause.
+  'create a new todo': CreateTodo,
+};

--- a/benchmark/src/worker.ts
+++ b/benchmark/src/worker.ts
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  TodoListApplication,
+  TodoRepository,
+  Route,
+} from '@loopback/example-todo';
+
+async function main() {
+  const app = new TodoListApplication({
+    rest: {
+      host: '127.0.0.1',
+      port: 0,
+    },
+  });
+
+  await app.boot();
+
+  // use in-memory storage without filesystem persistence
+  app.bind('datasources.config.db').to({connector: 'memory'});
+
+  await app.start();
+
+  // Tell the master thread what is our URL
+  console.log(app.restServer.url);
+}
+
+main().catch(err => {
+  console.log(err);
+  process.exit(1);
+});

--- a/benchmark/test/benchmark.integration.ts
+++ b/benchmark/test/benchmark.integration.ts
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import * as request from 'request-promise-native';
+import {Benchmark} from '..';
+import {Autocannon, EndpointStats} from '../src/autocannon';
+
+const debug = require('debug')('test');
+
+const DUMMY_STATS: EndpointStats = {
+  latency: 1,
+  requestsPerSecond: 1000,
+};
+
+describe('Benchmark (SLOW)', function() {
+  // Unfortunately, the todo app requires one second to start
+  // tslint:disable-next-line:no-invalid-this
+  this.timeout(5000);
+  it('works', async () => {
+    const bench = new Benchmark();
+    bench.cannonFactory = url => new AutocannonStub(url);
+    const result = await bench.run();
+    expect(result).to.eql({
+      'find all todos': DUMMY_STATS,
+      'create a new todo': DUMMY_STATS,
+    });
+  });
+
+  class AutocannonStub extends Autocannon {
+    constructor(url: string) {
+      super(url, 1 /* duration does not matter */);
+    }
+
+    async execute(
+      title: string,
+      urlPath: string,
+      // tslint:disable-next-line:no-any
+      options?: any,
+    ): Promise<EndpointStats> {
+      if (!options) options = {};
+
+      const requestOptions: request.OptionsWithUrl = {
+        url: this.buildUrl(urlPath),
+        method: options.method || 'GET',
+        body: options.body,
+      };
+
+      debug(
+        'Making a dummy autocannon request %s %s',
+        requestOptions.method,
+        requestOptions.url,
+      );
+
+      // Verify that the server is implementing the requested URL
+      await request(requestOptions);
+
+      return DUMMY_STATS;
+    }
+  }
+});

--- a/benchmark/test/mocha.opts
+++ b/benchmark/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--require source-map-support/register

--- a/benchmark/tsconfig.build.json
+++ b/benchmark/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../packages/build/config/tsconfig.common.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["index.ts", "src", "test"]
+}

--- a/examples/todo/src/index.ts
+++ b/examples/todo/src/index.ts
@@ -15,3 +15,10 @@ export async function main(options?: ApplicationConfig) {
   console.log(`Server is running at ${url}`);
   return app;
 }
+
+// re-exports for our benchmark, not needed for the tutorial itself
+export {TodoListApplication};
+
+export * from './models';
+export * from './repositories';
+export * from '@loopback/rest';

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,12 @@
 {
   "lerna": "2.9.1",
-  "packages": ["packages/*", "examples/*", "docs", "sandbox/*"],
+  "packages": [
+    "benchmark",
+    "docs",
+    "examples/*",
+    "packages/*",
+    "sandbox/*"
+  ],
   "command": {
     "publish": {
       "forcePublish": "@loopback/cli,@loopback/docs",


### PR DESCRIPTION
Add two simple benchmarks to measure how fast we can fetch data (`repository#find`) and create new records (`repository#create`).

See #534

**An important discussion point: Should we check that the benchmark keeps working as part of our test suite?**

Autocannon, the library I use for hammering the app with client requests, does not support runs shorter than one second. Together with the worker-process setup, the minimum benchmark run is about five seconds.

I feel adding five seconds to our already long-running test suite may be too much.

On the other hand, if we don't run these test frequently, then we may end up with benchmarking code that no longer works.

Thoughts?

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

## Results

MacBookPro Mid 2015 Processor: 2.5 GHz Intel Core i7 Memory: 16 GB 1600 MHz DDR3

### Requests per seconds

_Average number of requests handled every second._

| scenario          |  rps |
| ----------------- | ---: |
| find all todos    | 4569 |
| create a new todo |  348 |

### Latency

_Average time to handle a request in milliseconds._

| scenario          | latency |
| ----------------- | ------: |
| find all todos    |    1.68 |
| create a new todo |   28.27 |
