### PR TITLE
fix(openapi-v3): set required to true for path parameters

### DIFF
--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -121,7 +121,13 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
        *   }
        * ```
        */
-      operationSpec.parameters = params.filter(p => p != null);
+      operationSpec.parameters = params.filter(p => p != null).map(p => {
+        // Per OpenAPI spec, `required` must be `true` for path parameters
+        if (p.in === 'path') {
+          p.required = true;
+        }
+        return p;
+      });
     }
 
     debug('  processing requestBody for method %s', op);

--- a/packages/openapi-v3/test/integration/operation-spec.integration.ts
+++ b/packages/openapi-v3/test/integration/operation-spec.integration.ts
@@ -37,7 +37,12 @@ describe('operation arguments', () => {
             parameters: [
               {name: 'type', in: 'query', schema: {type: 'string'}},
               {name: 'token', in: 'header', schema: {type: 'string'}},
-              {name: 'location', in: 'path', schema: {type: 'string'}},
+              {
+                name: 'location',
+                in: 'path',
+                required: true,
+                schema: {type: 'string'},
+              },
             ],
             requestBody: {
               content: {
@@ -60,6 +65,7 @@ describe('operation arguments', () => {
         },
       },
     };
-    expect(getControllerSpec(MyController)).to.eql(expectedSpec);
+    const spec = getControllerSpec(MyController);
+    expect(spec).to.eql(expectedSpec);
   });
 });

--- a/packages/openapi-v3/test/unit/decorators/param/param-path.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/param/param-path.decorator.unit.ts
@@ -16,6 +16,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'string',
         },
@@ -33,6 +34,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'number',
         },
@@ -50,6 +52,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'integer',
           format: 'int32',
@@ -72,6 +75,7 @@ describe('Routing metadata for parameters', () => {
         {
           name: 'name',
           in: 'path',
+          required: true,
           schema: {
             type: 'boolean',
           },
@@ -89,6 +93,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'integer',
           format: 'int64',
@@ -107,6 +112,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'number',
           format: 'float',
@@ -125,6 +131,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'number',
           format: 'double',
@@ -143,6 +150,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'string',
           format: 'byte',
@@ -161,6 +169,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'string',
           format: 'binary',
@@ -179,6 +188,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'string',
           format: 'date',
@@ -197,6 +207,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'string',
           format: 'date-time',
@@ -215,6 +226,7 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
         schema: {
           type: 'string',
           format: 'password',

--- a/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
@@ -44,6 +44,7 @@ describe('Routing metadata for parameters', () => {
           @param({
             name: 'id',
             in: 'path',
+            required: true,
           })
           id: string,
           @param({
@@ -80,6 +81,7 @@ describe('Routing metadata for parameters', () => {
             type: 'string',
           },
           in: 'path',
+          required: true,
         })
         .withParameter({
           name: 'name',

--- a/packages/rest/test/unit/parser.unit.ts
+++ b/packages/rest/test/unit/parser.unit.ts
@@ -29,6 +29,7 @@ describe('operationArgsParser', () => {
         name: 'id',
         type: 'number',
         in: 'path',
+        required: true,
       },
     ]);
     const route = givenResolvedRoute(spec, {id: 1});


### PR DESCRIPTION
https://github.com/strongloop/loopback-next/issues/1531

It sets `required: true` for path parameters to be compliant with OpenAPI spec.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
