### PR TITLE
feat(cli): add repositorymixin and imports by a new switch

### DIFF
--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -11,6 +11,7 @@ module.exports = class AppGenerator extends ProjectGenerator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);
+    this.buildOptions.push('enableRepository');
   }
 
   _setupGenerator() {
@@ -19,6 +20,11 @@ module.exports = class AppGenerator extends ProjectGenerator {
     this.option('applicationName', {
       type: String,
       description: 'Application class name',
+    });
+
+    this.option('enableRepository', {
+      type: Boolean,
+      description: 'Include repository imports and RepositoryMixin',
     });
 
     return super._setupGenerator();

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -5,9 +5,22 @@ import {MySequence} from './sequence';
 /* tslint:disable:no-unused-variable */
 // Binding and Booter imports are required to infer types for BootMixin!
 import {BootMixin, Booter, Binding} from '@loopback/boot';
+<% if (project.enableRepository) { -%>
+
+// juggler imports are required to infer types for RepositoryMixin!
+import {
+  Class,
+  Repository,
+  RepositoryMixin,
+  juggler,
+} from '@loopback/repository';
+<% } -%>
 /* tslint:enable:no-unused-variable */
 
-export class <%= project.applicationName %> extends BootMixin(RestApplication) {
+export class <%= project.applicationName %> <% if (!project.enableRepository) {-%>extends BootMixin(RestApplication) {<% } else { -%>extends BootMixin(
+  RepositoryMixin(RestApplication),
+) {
+<% } -%>
   constructor(options?: ApplicationConfig) {
     super(options);
 

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -31,7 +31,11 @@ describe('app-generator specific files', () => {
     assert.file('src/application.ts');
     assert.fileContent(
       'src/application.ts',
-      /class MyAppApplication extends BootMixin\(RestApplication/,
+      /class MyAppApplication extends BootMixin\(/,
+    );
+    assert.fileContent(
+      'src/application.ts',
+      /RepositoryMixin\(RestApplication\)/,
     );
     assert.fileContent('src/application.ts', /constructor\(/);
     assert.fileContent('src/application.ts', /this.projectRoot = __dirname/);
@@ -67,9 +71,13 @@ describe('app-generator with --applicationName', () => {
   });
   it('generates all the proper files', () => {
     assert.file('src/application.ts');
+    assert.fileContent('src/application.ts', /class MyApp extends BootMixin\(/);
+  });
+  it('generates the application with RepositoryMixin', () => {
+    assert.file('src/application.ts');
     assert.fileContent(
       'src/application.ts',
-      /class MyApp extends BootMixin\(RestApplication/,
+      /RepositoryMixin\(RestApplication\)/,
     );
   });
 });
@@ -96,9 +104,13 @@ function testFormat() {
   });
   it('generates all the proper files', () => {
     assert.file('src/application.ts');
+    assert.fileContent('src/application.ts', /class MyApp extends BootMixin\(/);
+  });
+  it('generates the application with RepositoryMixin', () => {
+    assert.file('src/application.ts');
     assert.fileContent(
       'src/application.ts',
-      /class MyApp extends BootMixin\(RestApplication/,
+      /RepositoryMixin\(RestApplication\)/,
     );
   });
 }


### PR DESCRIPTION
add the switch --enableRepository to CLI to automatically add the juggler imports and include
RepositoryMixin in the extended class

Fixes #1594

I tried to follow the pattern in applicationName and loopbackBuild in the switch name and followed @raymondfeng suggested switch name (--enable-repository). Please review and let me know if it makes sense. This is a minor change but really useful when creating the application.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
