### PR TITLE
feat(openapi-v3): responses decorator

### DIFF
--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -13,33 +13,68 @@ export class TodoListTodoController {
     @repository(TodoListRepository) protected todoListRepo: TodoListRepository,
   ) {}
 
-  @post('/todo-lists/{id}/todos')
-  async create(@param.path.number('id') id: number, @requestBody() todo: Todo) {
+  @post('/todo-lists/{id}/todos', {
+    responses: {
+      '200': {
+        description: 'TodoList.Todo model instance',
+        content: {'application/json': {'x-ts-type': Todo}},
+      },
+    },
+  })
+  async create(
+    @param.path.number('id') id: number,
+    @requestBody() todo: Todo,
+  ): Promise<Todo> {
     return await this.todoListRepo.todos(id).create(todo);
   }
 
-  @get('/todo-lists/{id}/todos')
+  @get('/todo-lists/{id}/todos', {
+    responses: {
+      '200': {
+        description: "Array of Todo's belonging to TodoList",
+        content: {
+          'application/json': {
+            schema: {type: 'array', items: {'x-ts-type': Todo}},
+          },
+        },
+      },
+    },
+  })
   async find(
     @param.path.number('id') id: number,
     @param.query.string('filter') filter?: Filter,
-  ) {
+  ): Promise<Todo[]> {
     return await this.todoListRepo.todos(id).find(filter);
   }
 
-  @patch('/todo-lists/{id}/todos')
+  @patch('/todo-lists/{id}/todos', {
+    responses: {
+      '200': {
+        description: 'TodoList.Todo PATCH success count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
   async patch(
     @param.path.number('id') id: number,
     @requestBody() todo: Partial<Todo>,
     @param.query.string('where') where?: Where,
-  ) {
+  ): Promise<number> {
     return await this.todoListRepo.todos(id).patch(todo, where);
   }
 
-  @del('/todo-lists/{id}/todos')
+  @del('/todo-lists/{id}/todos', {
+    responses: {
+      '200': {
+        description: 'TodoList.Todo DELETE success count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
   async delete(
     @param.path.number('id') id: number,
     @param.query.string('where') where?: Where,
-  ) {
+  ): Promise<number> {
     return await this.todoListRepo.todos(id).delete(where);
   }
 }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -14,24 +14,52 @@ export class TodoListController {
     public todoListRepository: TodoListRepository,
   ) {}
 
-  @post('/todo-lists')
+  @post('/todo-lists', {
+    responses: {
+      '200': {
+        description: 'TodoList model instance',
+        content: {'application/json': {'x-ts-type': TodoList}},
+      },
+    },
+  })
   async create(@requestBody() obj: TodoList): Promise<TodoList> {
     return await this.todoListRepository.create(obj);
   }
 
-  @get('/todo-lists/count')
+  @get('/todo-lists/count', {
+    responses: {
+      '200': {
+        description: 'TodoList model count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
   async count(@param.query.string('where') where?: Where): Promise<number> {
     return await this.todoListRepository.count(where);
   }
 
-  @get('/todo-lists')
+  @get('/todo-lists', {
+    responses: {
+      '200': {
+        description: 'Array of TodoList model instances',
+        content: {'application/json': {'x-ts-type': TodoList}},
+      },
+    },
+  })
   async find(
     @param.query.string('filter') filter?: Filter,
   ): Promise<TodoList[]> {
     return await this.todoListRepository.find(filter);
   }
 
-  @patch('/todo-lists')
+  @patch('/todo-lists', {
+    responses: {
+      '200': {
+        description: 'TodoList PATCH success count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
   async updateAll(
     @requestBody() obj: Partial<TodoList>,
     @param.query.string('where') where?: Where,
@@ -39,12 +67,26 @@ export class TodoListController {
     return await this.todoListRepository.updateAll(obj, where);
   }
 
-  @get('/todo-lists/{id}')
+  @get('/todo-lists/{id}', {
+    responses: {
+      '200': {
+        description: 'TodoList model instance',
+        content: {'application/json': {'x-ts-type': TodoList}},
+      },
+    },
+  })
   async findById(@param.path.number('id') id: number): Promise<TodoList> {
     return await this.todoListRepository.findById(id);
   }
 
-  @patch('/todo-lists/{id}')
+  @patch('/todo-lists/{id}', {
+    responses: {
+      '200': {
+        description: 'TodoList PATCH success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async updateById(
     @param.path.number('id') id: number,
     @requestBody() obj: TodoList,
@@ -52,7 +94,14 @@ export class TodoListController {
     return await this.todoListRepository.updateById(id, obj);
   }
 
-  @del('/todo-lists/{id}')
+  @del('/todo-lists/{id}', {
+    responses: {
+      '200': {
+        description: 'TodoList DELETE success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async deleteById(@param.path.number('id') id: number): Promise<boolean> {
     return await this.todoListRepository.deleteById(id);
   }

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -11,12 +11,26 @@ import {TodoRepository} from '../repositories';
 export class TodoController {
   constructor(@repository(TodoRepository) protected todoRepo: TodoRepository) {}
 
-  @post('/todos')
+  @post('/todos', {
+    responses: {
+      '200': {
+        description: 'Todo model instance',
+        content: {'application/json': {'x-ts-type': Todo}},
+      },
+    },
+  })
   async createTodo(@requestBody() todo: Todo) {
     return await this.todoRepo.create(todo);
   }
 
-  @get('/todos/{id}')
+  @get('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo model instance',
+        content: {'application/json': {'x-ts-type': Todo}},
+      },
+    },
+  })
   async findTodoById(
     @param.path.number('id') id: number,
     @param.query.boolean('items') items?: boolean,
@@ -24,12 +38,30 @@ export class TodoController {
     return await this.todoRepo.findById(id);
   }
 
-  @get('/todos')
+  @get('/todos', {
+    responses: {
+      '200': {
+        description: 'Array of Todo model instances',
+        content: {
+          'application/json': {
+            schema: {type: 'array', items: {'x-ts-type': Todo}},
+          },
+        },
+      },
+    },
+  })
   async findTodos(): Promise<Todo[]> {
     return await this.todoRepo.find();
   }
 
-  @put('/todos/{id}')
+  @put('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo PUT success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async replaceTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
@@ -37,7 +69,14 @@ export class TodoController {
     return await this.todoRepo.replaceById(id, todo);
   }
 
-  @patch('/todos/{id}')
+  @patch('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo PATCH success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async updateTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
@@ -45,7 +84,14 @@ export class TodoController {
     return await this.todoRepo.updateById(id, todo);
   }
 
-  @del('/todos/{id}')
+  @del('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo DELETE success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async deleteTodo(@param.path.number('id') id: number): Promise<boolean> {
     return await this.todoRepo.deleteById(id);
   }

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -16,8 +16,15 @@ export class TodoController {
     @inject('services.GeocoderService') protected geoService: GeocoderService,
   ) {}
 
-  @post('/todos')
-  async createTodo(@requestBody() todo: Todo) {
+  @post('/todos', {
+    responses: {
+      '200': {
+        description: 'Todo model instance',
+        content: {'application/json': {'x-ts-type': Todo}},
+      },
+    },
+  })
+  async createTodo(@requestBody() todo: Todo): Promise<Todo> {
     if (todo.remindAtAddress) {
       // TODO(bajtos) handle "address not found"
       const geo = await this.geoService.geocode(todo.remindAtAddress);
@@ -26,11 +33,17 @@ export class TodoController {
       // https://gis.stackexchange.com/q/7379
       todo.remindAtGeo = `${geo[0].y},${geo[0].x}`;
     }
-
     return await this.todoRepo.create(todo);
   }
 
-  @get('/todos/{id}')
+  @get('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo model instance',
+        content: {'application/json': {'x-ts-type': Todo}},
+      },
+    },
+  })
   async findTodoById(
     @param.path.number('id') id: number,
     @param.query.boolean('items') items?: boolean,
@@ -38,12 +51,30 @@ export class TodoController {
     return await this.todoRepo.findById(id);
   }
 
-  @get('/todos')
+  @get('/todos', {
+    responses: {
+      '200': {
+        description: 'Array of Todo model instances',
+        content: {
+          'application/json': {
+            schema: {type: 'array', items: {'x-ts-type': Todo}},
+          },
+        },
+      },
+    },
+  })
   async findTodos(): Promise<Todo[]> {
     return await this.todoRepo.find();
   }
 
-  @put('/todos/{id}')
+  @put('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo PUT success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async replaceTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
@@ -51,7 +82,14 @@ export class TodoController {
     return await this.todoRepo.replaceById(id, todo);
   }
 
-  @patch('/todos/{id}')
+  @patch('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo PATCH success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async updateTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
@@ -59,7 +97,14 @@ export class TodoController {
     return await this.todoRepo.updateById(id, todo);
   }
 
-  @del('/todos/{id}')
+  @del('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo DELETE success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async deleteTodo(@param.path.number('id') id: number): Promise<boolean> {
     return await this.todoRepo.deleteById(id);
   }

--- a/packages/boot/test/fixtures/multiple.artifact.ts
+++ b/packages/boot/test/fixtures/multiple.artifact.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get} from '@loopback/openapi-v3';
+import {get} from '@loopback/rest';
 
 export class ArtifactOne {
   @get('/one')

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -16,24 +16,56 @@ export class <%= className %>Controller {
     public <%= repositoryNameCamel %> : <%= repositoryName %>,
   ) {}
 
-  @post('<%= httpPathName %>')
+  @post('<%= httpPathName %>', {
+    responses: {
+      '200': {
+        description: '<%= modelName %> model instance',
+        content: {'application/json': {'x-ts-type': <%= modelName %>}},
+      },
+    },
+  })
   async create(@requestBody() <%= name %>: <%= modelName %>)
     : Promise<<%= modelName %>> {
     return await this.<%= repositoryNameCamel %>.create(<%= name %>);
   }
 
-  @get('<%= httpPathName %>/count')
+  @get('<%= httpPathName %>/count', {
+    responses: {
+      '200': {
+        description: '<%= modelName %> model count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
   async count(@param.query.string('where') where?: Where): Promise<number> {
     return await this.<%= repositoryNameCamel %>.count(where);
   }
 
-  @get('<%= httpPathName %>')
+  @get('<%= httpPathName %>', {
+    responses: {
+      '200': {
+        description: 'Array of <%= modelName %> model instances',
+        content: {
+          'application/json': {
+            schema: {type: 'array', items: {'x-ts-type': <%= modelName %>}},
+          },
+        },
+      },
+    },
+  })
   async find(@param.query.string('filter') filter?: Filter)
     : Promise<<%= modelName %>[]> {
     return await this.<%= repositoryNameCamel %>.find(filter);
   }
 
-  @patch('<%= httpPathName %>')
+  @patch('<%= httpPathName %>', {
+    responses: {
+      '200': {
+        description: '<%= modelName %> PATCH success count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
   async updateAll(
     @requestBody() <%= name %>: <%= modelName %>,
     @param.query.string('where') where?: Where
@@ -41,12 +73,26 @@ export class <%= className %>Controller {
     return await this.<%= repositoryNameCamel %>.updateAll(<%= name %>, where);
   }
 
-  @get('<%= httpPathName %>/{id}')
+  @get('<%= httpPathName %>/{id}', {
+    responses: {
+      '200': {
+        description: '<%= modelName %> model instance',
+        content: {'application/json': {'x-ts-type': <%= modelName %>}},
+      },
+    },
+  })
   async findById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<<%= modelName %>> {
     return await this.<%= repositoryNameCamel %>.findById(id);
   }
 
-  @patch('<%= httpPathName %>/{id}')
+  @patch('<%= httpPathName %>/{id}', {
+    responses: {
+      '200': {
+        description: '<%= modelName %> PATCH success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async updateById(
     @param.path.<%= idType %>('id') id: <%= idType %>,
     @requestBody() <%= name %>: <%= modelName %>
@@ -54,7 +100,14 @@ export class <%= className %>Controller {
     return await this.<%= repositoryNameCamel %>.updateById(id, <%= name %>);
   }
 
-  @del('<%= httpPathName %>/{id}')
+  @del('<%= httpPathName %>/{id}', {
+    responses: {
+      '200': {
+        description: '<%= modelName %> DELETE success',
+        content: {'application/json': {'x-ts-type': Boolean}},
+      },
+    },
+  })
   async deleteById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<boolean> {
     return await this.<%= repositoryNameCamel %>.deleteById(id);
   }

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -241,34 +241,96 @@ function checkRestCrudContents() {
   assert.fileContent(expectedFile, /barRepository \: BarRepository/);
 
   // Assert that the decorators are present in the correct groupings!
-  assert.fileContent(
-    expectedFile,
-    /\@post\('\/product-reviews'\)\s{1,}async create\(\@requestBody\(\)/,
-  );
-  assert.fileContent(
-    expectedFile,
-    /\@get\('\/product-reviews\/count'\)\s{1,}async count\(\@param.query.string\('where'\)/,
-  );
-  assert.fileContent(
-    expectedFile,
-    /\@get\('\/product-reviews'\)\s{1,}async find\(\@param.query.string\('filter'\)/,
-  );
-  assert.fileContent(
-    expectedFile,
-    /\@patch\('\/product-reviews'\)\s{1,}async updateAll\(\s{1,}\@requestBody\(\).*,\s{1,}\@param.query.string\('where'\) where\?: Where/,
-  );
-  assert.fileContent(
-    expectedFile,
-    /\@get\('\/product-reviews\/{id}'\)\s{1,}async findById\(\@param.path.number\('id'\)/,
-  );
-  assert.fileContent(
-    expectedFile,
-    /\@patch\('\/product-reviews\/{id}'\)\s{1,}async updateById\(\s{1,}\@param.path.number\('id'\) id: number,\s{1,}\@requestBody\(\)/,
-  );
-  assert.fileContent(
-    expectedFile,
-    /\@del\('\/product-reviews\/{id}'\)\s{1,}async deleteById\(\@param.path.number\('id'\) id: number\)/,
-  );
+  // @post - create
+  const postCreateRegEx = [
+    /\@post\('\/product-reviews', {/,
+    /responses: {/,
+    /'200': {/,
+    /description: 'ProductReview model instance'/,
+    /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /async create\(\@requestBody\(\)/,
+  ];
+  postCreateRegEx.forEach(regex => {
+    assert.fileContent(expectedFile, regex);
+  });
+
+  // @get - count
+  const getCountRegEx = [
+    /\@get\('\/product-reviews\/count', {/,
+    /responses: {/,
+    /'200': {/,
+    /description: 'ProductReview model count'/,
+    /content: {'application\/json': {'x-ts-type': Number}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /async count\(\@param.query.string\('where'\)/,
+  ];
+  getCountRegEx.forEach(regex => {
+    assert.fileContent(expectedFile, regex);
+  });
+
+  // @get - find
+  const getFindRegEx = [
+    /\@get\('\/product-reviews', {/,
+    /responses: {/,
+    /'200': {/,
+    /description: 'Array of ProductReview model instances'/,
+    /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /async find\(\@param.query.string\('filter'\)/,
+  ];
+  getFindRegEx.forEach(regex => {
+    assert.fileContent(expectedFile, regex);
+  });
+
+  // @patch - updateAll
+  const patchUpdateAllRegEx = [
+    /\@patch\('\/product-reviews', {/,
+    /responses: {/,
+    /'200': {/,
+    /description: 'ProductReview PATCH success count'/,
+    /content: {'application\/json': {'x-ts-type': Number}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /async updateAll\(\s{1,}\@requestBody\(\).*,\s{1,}\@param.query.string\('where'\) where\?: Where/,
+  ];
+  patchUpdateAllRegEx.forEach(regex => {
+    assert.fileContent(expectedFile, regex);
+  });
+
+  // @get - findById
+  const getFindByIdRegEx = [
+    /\@get\('\/product-reviews\/{id}', {/,
+    /responses: {/,
+    /'200': {/,
+    /description: 'ProductReview model instance'/,
+    /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /async findById\(\@param.path.number\('id'\)/,
+  ];
+  getFindByIdRegEx.forEach(regex => {
+    assert.fileContent(expectedFile, regex);
+  });
+
+  // @patch - updateById
+  const patchUpdateByIdRegEx = [
+    /\@patch\('\/product-reviews\/{id}'/,
+    /responses: {/,
+    /'200': {/,
+    /description: 'ProductReview PATCH success'/,
+    /content: {'application\/json': {'x-ts-type': Boolean}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /async updateById\(\s{1,}\@param.path.number\('id'\) id: number,\s{1,}\@requestBody\(\)/,
+  ];
+  patchUpdateByIdRegEx.forEach(regex => {
+    assert.fileContent(expectedFile, regex);
+  });
+
+  // @del - deleteById
+  const deleteByIdRegEx = [
+    /\@del\('\/product-reviews\/{id}', {/,
+    /responses: {/,
+    /'200': {/,
+    /description: 'ProductReview DELETE success'/,
+    /content: {'application\/json': {'x-ts-type': Boolean}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /async deleteById\(\@param.path.number\('id'\) id: number\)/,
+  ];
+  deleteByIdRegEx.forEach(regex => {
+    assert.fileContent(expectedFile, regex);
+  });
 }
 
 /**
@@ -278,30 +340,30 @@ function checkRestCrudContents() {
 function checkRestPaths(restUrl) {
   assert.fileContent(
     expectedFile,
-    new RegExp(/@post\('/.source + restUrl + /'\)/.source),
+    new RegExp(/@post\('/.source + restUrl + /', {/.source),
   );
   assert.fileContent(
     expectedFile,
-    new RegExp(/@get\('/.source + restUrl + /\/count'\)/.source),
+    new RegExp(/@get\('/.source + restUrl + /\/count', {/.source),
   );
   assert.fileContent(
     expectedFile,
-    new RegExp(/@get\('/.source + restUrl + /'\)/.source),
+    new RegExp(/@get\('/.source + restUrl + /', {/.source),
   );
   assert.fileContent(
     expectedFile,
-    new RegExp(/@patch\('/.source + restUrl + /'\)/.source),
+    new RegExp(/@patch\('/.source + restUrl + /', {/.source),
   );
   assert.fileContent(
     expectedFile,
-    new RegExp(/@get\('/.source + restUrl + /\/{id}'\)/.source),
+    new RegExp(/@get\('/.source + restUrl + /\/{id}', {/.source),
   );
   assert.fileContent(
     expectedFile,
-    new RegExp(/@patch\('/.source + restUrl + /\/{id}'\)/.source),
+    new RegExp(/@patch\('/.source + restUrl + /\/{id}', {/.source),
   );
   assert.fileContent(
     expectedFile,
-    new RegExp(/@del\('/.source + restUrl + /\/{id}'\)/.source),
+    new RegExp(/@del\('/.source + restUrl + /\/{id}', {/.source),
   );
 }

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -120,7 +120,7 @@ export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
 export class OperationSpecBuilder extends BuilderBase<OperationObject> {
   constructor() {
     super({
-      responses: {},
+      responses: {'200': {description: 'An undocumented response body.'}},
     });
   }
 

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -11,7 +11,7 @@ import {
   SchemaObject,
 } from '@loopback/openapi-v3-types';
 import {MetadataInspector, ParameterDecoratorFactory} from '@loopback/context';
-import {getSchemaForParam} from '../generate-schema';
+import {resolveSchema} from '../generate-schema';
 import {OAI3Keys} from '../keys';
 
 /**
@@ -48,8 +48,8 @@ export function param(paramSpec: ParameterObject) {
         // generate schema if `paramSpec` has `schema` but without `type`
         (isSchemaObject(paramSpec.schema) && !paramSpec.schema.type)
       ) {
-        // please note `getSchemaForParam` only adds `type` and `format` for `schema`
-        paramSpec.schema = getSchemaForParam(paramType, paramSpec.schema);
+        // please note `resolveSchema` only adds `type` and `format` for `schema`
+        paramSpec.schema = resolveSchema(paramType, paramSpec.schema);
       }
     }
 

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -9,7 +9,7 @@ import {
   ReferenceObject,
 } from '@loopback/openapi-v3-types';
 import {MetadataInspector, ParameterDecoratorFactory} from '@loopback/context';
-import {getSchemaForRequestBody} from '../generate-schema';
+import {resolveSchema} from '../generate-schema';
 import {OAI3Keys} from '../keys';
 import * as _ from 'lodash';
 import {inspect} from 'util';
@@ -94,7 +94,7 @@ export function requestBody(requestBodySpec?: Partial<RequestBodyObject>) {
     const paramTypes = (methodSig && methodSig.parameterTypes) || [];
 
     const paramType = paramTypes[index];
-    const schema = getSchemaForRequestBody(paramType);
+    const schema = resolveSchema(paramType);
     debug('  inferred schema: %s', inspect(schema, {depth: null}));
     requestBodySpec.content = _.mapValues(requestBodySpec.content, c => {
       if (!c.schema) {

--- a/packages/openapi-v3/src/generate-schema.ts
+++ b/packages/openapi-v3/src/generate-schema.ts
@@ -6,14 +6,6 @@
 import {SchemaObject} from '@loopback/openapi-v3-types';
 
 /**
- * @private
- */
-interface TypeAndFormat {
-  type?: string;
-  format?: string;
-}
-
-/**
  * Generate the `type` and `format` property in a Schema Object according to a
  * parameter's type.
  * `type` and `format` will be preserved if provided in `schema`
@@ -22,44 +14,29 @@ interface TypeAndFormat {
  * @param type The JavaScript type of a parameter
  * @param schema The schema object provided in an parameter object
  */
-export function getSchemaForParam(
-  type: Function,
-  schema?: SchemaObject,
+export function resolveSchema(
+  fn?: Function,
+  schema: SchemaObject = {},
 ): SchemaObject {
-  schema = schema || {};
-  // preserve `type` and `format` provided by user
-  if (schema.type && schema.format) return schema;
+  let resolvedSchema: SchemaObject = {};
 
-  let typeAndFormat: TypeAndFormat = {};
-  if (type === String) {
-    typeAndFormat.type = 'string';
-  } else if (type === Number) {
-    typeAndFormat.type = 'number';
-  } else if (type === Boolean) {
-    typeAndFormat.type = 'boolean';
-  } else if (type === Array) {
-    // item type cannot be inspected
-    typeAndFormat.type = 'array';
-  } else if (type === Object) {
-    typeAndFormat.type = 'object';
+  if (typeof fn === 'function') {
+    if (fn === String) {
+      resolvedSchema = {type: 'string'};
+    } else if (fn === Number) {
+      resolvedSchema = {type: 'number'};
+    } else if (fn === Boolean) {
+      resolvedSchema = {type: 'boolean'};
+    } else if (fn === Date) {
+      resolvedSchema = {type: 'string', format: 'date'};
+    } else if (fn === Object) {
+      resolvedSchema = {type: 'object'};
+    } else if (fn === Array) {
+      resolvedSchema = {type: 'array'};
+    } else {
+      resolvedSchema = {$ref: `#/components/schemas/${fn.name}`};
+    }
   }
 
-  if (typeAndFormat.type && !schema.type) schema.type = typeAndFormat.type;
-  if (typeAndFormat.format && !schema.format)
-    schema.format = typeAndFormat.format;
-
-  return schema;
-}
-
-/**
- * Get OpenAPI Schema for a JavaScript type for a body parameter
- *
- * @private
- * @param type The JavaScript type of an argument deccorated by @requestBody
- */
-export function getSchemaForRequestBody(type: Function): SchemaObject {
-  let generatedSchema = getSchemaForParam(type);
-  if (!generatedSchema.type)
-    generatedSchema.$ref = '#/components/schemas/' + type.name;
-  return generatedSchema;
+  return Object.assign(schema, resolvedSchema);
 }

--- a/packages/openapi-v3/test/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/test/integration/controller-spec.integration.ts
@@ -6,7 +6,7 @@
 import {expect} from '@loopback/testlab';
 import {model, property} from '@loopback/repository';
 import {ParameterObject} from '@loopback/openapi-v3-types';
-import {param, requestBody, getControllerSpec, post} from '../../';
+import {param, requestBody, getControllerSpec, post, get} from '../../';
 
 describe('controller spec', () => {
   it('adds property schemas in components.schemas', () => {
@@ -41,7 +41,11 @@ describe('controller spec', () => {
       paths: {
         '/foo': {
           post: {
-            responses: {},
+            responses: {
+              '200': {
+                description: 'Return value of FooController.create',
+              },
+            },
             requestBody: {
               description: 'a foo instance',
               required: true,
@@ -105,6 +109,7 @@ describe('controller spec', () => {
     expect(schemas).to.have.keys('MyParam', 'Foo');
     expect(schemas!.MyParam).to.not.have.key('definitions');
   });
+
   it('infers no properties if no property metadata is present', () => {
     const paramSpec: ParameterObject = {
       name: 'foo',
@@ -147,5 +152,103 @@ describe('controller spec', () => {
 
     expect(schemas).to.have.key('MyParam');
     expect(schemas!.MyParam).to.deepEqual({});
+  });
+
+  it('generates a default responses object if not set', () => {
+    class MyController {
+      @get('/')
+      hello() {
+        return 'hello world';
+      }
+    }
+
+    const spec = getControllerSpec(MyController);
+    expect(spec.paths['/'].get).to.have.property('responses');
+    expect(spec.paths['/'].get.responses).to.eql({
+      '200': {
+        description: 'Return value of MyController.hello',
+      },
+    });
+  });
+
+  it('generates a response given no content property', () => {
+    class MyController {
+      @get('/', {
+        responses: {
+          '200': {
+            description: 'hello world',
+          },
+        },
+      })
+      hello() {
+        return 'hello world';
+      }
+    }
+
+    const spec = getControllerSpec(MyController);
+    expect(spec.paths['/'].get).to.have.property('responses');
+    expect(spec.paths['/'].get.responses).to.eql({
+      '200': {
+        description: 'hello world',
+      },
+    });
+  });
+
+  it('generates schema from `x-ts-type`', () => {
+    class MyController {
+      @get('/', {
+        responses: {
+          '200': {
+            description: 'hello world',
+            content: {'application/json': {'x-ts-type': String}},
+          },
+        },
+      })
+      hello() {
+        return 'hello world';
+      }
+    }
+
+    const spec = getControllerSpec(MyController);
+    expect(spec.paths['/'].get).to.have.property('responses');
+    expect(spec.paths['/'].get.responses).to.eql({
+      '200': {
+        description: 'hello world',
+        content: {'application/json': {schema: {type: 'string'}}},
+      },
+    });
+  });
+
+  it('generates schema for an array from `x-ts-type`', () => {
+    class MyController {
+      @get('/', {
+        responses: {
+          '200': {
+            description: 'hello world array',
+            content: {
+              'application/json': {
+                schema: {type: 'array', items: {'x-ts-type': String}},
+              },
+            },
+          },
+        },
+      })
+      hello() {
+        return ['hello', 'world'];
+      }
+    }
+
+    const spec = getControllerSpec(MyController);
+    expect(spec.paths['/'].get).to.have.property('responses');
+    expect(spec.paths['/'].get.responses).to.eql({
+      '200': {
+        description: 'hello world array',
+        content: {
+          'application/json': {
+            schema: {type: 'array', items: {type: 'string'}},
+          },
+        },
+      },
+    });
   });
 });

--- a/packages/openapi-v3/test/integration/operation-spec.integration.ts
+++ b/packages/openapi-v3/test/integration/operation-spec.integration.ts
@@ -33,7 +33,9 @@ describe('operation arguments', () => {
       paths: {
         '/users/{location}': {
           post: {
-            responses: {},
+            responses: {
+              '200': {description: 'Return value of MyController.createUser'},
+            },
             parameters: [
               {name: 'type', in: 'query', schema: {type: 'string'}},
               {name: 'token', in: 'header', schema: {type: 'string'}},

--- a/packages/openapi-v3/test/unit/decorators/operation.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/operation.decorator.unit.ts
@@ -207,7 +207,7 @@ describe('Routing metadata', () => {
 
     expect(actualSpec.paths['/greet']['get']).to.eql({
       'x-operation-name': 'greet',
-      responses: {},
+      responses: {'200': {description: 'Return value of MyController.greet'}},
     });
   });
 
@@ -221,7 +221,9 @@ describe('Routing metadata', () => {
 
     expect(actualSpec.paths['/greeting']['post']).to.eql({
       'x-operation-name': 'createGreeting',
-      responses: {},
+      responses: {
+        '200': {description: 'Return value of MyController.createGreeting'},
+      },
     });
   });
 

--- a/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/param/param.decorator.unit.ts
@@ -33,6 +33,7 @@ describe('Routing metadata for parameters', () => {
       const expectedSpec = anOperationSpec()
         .withOperationName('greet')
         .withParameter(paramSpec)
+        .withResponse(200, {description: 'Return value of MyController.greet'})
         .build();
       expect(actualSpec.paths['/greet']['get']).to.eql(expectedSpec);
     });
@@ -75,6 +76,7 @@ describe('Routing metadata for parameters', () => {
 
       const expectedSpec = anOperationSpec()
         .withOperationName('update')
+        .withResponse(200, {description: 'Return value of MyController.update'})
         .withParameter({
           name: 'id',
           schema: {
@@ -143,6 +145,7 @@ describe('Routing metadata for parameters', () => {
 
       const expectedSpec = anOperationSpec()
         .withOperationName('greet')
+        .withResponse(200, {description: 'Return value of MyController.greet'})
         .withParameter({
           name: 'names',
           schema: {
@@ -188,6 +191,7 @@ describe('Routing metadata for parameters', () => {
 
       const expectedSpec = anOperationSpec()
         .withOperationName('greet')
+        .withResponse(200, {description: 'Return value of MyController.greet'})
         .withParameter({
           name: 'names',
           schema: {

--- a/packages/openapi-v3/test/unit/generate-schema.unit.ts
+++ b/packages/openapi-v3/test/unit/generate-schema.unit.ts
@@ -1,0 +1,49 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v3.
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {resolveSchema} from '../../src/generate-schema';
+
+describe('generate-schema unit tests', () => {
+  it('returns an empty object given no arguments', () => {
+    expect(resolveSchema()).to.eql({});
+  });
+
+  it('resolves type String', () => {
+    expect(resolveSchema(String)).to.eql({type: 'string'});
+  });
+
+  it('resolves type Number', () => {
+    expect(resolveSchema(Number)).to.eql({type: 'number'});
+  });
+
+  it('resolves type Boolean', () => {
+    expect(resolveSchema(Boolean)).to.eql({type: 'boolean'});
+  });
+
+  it('resolves type Date', () => {
+    expect(resolveSchema(Date)).to.eql({type: 'string', format: 'date'});
+  });
+
+  it('resolves type Object', () => {
+    expect(resolveSchema(Object)).to.eql({type: 'object'});
+  });
+
+  it('resolves type Array', () => {
+    expect(resolveSchema(Array)).to.eql({type: 'array'});
+  });
+
+  it('resolves type Class', () => {
+    class MyModel {}
+    expect(resolveSchema(MyModel)).to.eql({
+      $ref: '#/components/schemas/MyModel',
+    });
+  });
+
+  it('preserves existing schema properties', () => {
+    const schema = {foo: 'bar'};
+    expect(resolveSchema(String, schema)).to.eql({type: 'string', foo: 'bar'});
+  });
+});

--- a/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -118,7 +118,7 @@ describe('RestServer.getApiSpec()', () => {
 
   it('honors tags in the operation spec', () => {
     class MyController {
-      @get('/greet', {responses: {}, tags: ['MyTag']})
+      @get('/greet', {responses: {'200': {description: ''}}, tags: ['MyTag']})
       greet() {}
     }
     app.controller(MyController);
@@ -127,7 +127,7 @@ describe('RestServer.getApiSpec()', () => {
     expect(spec.paths).to.eql({
       '/greet': {
         get: {
-          responses: {},
+          responses: {'200': {description: ''}},
           'x-controller-name': 'MyController',
           'x-operation-name': 'greet',
           tags: ['MyTag'],
@@ -147,7 +147,9 @@ describe('RestServer.getApiSpec()', () => {
     expect(spec.paths).to.eql({
       '/greet': {
         get: {
-          responses: {},
+          responses: {
+            '200': {description: 'Return value of MyController.greet'},
+          },
           'x-controller-name': 'MyController',
           'x-operation-name': 'greet',
           tags: ['MyController'],


### PR DESCRIPTION
connected to #1531 

---

This PR:
- Ensures we set a default `responses` property on a Controller methods OpenAPI Spec if one isn't given
- Extends the OpenAPI spec by introducing a `x-ts-type` property that can be used to specify the schema of a response object. Can also be used to specify the type of array items. 
```
content: {'x-ts-type': Todo} => content: {schema: {$ref: '#components/schemas/Todo'}}
content: {schema: {type: 'array', items: {x-ts-type: Todo}}} => content: {schema: {type: 'array', items: {$ref: '#components/schemas/Todo'}}}
```
- Refactors `generate-schema` to have a single function to resolve schema from a Function.
- Updates CLI Controller template to set a `responses` object based on the Model
- Updates `example-todo` / `example-todo-list` to set `responses` object

~This PR introduces:~
~- a new `@responses` decorator that can be used to decorate a Controller method with the appropriate OpenAPI responses object.~
~- for controller's not decorated with this property, or via the `@operation` and family (get, post, etc.) of decorators, we generate a default responses object to be OpenAPI 3.0 compliant~
~- `controller-spec` generator can set Model as `$ref` for `{schema: Model}` or {schema: {type: 'array', items: Model}}}` in the responses object.~
~- Decorate `example-todo` with `@responses()` decorator as an example. Once this PR is agreed upon, a follow up PR/commit will add decoration to CLI template + remaining examples + docs~


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
