### PR TITLE
test(example-soap-calculator): remove givenDataSource from test

### DIFF
--- a/examples/soap-calculator/README.md
+++ b/examples/soap-calculator/README.md
@@ -14,7 +14,7 @@ tests are provided.
 
 You'll need to make sure you have some things installed:
 
-- [Node.js](https://nodejs.org/en/) at v8.x or greater
+- [Node.js](https://nodejs.org/en/) at v8.9 or greater
 
 Lastly, you'll need to install the LoopBack 4 CLI toolkit:
 

--- a/examples/soap-calculator/test/acceptance/application.acceptance.ts
+++ b/examples/soap-calculator/test/acceptance/application.acceptance.ts
@@ -1,17 +1,15 @@
 import {supertest} from '@loopback/testlab';
 import {SoapCalculatorApplication} from '../../src/application';
 import {expect} from '@loopback/testlab';
-import {givenAConnectedDataSource} from '../helpers';
 
 describe('Application', function() {
   let app: SoapCalculatorApplication;
   let client: supertest.SuperTest<supertest.Test>;
 
   // tslint:disable-next-line:no-invalid-this
-  this.timeout(5000);
+  this.timeout(10000);
 
   before(givenAnApplication);
-  before(givenAConnectedDataSource);
 
   before(async () => {
     await app.boot();


### PR DESCRIPTION
remove the call to givenDataSource since it is not needed as the datasource booter takes care of it
 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
