### PR TITLE
docs: remove testing-your-extension double entry in sidebar

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -232,10 +232,6 @@ children:
     url: Testing-your-application.html
     output: 'web, pdf'
 
-  - title: 'Testing your extension'
-    url: Testing-your-extension.html
-    output: 'web, pdf'
-
 - title: 'Extending LoopBack 4'
   url: Extending-LoopBack-4.html
   output: 'web, pdf'


### PR DESCRIPTION
See https://loopback.io/doc/en/lb4/Testing-your-extension.html

The entry appears twice in the sidebar ... making the sidebar look all weird with both entries highlighted. Should only appear once. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
