### PR TITLE
fix(cli): rename repository/service feature flags

### DIFF
--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -41,7 +41,14 @@ Answer the prompts as follows:
 ? Project description: Getting started tutorial
 ? Project root directory: (getting-started)
 ? Application class name: StarterApplication
-? Select project build settings: Enable tslint, Enable prettier, Enable mocha, Enable loopbackBuild, Enable vscode
+? Select features to enable in the project:
+❯◉ Enable tslint
+ ◉ Enable prettier
+ ◉ Enable mocha
+ ◉ Enable loopbackBuild
+ ◉ Enable vscode
+ ◉ Enable repositories
+ ◉ Enable services
 ```
 
 ### Starting the project

--- a/docs/site/soap-calculator-tutorial-scaffolding.md
+++ b/docs/site/soap-calculator-tutorial-scaffolding.md
@@ -12,13 +12,13 @@ Let's start by creating the initial application by running the following
 command:
 
 ```sh
-lb4 app soap-calculator --enableRepository --enableServices
+lb4 app soap-calculator --repositories --services
 ```
 
-**Note:** The option **--enableRepository** instructs the **CLI** to include a
+**Note:** The option **--repositories** instructs the **CLI** to include a
 `RepositoryMixin` class in the application constructor which will be needed when
-we create the datasource. The option **--enableServices** instructs the **CLI**
-to include a `ServiceMixin` class in the application constructor which will be
+we create the datasource. The option **--services** instructs the **CLI** to
+include a `ServiceMixin` class in the application constructor which will be
 needed to register our SOAP service client.
 
 **LB4** will ask you a few questions _(you can leave the default options)_. The
@@ -33,20 +33,22 @@ application.ts file.
 ```
 
 Next you will see a list of options for the build settings, if you did not
-specify `--enableRepository` and `--enableServices` in the last command, then
-you will see them in this list, make sure you enable both the repository and the
-services for the application.
+specify `--repositories` and `--services` in the last command, then you will see
+them in this list, make sure you enable both the repository and the services for
+the application.
 
 **Note:** Enable all options, unless you know what you are doing, see
 [The Getting Started guide](Getting-started.md) for more information.
 
 ```sh
-? Select project build settings:  (Press <space> to select, <a> to toggle all, <i> to invert selection)
+? Select features to enable in the project:
 ❯◉ Enable tslint
  ◉ Enable prettier
  ◉ Enable mocha
  ◉ Enable loopbackBuild
  ◉ Enable vscode
+ ◉ Enable repositories
+ ◉ Enable services
 ```
 
 #### Run the Application

--- a/docs/site/todo-tutorial-scaffolding.md
+++ b/docs/site/todo-tutorial-scaffolding.md
@@ -22,12 +22,14 @@ $ lb4 app
 ? Project description: A todo list API made with LoopBack 4.
 ? Project root directory: (todo-list)
 ? Application class name: (TodoListApplication)
-? Select project build settings:  (Press <space> to select, <a> to toggle all, <i> to inverse selection)
+? Select features to enable in the project:
 ❯◉ Enable tslint
  ◉ Enable prettier
  ◉ Enable mocha
  ◉ Enable loopbackBuild
  ◉ Enable vscode
+ ◉ Enable repositories
+ ◉ Enable services
  # npm will install dependencies now
  Application todo-list was created in todo-list.
 ```

--- a/examples/log-extension/README.md
+++ b/examples/log-extension/README.md
@@ -76,8 +76,8 @@ Initialize your new extension project as follows: `lb4 extension`
 - Project description: `An example extension project for LoopBack 4`
 - Project root directory: `(loopback4-example-log-extension)`
 - Component class name: `LogComponent`
-- Select project build settings:
-  `Enable tslint, Enable prettier, Enable mocha, Enable loopbackBuild`
+- Select features to enable in the project': `tslint`, `prettier`, `mocha`,
+  `loopbackBuild`
 
 Now you can write the extension as follows:
 

--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -11,8 +11,8 @@ module.exports = class AppGenerator extends ProjectGenerator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);
-    this.buildOptions.push('enableRepository');
-    this.buildOptions.push('enableServices');
+    this.buildOptions.push('repositories');
+    this.buildOptions.push('services');
   }
 
   _setupGenerator() {
@@ -23,12 +23,12 @@ module.exports = class AppGenerator extends ProjectGenerator {
       description: 'Application class name',
     });
 
-    this.option('enableRepository', {
+    this.option('repositories', {
       type: Boolean,
       description: 'Include repository imports and RepositoryMixin',
     });
 
-    this.option('enableServices', {
+    this.option('services', {
       type: Boolean,
       description: 'Include service-proxy imports and ServiceMixin',
     });
@@ -88,14 +88,14 @@ module.exports = class AppGenerator extends ProjectGenerator {
 
   buildAppClassMixins() {
     if (this.shouldExit()) return false;
-    const {enableRepository, enableServices} = this.projectInfo || {};
-    if (!enableRepository && !enableServices) return;
+    const {repositories, services} = this.projectInfo || {};
+    if (!repositories && !services) return;
 
     let appClassWithMixins = 'RestApplication';
-    if (enableRepository) {
+    if (repositories) {
       appClassWithMixins = `RepositoryMixin(${appClassWithMixins})`;
     }
-    if (enableServices) {
+    if (services) {
       appClassWithMixins = `ServiceMixin(${appClassWithMixins})`;
     }
 

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -1,10 +1,10 @@
 import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
-<% if (project.enableRepository) { -%>
+<% if (project.repositories) { -%>
 import {RepositoryMixin} from '@loopback/repository';
 <% } -%>
 import {RestApplication} from '@loopback/rest';
-<% if (project.enableServices) { -%>
+<% if (project.services) { -%>
 import {ServiceMixin} from '@loopback/service-proxy';
 <% } -%>
 import {MySequence} from './sequence';

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -78,10 +78,10 @@
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
     "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>",
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
-<% if (project.enableRepository) { -%>
+<% if (project.repositories) { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
 <% } -%>
-<% if (project.enableServices) { -%>
+<% if (project.services) { -%>
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
     "@loopback/service-proxy": "<%= project.dependencies['@loopback/service-proxy'] -%>"
 <% } else { -%>

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -169,7 +169,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     const prompts = [
       {
         name: 'settings',
-        message: 'Select project build settings: ',
+        message: 'Select features to enable in the project',
         type: 'checkbox',
         choices: choices,
         // Skip if all features are enabled by cli options


### PR DESCRIPTION
_This is a follow-up for #1652 and #1649._

- Rename `--enableRepository` to `--repositories`  (notice the plural form)
- Rename `--enableServices` to `--services`

This commit fixes the inconsistency where `--enableRepository` was using the singular form, while `--enableServices` was using the plural form.

It also improves the feature prompt so that the word "enable" is not
repeated twice.

Before:

    ? Select project build settings:
    ❯◉ Enable tslint
     ◉ Enable prettier
     ◉ Enable mocha
     ◉ Enable loopbackBuild
     ◉ Enable vscode
     ◉ Enable enableRepository
     ◉ Enable enableServices

After:

    ? Select features to enable in the project:
    ❯◉ Enable tslint
     ◉ Enable prettier
     ◉ Enable mocha
     ◉ Enable loopbackBuild
     ◉ Enable vscode
     ◉ Enable repositories
     ◉ Enable services

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated