### PR TITLE
build: fix tslint issues related to promises

### DIFF
--- a/packages/build/config/tslint.build.json
+++ b/packages/build/config/tslint.build.json
@@ -15,8 +15,8 @@
     // User-land promises like Bluebird implement "PromiseLike" (not "Promise")
     // interface only. The string "PromiseLike" bellow is needed to
     // tell tslint that it's ok to `await` such promises.
-    "await-promise": [true, "PromiseLike"],
-    "no-floating-promises": true,
+    "await-promise": [true, "PromiseLike", "RequestPromise"],
+    "no-floating-promises": [true, "PromiseLike", "RequestPromise"],
     "no-unused-variable": true,
     "no-void-expression": [true, "ignore-arrow-function-shorthand"]
   }

--- a/packages/context/test/unit/value-promise.unit.ts
+++ b/packages/context/test/unit/value-promise.unit.ts
@@ -251,6 +251,7 @@ describe('resolveUntil', () => {
       v => Promise.reject(new Error(v)),
       (s, v) => true,
     );
+    // tslint:disable-next-line:no-floating-promises
     expect(result).be.rejectedWith('a');
   });
 
@@ -276,6 +277,7 @@ describe('resolveUntil', () => {
         throw new Error(v);
       },
     );
+    // tslint:disable-next-line:no-floating-promises
     expect(result).be.rejectedWith('A');
   });
 
@@ -343,6 +345,7 @@ describe('transformValueOrPromise', () => {
     const result = transformValueOrPromise('a', v =>
       Promise.reject(new Error(v)),
     );
+    // tslint:disable-next-line:no-floating-promises
     expect(result).be.rejectedWith('a');
   });
 

--- a/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
@@ -53,6 +53,6 @@ describe('Coercion', () => {
     app = new RestApplication();
     app.controller(MyController);
     await app.start();
-    client = await createClientForHandler(app.requestHandler);
+    client = createClientForHandler(app.requestHandler);
   }
 });

--- a/packages/rest/test/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/test/acceptance/validation/validation.acceptance.ts
@@ -156,6 +156,6 @@ describe('Validation at REST level', () => {
     app.controller(controller);
     await app.start();
 
-    client = await createClientForHandler(app.requestHandler);
+    client = createClientForHandler(app.requestHandler);
   }
 });

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -45,7 +45,7 @@ describe('RestServer (integration)', () => {
 
   it('honors port binding after instantiation', async () => {
     const server = await givenAServer({rest: {port: 80}});
-    await server.bind(RestBindings.PORT).to(0);
+    server.bind(RestBindings.PORT).to(0);
     await server.start();
     expect(server.getSync(RestBindings.PORT)).to.not.equal(80);
     await server.stop();
@@ -358,7 +358,7 @@ servers:
     let serverUrl = server.getSync(RestBindings.URL);
     await expect(httpsGetAsync(serverUrl)).to.be.rejectedWith(/EPROTO/);
     await server.stop();
-    await server.bind(RestBindings.HTTPS_OPTIONS).to({
+    server.bind(RestBindings.HTTPS_OPTIONS).to({
       key: fs.readFileSync(keyPath),
       cert: fs.readFileSync(certPath),
     });

--- a/packages/rest/test/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.unit.ts
@@ -64,7 +64,7 @@ describe('RestServer', () => {
       const app = new Application();
       app.component(RestComponent);
       const server = await app.getServer(RestServer);
-      const host = await server.getSync(RestBindings.HOST);
+      const host = await server.get(RestBindings.HOST);
       expect(host).to.be.undefined();
     });
 


### PR DESCRIPTION
A follow-up for https://github.com/strongloop/loopback-next/pull/1648.

> After I disabled no-unused-variable check, tslint started to complain about places incorrectly using promises. Some of the warnings were legitimate and I fixed the code. Other cases were not valid, I fixed them by modifying tslint config and adding comments to disable the problematic rule for few source code lines.

It makes me wonder why `tslint` is not reporting these promise-related problems when `no-unused-variable` is enabled, but I can't be bothered to investigate.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated