### PR TITLE
fix(cli): tweaks to templates

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -17,7 +17,7 @@
     "clean": "lb-clean *example-hello-world*.tgz dist* package api-docs",
     "verify": "npm pack && tar xf *example-hello-world*.tgz && tree package && npm run clean",
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -15,7 +15,7 @@
     "build:watch": "lb-tsc --watch",
     "clean": "lb-clean *example-log-extension-*.tgz dist* package api-docs",
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -18,7 +18,7 @@
     "build:watch": "lb-tsc --watch",
     "clean": "lb-clean dist*",
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -22,7 +22,7 @@
     "build:watch": "lb-tsc --watch",
     "clean": "lb-clean *example-soap*.tgz dist* package api-docs dist*",
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -15,7 +15,7 @@
     "build:watch": "lb-tsc --watch",
     "clean": "lb-clean *example-todo-list*.tgz dist* package api-docs",
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -15,7 +15,7 @@
     "build:watch": "lb-tsc --watch",
     "clean": "lb-clean *example-todo*.tgz dist* package api-docs",
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "precoverage": "npm test",
     "coverage": "open coverage/index.html",
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "tslint": "node packages/build/bin/run-tslint --project tsconfig.json",
     "tslint:fix": "npm run tslint -- --fix",
     "prettier:cli": "node packages/build/bin/run-prettier \"**/*.ts\" \"**/*.js\" \"**/*.md\"",

--- a/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
+++ b/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
@@ -1,6 +1,6 @@
 import {createClientForHandler, supertest} from '@loopback/testlab';
 import {RestServer} from '@loopback/rest';
-import {<%= project.applicationName %>} from '../';
+import {<%= project.applicationName %>} from '../..';
 
 describe('PingController', () => {
   let app: <%= project.applicationName %>;

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -17,9 +17,9 @@ export class <%= className %>Controller {
   ) {}
 
   @post('<%= httpPathName %>')
-  async create(@requestBody() obj: <%= modelName %>)
+  async create(@requestBody() <%= name %>: <%= modelName %>)
     : Promise<<%= modelName %>> {
-    return await this.<%= repositoryNameCamel %>.create(obj);
+    return await this.<%= repositoryNameCamel %>.create(<%= name %>);
   }
 
   @get('<%= httpPathName %>/count')
@@ -35,10 +35,10 @@ export class <%= className %>Controller {
 
   @patch('<%= httpPathName %>')
   async updateAll(
-    @requestBody() obj: <%= modelName %>,
+    @requestBody() <%= name %>: <%= modelName %>,
     @param.query.string('where') where?: Where
   ): Promise<number> {
-    return await this.<%= repositoryNameCamel %>.updateAll(obj, where);
+    return await this.<%= repositoryNameCamel %>.updateAll(<%= name %>, where);
   }
 
   @get('<%= httpPathName %>/{id}')
@@ -49,9 +49,9 @@ export class <%= className %>Controller {
   @patch('<%= httpPathName %>/{id}')
   async updateById(
     @param.path.<%= idType %>('id') id: <%= idType %>,
-    @requestBody() obj: <%= modelName %>
+    @requestBody() <%= name %>: <%= modelName %>
   ): Promise<boolean> {
-    return await this.<%= repositoryNameCamel %>.updateById(id, obj);
+    return await this.<%= repositoryNameCamel %>.updateById(id, <%= name %>);
   }
 
   @del('<%= httpPathName %>/{id}')

--- a/packages/cli/generators/datasource/templates/datasource.ts.ejs
+++ b/packages/cli/generators/datasource/templates/datasource.ts.ejs
@@ -1,5 +1,5 @@
 import {inject} from '@loopback/core';
-import {juggler, DataSource, AnyObject} from '@loopback/repository';
+import {juggler, AnyObject} from '@loopback/repository';
 const config = require('./<%= jsonFileName %>');
 
 export class <%= className %>DataSource extends juggler.DataSource {

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -20,7 +20,7 @@
     "clean": "lb-clean dist*",
 <% if (project.prettier && project.tslint) { -%>
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
 <% } else if (project.prettier) { -%>
     "lint": "npm run prettier:check",
     "lint:fix": "npm run prettier:fix",
@@ -72,14 +72,14 @@
     "src"
   ],
   "dependencies": {
-    "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
+    "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",
 <% if (project.projectType === 'application') { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
     "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>",
+    "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
-    "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
-    "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>"
+    "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>"
 <% } else { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
     "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>"
@@ -87,14 +87,14 @@
   },
   "devDependencies": {
     "@loopback/build": "<%= project.dependencies['@loopback/build'] -%>",
-    "@types/node": "<%= project.dependencies['@types/node'] -%>",
-<% if (project.mocha) { -%>
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
+<% if (project.mocha) { -%>
     "@types/mocha": "<%= project.dependencies['@types/mocha'] -%>",
+<% } -%>
+    "@types/node": "<%= project.dependencies['@types/node'] -%>"<% if (project.mocha) { -%>,<% } %>
+<% if (project.mocha) { -%>
     "mocha": "<%= project.dependencies['mocha'] -%>",
     "source-map-support": "<%= project.dependencies['source-map-support'] -%>"
-<% } else { -%>
-    "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>"
 <% } -%>
   }
 }

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist",
 <% if (project.prettier && project.tslint) { -%>
     "lint": "npm run prettier:check && npm run tslint",
-    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "lint:fix": "npm run tslint:fix && npm run prettier:fix",
 <% } else if (project.prettier) { -%>
     "lint": "npm run prettier:check",
     "lint:fix": "npm run prettier:fix",
@@ -67,32 +67,36 @@
     "src"
   ],
   "dependencies": {
-    "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
+    "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",
 <% if (project.projectType === 'application') { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
     "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>",
+    "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
-    "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
-    "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>"
+    "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>"
 <% } else { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>"
 <% } -%>
   },
   "devDependencies": {
+    "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
+<% if (project.mocha) { -%>
+    "@types/mocha": "<%= project.dependencies['@types/mocha'] -%>",
+<% } -%>
+    "@types/node": "<%= project.dependencies['@types/node'] -%>",
+<% if (project.mocha) { -%>
+    "mocha": "<%= project.dependencies['mocha'] -%>",
+<% } -%>
 <% if (project.prettier) { -%>
     "prettier": "<%= project.dependencies['prettier'] -%>",
+<% } -%>
+<% if (project.mocha) { -%>
+    "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
 <% } -%>
 <% if (project.tslint) { -%>
     "tslint": "<%= project.dependencies['tslint'] -%>",
 <% } -%>
-    "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
-<% if (project.mocha) { -%>
-    "@types/mocha": "<%= project.dependencies['@types/mocha'] -%>",
-    "mocha": "<%= project.dependencies['mocha'] -%>",
-    "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
-<% } -%>
-    "@types/node": "<%= project.dependencies['@types/node'] -%>",
     "typescript": "<%= project.dependencies['typescript'] -%>"
   }
 }

--- a/packages/cli/test/integration/generators/datasource.integration.js
+++ b/packages/cli/test/integration/generators/datasource.integration.js
@@ -163,7 +163,7 @@ function checkBasicDataSourceFiles() {
   assert.fileContent(expectedTSFile, /import {inject} from '@loopback\/core';/);
   assert.fileContent(
     expectedTSFile,
-    /import {juggler, DataSource, AnyObject} from '@loopback\/repository';/,
+    /import {juggler, AnyObject} from '@loopback\/repository';/,
   );
   assert.fileContent(
     expectedTSFile,


### PR DESCRIPTION
Came across the following annoyances when working on `@loopback/example-shopping`

- Move `ping.controller.acceptance.ts` from `/test` to `/test/acceptance`.
- For REST Controller Template change `obj` to the model name as it's more descriptive
- Remove unused import from datasource template
- Run `tslint:fix` before `prettire:fix` for `lint:fix` since I ran into an issue where tslint:fix breaks prettier formatting requiring you to run `prettier:fix` / `lint:fix` again.
- Reorder the dependencies so they are alphabetical otherwise `npm install` results in additional changes to the file diff ass it reorders the deps alphabetically.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
