### PR TITLE
fix(rest): pass a better detailed error message into the response body

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -41,6 +41,7 @@
     "lodash": "^4.17.5",
     "openapi-schema-to-json-schema": "^2.1.0",
     "path-to-regexp": "^2.2.0",
+    "strong-error-handler": "^3.2.0",
     "validator": "^10.4.0"
   },
   "devDependencies": {

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -24,6 +24,7 @@ import {
 
 import {HttpProtocol} from '@loopback/http-server';
 import * as https from 'https';
+import {ErrorWriterOptions} from 'strong-error-handler';
 
 /**
  * RestServer-specific bindings
@@ -59,6 +60,13 @@ export namespace RestBindings {
    * Internal binding key for http-handler
    */
   export const HANDLER = BindingKey.create<HttpHandler>('rest.handler');
+  /**
+   * Binding key for setting and injecting Reject action's error handling
+   * options
+   */
+  export const ERROR_WRITER_OPTIONS = BindingKey.create<ErrorWriterOptions>(
+    'rest.errorWriterOptions',
+  );
 
   /**
    * Binding key for setting and injecting an OpenAPI spec

--- a/packages/rest/src/writer.ts
+++ b/packages/rest/src/writer.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {OperationRetval, Response} from './types';
-import {HttpError} from 'http-errors';
 import {Readable} from 'stream';
 
 /**
@@ -49,41 +48,5 @@ export function writeResultToResponse(
     }
     response.write(result);
   }
-  response.end();
-}
-
-/**
- * Write an error into the HTTP response
- * @param response HTTP response
- * @param error Error
- */
-export function writeErrorToResponse(response: Response, error: Error) {
-  const e = <HttpError>error;
-  const statusCode = (response.statusCode = e.statusCode || e.status || 500);
-  if (e.headers) {
-    // Set response headers for the error
-    for (const h in e.headers) {
-      response.setHeader(h, e.headers[h]);
-    }
-  }
-  // Build an error object
-  const errObj: Partial<HttpError> = {
-    statusCode,
-  };
-  if (e.expose) {
-    // Expose other properties if the `expose` flag is set to `true`
-    for (const p in e) {
-      if (
-        p === 'headers' ||
-        p === 'expose' ||
-        p === 'status' ||
-        p === 'statusCode'
-      )
-        continue;
-      errObj[p] = e[p];
-    }
-  }
-  response.setHeader('Content-Type', 'application/json');
-  response.write(JSON.stringify(errObj));
   response.end();
 }


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

This PR configures `writer.ts` to use `strong-error-handler` to transform the thrown error.
Please take a look at the modified test cases to see what the response body would now look like.

- fixes #1434 
- depends on https://github.com/strongloop/strong-error-handler/pull/77

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated