### PR TITLE
docs(example-soap-calculator): fix image link from README.md file

### DIFF
--- a/docs/site/soap-calculator-tutorial.md
+++ b/docs/site/soap-calculator-tutorial.md
@@ -45,8 +45,8 @@ Follow the following steps to start buiding your application:
 3. [Add a data source](soap-calculator-tutorial-add-datasource.md)
 4. [Add a Service](soap-calculator-tutorial-add-service.md)
 5. [Add a controller](soap-calculator-tutorial-add-controller.md)
-6. [Register the service](soap-calculator-tutorial-make-service-available.md)
-7. [Run and Test the application](soap-calculator-run-and-and-test.md)
+6. [Register the service](soap-calculator-tutorial-register-service.md)
+7. [Run and Test the application](soap-calculator-tutorial-run-and-test.md)
 
 ## or Try it out
 

--- a/docs/site/soap-calculator-tutorial.md
+++ b/docs/site/soap-calculator-tutorial.md
@@ -2,90 +2,10 @@
 lang: en
 title: 'SOAP calculator Web Service integration tutorial'
 keywords: LoopBack 4.0, LoopBack 4
+layout: readme
+source: loopback-next
+file: examples/soap-calculator/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial.html
-summary: Integrating a Calculator SOAP web service with LoopBack 4.
+summary: LoopBack 4 SOAP Web Service Tutorial
 ---
-
-# @loopback/example-soap-calculator
-
-Integrating a Calculator SOAP web service with LoopBack 4.
-
-## Overview
-
-This example project shows how to integrate a SOAP web service with LoopBack 4
-and expose its methods through the REST API server. Acceptance and Integration
-tests are provided.
-
-Before each step, you will be presented an image containing the artifacts that
-you will be creating in blue.
-
-![soap-calculator-overview](./imgs/loopback-example-soap-calculator_figure1.png)
-
-## Setup
-
-You'll need to make sure you have some things installed:
-
-- [Node.js](https://nodejs.org/en/) at v8.9 or greater
-
-Lastly, you'll need to install the LoopBack 4 CLI toolkit:
-
-```sh
-npm i -g @loopback/cli
-```
-
-## Start the Tutorial
-
-Follow the following steps to start buiding your application:
-
-### Steps
-
-1. [SOAP Web Service Overview](soap-calculator-tutorial-web-service-overview.md)
-2. [Scaffold the Application](soap-calculator-tutorial-scaffolding.md)
-3. [Add a data source](soap-calculator-tutorial-add-datasource.md)
-4. [Add a Service](soap-calculator-tutorial-add-service.md)
-5. [Add a controller](soap-calculator-tutorial-add-controller.md)
-6. [Register the service](soap-calculator-tutorial-register-service.md)
-7. [Run and Test the application](soap-calculator-tutorial-run-and-test.md)
-
-## or Try it out
-
-If you'd like to see the final results of this tutorial as an example
-application, follow these steps:
-
-### Generate the example using CLI
-
-1.Run the `lb4 example` command to select and clone the soap-calculator
-repository:
-
-```sh
-$ lb4 example
-? What example would you like to clone? (Use arrow keys)
-  todo: Tutorial example on how to build an application with LoopBack 4.
-  todo-list: Continuation of the todo example using relations in LoopBack 4.
-  hello-world: A simple hello-world Application using LoopBack 4.
-  log-extension: An example extension project for LoopBack 4.
-  rpc-server: A basic RPC server using a made-up protocol.
-> soap-calculator: An example on how to integrate SOAP web services.
-```
-
-2.Jump into the directory and then install the required dependencies:
-
-```sh
-cd loopback4-example-soap-calculator
-```
-
-3.Finally, start the application!
-
-    ```sh
-    $ npm start
-
-    Server is running on port 3000
-    ```
-
-Feel free to look around in the application's code to get a feel for how it
-works.
-
-## License
-
-MIT

--- a/examples/soap-calculator/README.md
+++ b/examples/soap-calculator/README.md
@@ -8,6 +8,9 @@ This example project shows how to integrate a SOAP web service with LoopBack 4
 and expose its methods through the REST API server. Acceptance and Integration
 tests are provided.
 
+Before each step, you will be presented an image containing the artifacts that
+you will be creating in blue.
+
 ![soap-calculator-overview](https://loopback.io/pages/en/lb4/imgs/loopback-example-soap-calculator_figure1.png)
 
 ## Setup
@@ -22,10 +25,29 @@ Lastly, you'll need to install the LoopBack 4 CLI toolkit:
 npm i -g @loopback/cli
 ```
 
-## Generate the example using CLI
+## Start the Tutorial
 
-1.  Run the `lb4 example` command to select and clone the soap-calculator
-    repository:
+Follow the following steps to start buiding your application:
+
+### Steps
+
+1. [SOAP Web Service Overview](https://loopback.io/doc/en/lb4/soap-calculator-tutorial-web-service-overview.html)
+2. [Scaffold the Application](https://loopback.io/doc/en/lb4/soap-calculator-tutorial-scaffolding.html)
+3. [Add a data source](https://loopback.io/doc/en/lb4/soap-calculator-tutorial-add-datasource.html)
+4. [Add a Service](https://loopback.io/doc/en/lb4/soap-calculator-tutorial-add-service.html)
+5. [Add a controller](https://loopback.io/doc/en/lb4/soap-calculator-tutorial-add-controller.html)
+6. [Register the service](https://loopback.io/doc/en/lb4/soap-calculator-tutorial-make-service-available.md)
+7. [Run and Test the application](https://loopback.io/doc/en/lb4/soap-calculator-run-and-and-test.md)
+
+## or Try it out
+
+If you'd like to see the final results of this tutorial as an example
+application, follow these steps:
+
+### Generate the example using CLI
+
+1.Run the `lb4 example` command to select and clone the soap-calculator
+repository:
 
 ```sh
 $ lb4 example
@@ -38,13 +60,13 @@ $ lb4 example
 > soap-calculator: An example on how to integrate SOAP web services.
 ```
 
-2.  Jump into the directory and then install the required dependencies:
+2.Jump into the directory and then install the required dependencies:
 
 ```sh
 cd loopback4-example-soap-calculator
 ```
 
-3.  Finally, start the application!
+3.Finally, start the application!
 
     ```sh
     $ npm start
@@ -54,30 +76,6 @@ cd loopback4-example-soap-calculator
 
 Feel free to look around in the application's code to get a feel for how it
 works.
-
-### Stuck?
-
-Check out our [Gitter channel](https://gitter.im/strongloop/loopback) and ask
-for help with this tutorial!
-
-### Bugs/Feedback
-
-Open an issue in [loopback-next](https://github.com/strongloop/loopback-next)
-and we'll take a look!
-
-## Contributions
-
-- [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md)
-- [Join the team](https://github.com/strongloop/loopback-next/issues/110)
-
-## Tests
-
-Run `npm test` from the root folder.
-
-## Contributors
-
-See
-[all contributors](https://github.com/strongloop/loopback-next/graphs/contributors).
 
 ## License
 

--- a/examples/soap-calculator/README.md
+++ b/examples/soap-calculator/README.md
@@ -8,7 +8,7 @@ This example project shows how to integrate a SOAP web service with LoopBack 4
 and expose its methods through the REST API server. Acceptance and Integration
 tests are provided.
 
-![soap-calculator-overview](../../docs/img/loopback-example-soap-calculator_figure1.png)
+![soap-calculator-overview](https://loopback.io/pages/en/lb4/imgs/loopback-example-soap-calculator_figure1.png)
 
 ## Setup
 


### PR DESCRIPTION
add full path of image and adjust 2 links that were still not working from inside the first page. sorry this was not covered in the last PR (missed it).

## Checklist

- [ x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
