### PR TITLE
docs: fix info style

### DIFF
--- a/docs/site/Application.md
+++ b/docs/site/Application.md
@@ -173,7 +173,8 @@ It will automatically create bindings for these configurations and later be
 injected through dependency injections. Visit
 [Dependency Injection](Dependency-injection.md) for more details.
 
-{% include note.html content=" Binding configuration such as component binding,
+{% include note.html content="
+Binding configuration such as component binding,
 provider binding, or binding scopes are not possible with the constructor-based
 configuration approach.
 " %}

--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -259,10 +259,10 @@ runtime even if you do not know the value when writing up the Controller. The
 above will print `Hello John` at run time.
 
 {% include note.html content="
-  `@inject` decorator is not able to leverage the value-type information
-  associated with a binding key yet, therefore the TypeScript compiler will not
-  check that the injection target (e.g. a constructor argument) was declared
-  with a type that the bound value can be assigned to.
+`@inject` decorator is not able to leverage the value-type information
+associated with a binding key yet, therefore the TypeScript compiler will not
+check that the injection target (e.g. a constructor argument) was declared
+with a type that the bound value can be assigned to.
 " %}
 
 Please refer to [Dependency injection](Dependency-injection.md) for further

--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -108,8 +108,8 @@ class MyController {
 }
 ```
 
-{% include note.html title="A note on binding names" content="To avoid name
-conflicts, add a unique prefix to your binding key (for example, `my-component.`
+{% include note.html title="A note on binding names" content="
+To avoid name conflicts, add a unique prefix to your binding key (for example, `my-component.`
 in the example above). See [Reserved binding keys](Reserved-binding-keys.md) for
 the list of keys reserved for the framework use.
 " %}

--- a/docs/site/Defining-the-API-using-code-first-approach.md
+++ b/docs/site/Defining-the-API-using-code-first-approach.md
@@ -44,8 +44,8 @@ layer and the datasource layer. Since your API is going to be built around the
 manipulation of models and their properties, they will be the first to be
 defined.
 
-{% include note.html content=" `Todo` model from
-[tutorial](https://github.com/strongloop/loopback-next/blob/master/docs/site/todo-tutorial-model.md#srcmodelstodomodelts)
+{% include note.html content="
+`Todo` model from [tutorial](https://github.com/strongloop/loopback-next/blob/master/docs/site/todo-tutorial-model.md#srcmodelstodomodelts)
 is used for demonstration here.
 " %}
 
@@ -98,8 +98,8 @@ export class Todo {
 
 ### Define your routes
 
-{% include note.html content=" `TodoController` from
-[tutorial](https://github.com/strongloop/loopback-next/blob/master/docs/site/todo-tutorial-controller.md#srccontrollerstodocontrollerts-2)
+{% include note.html content="
+`TodoController` from [tutorial](https://github.com/strongloop/loopback-next/blob/master/docs/site/todo-tutorial-controller.md#srccontrollerstodocontrollerts-2)
 is used for demonstration here.
 " %}
 

--- a/docs/site/Defining-the-API-using-design-first-approach.shelved.md
+++ b/docs/site/Defining-the-API-using-design-first-approach.shelved.md
@@ -429,9 +429,9 @@ See
 [Validate your OpenAPI specification](Testing-your-application.md#validate-your-openapi-specification)
 from [Testing your application](Testing-your-application.md) for more details.
 
-{% include note.html content=" If you would like to make tweaks to your API as
-you develop your application, refer to
-[Defining the API using code-first approach](Defining-the-API-using-code-first-approach.md)
+{% include note.html content="
+If you would like to make tweaks to your API as you develop your application,
+refer to [Defining the API using code-first approach](Defining-the-API-using-code-first-approach.md)
 page for best practices.
 " %}
 

--- a/docs/site/Parsing-requests.md
+++ b/docs/site/Parsing-requests.md
@@ -43,11 +43,12 @@ and raw data is parsed from request according to the specification. In the
 example above, the first parameter is from source `path`, so its value will be
 parsed from a request's path.
 
-{% include note.html title="Controller documentation" content="See [controller](Controller.md) for more details of defining an endpoint.
+{% include note.html title="Controller documentation" content="
+See [controller](Controller.md) for more details of defining an endpoint.
 " %}
 
-{% include note.html title="OpenAPI operation object" content="See
-[OpenAPI operation object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject)
+{% include note.html title="OpenAPI operation object" content="
+See [OpenAPI operation object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject)
 to know more about its structure.
 " %}
 
@@ -135,7 +136,8 @@ The request body specification is defined by applying `@requestBody()` to
 argument `todo`, and the schema specification inside it is inferred from its
 type `Todo`. The type is exported from a `Todo` model.
 
-{% include note.html title="Model documentation" content="See [model](Model.md) to know more details about how to decorate a model class.
+{% include note.html title="Model documentation" content="
+See [model](Model.md) to know more details about how to decorate a model class.
 " %}
 
 When the `PUT` method on the `/todo/{id}` gets called, the `todo` instance from

--- a/docs/site/Preparing-the-API-for-consumption.shelved.md
+++ b/docs/site/Preparing-the-API-for-consumption.shelved.md
@@ -31,7 +31,8 @@ npm start
 Open <http://localhost:3000/swagger-ui> to see the API endpoints defined by
 `swagger.json`.
 
-{% include note.html content=" Swagger UI provides users with interactive
+{% include note.html content="
+Swagger UI provides users with interactive
 environment to test the API endpoints defined by the raw spec found at
 <http://localhost:3000/openapi.json>. The API spec is also available in YAML
 flavour at <http://localhost:3000/openapi.yaml>

--- a/docs/site/Reserved-binding-keys.md
+++ b/docs/site/Reserved-binding-keys.md
@@ -30,11 +30,11 @@ app.bind(BindKeyNameSpace.KeyName).to('value');
 Following is a list of links to the apidocs on the binding keys in use by
 various `@loopback` packages:
 
-{% include note.html title="Declaring new binding keys" content="For component
-developers creating a new Binding, to avoid conflict with other packages, it is
-recommended that the binding key start with the package name as the prefix.
-Example: `@loopback/authentication` component uses the prefix `authentication`
-for its binding keys.
+{% include note.html title="Declaring new binding keys" content="
+For component developers creating a new Binding, to avoid conflict with other
+packages, it is recommended that the binding key start with the package name as
+the prefix. Example: `@loopback/authentication` component uses the prefix
+`authentication` for its binding keys.
 " %}
 
 - [AuthenticationBindings](http://apidocs.loopback.io/@loopback%2fdocs/authentication.html#AuthenticationBindings)

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -307,7 +307,8 @@ There are three kinds of test doubles provided by Sinon.JS:
   stubs) as well as pre-programmed expectations. A mock will fail your test if
   it is not used as expected.
 
-{% include note.html content=" We recommend against using test mocks. With test
+{% include note.html content="
+We recommend against using test mocks. With test
 mocks, the expectations must be defined before the tested scenario is executed,
 which breaks the recommended test layout 'arrange-act-assert' (or
 'given-when-then') and also produces code that's difficult to comprehend.


### PR DESCRIPTION
Fixes how this page is rendered on the docs: https://loopback.io/doc/en/lb4/Parsing-requests.html

Tested in Chrome. Verified all pages I changed to make sure none others broke (after making the usage consistent).

Before: 
![image](https://user-images.githubusercontent.com/3311536/43529545-88be08f8-9579-11e8-9abb-afa7173bfa12.png)

After:
![image](https://user-images.githubusercontent.com/3311536/43529858-332fc5a6-957a-11e8-90a1-20a6e80bf5e0.png)

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
