### PR TITLE
feat: default 404 for delete request to non-existent resource

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -147,6 +147,14 @@ class MyFlexibleModel extends Entity {
 }
 ```
 
+The default response for a delete request to a non-existent resource is a `404`.
+You can change this behavior to `200` by setting `strictDelete` to `false`.
+
+```ts
+@model({settings: {strictDelete: false}})
+class Todo extends Entity { ... }
+```
+
 ### Model Decorator
 
 The model decorator can be used without any additional parameters, or can be

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -125,7 +125,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
     this.modelClass = dataSource.createModel<juggler.PersistedModelClass>(
       definition.name,
       properties,
-      Object.assign({strict: true}, definition.settings),
+      Object.assign({strict: true, strictDelete: true}, definition.settings),
     );
     this.modelClass.attachTo(dataSource);
   }

--- a/packages/repository/test/acceptance/repository.acceptance.ts
+++ b/packages/repository/test/acceptance/repository.acceptance.ts
@@ -71,6 +71,36 @@ describe('Repository in Thinking in LoopBack', () => {
     expect(stored).to.containDeep({extra: 'additional data'});
   });
 
+  it('enables strict delete by default', async () => {
+    await repo.create({slug: 'pencil'});
+    await expect(repo.deleteById(10000)).to.be.rejectedWith(
+      /No instance with id/,
+    );
+  });
+
+  it('disables strict delete via configuration', async () => {
+    @model({settings: {strictDelete: false}})
+    class Pencil extends Entity {
+      @property({id: true})
+      id: number;
+      @property({type: 'string'})
+      name: string;
+    }
+
+    const pencilRepo = new DefaultCrudRepository<
+      Pencil,
+      typeof Pencil.prototype.id
+    >(Pencil, new DataSource({connector: 'memory'}));
+
+    await pencilRepo.create({
+      name: 'Green Pencil',
+    });
+
+    // When `strictDelete` is set to `false`, `deleteById()` on a non-existing
+    // resource is resolved with `false`, instead of being rejected.
+    await expect(pencilRepo.deleteById(10000)).to.be.fulfilledWith(false);
+  });
+
   function givenProductRepository() {
     const db = new DataSource({
       connector: 'memory',


### PR DESCRIPTION
Send 404 for delete requests to non-existent resource by default. Addresses issues like #1472

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
