### PR TITLE
fix(cli): install dependencies for cloned examples

### DIFF
--- a/docs/site/Download-examples.md
+++ b/docs/site/Download-examples.md
@@ -36,6 +36,6 @@ The tool will prompt you for:
 
 ### Output
 
-The example project is downloaded to a new directory. For example, when
-downloading `todo` example, the tool stores the files under the newly created
-`loopback4-example-todo` directory.
+The example project is downloaded to a new directory and its dependencies are
+installed. For example, when downloading `todo` example, the tool stores the
+files under the newly created `loopback4-example-todo` directory.

--- a/docs/site/Preparing-the-API-for-consumption.shelved.md
+++ b/docs/site/Preparing-the-API-for-consumption.shelved.md
@@ -24,7 +24,6 @@ application:
 ```sh
 lb4 example todo
 cd loopback4-example-todo
-npm i
 npm start
 ```
 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -35,10 +35,10 @@ npm i -g @loopback/cli
 lb4 example hello-world
 ```
 
-3.  Switch to the directory and install dependencies.
+3.  Switch to the directory.
 
 ```sh
-cd loopback4-example-hello-world && npm i
+cd loopback4-example-hello-world
 ```
 
 ## Use

--- a/examples/log-extension/README.md
+++ b/examples/log-extension/README.md
@@ -63,7 +63,7 @@ You can obtain a local clone of this project (without the rest of our monorepo)
 using the following command:
 
 ```sh
-lb4 example todo
+lb4 example log-extension
 ```
 
 ## Tutorial

--- a/examples/rpc-server/README.md
+++ b/examples/rpc-server/README.md
@@ -19,10 +19,10 @@ npm i -g @loopback/cli
 lb4 example rpc-server
 ```
 
-3.  Switch to the directory and install dependencies.
+3.  Switch to the directory.
 
 ```sh
-cd loopback-example-rpc-server && npm i
+cd loopback-example-rpc-server
 ```
 
 4.  Start the app!

--- a/examples/todo-list/README.md
+++ b/examples/todo-list/README.md
@@ -69,10 +69,10 @@ application, follow these steps:
       rpc-server: A basic RPC server using a made-up protocol.
     ```
 
-2.  Jump into the directory and then install the required dependencies:
+2.  Switch to the directory.
 
     ```sh
-    cd loopback4-example-todo-list && npm i
+    cd loopback4-example-todo-list
     ```
 
 3.  Finally, start the application!

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -62,10 +62,10 @@ application, follow these steps:
     rpc-server: A basic RPC server using a made-up protocol.
     ```
 
-2.  Jump into the directory and then install the required dependencies:
+2.  Switch to the directory.
 
     ```sh
-    cd loopback4-example-todo && npm i
+    cd loopback4-example-todo
     ```
 
 3.  Finally, start the application!

--- a/packages/cli/generators/example/index.js
+++ b/packages/cli/generators/example/index.js
@@ -93,6 +93,12 @@ module.exports = class extends BaseGenerator {
     this.outDir = path.relative(cwd, absOutDir);
   }
 
+  install() {
+    if (this.shouldExit()) return false;
+    this.destinationRoot(this.outDir);
+    return super.install();
+  }
+
   end() {
     if (!super.end()) return false;
     this.log();

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -258,6 +258,18 @@ module.exports = class BaseGenerator extends Generator {
   }
 
   /**
+   * Run `npm install` in the project
+   */
+  install() {
+    if (this.shouldExit()) return false;
+    const opts = this.options.npmInstall || {};
+    const spawnOpts = Object.assign({}, this.options.spawn, {
+      cwd: this.destinationRoot(),
+    });
+    this.npmInstall(null, opts, spawnOpts);
+  }
+
+  /**
    * Checks if current directory is a LoopBack project by checking for
    * keyword 'loopback' under 'keywords' attribute in package.json.
    * 'keywords' is an array

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -246,13 +246,4 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       this.fs.delete(this.destinationPath('.vscode'));
     }
   }
-
-  install() {
-    if (this.shouldExit()) return false;
-    const opts = this.options.npmInstall || {};
-    const spawnOpts = Object.assign({}, this.options.spawn, {
-      cwd: this.destinationRoot(),
-    });
-    this.npmInstall(null, opts, spawnOpts);
-  }
 };

--- a/packages/cli/test/integration/generators/example.integration.js
+++ b/packages/cli/test/integration/generators/example.integration.js
@@ -49,7 +49,7 @@ describe('lb4 example', function() {
       .executeGenerator(generator)
       .withPrompts({name: VALID_EXAMPLE})
       .then(() => {
-        const targetPkgFile = `loopback4-example-${VALID_EXAMPLE}/package.json`;
+        const targetPkgFile = 'package.json';
         const originalPkgMeta = require(`../../../../../examples/${VALID_EXAMPLE}/package.json`);
         assert.file(targetPkgFile);
         assert.jsonFileContent(targetPkgFile, {
@@ -64,7 +64,7 @@ describe('lb4 example', function() {
       .executeGenerator(generator)
       .withArguments([VALID_EXAMPLE])
       .then(() => {
-        const targetPkgFile = `loopback4-example-${VALID_EXAMPLE}/package.json`;
+        const targetPkgFile = 'package.json';
         const originalPkgMeta = require(`../../../../../examples/${VALID_EXAMPLE}/package.json`);
         assert.file(targetPkgFile);
         assert.jsonFileContent(targetPkgFile, {


### PR DESCRIPTION
fixes #1555 

Output for `lb4 example todo` now:

```
? What example would you like to clone? todo

> sinon@4.5.0 postinstall /Users/taranveer/LoopBack/loopback4-example-todo/node_modules/sinon
> node scripts/support-sinon.js

Have some ❤️ for Sinon? You can support the project via Open Collective:
 > https://opencollective.com/sinon/donate

npm notice created a lockfile as package-lock.json. You should commit this file.
added 752 packages from 1412 contributors and audited 4565 packages in 12.455s
found 0 vulnerabilities


The example was cloned to loopback4-example-todo.
```

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
