### PR TITLE
build: move unused-variable check from tslint to tsc

### DIFF
--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -5,6 +5,7 @@
     "experimentalDecorators": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "noUnusedLocals": true,
 
     "lib": ["es2018", "dom", "esnext.asynciterable"],
     "module": "commonjs",

--- a/packages/build/config/tslint.build.json
+++ b/packages/build/config/tslint.build.json
@@ -17,7 +17,6 @@
     // tell tslint that it's ok to `await` such promises.
     "await-promise": [true, "PromiseLike"],
     "no-floating-promises": true,
-    "no-unused-variable": true,
     "no-void-expression": [true, "ignore-arrow-function-shorthand"]
   }
 }

--- a/packages/build/config/tslint.build.json
+++ b/packages/build/config/tslint.build.json
@@ -15,8 +15,8 @@
     // User-land promises like Bluebird implement "PromiseLike" (not "Promise")
     // interface only. The string "PromiseLike" bellow is needed to
     // tell tslint that it's ok to `await` such promises.
-    "await-promise": [true, "PromiseLike"],
-    "no-floating-promises": true,
+    "await-promise": [true, "PromiseLike", "RequestPromise"],
+    "no-floating-promises": [true, "PromiseLike", "RequestPromise"],
     "no-void-expression": [true, "ignore-arrow-function-shorthand"]
   }
 }

--- a/packages/cli/generators/project/templates/tsconfig.json.ejs
+++ b/packages/cli/generators/project/templates/tsconfig.json.ejs
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "noUnusedLocals": true,
 
     "lib": ["es2018", "dom", "esnext.asynciterable"],
     "module": "commonjs",

--- a/packages/cli/generators/project/templates/tslint.json.ejs
+++ b/packages/cli/generators/project/templates/tslint.json.ejs
@@ -24,7 +24,6 @@
     "no-shadowed-variable": true,
     "no-string-throw": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-var-keyword": true,
     "triple-equals": [true, "allow-null-check", "allow-undefined-check"]
   }

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -5,7 +5,6 @@
 
 export type BindingAddress<T> = string | BindingKey<T>;
 
-// tslint:disable-next-line:no-unused-variable
 export class BindingKey<ValueType> {
   static readonly PROPERTY_SEPARATOR = '#';
 

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -12,10 +12,6 @@ import {DecoratorFactory} from '@loopback/metadata';
 const debugSession = debugModule('loopback:context:resolver:session');
 const getTargetName = DecoratorFactory.getTargetName;
 
-// NOTE(bajtos) The following import is required to satisfy TypeScript compiler
-// tslint:disable-next-line:no-unused-variable
-import {BindingKey} from './binding-key';
-
 /**
  * A function to be executed with the resolution session
  */

--- a/packages/context/test/unit/inject.unit.ts
+++ b/packages/context/test/unit/inject.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {
   inject,
   describeInjectedArguments,
@@ -12,10 +12,10 @@ import {
 
 describe('function argument injection', () => {
   it('can decorate class constructor arguments', () => {
-    // tslint:disable-next-line:no-unused-variable
     class TestClass {
-      constructor(@inject('foo') foo: string) {}
+      constructor(@inject('foo') public foo: string) {}
     }
+    disableUnusedLocalError(TestClass);
     // the test passes when TypeScript Compiler is happy
   });
 
@@ -29,10 +29,10 @@ describe('function argument injection', () => {
   });
 
   it('can retrieve information about injected method arguments', () => {
-    // tslint:disable-next-line:no-unused-variable
     class TestClass {
       test(@inject('foo') foo: string) {}
     }
+    disableUnusedLocalError(TestClass);
 
     const meta = describeInjectedArguments(TestClass.prototype, 'test');
     expect(meta.map(m => m.bindingKey)).to.deepEqual(['foo']);
@@ -82,7 +82,7 @@ describe('function argument injection', () => {
 
   it('supports inheritance with overriding constructor - no args', () => {
     class TestClass {
-      constructor(@inject('foo') foo: string) {}
+      constructor(@inject('foo') public foo: string) {}
     }
 
     class SubTestClass extends TestClass {
@@ -92,16 +92,17 @@ describe('function argument injection', () => {
     }
     const meta = describeInjectedArguments(SubTestClass);
     expect(meta.map(m => m.bindingKey)).to.deepEqual([]);
+    disableUnusedLocalError(TestClass);
   });
 });
 
 describe('property injection', () => {
   it('can decorate properties', () => {
-    // tslint:disable-next-line:no-unused-variable
     class TestClass {
       @inject('foo')
       foo: string;
     }
+    disableUnusedLocalError(TestClass);
     // the test passes when TypeScript Compiler is happy
   });
 
@@ -126,21 +127,21 @@ describe('property injection', () => {
 
   it('cannot decorate static properties', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class TestClass {
         @inject('foo')
         static foo: string;
       }
+      disableUnusedLocalError(TestClass);
     }).to.throw(/@inject is not supported for a static property/);
   });
 
   it('cannot decorate a method', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class TestClass {
         @inject('bar')
         foo() {}
       }
+      disableUnusedLocalError(TestClass);
     }).to.throw(/@inject cannot be used on a method/);
   });
 

--- a/packages/context/test/unit/resolution-session.unit.ts
+++ b/packages/context/test/unit/resolution-session.unit.ts
@@ -3,14 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {ResolutionSession, Binding, Injection, inject} from '../..';
 
 describe('ResolutionSession', () => {
   class MyController {
-    // tslint:disable-next-line:no-unused-variable
-    constructor(@inject('b') private b: string) {}
+    constructor(@inject('b') public b: string) {}
   }
+  disableUnusedLocalError(MyController);
+
   function givenInjection(): Injection {
     return {
       target: MyController,

--- a/packages/context/test/unit/value-promise.unit.ts
+++ b/packages/context/test/unit/value-promise.unit.ts
@@ -251,6 +251,7 @@ describe('resolveUntil', () => {
       v => Promise.reject(new Error(v)),
       (s, v) => true,
     );
+    // tslint:disable-next-line:no-floating-promises
     expect(result).be.rejectedWith('a');
   });
 
@@ -276,6 +277,7 @@ describe('resolveUntil', () => {
         throw new Error(v);
       },
     );
+    // tslint:disable-next-line:no-floating-promises
     expect(result).be.rejectedWith('A');
   });
 
@@ -343,6 +345,7 @@ describe('transformValueOrPromise', () => {
     const result = transformValueOrPromise('a', v =>
       Promise.reject(new Error(v)),
     );
+    // tslint:disable-next-line:no-floating-promises
     expect(result).be.rejectedWith('a');
   });
 

--- a/packages/metadata/test/unit/decorator-factory.unit.ts
+++ b/packages/metadata/test/unit/decorator-factory.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {
   ClassDecoratorFactory,
   PropertyDecoratorFactory,
@@ -113,8 +113,8 @@ describe('ClassDecoratorFactory', () => {
     expect(() => {
       @classDecorator({x: 1})
       @classDecorator({y: 2})
-      // tslint:disable-next-line:no-unused-variable
       class MyController {}
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /Decorator cannot be applied more than once on class MyController/,
     );
@@ -352,12 +352,12 @@ describe('PropertyDecoratorFactory', () => {
 
   it('throws if applied more than once on the same property', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class MyController {
         @propertyDecorator({x: 1})
         @propertyDecorator({y: 2})
         myProp: string;
       }
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /Decorator cannot be applied more than once on MyController\.prototype\.myProp/,
     );
@@ -400,12 +400,12 @@ describe('PropertyDecoratorFactory for static properties', () => {
 
   it('throws if applied more than once on the same static property', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class MyController {
         @propertyDecorator({x: 1})
         @propertyDecorator({y: 2})
         static myProp: string;
       }
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /Decorator cannot be applied more than once on MyController\.myProp/,
     );
@@ -448,12 +448,12 @@ describe('MethodDecoratorFactory', () => {
 
   it('throws if applied more than once on the same method', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class MyController {
         @methodDecorator({x: 1})
         @methodDecorator({y: 2})
         myMethod() {}
       }
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /Decorator cannot be applied more than once on MyController\.prototype\.myMethod\(\)/,
     );
@@ -496,12 +496,12 @@ describe('MethodDecoratorFactory for static methods', () => {
 
   it('throws if applied more than once on the same static method', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class MyController {
         @methodDecorator({x: 1})
         @methodDecorator({y: 2})
         static myMethod() {}
       }
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /Decorator cannot be applied more than once on MyController\.myMethod\(\)/,
     );
@@ -545,7 +545,6 @@ describe('ParameterDecoratorFactory', () => {
 
   it('throws if applied more than once on the same parameter', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class MyController {
         myMethod(
           @parameterDecorator({x: 1})
@@ -553,6 +552,7 @@ describe('ParameterDecoratorFactory', () => {
           x: string,
         ) {}
       }
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /Decorator cannot be applied more than once on MyController\.prototype\.myMethod\[0\]/,
     );
@@ -634,7 +634,6 @@ describe('ParameterDecoratorFactory for a static method', () => {
 
   it('throws if applied more than once on the same parameter', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class MyController {
         static myMethod(
           @parameterDecorator({x: 1})
@@ -642,6 +641,7 @@ describe('ParameterDecoratorFactory for a static method', () => {
           x: string,
         ) {}
       }
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /Decorator cannot be applied more than once on MyController\.myMethod\[0\]/,
     );
@@ -695,13 +695,13 @@ describe('MethodParameterDecoratorFactory with invalid decorations', () => {
 
   it('reports error if the # of decorations exceeeds the # of params', () => {
     expect(() => {
-      // tslint:disable-next-line:no-unused-variable
       class MyController {
         @methodParameterDecorator({x: 1}) // Causing error
         @methodParameterDecorator({x: 2}) // For a
         @methodParameterDecorator({x: 3}) // For b
         myMethod(a: string, b: number) {}
       }
+      disableUnusedLocalError(MyController);
     }).to.throw(
       /The decorator is used more than 2 time\(s\) on MyController\.prototype\.myMethod\(\)/,
     );

--- a/packages/openapi-v3-types/test/unit/openapi-v3-spec-types.unit.ts
+++ b/packages/openapi-v3-types/test/unit/openapi-v3-spec-types.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {
   ExampleObject,
   ReferenceObject,
@@ -57,7 +57,6 @@ describe('openapi-v3-types unit tests', () => {
      * original OAS 3 definition. (Though some interfaces allow for extensibility).
      */
 
-    // tslint:disable-next-line:no-unused-variable
     class TestObject implements ExampleObject {
       summary: 'test object';
       description: 'test object';
@@ -65,21 +64,21 @@ describe('openapi-v3-types unit tests', () => {
       externalValue: '1';
       randomProperty: 'extension value';
     }
+    disableUnusedLocalError(TestObject);
 
-    // tslint:disable-next-line:no-unused-variable
     class ReferenceTestObject implements ReferenceObject {
       $ref: '#def/reference-object';
     }
+    disableUnusedLocalError(ReferenceTestObject);
 
-    // tslint:disable-next-line:no-unused-variable
     class DiscriminatorTestObject implements DiscriminatorObject {
       propertyName: 'test';
       mapping: {
         hello: 'world';
       };
     }
+    disableUnusedLocalError(DiscriminatorTestObject);
 
-    // tslint:disable-next-line:no-unused-variable
     class XMLTestObject implements XmlObject {
       name: 'test';
       namespace: 'test';
@@ -87,16 +86,17 @@ describe('openapi-v3-types unit tests', () => {
       attribute: false;
       wrapped: false;
     }
+    disableUnusedLocalError(XMLTestObject);
 
-    // tslint:disable-next-line:no-unused-variable
     class TestExternalDocumentationObject
       implements ExternalDocumentationObject {
       url: 'https://test.com/test.html';
     }
+    disableUnusedLocalError(TestExternalDocumentationObject);
 
-    // tslint:disable-next-line:no-unused-variable
     class TestISpecificationExtension implements ISpecificationExtension {
       test: 'test';
     }
+    disableUnusedLocalError(TestISpecificationExtension);
   });
 });

--- a/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
@@ -10,7 +10,7 @@ import {
 } from '@loopback/openapi-v3-types';
 import {param, get, patch, operation, getControllerSpec} from '../../../../';
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 
 describe('Routing metadata for parameters', () => {
   describe('@param', () => {
@@ -161,13 +161,13 @@ describe('Routing metadata for parameters', () => {
     it('reports error if an array parameter type is not Array', () => {
       expect.throws(
         () => {
-          // tslint:disable-next-line:no-unused-variable
           class MyController {
             @get('/greet')
             greet(
               @param.array('names', 'query', {type: 'string'}) names: string,
             ) {}
           }
+          disableUnusedLocalError(MyController);
         },
         Error,
         `The parameter type is set to 'array' but the JavaScript type is String`,

--- a/packages/repository-json-schema/test/unit/json-schema.unit.ts
+++ b/packages/repository-json-schema/test/unit/json-schema.unit.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {disableUnusedLocalError} from '@loopback/testlab';
 import {JsonSchema} from '../../src';
 
 describe('JSON Schema type', () => {
@@ -15,7 +16,6 @@ describe('JSON Schema type', () => {
      * Inspired by https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/json-schema/json-schema-tests.ts
      */
 
-    // tslint:disable-next-line:no-unused-variable
     const testSchema: JsonSchema = {
       $id: 'test',
       $ref: 'test/sub',
@@ -59,5 +59,6 @@ describe('JSON Schema type', () => {
       propertyNames: {enum: ['foo', 'bar']},
       format: 'email',
     };
+    disableUnusedLocalError(testSchema);
   });
 });

--- a/packages/repository/examples/controllers/customer-with-constructor-di.controller.ts
+++ b/packages/repository/examples/controllers/customer-with-constructor-di.controller.ts
@@ -3,20 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// tslint:disable:no-unused-variable
-
 import {EntityCrudRepository, repository} from '../..';
 import {Customer} from '../models/customer.model';
+
 /**
  * Controller for Customer
  */
-// @controller
-
 export class CustomerController {
   constructor(
     // Use constructor dependency injection
-    // tslint:disable-next-line:no-unused-variable
     @repository('Customer', 'mongodbDataSource')
-    private _repository: EntityCrudRepository<Customer, string>,
+    public repo: EntityCrudRepository<Customer, string>,
   ) {}
 }

--- a/packages/repository/examples/controllers/customer-with-property-di.controller.ts
+++ b/packages/repository/examples/controllers/customer-with-property-di.controller.ts
@@ -3,17 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// tslint:disable:no-unused-variable
-
 import {EntityCrudRepository, repository} from '../..';
 import {Customer} from '../models/customer.model';
 
 /**
  * Controller for Customer
  */
-// @controller
 export class CustomerController {
   // Use property dependency injection
   @repository('Customer', 'mongodbDataSource')
-  private repository: EntityCrudRepository<Customer, string>;
+  public repository: EntityCrudRepository<Customer, string>;
 }

--- a/packages/repository/examples/models/order.model.ts
+++ b/packages/repository/examples/models/order.model.ts
@@ -6,10 +6,8 @@
 import {Entity, model, property, belongsTo} from '../..';
 import {Customer} from './customer.model';
 
-// tslint:disable:no-unused-variable
-
 @model()
-class Order extends Entity {
+export class Order extends Entity {
   @property({
     // TODO(bajtos) type should be optional for TypeScript based properties,
     // as simple types string, number, boolean can be inferred

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -17,8 +17,6 @@ import {DataSource} from '../datasource';
 import {CrudConnector} from '../connectors';
 import {Filter, Where} from '../query';
 
-// tslint:disable:no-unused-variable
-
 export interface Repository<T extends Model> {}
 
 export interface ExecutableRepository<T extends Model> extends Repository<T> {
@@ -297,10 +295,9 @@ export class CrudRepositoryImpl<T extends Entity, ID>
       return this.connector.replaceById(this.model, id, data, options);
     }
     // FIXME: populate inst with all properties
-    // tslint:disable-next-line:no-unused-variable
     const inst = data;
     const where = this.model.buildWhereForId(id);
-    return this.updateAll(data, where, options).then(
+    return this.updateAll(inst, where, options).then(
       (count: number) => count > 0,
     );
   }

--- a/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {
   model,
   property,
@@ -337,11 +337,11 @@ describe('model decorator', () => {
       it('throws when @property.array is used on a non-array property', () => {
         expect.throws(
           () => {
-            // tslint:disable-next-line:no-unused-variable
             class Oops {
               @property.array(Product)
               product: Product;
             }
+            disableUnusedLocalError(Oops);
           },
           Error,
           property.ERR_PROP_NOT_ARRAY,

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {Entity, hasMany, RELATIONS_KEY, RelationType, property} from '../../..';
 import {MetadataInspector} from '@loopback/context';
 import {MODEL_PROPERTIES_KEY, model} from '../../../src';
@@ -19,13 +19,13 @@ describe('relation decorator', () => {
           province: string;
         }
 
-        // tslint:disable-next-line:no-unused-variable
         class AddressBook extends Entity {
           id: number;
 
           @hasMany(Address)
           addresses: Address[];
         }
+        disableUnusedLocalError(AddressBook);
       }).throw(/addressBookId not found on Address/);
     });
 
@@ -110,7 +110,6 @@ describe('relation decorator', () => {
             province: string;
           }
 
-          // tslint:disable-next-line:no-unused-variable
           class AddressBook extends Entity {
             id: number;
             @property.array(Entity)
@@ -119,6 +118,7 @@ describe('relation decorator', () => {
             })
             addresses: Address[];
           }
+          disableUnusedLocalError(AddressBook);
         }).to.throw(/Decorator cannot be applied more than once/);
       });
     });

--- a/packages/repository/test/unit/decorator/repository.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/repository.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {Context} from '@loopback/context';
 
 import {
@@ -72,8 +72,8 @@ describe('repository decorator', () => {
   it('throws not implemented for class-level @repository', () => {
     expect(() => {
       @repository('noteRepo')
-      // tslint:disable-next-line:no-unused-variable
       class Controller1 {}
+      disableUnusedLocalError(Controller1);
     }).to.throw(/not implemented/);
   });
 

--- a/packages/repository/test/unit/model/model.unit.ts
+++ b/packages/repository/test/unit/model/model.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
+import {expect, disableUnusedLocalError} from '@loopback/testlab';
 import {STRING} from '../../../';
 import {Entity, ModelDefinition} from '../../../';
 
@@ -60,7 +60,6 @@ describe('model', () => {
     }
   }
 
-  // tslint:disable-next-line:no-unused-variable
   class User extends Entity {
     static definition = userDef;
     id: string;
@@ -71,6 +70,7 @@ describe('model', () => {
       super(data);
     }
   }
+  disableUnusedLocalError(User);
 
   class Flexible extends Entity {
     static definition = flexibleDef;

--- a/packages/repository/test/unit/repositories/relation.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/relation.repository.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {sinon, expect} from '@loopback/testlab';
+import {sinon, expect, disableUnusedLocalError} from '@loopback/testlab';
 import {
   EntityCrudRepository,
   HasManyRepository,
@@ -25,7 +25,6 @@ describe('relation repository', () => {
      * interface. The TS Compiler will complain if the interface changes.
      */
 
-    // tslint:disable-next-line:no-unused-variable
     class testHasManyEntityCrudRepository<
       T extends Entity,
       ID,
@@ -58,6 +57,7 @@ describe('relation repository', () => {
         throw new Error('Method not implemented.');
       }
     }
+    disableUnusedLocalError(testHasManyEntityCrudRepository);
   });
 
   context('DefaultHasManyEntityCrudRepository', () => {

--- a/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
@@ -53,6 +53,6 @@ describe('Coercion', () => {
     app = new RestApplication();
     app.controller(MyController);
     await app.start();
-    client = await createClientForHandler(app.requestHandler);
+    client = createClientForHandler(app.requestHandler);
   }
 });

--- a/packages/rest/test/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/test/acceptance/validation/validation.acceptance.ts
@@ -156,6 +156,6 @@ describe('Validation at REST level', () => {
     app.controller(controller);
     await app.start();
 
-    client = await createClientForHandler(app.requestHandler);
+    client = createClientForHandler(app.requestHandler);
   }
 });

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -45,7 +45,7 @@ describe('RestServer (integration)', () => {
 
   it('honors port binding after instantiation', async () => {
     const server = await givenAServer({rest: {port: 80}});
-    await server.bind(RestBindings.PORT).to(0);
+    server.bind(RestBindings.PORT).to(0);
     await server.start();
     expect(server.getSync(RestBindings.PORT)).to.not.equal(80);
     await server.stop();
@@ -358,7 +358,7 @@ servers:
     let serverUrl = server.getSync(RestBindings.URL);
     await expect(httpsGetAsync(serverUrl)).to.be.rejectedWith(/EPROTO/);
     await server.stop();
-    await server.bind(RestBindings.HTTPS_OPTIONS).to({
+    server.bind(RestBindings.HTTPS_OPTIONS).to({
       key: fs.readFileSync(keyPath),
       cert: fs.readFileSync(certPath),
     });

--- a/packages/rest/test/unit/re-export.unit.ts
+++ b/packages/rest/test/unit/re-export.unit.ts
@@ -2,11 +2,11 @@
 // Node module: @loopback/rest
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+import {disableUnusedLocalError} from '@loopback/testlab';
 import {get} from '../..';
 
 describe('re-export controller decorators', () => {
   it('exports functions from @loopback/openapi-v3', async () => {
-    /* tslint:disable-next-line:no-unused-variable */
     class Test {
       // Make sure the decorators are exported
       @get('/test')
@@ -14,5 +14,6 @@ describe('re-export controller decorators', () => {
         return '';
       }
     }
+    disableUnusedLocalError(Test);
   });
 });

--- a/packages/rest/test/unit/rest.application/rest.application.unit.ts
+++ b/packages/rest/test/unit/rest.application/rest.application.unit.ts
@@ -14,7 +14,6 @@ import {expect} from '@loopback/testlab';
 describe('RestApplication', () => {
   describe('throws', () => {
     it('when attempting to bind another server', () => {
-      // tslint:disable-next-line:no-unused-variable
       const app = new RestApplication();
       expect.throws(
         () => {
@@ -26,7 +25,6 @@ describe('RestApplication', () => {
     });
 
     it('when attempting to bind an array of servers', () => {
-      // tslint:disable-next-line:no-unused-variable
       const app = new RestApplication();
       expect.throws(
         () => {
@@ -41,7 +39,6 @@ describe('RestApplication', () => {
       class OtherRestComponent extends RestComponent {}
       expect.throws(
         () => {
-          // tslint:disable-next-line:no-unused-variable
           const app = new RestApplication();
           app.component(RestComponent);
           app.component(OtherRestComponent);

--- a/packages/rest/test/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.unit.ts
@@ -64,7 +64,7 @@ describe('RestServer', () => {
       const app = new Application();
       app.component(RestComponent);
       const server = await app.getServer(RestServer);
-      const host = await server.getSync(RestBindings.HOST);
+      const host = await server.get(RestBindings.HOST);
       expect(host).to.be.undefined();
     });
 

--- a/packages/testlab/src/disable-unused-local-error.ts
+++ b/packages/testlab/src/disable-unused-local-error.ts
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+// tslint:disable-next-line:no-any
+let ref: any = true;
+
+// Disable compiler error: 'ref' is declared but its value is never read.
+ref = !ref;
+
+/**
+ * A helper function to create a dummy reference to a local value that's
+ * otherwise not used anywhere in the code. Use it to surpress "tsc" warning
+ * "(something) is declared but never used".
+ *
+ * @param value A value to mark as used for the compiler.
+ */
+export function disableUnusedLocalError<T>(value: T) {
+  ref = value;
+}

--- a/packages/testlab/src/index.ts
+++ b/packages/testlab/src/index.ts
@@ -12,3 +12,4 @@ export * from './test-sandbox';
 export * from './skip-travis';
 export * from './request';
 export * from './http-server-config';
+export * from './disable-unused-local-error';


### PR DESCRIPTION
Now that we no longer need additional imports of referenced types to satisfy the compiler (see #1641), we have the opportunity to enable unused-variable checking at TypeScript level.

This pull request has two parts:

**build: move unused-variable check from tslint to tsc** (94c4440)

Disable tslint's "no-unused-variable" rule, it has been deprecated.

Enable TypeScript rule "noUnusedLocals", rework all places violating
this rule to use a different mechanism for turning this rule off.

Checking unused variables at compile time has the following benefits:

- Unused variables (locals) are highlighted directly in VS Code.
  Before, we had to run tslint to discover unused variables, since
  the VS Code extension for tslint was not able to detect unused vars.

- The output of tslint is clean again with no deprecation warnings
  cluttering the output.

**build: fix tslint issues related to promises** (fd3317e)

After I disabled no-unused-variable check, tslint started to complain about places incorrectly using promises. Some of the warnings were legitimate and I fixed the code. Other cases were not valid, I fixed them by modifying tslint config and adding comments to disable the problematic rule for few source code lines.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->



## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated