### PR TITLE
fix: return 404 when a model was not found

### DIFF
--- a/docs/site/Error-handling.md
+++ b/docs/site/Error-handling.md
@@ -11,9 +11,12 @@ permalink: /doc/en/lb4/Error-handling.html
 In order to allow clients to reliably detect individual error causes, LoopBack
 sets the error `code` property to a machine-readable string.
 
-| Error code       | Description                                                                                                                                                                                                              |
-| :--------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ENTITY_NOT_FOUND | The entity (model) was not found. This error is returned for example by [`EntityCrudRepository.prototype.findById`](http://apidocs.loopback.io/@loopback%2fdocs/repository.html#EntityCrudRepository.prototype.findById) |
+| Error code                 | Description                                                                                                                                                                                                              |
+| :------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ENTITY_NOT_FOUND           | The entity (model) was not found. This error is returned for example by [`EntityCrudRepository.prototype.findById`](http://apidocs.loopback.io/@loopback%2fdocs/repository.html#EntityCrudRepository.prototype.findById) |
+| VALIDATION_FAILED          | The data provided by the client is not a valid entity.                                                                                                                                                                   |
+| INVALID_PARAMETER_VALUE    | The value provided for a parameter of a REST endpoint is not valid. For example, a string value was provided for a numeric parameter.                                                                                    |
+| MISSING_REQUIRED_PARAMETER | No value was provided for a required parameter.                                                                                                                                                                          |
 
 Besides LoopBack-specific error codes, your application can encounter low-level
 error codes from Node.js and the underlying operating system. For example, when

--- a/docs/site/Error-handling.md
+++ b/docs/site/Error-handling.md
@@ -1,0 +1,26 @@
+---
+lang: en
+title: Error Handling
+keywords: LoopBack 4.0
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Error-handling.html
+---
+
+## Known Error Codes
+
+In order to allow clients to reliably detect individual error causes, LoopBack
+sets the error `code` property to a machine-readable string.
+
+| Error code       | Description                                                                                                                                                                                                              |
+| :--------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ENTITY_NOT_FOUND | The entity (model) was not found. This error is returned for example by [`EntityCrudRepository.prototype.findById`](http://apidocs.loopback.io/@loopback%2fdocs/repository.html#EntityCrudRepository.prototype.findById) |
+
+Besides LoopBack-specific error codes, your application can encounter low-level
+error codes from Node.js and the underlying operating system. For example, when
+a connector is not able to reach the database, an error with code `ECONNREFUSED`
+is returned.
+
+See the following resources for a list of low-level error codes:
+
+- [Common System Errors](https://nodejs.org/api/errors.html#errors_common_system_errors)
+- [Node.js Error Codes](https://nodejs.org/api/errors.html#errors_node_js_error_codes)

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -182,6 +182,10 @@ children:
       url: Decorators_repository.html
       output: 'web, pdf'
 
+  - title: 'Error handling'
+    url: Error-handling.html
+    output: 'web, pdf'
+
 - title: 'Booting an Application'
   url: Booting-an-Application.html
   output: 'web, pdf'

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Filter, Where, repository} from '@loopback/repository';
-import {post, param, get, patch, del, requestBody} from '@loopback/rest';
+import {Filter, repository, Where} from '@loopback/repository';
+import {del, get, param, patch, post, requestBody} from '@loopback/rest';
 import {TodoList} from '../models';
 import {TodoListRepository} from '../repositories';
 

--- a/examples/todo-list/test/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list.acceptance.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {EntityNotFoundError} from '@loopback/repository';
 import {createClientForHandler, expect, supertest} from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {TodoList} from '../../src/models/';
@@ -110,7 +111,7 @@ describe('Application', () => {
         .expect(200);
       await expect(
         todoListRepo.findById(persistedTodoList.id),
-      ).to.be.rejectedWith(/no TodoList found with id/);
+      ).to.be.rejectedWith(EntityNotFoundError);
     });
   });
 

--- a/examples/todo-list/test/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list.acceptance.ts
@@ -92,6 +92,10 @@ describe('Application', () => {
       expect(result.body).to.deepEqual(expected);
     });
 
+    it('returns 404 when a todo does not exist', () => {
+      return client.get('/todo-lists/99999').expect(404);
+    });
+
     it('updates a todoList by ID', async () => {
       const updatedTodoList = givenTodoList({
         title: 'A different title to the todo list',

--- a/examples/todo-list/test/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo.acceptance.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {EntityNotFoundError} from '@loopback/repository';
 import {createClientForHandler, expect, supertest} from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {Todo} from '../../src/models/';
@@ -96,7 +97,7 @@ describe('Application', () => {
         .send()
         .expect(200);
       await expect(todoRepo.findById(persistedTodo.id)).to.be.rejectedWith(
-        /no Todo found with id/,
+        EntityNotFoundError,
       );
     });
   });

--- a/examples/todo-list/test/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo.acceptance.ts
@@ -64,6 +64,10 @@ describe('Application', () => {
       expect(result.body).to.deepEqual(expected);
     });
 
+    it('returns 404 when a todo does not exist', () => {
+      return client.get('/todos/99999').expect(404);
+    });
+
     it('replaces the todo by ID', async () => {
       const updatedTodo = givenTodo({
         title: 'DO SOMETHING AWESOME',

--- a/examples/todo/test/acceptance/todo.acceptance.ts
+++ b/examples/todo/test/acceptance/todo.acceptance.ts
@@ -3,16 +3,17 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {EntityNotFoundError} from '@loopback/repository';
 import {createClientForHandler, expect, supertest} from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {Todo} from '../../src/models/';
 import {TodoRepository} from '../../src/repositories/';
 import {
-  HttpCachingProxy,
   aLocation,
   getProxiedGeoCoderConfig,
   givenCachingProxy,
   givenTodo,
+  HttpCachingProxy,
 } from '../helpers';
 
 describe('Application', () => {
@@ -128,7 +129,7 @@ describe('Application', () => {
         .send()
         .expect(200);
       await expect(todoRepo.findById(persistedTodo.id)).to.be.rejectedWith(
-        /no Todo found with id/,
+        EntityNotFoundError,
       );
     });
   });

--- a/examples/todo/test/acceptance/todo.acceptance.ts
+++ b/examples/todo/test/acceptance/todo.acceptance.ts
@@ -96,6 +96,10 @@ describe('Application', () => {
       expect(result.body).to.deepEqual(expected);
     });
 
+    it('returns 404 when a todo does not exist', () => {
+      return client.get('/todos/99999').expect(404);
+    });
+
     it('replaces the todo by ID', async () => {
       const updatedTodo = givenTodo({
         title: 'DO SOMETHING AWESOME',

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -1,4 +1,5 @@
-import {Filter, Where, repository} from '@loopback/repository';
+import {Filter, repository, Where} from '@loopback/repository';
+
 import {
   post,
   param,

--- a/packages/cli/test/unit/update-index.unit.js
+++ b/packages/cli/test/unit/update-index.unit.js
@@ -40,7 +40,7 @@ describe('update-index unit tests', () => {
   });
 
   it('throws an error when given a non-ts file', async () => {
-    expect(updateIndex(SANDBOX_PATH, 'test.js')).to.be.rejectedWith(
+    await expect(updateIndex(SANDBOX_PATH, 'test.js')).to.be.rejectedWith(
       /test.js must be a TypeScript \(.ts\) file/,
     );
   });

--- a/packages/context/test/unit/value-promise.unit.ts
+++ b/packages/context/test/unit/value-promise.unit.ts
@@ -244,15 +244,14 @@ describe('resolveUntil', () => {
     expect(result).to.eql('A');
   });
 
-  it('handles a rejected promise from resolver', () => {
+  it('handles a rejected promise from resolver', async () => {
     const source = ['a', 'b', 'c'];
     const result = resolveUntil<string, string>(
       source[Symbol.iterator](),
       v => Promise.reject(new Error(v)),
       (s, v) => true,
     );
-    // tslint:disable-next-line:no-floating-promises
-    expect(result).be.rejectedWith('a');
+    await expect(result).be.rejectedWith('a');
   });
 
   it('reports an error thrown from resolver', () => {
@@ -268,7 +267,7 @@ describe('resolveUntil', () => {
     expect(task).throw('a');
   });
 
-  it('handles a rejected promise from evaluator', () => {
+  it('handles a rejected promise from evaluator', async () => {
     const source = ['a', 'b', 'c'];
     const result = resolveUntil<string, string>(
       source[Symbol.iterator](),
@@ -277,8 +276,7 @@ describe('resolveUntil', () => {
         throw new Error(v);
       },
     );
-    // tslint:disable-next-line:no-floating-promises
-    expect(result).be.rejectedWith('A');
+    await expect(result).be.rejectedWith('A');
   });
 
   it('handles mixed value and promise items ', async () => {
@@ -341,12 +339,11 @@ describe('transformValueOrPromise', () => {
     expect(result).to.eql('A');
   });
 
-  it('handles a rejected promise from the transformer', () => {
+  it('handles a rejected promise from the transformer', async () => {
     const result = transformValueOrPromise('a', v =>
       Promise.reject(new Error(v)),
     );
-    // tslint:disable-next-line:no-floating-promises
-    expect(result).be.rejectedWith('a');
+    await expect(result).be.rejectedWith('a');
   });
 
   it('handles an error thrown from the transformer', () => {

--- a/packages/repository/src/errors/entity-not-found.error.ts
+++ b/packages/repository/src/errors/entity-not-found.error.ts
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity} from '../model';
+
+export class EntityNotFoundError<ID, Props extends object = {}> extends Error {
+  code: string;
+  entityName: string;
+  entityId: ID;
+
+  constructor(
+    entityOrName: typeof Entity | string,
+    entityId: ID,
+    extraProperties?: Props,
+  ) {
+    const entityName =
+      typeof entityOrName === 'string'
+        ? entityOrName
+        : entityOrName.modelName || entityOrName.name;
+
+    const quotedId = JSON.stringify(entityId);
+
+    super(`Entity not found: ${entityName} with id ${quotedId}`);
+
+    Error.captureStackTrace(this, this.constructor);
+
+    this.code = 'ENTITY_NOT_FOUND';
+    this.entityName = entityName;
+    this.entityId = entityId;
+
+    Object.assign(this, extraProperties);
+  }
+}
+
+// tslint:disable-next-line:no-any
+export function isEntityNotFoundError(e: any): e is EntityNotFoundError<any> {
+  return e instanceof EntityNotFoundError;
+}

--- a/packages/repository/src/errors/index.ts
+++ b/packages/repository/src/errors/index.ts
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './entity-not-found.error';

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from './connectors';
 export * from './decorators';
+export * from './errors';
 export * from './mixins';
 export * from './repositories';
 export * from './types';

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -167,7 +167,10 @@ function asObject(value: any, options?: Options): any {
  * Base class for models
  */
 export abstract class Model {
-  static modelName: string;
+  static get modelName(): string {
+    return (this.definition && this.definition.name) || this.name;
+  }
+
   static definition: ModelDefinition;
 
   /**

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -3,26 +3,26 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as legacy from 'loopback-datasource-juggler';
-
-import * as assert from 'assert';
 import {isPromiseLike} from '@loopback/context';
+import * as assert from 'assert';
+import * as legacy from 'loopback-datasource-juggler';
 import {
-  Options,
   AnyObject,
   Command,
-  NamedParameters,
-  PositionalParameters,
   DataObject,
+  NamedParameters,
+  Options,
+  PositionalParameters,
 } from '../common-types';
+import {HasManyDefinition} from '../decorators/relation.decorator';
+import {EntityNotFoundError} from '../errors';
 import {Entity, ModelDefinition} from '../model';
 import {Filter, Where} from '../query';
-import {EntityCrudRepository} from './repository';
 import {
   createHasManyRepositoryFactory,
   HasManyRepositoryFactory,
 } from './relation.factory';
-import {HasManyDefinition} from '../decorators/relation.decorator';
+import {EntityCrudRepository} from './repository';
 
 export namespace juggler {
   export import DataSource = legacy.DataSource;
@@ -211,7 +211,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
       this.modelClass.findById(id, filter, options),
     );
     if (!model) {
-      throw new Error(`no ${this.modelClass.name} found with id "${id}"`);
+      throw new EntityNotFoundError(this.entityClass, id);
     }
     return this.toEntity(model);
   }

--- a/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
@@ -164,6 +164,12 @@ describe('model decorator', () => {
     expect(meta).to.eql({name: 'foo'});
   });
 
+  it('updates static property "modelName"', () => {
+    @model()
+    class Category extends Entity {}
+    expect(Category.modelName).to.equal('Category');
+  });
+
   it('adds model metadata with arbitrary properties', () => {
     @model({arbitrary: 'property'})
     class Arbitrary {

--- a/packages/repository/test/unit/errors/entity-not-found-error.test.ts
+++ b/packages/repository/test/unit/errors/entity-not-found-error.test.ts
@@ -18,7 +18,9 @@ describe('EntityNotFoundError', () => {
     expect(err).to.be.instanceof(Error);
     expect(err.stack)
       .to.be.String()
-      .and.match((s: string) => s.indexOf(__filename) > -1);
+      // NOTE(bajtos) We cannot assert using __filename because stack traces
+      // are typically converted from JS paths to TS paths using source maps.
+      .and.match(/entity-not-found-error.test.(ts|js)/);
   });
 
   it('sets code to "ENTITY_NOT_FOUND"', () => {

--- a/packages/repository/test/unit/errors/entity-not-found-error.test.ts
+++ b/packages/repository/test/unit/errors/entity-not-found-error.test.ts
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  Entity,
+  EntityNotFoundError,
+  model,
+  isEntityNotFoundError,
+} from '../../../';
+
+describe('EntityNotFoundError', () => {
+  it('inherits from Error correctly', () => {
+    const err = givenAnErrorInstance();
+    expect(err).to.be.instanceof(EntityNotFoundError);
+    expect(err).to.be.instanceof(Error);
+    expect(err.stack)
+      .to.be.String()
+      .and.match((s: string) => s.indexOf(__filename) > -1);
+  });
+
+  it('sets code to "ENTITY_NOT_FOUND"', () => {
+    const err = givenAnErrorInstance();
+    expect(err.code).to.equal('ENTITY_NOT_FOUND');
+  });
+
+  it('sets entity name and id properties', () => {
+    const err = new EntityNotFoundError('Product', 'an-id');
+    expect(err).to.have.properties({
+      entityName: 'Product',
+      entityId: 'an-id',
+    });
+  });
+
+  it('has a descriptive error message', () => {
+    const err = new EntityNotFoundError('Product', 'an-id');
+    expect(err.message).to.match(/not found.*Product.*"an-id"/);
+  });
+
+  it('infers entity name from entity class via name', () => {
+    class Product extends Entity {}
+
+    const err = new EntityNotFoundError(Product, 1);
+    expect(err.entityName).to.equal('Product');
+  });
+
+  it('infers entity name from entity class via modelName', () => {
+    @model({name: 'CustomProduct'})
+    class Product extends Entity {}
+
+    const err = new EntityNotFoundError(Product, 1);
+    expect(err.entityName).to.equal('CustomProduct');
+  });
+
+  function givenAnErrorInstance() {
+    return new EntityNotFoundError('Product', 1);
+  }
+});
+
+describe('isEntityNotFoundError', () => {
+  it('returns true for an instance of EntityNotFoundError', () => {
+    const error = new EntityNotFoundError('Product', 123);
+    expect(isEntityNotFoundError(error)).to.be.true();
+  });
+
+  it('returns false for an instance of Error', () => {
+    const error = new Error('A generic error');
+    expect(isEntityNotFoundError(error)).to.be.false();
+  });
+});

--- a/packages/repository/test/unit/model/model.unit.ts
+++ b/packages/repository/test/unit/model/model.unit.ts
@@ -293,4 +293,13 @@ describe('model', () => {
     const instance = new NoId();
     expect(() => instance.getId()).to.throw(/missing.*id/);
   });
+
+  it('reads model name from the definition', () => {
+    expect(Customer.modelName).to.equal('Customer');
+  });
+
+  it('reads model name from the class name', () => {
+    class MyModel extends Entity {}
+    expect(MyModel.modelName).to.equal('MyModel');
+  });
 });

--- a/packages/rest/src/rest-http-error.ts
+++ b/packages/rest/src/rest-http-error.ts
@@ -7,12 +7,22 @@ export namespace RestHttpErrors {
     extraProperties?: Props,
   ): HttpErrors.HttpError & Props {
     const msg = `Invalid data ${JSON.stringify(data)} for parameter ${name}!`;
-    return Object.assign(new HttpErrors.BadRequest(msg), extraProperties);
+    return Object.assign(
+      new HttpErrors.BadRequest(msg),
+      {
+        code: 'INVALID_PARAMETER_VALUE',
+        parameterName: name,
+      },
+      extraProperties,
+    );
   }
 
   export function missingRequired(name: string): HttpErrors.HttpError {
     const msg = `Required parameter ${name} is missing!`;
-    return new HttpErrors.BadRequest(msg);
+    return Object.assign(new HttpErrors.BadRequest(msg), {
+      code: 'MISSING_REQUIRED_PARAMETER',
+      parameterName: name,
+    });
   }
 
   export function invalidParamLocation(location: string): HttpErrors.HttpError {
@@ -23,7 +33,12 @@ export namespace RestHttpErrors {
   export const INVALID_REQUEST_BODY_MESSAGE =
     'The request body is invalid. See error object `details` property for more info.';
   export function invalidRequestBody(): HttpErrors.HttpError {
-    return new HttpErrors.UnprocessableEntity(INVALID_REQUEST_BODY_MESSAGE);
+    return Object.assign(
+      new HttpErrors.UnprocessableEntity(INVALID_REQUEST_BODY_MESSAGE),
+      {
+        code: 'VALIDATION_FAILED',
+      },
+    );
   }
 
   /**

--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -33,8 +33,18 @@ export function validateRequestBody(
   requestBodySpec: RequestBodyObject | undefined,
   globalSchemas?: SchemasObject,
 ) {
-  if (requestBodySpec && requestBodySpec.required && body == undefined)
-    throw new HttpErrors.BadRequest('Request body is required');
+  if (!requestBodySpec) return;
+
+  if (requestBodySpec.required && body == undefined) {
+    const err = Object.assign(
+      new HttpErrors.BadRequest('Request body is required'),
+      {
+        code: 'MISSING_REQUIRED_PARAMETER',
+        parameterName: 'request body',
+      },
+    );
+    throw err;
+  }
 
   const schema = getRequestBodySchema(requestBodySpec);
   debug('Request body schema: %j', util.inspect(schema, {depth: null}));
@@ -49,10 +59,8 @@ export function validateRequestBody(
  * @param requestBodySpec The requestBody specification defined in `@requestBody()`.
  */
 function getRequestBodySchema(
-  requestBodySpec: RequestBodyObject | undefined,
+  requestBodySpec: RequestBodyObject,
 ): SchemaObject | undefined {
-  if (!requestBodySpec) return;
-
   const content = requestBodySpec.content;
   // FIXME(bajtos) we need to find the entry matching the content-type
   // header from the incoming request (e.g. "application/json").

--- a/packages/rest/test/unit/request-body.validator.test.ts
+++ b/packages/rest/test/unit/request-body.validator.test.ts
@@ -67,6 +67,7 @@ describe('validateRequestBody', () => {
     ];
     verifyValidationRejectsInputWithError(
       INVALID_MSG,
+      'VALIDATION_FAILED',
       details,
       {
         description: 'missing required "title"',
@@ -86,6 +87,7 @@ describe('validateRequestBody', () => {
     ];
     verifyValidationRejectsInputWithError(
       INVALID_MSG,
+      'VALIDATION_FAILED',
       details,
       {
         title: 'todo with a string value of "isComplete"',
@@ -112,6 +114,7 @@ describe('validateRequestBody', () => {
     ];
     verifyValidationRejectsInputWithError(
       INVALID_MSG,
+      'VALIDATION_FAILED',
       details,
       {
         description: 'missing title and a string value of "isComplete"',
@@ -140,6 +143,7 @@ describe('validateRequestBody', () => {
     ];
     verifyValidationRejectsInputWithError(
       INVALID_MSG,
+      'VALIDATION_FAILED',
       details,
       {description: 'missing title'},
       aBodySpec({$ref: '#/components/schemas/Todo'}),
@@ -150,6 +154,7 @@ describe('validateRequestBody', () => {
   it('rejects empty values when body is required', () => {
     verifyValidationRejectsInputWithError(
       'Request body is required',
+      'MISSING_REQUIRED_PARAMETER',
       undefined,
       null,
       aBodySpec(TODO_SCHEMA, {required: true}),
@@ -176,6 +181,7 @@ describe('validateRequestBody', () => {
     };
     verifyValidationRejectsInputWithError(
       INVALID_MSG,
+      'VALIDATION_FAILED',
       details,
       {count: 'string value'},
       aBodySpec(schema),
@@ -205,6 +211,7 @@ describe('validateRequestBody', () => {
       };
       verifyValidationRejectsInputWithError(
         INVALID_MSG,
+        'VALIDATION_FAILED',
         details,
         {orders: ['order1', 1]},
         aBodySpec(schema),
@@ -228,6 +235,7 @@ describe('validateRequestBody', () => {
       };
       verifyValidationRejectsInputWithError(
         INVALID_MSG,
+        'VALIDATION_FAILED',
         details,
         [{title: 'a good todo'}, {description: 'a todo item missing title'}],
         aBodySpec(schema),
@@ -263,6 +271,7 @@ describe('validateRequestBody', () => {
       };
       verifyValidationRejectsInputWithError(
         INVALID_MSG,
+        'VALIDATION_FAILED',
         details,
         {
           todos: [
@@ -298,6 +307,7 @@ describe('validateRequestBody', () => {
       };
       verifyValidationRejectsInputWithError(
         INVALID_MSG,
+        'VALIDATION_FAILED',
         details,
         {
           accounts: [
@@ -314,8 +324,9 @@ describe('validateRequestBody', () => {
 // ----- HELPERS ----- /
 
 function verifyValidationRejectsInputWithError(
-  errorMatcher: Error | RegExp | string,
-  details: RestHttpErrors.ValidationErrorDetails[] | undefined,
+  expectedMessage: string,
+  expectedCode: string,
+  expectedDetails: RestHttpErrors.ValidationErrorDetails[] | undefined,
   body: object | null,
   spec: RequestBodyObject | undefined,
   schemas?: SchemasObject,
@@ -326,7 +337,8 @@ function verifyValidationRejectsInputWithError(
       "expected Function { name: 'validateRequestBody' } to throw exception",
     );
   } catch (err) {
-    expect(err.message).to.equal(errorMatcher);
-    expect(err.details).to.deepEqual(details);
+    expect(err.message).to.equal(expectedMessage);
+    expect(err.code).to.equal(expectedCode);
+    expect(err.details).to.deepEqual(expectedDetails);
   }
 }

--- a/packages/rest/test/unit/router/reject.provider.unit.ts
+++ b/packages/rest/test/unit/router/reject.provider.unit.ts
@@ -28,6 +28,18 @@ describe('reject', () => {
     expect(result).to.have.property('statusCode', 500);
   });
 
+  it('converts error code ENTITY_NOT_FOUND to status code 404', async () => {
+    const reject = new RejectProvider(noopLogger).value();
+
+    const notFoundError: Error & {code?: string} = new Error('not found');
+    notFoundError.code = 'ENTITY_NOT_FOUND';
+
+    reject(contextStub, notFoundError);
+    const result = await contextStub.result;
+
+    expect(result.statusCode).to.equal(404);
+  });
+
   it('logs the error', async () => {
     const logger = sinon.spy() as LogError & SinonSpy;
     const reject = new RejectProvider(logger).value();


### PR DESCRIPTION
_This is an alternative solution to #1617 that fixes #1469._

- test: fix incorrect usage of rejectedWith assertion. I discovered this problem while fixing tests added as part of this pull request.
- feat(repository): change Model.modelName to a computed property. This ensures `modelName` is always available and match model definition.
- feat(repository): implement EntityNotFoundError. This error builds a descriptive error message and sets `error.code` to `ENTITY_NOT_FOUND` string.
- refactor: rework "findById" to leverage EntityNotFoundError. As a result, "model not found" scenario can be detected by checking whether the error `code` is `ENTITY_NOT_FOUND`.
- fix(rest): return 404 when a model was not found. Here we modify the `reject` action to convert `ENTITY_NOT_FOUND` error code to response status code 404.
- docs: add Error-handling.md, describe error codes
- feat(rest): add error codes for REST validation errors
    `VALIDATION_FAILED`, `INVALID_PARAMETER_VALUE`, `MISSING_REQUIRED_PARAMETER`

Out of scope of this pull request:
 - Update updateById,deleteById to throw EntityNotFound error for consistency.
 - Add a factory method allowing people to obtain a modified Repo instance that returns undefined if not found, as described in https://github.com/strongloop/loopback-next/pull/1658#issuecomment-420318023.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated