### PR TITLE
docs: add oneliners and links to tutorials per 1444

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -18,15 +18,15 @@ Models can be used for data exchange on the wire or between different systems.
 For example, a JSON object conforming to the `Customer` model definition can be
 passed in REST/HTTP payload to create a new customer or stored in a document
 database such as MongoDB. Model definitions can also be mapped to other forms,
-such as relational database schema, XML schema, JSON schema, OpenAPI schema, or
-gRPC message definition, and vice versa.
+such as relational database schemas, XML schemas, JSON schemas, OpenAPI schemas,
+or gRPC message definitions, and vice versa.
 
 There are two subtly different types of models for domain objects:
 
 - Value Object: A domain object that does not have an identity (ID). Its
   equality is based on the structural value. For example, `Address` can be
-  modeled as `Value Object` as two US addresses are equal if they have the same
-  street number, street name, city, and zip code values. For example:
+  modeled as a `Value Object` because two US addresses are equal if they have
+  the same street number, street name, city, and zip code values. For example:
 
 ```json
 {
@@ -41,10 +41,9 @@ There are two subtly different types of models for domain objects:
 ```
 
 - Entity: A domain object that has an identity (ID). Its equality is based on
-  the identity. For example, `Customer` can be modeled as `Entity` as each
-  customer should have a unique customer id. Two instances of `Customer` with
-  the same customer id are equal since they refer to the same customer. For
-  example:
+  the identity. For example, `Customer` can be modeled as an `Entity` because
+  each customer has a unique customer id. Two instances of `Customer` with the
+  same customer id are equal since they refer to the same customer. For example:
 
 ```json
 {
@@ -77,7 +76,7 @@ export class Customer {
 ```
 
 Extensibility is a core feature of LoopBack. There are external packages that
-add additional features, for example, integration with the legacy juggler or
+add additional features, for example, integration with the juggler bridge or
 JSON Schema generation. These features become available to a LoopBack model
 through the `@model` and `@property` decorators from the `@loopback/repository`
 module.
@@ -96,9 +95,9 @@ export class Customer {
 }
 ```
 
-## Using Legacy Juggler
+## Using the Juggler Bridge
 
-To define a model for use with the legacy juggler, extend your classes from
+To define a model for use with the juggler bridge, extend your classes from
 `Entity` and decorate them with the `@model` and `@property` decorators.
 
 ```ts
@@ -124,10 +123,10 @@ export class Product extends Entity {
 }
 ```
 
-As you can see, models are defined primarily by their TypeScript class. By
-default, classes forbid additional properties not specified in the type
-definition. The persistence layer is respecting this constraint and configures
-underlying PersistedModel classes to enforce `strict` mode.
+Models are defined primarily by their TypeScript class. By default, classes
+forbid additional properties that are not specified in the type definition. The
+persistence layer respects this constraint and configures underlying
+PersistedModel classes to enforce `strict` mode.
 
 To create a model that allows both well-defined but also arbitrary extra
 properties, you need to disable `strict` mode in model settings and tell
@@ -193,7 +192,7 @@ class Product extends Entity {
 
 Additionally, the model decorator is able to build the properties object through
 the information passed in or inferred by the property decorators, so the
-properties key value pair can be omitted as well by using property decorators.
+properties key value pair can also be omitted.
 
 ### Property Decorator
 
@@ -238,7 +237,7 @@ LoopBack, due to the nature of arrays in JavaScript. In JavaScript, arrays do
 not possess any information about the types of their members. By traversing an
 array, you can inspect the members of an array to determine if they are of a
 primitive type (string, number, array, boolean), object or function, but this
-would not tell us anything about what the value would be if it were an object or
+does not tell you anything about what the value would be if it were an object or
 function.
 
 For consistency, we require the use of the `@property.array` decorator, which
@@ -259,7 +258,7 @@ class Thread extends Entity {
 }
 ```
 
-Additionally, the `@property.array` decorator can still take an optional 2nd
+Additionally, the `@property.array` decorator can still take an optional second
 parameter to define or override metadata in the same fashion as the `@property`
 decorator.
 
@@ -280,7 +279,7 @@ Use the `@loopback/repository-json-schema module` to build a JSON schema from a
 decorated model. Type information is inferred from the `@model` and `@property`
 decorators. The `@loopback/repository-json-schema` module contains the
 `getJsonSchema` function to access the metadata stored by the decorators to
-build a matching JSON Schema of your model.
+build a matching JSON schema of your model.
 
 ```ts
 import {model, property} from '@loopback/repository';
@@ -346,7 +345,7 @@ This feature is still a work in progress and is incomplete.
 " %}
 
 Following are the supported keywords that can be explicitly passed into the
-decorators to better tailor towards the JSON Schema being produced.
+decorators to better tailor towards the JSON Schema being produced:
 
 | Keywords    | Decorator   | Type    | Default      | Description                                             |
 | ----------- | ----------- | ------- | ------------ | ------------------------------------------------------- |

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -6,12 +6,12 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Repositories.html
 ---
 
-`Repository` represents a specialized `Service` interface that provides
+A `Repository` represents a specialized `Service` interface that provides
 strong-typed data access (for example, CRUD) operations of a domain model
 against the underlying database or service.
 
-`Repository` can be defined and implemented by application developers. LoopBack
-ships a few predefined `Repository` interfaces for typical CRUD and KV
+A `Repository` can be defined and implemented by application developers.
+LoopBack ships a few predefined `Repository` interfaces for typical CRUD and KV
 operations. These `Repository` implementations leverage `Model` definition and
 `DataSource` configuration to fulfill the logic for data access.
 

--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -14,8 +14,15 @@ Each function on a controller can be addressed individually to handle an
 incoming request (like a POST request to `/todos`), to perform business logic,
 and to return a response.
 
+`Controller` is a class that implements operations defined by application's API.
+It implements an application's business logic and acts as a bridge between the
+HTTP/REST API and domain/database models.
+
 In this respect, controllers are the regions _in which most of your business
 logic will live_!
+
+For more information about Controllers, see
+[Controllers](https://loopback.io/doc/en/lb4/Controllers.html).
 
 ### Create your controller
 

--- a/docs/site/todo-tutorial-datasource.md
+++ b/docs/site/todo-tutorial-datasource.md
@@ -10,11 +10,18 @@ summary: LoopBack 4 Todo Application Tutorial - Add a Datasource
 ### Datasources
 
 Datasources are LoopBack's way of connecting to various sources of data, such as
-databases, APIs, message queues and more. In LoopBack 4, datasources can be
-represented as strongly-typed objects and freely made available for
-[injection](Dependency-injection.md) throughout the application. Typically, in
-LoopBack 4, datasources are used in conjunction with
+databases, APIs, message queues and more. A `DataSource` in LoopBack 4 is a
+named configuration for a Connector instance that represents data in an external
+system. The Connector is used by `legacy-juggler-bridge` to power LoopBack 4
+Repositories for Data operations.
+
+In LoopBack 4, datasources can be represented as strongly-typed objects and
+freely made available for [injection](Dependency-injection.md) throughout the
+application. Typically, in LoopBack 4, datasources are used in conjunction with
 [Repositories](Repositories.md) to provide access to data.
+
+For more information about datasources in LoopBack, see
+[DataSources](https://loopback.io/doc/en/lb4/DataSources.html).
 
 Since our Todo API will need to persist instances of Todo items, we'll need to
 create a datasource definition to make this possible.

--- a/docs/site/todo-tutorial-model.md
+++ b/docs/site/todo-tutorial-model.md
@@ -16,6 +16,14 @@ instances of a task for our Todo list. The Todo model will serve both as a
 known as a DTO) for representing incoming Todo instances on requests, as well as
 our data structure for use with loopback-datasource-juggler.
 
+A model describes business domain objects and defines a list of properties with
+name, type, and other constraints.
+
+Models are used for data exchange on the wire or between different systems.
+
+For more information about Models and how they are used in LoopBack, see
+[Models](https://loopback.io/doc/en/lb4/todo-tutorial-model.html).
+
 > **NOTE:** LoopBack 3 treated models as the "center" of operations; in LoopBack
 > 4, that is no longer the case. While LoopBack 4 provides many of the helper
 > methods and decorators that allow you to utilize models in a similar way, you
@@ -28,7 +36,8 @@ let you label tasks so that you can distinguish between them, add extra
 information to describe those tasks, and finally, provide a way of tracking
 whether or not they're complete.
 
-For our Todo model to represent our Todo instances, it will need:
+For our Todo model to represent our Todo instances for our business domain, it
+will need:
 
 - a unique id
 - a title

--- a/docs/site/todo-tutorial-repository.md
+++ b/docs/site/todo-tutorial-repository.md
@@ -15,6 +15,13 @@ themselves to perform CRUD operations. In LoopBack 4, the layer responsible for
 this has been separated from the definition of the model itself, into the
 repository layer.
 
+A `Repository` represents a specialized `Service` interface that provides
+strong-typed data access (for example, CRUD) operations of a domain model
+against the underlying database or service.
+
+For more information about Repositories, see
+[Repositories](https://loopback.io/doc/en/lb4/Repositories.html).
+
 ### Create your repository
 
 In the `src/repositories` directory, create two files:


### PR DESCRIPTION
<!--
Added one liners and links to concepts topics in the Model, Datasource, Repository and Controller todo tutorials
WIP for 1444
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
