### PR TITLE
fix: #1643: import MetadataAccessor direct from metadata…

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@loopback/context": "^0.12.5",
+    "@loopback/metadata": "^0.9.5",
     "@loopback/core": "^0.11.5",
     "@loopback/dist-util": "^0.3.6",
     "@loopback/openapi-v3": "^0.12.5",

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -6,7 +6,8 @@
 import {Strategy} from 'passport';
 import {AuthenticateFn, UserProfile} from './types';
 import {AuthenticationMetadata} from './decorators/authenticate.decorator';
-import {BindingKey, MetadataAccessor} from '@loopback/context';
+import {BindingKey} from '@loopback/context';
+import {MetadataAccessor} from '@loopback/metadata';
 
 /**
  * Binding keys used by this component.

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@loopback/context": "^0.12.5",
+    "@loopback/metadata": "^0.9.5",
     "@loopback/dist-util": "^0.3.6",
     "@loopback/repository": "^0.15.1",
     "@types/json-schema": "^6.0.1"

--- a/packages/repository-json-schema/src/keys.ts
+++ b/packages/repository-json-schema/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataAccessor} from '@loopback/context';
+import {MetadataAccessor} from '@loopback/metadata';
 import {JSONSchema6 as JSONSchema} from 'json-schema';
 
 /**


### PR DESCRIPTION
… to avoid TypeScript 3 compiler issue

Fixes #1643 by changing places that import `MetadataAcessor` from `@loopback/context` to be from `@loopback/metadata`, and add the reference to that in the corresponding `package.json` files.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] ~API Documentation in code was updated~ N/A
- [ ] ~Documentation in [/docs/site](../tree/master/docs/site) was updated~ N/A
- [ ] ~Affected artifact templates in `packages/cli` were updated~ N/A
- [ ] ~Affected example projects in `examples/*` were updated~ N/A

I also, naturally, verified that this fixes the build issues in my project.

I'm not quite sure how to add tests within the repo to verify this change.