### PR TITLE
feat(rest): allow static assets to be served by a rest server

### DIFF
--- a/docs/site/Application.md
+++ b/docs/site/Application.md
@@ -206,10 +206,39 @@ This means you can call these `RestServer` functions to do all of your
 server-level setups in the app constructor without having to explicitly retrieve
 an instance of your server.
 
+### Serve static files
+
+The `RestServer` allows static files to be served. It can be set up by calling
+the `static()` API.
+
+```ts
+app.static('/html', rootDirForHtml);
+```
+
+or
+
+```ts
+server.static(['/html', '/public'], rootDirForHtml);
+```
+
+Static assets are not allowed to be mounted on `/` to avoid performance penalty
+as `/` matches all paths and incurs file system access for each HTTP request.
+
+The static() API delegates to
+[serve-static](https://expressjs.com/en/resources/middleware/serve-static.html)
+to serve static files. Please see
+https://expressjs.com/en/starter/static-files.html and
+https://expressjs.com/en/4x/api.html#express.static for details.
+
+**WARNING**:
+
+> The static assets are served before LoopBack sequence of actions. If an error
+> is thrown, the `reject` action will NOT be triggered.
+
 ### Use unique bindings
 
 Use binding names that are prefixed with a unique string that does not overlap
-with loopback's bindings. As an example, if your application is built for your
+with LoopBack's bindings. As an example, if your application is built for your
 employer FooCorp, you can prefix your bindings with `fooCorp`.
 
 ```ts

--- a/docs/site/Defining-the-API-using-code-first-approach.md
+++ b/docs/site/Defining-the-API-using-code-first-approach.md
@@ -21,7 +21,7 @@ There are various tools available to LoopBack which allows this bottom-up
 approach of building your application to be simple through the usages of
 metadata and decorators.
 
-### Start with LoopBack artfiacts
+### Start with LoopBack artifacts
 
 With TypeScript's
 [experimental decorator](https://www.typescriptlang.org/docs/handbook/decorators.html)

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -299,7 +299,7 @@ We can now access key-value stores such as [Redis](https://redis.io/) using the
 ### Define a KeyValue Datasource
 
 We first need to define a datasource to configure the key-value store. For
-better flexibility, we spilt the datasource definition into two files. The json
+better flexibility, we split the datasource definition into two files. The json
 file captures the configuration properties and it can be possibly overridden by
 dependency injection.
 

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -16,6 +16,8 @@ import {
   ControllerFactory,
 } from './router/routing-table';
 import {OperationObject, OpenApiSpec} from '@loopback/openapi-v3-types';
+import {ServeStaticOptions} from 'serve-static';
+import {PathParams} from 'express-serve-static-core';
 
 export const ERR_NO_MULTI_SERVER = format(
   'RestApplication does not support multiple servers!',
@@ -81,6 +83,19 @@ export class RestApplication extends Application implements HttpServerLike {
 
   handler(handlerFn: SequenceFunction) {
     this.restServer.handler(handlerFn);
+  }
+
+  /**
+   * Mount static assets to the REST server.
+   * See https://expressjs.com/en/4x/api.html#express.static
+   * @param path The path(s) to serve the asset.
+   * See examples at https://expressjs.com/en/4x/api.html#path-examples
+   * To avoid performance penalty, `/` is not allowed for now.
+   * @param rootDir The root directory from which to serve static assets
+   * @param options Options for serve-static
+   */
+  static(path: PathParams, rootDir: string, options?: ServeStaticOptions) {
+    this.restServer.static(path, rootDir, options);
   }
 
   /**

--- a/packages/rest/test/integration/fixtures/index.html
+++ b/packages/rest/test/integration/fixtures/index.html
@@ -1,0 +1,8 @@
+<html>
+  <header>
+    <title>Test Page</title>
+  </header>
+  <body>
+    <h1>Hello, World!</h1>
+  </body>
+</html>


### PR DESCRIPTION
This PR allows static assets to be served from a REST server by calling `static()`.

## Missing tests identified by @bajtos

- [ ] What happens when there is both a LB4 route (e.g. a controller method) and a static file mapped at the same URL.
- [x] New static assets can be registered after the app was started.
- ~~When a file cannot be read (e.g. because of permission problems), the error response is sent by the Sequence (as provided/customized by the app).~~

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated