### PR TITLE
chore(build): make sure prettier@^1.14.0 is used

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,7 @@
     "glob": "^7.1.2",
     "mocha": "^5.1.1",
     "nyc": "^11.7.1",
-    "prettier": "^1.13.3",
+    "prettier": "^1.14.0",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.5",
     "strong-docs": "^3.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,7 +80,7 @@
       "fs-extra": "^6.0.1",
       "mocha": "^5.1.1",
       "nyc": "^11.7.1",
-      "prettier": "^1.13.3",
+      "prettier": "^1.14.0",
       "rimraf": "^2.6.2",
       "source-map-support": "^0.5.5",
       "strong-docs": "^3.2.0",


### PR DESCRIPTION
Some of the code formatting depends on `prettier@^1.14.0`.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
