### PR TITLE
fix(cli): add esnext.asynciterable to lib for typescript

### DIFF
--- a/packages/cli/generators/project/templates/tsconfig.json.ejs
+++ b/packages/cli/generators/project/templates/tsconfig.json.ejs
@@ -9,7 +9,7 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
 
-    "lib": ["es2018", "dom"],
+    "lib": ["es2018", "dom", "esnext.asynciterable"],
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2017",


### PR DESCRIPTION
This fixes the build error for generated LB4 project without `loopbackBuild` selected:

```
> tsc --outDir dist --target es2017

node_modules/@loopback/repository/dist8/src/repositories/kv.repository.bridge.d.ts(29,55): error TS2304: Cannot find name 'AsyncIterable'.
node_modules/@loopback/repository/dist8/src/repositories/kv.repository.d.ts(72,56): error TS2304: Cannot find name 'AsyncIterable'.
```

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
