### PR TITLE
fix: remove extra imports for mixin dependencies

### DIFF
--- a/benchmark/src/benchmark.ts
+++ b/benchmark/src/benchmark.ts
@@ -35,8 +35,6 @@ export type AutocannonFactory = (url: string) => Autocannon;
 
 export class Benchmark {
   private options: Options;
-  private worker: ChildProcess;
-  private url: string;
 
   // Customization points
   public cannonFactory: AutocannonFactory;
@@ -81,7 +79,7 @@ export class Benchmark {
     const result = await runner.execute(autocannon);
     debug('Stats: %j', result);
 
-    closeWorker(worker);
+    await closeWorker(worker);
     debug('Worker stopped, done.');
 
     this.logger(name, result);
@@ -114,8 +112,4 @@ function startWorker() {
 async function closeWorker(worker: ChildProcess) {
   worker.kill();
   await pEvent(worker, 'close');
-}
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/benchmark/src/worker.ts
+++ b/benchmark/src/worker.ts
@@ -3,11 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  TodoListApplication,
-  TodoRepository,
-  Route,
-} from '@loopback/example-todo';
+import {TodoListApplication} from '@loopback/example-todo';
 
 async function main() {
   const app = new TodoListApplication({

--- a/docs/site/Booting-an-Application.md
+++ b/docs/site/Booting-an-Application.md
@@ -61,13 +61,8 @@ example below)_
 
 ### Using the BootMixin
 
-`Booter` and `Binding` types must be imported alongside `BootMixin` to allow
-TypeScript to infer types and avoid errors. _If using `tslint` with the
-`no-unused-variable` rule, you can disable it for the import line by adding
-`// tslint:disable-next-line:no-unused-variable` above the import statement_.
-
 ```ts
-import {BootMixin, Booter, Binding} from "@loopback/boot";
+import {BootMixin} from "@loopback/boot";
 
 class MyApplication extends BootMixin(Application) {
   constructor(options?: ApplicationConfig) {

--- a/docs/site/todo-tutorial-putting-it-together.md
+++ b/docs/site/todo-tutorial-putting-it-together.md
@@ -34,22 +34,11 @@ artifacts and inject them into our application for use.
 #### src/application.ts
 
 ```ts
+import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication, RestServer} from '@loopback/rest';
 import {MySequence} from './sequence';
-
-/* tslint:disable:no-unused-variable */
-// Binding and Booter imports are required to infer types for BootMixin!
-import {BootMixin, Booter, Binding} from '@loopback/boot';
-
-// juggler imports are required to infer types for RepositoryMixin!
-import {
-  Class,
-  Repository,
-  RepositoryMixin,
-  juggler,
-} from '@loopback/repository';
-/* tslint:enable:no-unused-variable */
 
 export class TodoListApplication extends BootMixin(
   RepositoryMixin(RestApplication),

--- a/examples/soap-calculator/src/application.ts
+++ b/examples/soap-calculator/src/application.ts
@@ -1,20 +1,9 @@
+import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig, Constructor, Provider} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
 import {MySequence} from './sequence';
 import {CalculatorServiceProvider} from './services/calculator.service';
-
-// Binding and Booter imports are required to infer types for BootMixin!
-/* tslint:disable:no-unused-variable */
-import {BootMixin, Booter, Binding} from '@loopback/boot';
-
-// juggler imports are required to infer types for RepositoryMixin!
-import {
-  Class,
-  Repository,
-  RepositoryMixin,
-  juggler,
-} from '@loopback/repository';
-/* tslint:enable:no-unused-variable */
 
 export class SoapCalculatorApplication extends BootMixin(
   RepositoryMixin(RestApplication),

--- a/examples/todo-list/src/application.ts
+++ b/examples/todo-list/src/application.ts
@@ -3,22 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
 import {MySequence} from './sequence';
-
-/* tslint:disable:no-unused-variable */
-// Binding and Booter imports are required to infer types for BootMixin!
-import {BootMixin, Booter, Binding} from '@loopback/boot';
-
-// juggler imports are required to infer types for RepositoryMixin!
-import {
-  Class,
-  Repository,
-  RepositoryMixin,
-  juggler,
-} from '@loopback/repository';
-/* tslint:enable:no-unused-variable */
 
 export class TodoListApplication extends BootMixin(
   RepositoryMixin(RestApplication),

--- a/examples/todo/src/application.ts
+++ b/examples/todo/src/application.ts
@@ -3,23 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ApplicationConfig, Provider, Constructor} from '@loopback/core';
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig, Constructor, Provider} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
 import {MySequence} from './sequence';
 import {GeocoderServiceProvider} from './services';
-
-/* tslint:disable:no-unused-variable */
-// Binding and Booter imports are required to infer types for BootMixin!
-import {BootMixin, Booter, Binding} from '@loopback/boot';
-
-// juggler imports are required to infer types for RepositoryMixin!
-import {
-  Class,
-  Repository,
-  RepositoryMixin,
-  juggler,
-} from '@loopback/repository';
-/* tslint:enable:no-unused-variable */
 
 export class TodoListApplication extends BootMixin(
   RepositoryMixin(RestApplication),

--- a/packages/boot/test/fixtures/application.ts
+++ b/packages/boot/test/fixtures/application.ts
@@ -3,20 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {RestApplication} from '@loopback/rest';
 import {ApplicationConfig} from '@loopback/core';
-// tslint:disable:no-unused-variable
-import {
-  RepositoryMixin,
-  Class,
-  Repository,
-  juggler,
-} from '@loopback/repository';
-// tslint:enable:no-unused-variable
-
-// Binding and Booter imports are required to infer types for BootMixin!
-// tslint:disable-next-line:no-unused-variable
-import {BootMixin, Booter, Binding} from '../../index';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {BootMixin} from '../../index';
 
 export class BooterApp extends RepositoryMixin(BootMixin(RestApplication)) {
   constructor(options?: ApplicationConfig) {

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -1,21 +1,10 @@
+import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
+<% if (project.enableRepository) { -%>
+import {RepositoryMixin} from '@loopback/repository';
+<% } -%>
 import {RestApplication} from '@loopback/rest';
 import {MySequence} from './sequence';
-
-/* tslint:disable:no-unused-variable */
-// Binding and Booter imports are required to infer types for BootMixin!
-import {BootMixin, Booter, Binding} from '@loopback/boot';
-<% if (project.enableRepository) { -%>
-
-// juggler imports are required to infer types for RepositoryMixin!
-import {
-  Class,
-  Repository,
-  RepositoryMixin,
-  juggler,
-} from '@loopback/repository';
-<% } -%>
-/* tslint:enable:no-unused-variable */
 
 export class <%= project.applicationName %> <% if (!project.enableRepository) {-%>extends BootMixin(RestApplication) {<% } else { -%>extends BootMixin(
   RepositoryMixin(RestApplication),

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -130,18 +130,11 @@ We'll use `BootMixin` on top of `RepositoryMixin` so that Repository bindings
 can be taken care of automatically at boot time before the application starts.
 
 ```ts
+import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
 import {db} from './datasources/db.datasource';
-/* tslint:disable:no-unused-variable */
-import {BootMixin, Booter, Binding} from '@loopback/boot';
-import {
-  RepositoryMixin,
-  Class,
-  Repository,
-  juggler,
-} from '@loopback/repository';
-/* tslint:enable:no-unused-variable */
 
 export class RepoApplication extends BootMixin(
   RepositoryMixin(RestApplication),

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -23,9 +23,6 @@ import {
   HasManyRepositoryFactory,
 } from './relation.factory';
 import {HasManyDefinition} from '../decorators/relation.decorator';
-// need the import for exporting of a return type
-// tslint:disable-next-line:no-unused-variable
-import {HasManyRepository} from './relation.repository';
 
 export namespace juggler {
   export import DataSource = legacy.DataSource;

--- a/packages/repository/test/unit/query/query-builder.unit.ts
+++ b/packages/repository/test/unit/query/query-builder.unit.ts
@@ -4,14 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {
-  FilterBuilder,
-  Filter,
-  WhereBuilder,
-  Where,
-  filterTemplate,
-  isFilter,
-} from '../../../';
+import {FilterBuilder, WhereBuilder, filterTemplate, isFilter} from '../../../';
 
 describe('WhereBuilder', () => {
   it('builds where object', () => {

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -22,9 +22,6 @@ import {
   Send,
 } from './types';
 
-// NOTE(bajtos) The following import is required to satisfy TypeScript compiler
-// tslint:disable-next-line:no-unused-variable
-import {OpenAPIObject} from '@loopback/openapi-v3-types';
 import {HttpProtocol} from '@loopback/http-server';
 import * as https from 'https';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,15 @@
 {
   "extends": "./packages/build/config/tsconfig.common.json",
-  "include": ["packages", "examples"],
-  "exclude": ["node_modules/**", "packages/*/node_modules/**", "examples/*/node_modules/**", "**/*.d.ts"]
+  "include": [
+    "benchmark",
+    "examples",
+    "packages"
+  ],
+  "exclude": [
+    "node_modules/**",
+    "benchmark/node_modules/**",
+    "examples/*/node_modules/**",
+    "packages/*/node_modules/**",
+    "**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
With the new TypeScript version, it is no longer necessary to manually import types referenced by mixin classes.

This commit removes those extra imports from the CLI template and scaffolded "application.ts" files; and also sorts import using VS Code's feature "Organize imports".

I have discovered this opportunity while working on service-registration mixin (#1439).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated