### PR TITLE
feat: coerce object arguments from query strings

### DIFF
--- a/docs/site/Parsing-requests.md
+++ b/docs/site/Parsing-requests.md
@@ -78,6 +78,36 @@ async replaceTodo(
 }
 ```
 
+#### Object values
+
+OpenAPI specification describes several ways how to encode object values into a
+string, see
+[Style Values](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#style-values)
+and
+[Style Examples](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#style-examples).
+
+At the moment, LoopBack supports object values for parameters in query strings
+with `style: "deepObject"` only. Please note that this style does not preserve
+encoding of primitive types, numbers and booleans are always parsed as strings.
+
+For example:
+
+```
+GET /todos?filter[where][completed]=false
+// filter={where: {completed: 'false'}}
+```
+
+As an extension to the deep-object encoding described by OpenAPI, when the
+parameter is specified with `style: "deepObject"`, we allow clients to provide
+the object value as a JSON-encoded string too.
+
+For example:
+
+```
+GET /todos?filter={"where":{"completed":false}}
+// filter={where: {completed: false}}
+```
+
 ### Validation
 
 Validations are applied on the parameters and the request body data. They also
@@ -107,6 +137,7 @@ Here are our default validation rules for each type:
   [RFC3339](https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14).
 - boolean: after converted to all upper case, should be one of the following
   values: `TRUE`, `1`, `FALSE` or `0`.
+- object: should be a plain data object, not an array.
 
 #### Request Body
 

--- a/packages/openapi-v3-types/package.json
+++ b/packages/openapi-v3-types/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@loopback/dist-util": "^0.3.6",
-    "openapi3-ts": "^0.11.0"
+    "openapi3-ts": "^1.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^0.7.1",

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -204,6 +204,29 @@ export namespace param {
      * @param name Parameter name.
      */
     password: createParamShortcut('query', builtinTypes.password),
+
+    /**
+     * Define a parameter accepting an object value encoded
+     * - as a JSON string, e.g. `filter={"where":{"id":1}}`); or
+     * - in multiple nested keys, e.g. `filter[where][id]=1`
+     *
+     * @param name Parameter name
+     * @param schema Optional OpenAPI Schema describing the object value.
+     */
+    object: function(
+      name: string,
+      schema: SchemaObject | ReferenceObject = {
+        type: 'object',
+        additionalProperties: true,
+      },
+    ) {
+      return param({
+        name,
+        in: 'query',
+        style: 'deepObject',
+        schema,
+      });
+    },
   };
 
   export const header = {

--- a/packages/openapi-v3/test/unit/decorators/param/param-query.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/param/param-query.decorator.unit.ts
@@ -5,6 +5,7 @@
 
 import {get, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
+import {ParameterObject} from '@loopback/openapi-v3-types';
 
 describe('Routing metadata for parameters', () => {
   describe('@param.query.string', () => {
@@ -214,6 +215,54 @@ describe('Routing metadata for parameters', () => {
         schema: {
           type: 'string',
           format: 'password',
+        },
+      };
+      expectSpecToBeEqual(MyController, expectedParamSpec);
+    });
+  });
+
+  describe('@param.query.object', () => {
+    it('sets in:query style:deepObject and a default schema', () => {
+      class MyController {
+        @get('/greet')
+        greet(@param.query.object('filter') filter: Object) {}
+      }
+      const expectedParamSpec = <ParameterObject>{
+        name: 'filter',
+        in: 'query',
+        style: 'deepObject',
+        schema: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      };
+      expectSpecToBeEqual(MyController, expectedParamSpec);
+    });
+
+    it('supports user-defined schema', () => {
+      class MyController {
+        @get('/greet')
+        greet(
+          @param.query.object('filter', {
+            type: 'object',
+            properties: {
+              where: {type: 'object', additionalProperties: true},
+              limit: {type: 'number'},
+            },
+          })
+          filter: Object,
+        ) {}
+      }
+      const expectedParamSpec: ParameterObject = {
+        name: 'filter',
+        in: 'query',
+        style: 'deepObject',
+        schema: {
+          type: 'object',
+          properties: {
+            where: {type: 'object', additionalProperties: true},
+            limit: {type: 'number'},
+          },
         },
       };
       expectSpecToBeEqual(MyController, expectedParamSpec);

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -31,6 +31,8 @@
     "@types/cors": "^2.8.3",
     "@types/express": "^4.11.1",
     "@types/http-errors": "^1.6.1",
+    "@types/parseurl": "^1.3.1",
+    "@types/qs": "^6.5.1",
     "ajv": "^6.5.1",
     "body": "^5.1.0",
     "cors": "^2.8.4",
@@ -40,7 +42,9 @@
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.5",
     "openapi-schema-to-json-schema": "^2.1.0",
+    "parseurl": "^1.3.2",
     "path-to-regexp": "^2.2.0",
+    "qs": "^6.5.2",
     "strong-error-handler": "^3.2.0",
     "validator": "^10.4.0"
   },

--- a/packages/rest/src/coercion/utils.ts
+++ b/packages/rest/src/coercion/utils.ts
@@ -21,8 +21,9 @@ export type IntegerCoercionOptions = {
 };
 
 export function isEmpty(data: string) {
-  debug('isEmpty %s', data);
-  return data === '';
+  const result = data === '';
+  debug('isEmpty(%j) -> %s', data, result);
+  return result;
 }
 /**
  * A set of truthy values. A data in this set will be coerced to `true`.
@@ -59,8 +60,9 @@ const REGEX_RFC3339_DATE = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]
  */
 export function matchDateFormat(date: string) {
   const pattern = new RegExp(REGEX_RFC3339_DATE);
-  debug('matchDateFormat: %s', pattern.test(date));
-  return pattern.test(date);
+  const result = pattern.test(date);
+  debug('matchDateFormat(%j) -> %s', date, result);
+  return result;
 }
 
 /**
@@ -70,8 +72,7 @@ export function matchDateFormat(date: string) {
  * @param format The format in an OpenAPI schema specification
  */
 export function getOAIPrimitiveType(type?: string, format?: string) {
-  // serizlize will be supported in next PR
-  if (type === 'object' || type === 'array') return 'serialize';
+  if (type === 'object' || type === 'array') return type;
   if (type === 'string') {
     switch (format) {
       case 'byte':

--- a/packages/rest/src/coercion/validator.ts
+++ b/packages/rest/src/coercion/validator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ParameterObject} from '@loopback/openapi-v3-types';
+import {ParameterObject, SchemaObject} from '@loopback/openapi-v3-types';
 import {RestHttpErrors} from '../';
 
 /**
@@ -63,6 +63,11 @@ export class Validator {
    */
   // tslint:disable-next-line:no-any
   isAbsent(value: any) {
-    return value === '' || value === undefined;
+    if (value === '' || value === undefined) return true;
+
+    const schema: SchemaObject = this.ctx.parameterSpec.schema || {};
+    if (schema.type === 'object' && value === 'null') return true;
+
+    return false;
   }
 }

--- a/packages/rest/src/rest-http-error.ts
+++ b/packages/rest/src/rest-http-error.ts
@@ -1,23 +1,31 @@
 import * as HttpErrors from 'http-errors';
 
 export namespace RestHttpErrors {
-  export function invalidData<T>(data: T, name: string) {
+  export function invalidData<T, Props extends object = {}>(
+    data: T,
+    name: string,
+    extraProperties?: Props,
+  ): HttpErrors.HttpError & Props {
     const msg = `Invalid data ${JSON.stringify(data)} for parameter ${name}!`;
-    return new HttpErrors.BadRequest(msg);
+    return Object.assign(new HttpErrors.BadRequest(msg), extraProperties);
   }
+
   export function missingRequired(name: string): HttpErrors.HttpError {
     const msg = `Required parameter ${name} is missing!`;
     return new HttpErrors.BadRequest(msg);
   }
+
   export function invalidParamLocation(location: string): HttpErrors.HttpError {
     const msg = `Parameters with "in: ${location}" are not supported yet.`;
     return new HttpErrors.NotImplemented(msg);
   }
+
   export const INVALID_REQUEST_BODY_MESSAGE =
     'The request body is invalid. See error object `details` property for more info.';
   export function invalidRequestBody(): HttpErrors.HttpError {
     return new HttpErrors.UnprocessableEntity(INVALID_REQUEST_BODY_MESSAGE);
   }
+
   /**
    * An invalid request body error contains a `details` property as the machine-readable error.
    * Each entry in `error.details` contains 4 attributes: `path`, `code`, `info` and `message`.

--- a/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
@@ -4,12 +4,15 @@ import {RestApplication, get, param} from '../../..';
 describe('Coercion', () => {
   let app: RestApplication;
   let client: supertest.SuperTest<supertest.Test>;
+  let spy: sinon.SinonSpy;
 
   before(givenAClient);
 
   after(async () => {
     await app.stop();
   });
+
+  afterEach(() => spy.restore());
 
   class MyController {
     @get('/create-number-from-path/{num}')
@@ -26,27 +29,65 @@ describe('Coercion', () => {
     createNumberFromHeader(@param.header.number('num') num: number) {
       return num;
     }
+
+    @get('/object-from-query')
+    getObjectFromQuery(@param.query.object('filter') filter: Object) {
+      return filter;
+    }
   }
 
   it('coerces parameter in path from string to number', async () => {
-    const spy = sinon.spy(MyController.prototype, 'createNumberFromPath');
+    spy = sinon.spy(MyController.prototype, 'createNumberFromPath');
     await client.get('/create-number-from-path/100').expect(200);
     sinon.assert.calledWithExactly(spy, 100);
   });
 
   it('coerces parameter in header from string to number', async () => {
-    const spy = sinon.spy(MyController.prototype, 'createNumberFromHeader');
+    spy = sinon.spy(MyController.prototype, 'createNumberFromHeader');
     await client.get('/create-number-from-header').set({num: 100});
     sinon.assert.calledWithExactly(spy, 100);
   });
 
   it('coerces parameter in query from string to number', async () => {
-    const spy = sinon.spy(MyController.prototype, 'createNumberFromQuery');
+    spy = sinon.spy(MyController.prototype, 'createNumberFromQuery');
     await client
       .get('/create-number-from-query')
       .query({num: 100})
       .expect(200);
     sinon.assert.calledWithExactly(spy, 100);
+  });
+
+  it('coerces parameter in query from JSON to object', async () => {
+    spy = sinon.spy(MyController.prototype, 'getObjectFromQuery');
+    await client
+      .get('/object-from-query')
+      .query({filter: '{"where":{"id":1,"name":"Pen", "active": true}}'})
+      .expect(200);
+    sinon.assert.calledWithExactly(spy, {
+      where: {id: 1, name: 'Pen', active: true},
+    });
+  });
+
+  it('coerces parameter in query from nested keys to object', async () => {
+    spy = sinon.spy(MyController.prototype, 'getObjectFromQuery');
+    await client
+      .get('/object-from-query')
+      .query({
+        'filter[where][id]': 1,
+        'filter[where][name]': 'Pen',
+        'filter[where][active]': true,
+      })
+      .expect(200);
+    sinon.assert.calledWithExactly(spy, {
+      // Notice that numeric and boolean values are converted to strings.
+      // This is because all values are encoded as strings on URL queries
+      // and we did not specify any schema in @param.query.object() decorator.
+      where: {
+        id: '1',
+        name: 'Pen',
+        active: 'true',
+      },
+    });
   });
 
   async function givenAClient() {

--- a/packages/rest/test/unit/coercion/paramObject.unit.ts
+++ b/packages/rest/test/unit/coercion/paramObject.unit.ts
@@ -1,0 +1,149 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ParameterObject} from '@loopback/openapi-v3-types';
+import * as qs from 'qs';
+import {RestHttpErrors} from '../../..';
+import {test} from './utils';
+
+const OPTIONAL_ANY_OBJECT: ParameterObject = {
+  in: 'query',
+  name: 'aparameter',
+  schema: {
+    type: 'object',
+    additionalProperties: true,
+  },
+  style: 'deepObject',
+};
+
+const REQUIRED_ANY_OBJECT = {
+  ...OPTIONAL_ANY_OBJECT,
+  required: true,
+};
+
+describe('coerce object param - required', function() {
+  context('valid values', () => {
+    // Use JSON-encoded style, qs.stringify() omits empty objects
+    test(REQUIRED_ANY_OBJECT, '{}', {});
+    test(REQUIRED_ANY_OBJECT, {key: 'value'}, {key: 'value'});
+
+    test(REQUIRED_ANY_OBJECT, {key: 'undefined'}, {key: 'undefined'});
+    test(REQUIRED_ANY_OBJECT, {key: 'null'}, {key: 'null'});
+    test(REQUIRED_ANY_OBJECT, {key: 'text'}, {key: 'text'});
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    test(
+      REQUIRED_ANY_OBJECT,
+      undefined, // the parameter is missing
+      RestHttpErrors.missingRequired(REQUIRED_ANY_OBJECT.name),
+    );
+
+    test(
+      REQUIRED_ANY_OBJECT,
+      '', // ?param=
+      RestHttpErrors.missingRequired(REQUIRED_ANY_OBJECT.name),
+    );
+
+    test(
+      REQUIRED_ANY_OBJECT,
+      'null', // ?param=null
+      RestHttpErrors.missingRequired(REQUIRED_ANY_OBJECT.name),
+    );
+  });
+
+  context('array values are not allowed', () => {
+    // JSON encoding
+    testInvalidDataError('[]');
+    testInvalidDataError('[1,2]');
+
+    // deepObject style
+    testInvalidDataError([1, 2]);
+  });
+
+  function testInvalidDataError<Props extends object = {}>(
+    input: string | object,
+    extraErrorProps?: Props,
+  ) {
+    test(
+      REQUIRED_ANY_OBJECT,
+      input,
+      RestHttpErrors.invalidData(
+        createInvalidDataInput(input),
+        REQUIRED_ANY_OBJECT.name,
+        extraErrorProps,
+      ),
+    );
+  }
+});
+
+describe('coerce object param - optional', function() {
+  context('valid values', () => {
+    // Use JSON-encoded style, qs.stringify() omits empty objects
+    test(OPTIONAL_ANY_OBJECT, '{}', {});
+    test(OPTIONAL_ANY_OBJECT, {key: 'value'}, {key: 'value'});
+    test(OPTIONAL_ANY_OBJECT, undefined, undefined);
+    test(OPTIONAL_ANY_OBJECT, '', undefined);
+    test(OPTIONAL_ANY_OBJECT, 'null', null);
+  });
+
+  context('nested values are not coerced', () => {
+    test(OPTIONAL_ANY_OBJECT, {key: 'undefined'}, {key: 'undefined'});
+    test(OPTIONAL_ANY_OBJECT, {key: 'null'}, {key: 'null'});
+    test(OPTIONAL_ANY_OBJECT, {key: 'text'}, {key: 'text'});
+    test(OPTIONAL_ANY_OBJECT, {key: '0'}, {key: '0'});
+    test(OPTIONAL_ANY_OBJECT, {key: '1'}, {key: '1'});
+    test(OPTIONAL_ANY_OBJECT, {key: '-1'}, {key: '-1'});
+    test(OPTIONAL_ANY_OBJECT, {key: '1.2'}, {key: '1.2'});
+    test(OPTIONAL_ANY_OBJECT, {key: '-1.2'}, {key: '-1.2'});
+    test(OPTIONAL_ANY_OBJECT, {key: 'true'}, {key: 'true'});
+    test(OPTIONAL_ANY_OBJECT, {key: 'false'}, {key: 'false'});
+    test(
+      OPTIONAL_ANY_OBJECT,
+      {key: '2016-05-19T13:28:51.299Z'},
+      {key: '2016-05-19T13:28:51.299Z'},
+    );
+  });
+
+  context('invalid values should trigger ERROR_BAD_REQUEST', () => {
+    testInvalidDataError('text', {
+      details: {
+        syntaxError: 'Unexpected token e in JSON at position 1',
+      },
+    });
+
+    testInvalidDataError('0');
+    testInvalidDataError('1');
+  });
+
+  context('array values are not allowed', () => {
+    testInvalidDataError('[]');
+    testInvalidDataError('[1,2]');
+    testInvalidDataError([1, 2]);
+  });
+
+  function testInvalidDataError<Props extends object = {}>(
+    input: string | object,
+    extraErrorProps?: Props,
+  ) {
+    test(
+      OPTIONAL_ANY_OBJECT,
+      input,
+      RestHttpErrors.invalidData(
+        createInvalidDataInput(input),
+        OPTIONAL_ANY_OBJECT.name,
+        extraErrorProps,
+      ),
+    );
+  }
+});
+
+function createInvalidDataInput(input: string | object) {
+  if (typeof input === 'string') return input;
+
+  // convert deep property values to strings, that's what our parser
+  // is going to receive on input and show in the error message
+  return qs.parse(qs.stringify({value: input})).value;
+}

--- a/packages/rest/test/unit/coercion/utils.ts
+++ b/packages/rest/test/unit/coercion/utils.ts
@@ -1,20 +1,20 @@
 import {OperationObject, ParameterObject} from '@loopback/openapi-v3-types';
-
 import {
-  ShotRequestOptions,
   expect,
+  ShotRequestOptions,
   stubExpressContext,
 } from '@loopback/testlab';
-
+import * as HttpErrors from 'http-errors';
+import * as qs from 'qs';
+import {format} from 'util';
 import {
-  PathParameterValues,
-  Request,
-  Route,
   createResolvedRoute,
   parseOperationArgs,
+  PathParameterValues,
+  Request,
   ResolvedRoute,
+  Route,
 } from '../../..';
-import * as HttpErrors from 'http-errors';
 
 function givenOperationWithParameters(params?: ParameterObject[]) {
   return <OperationObject>{
@@ -52,9 +52,33 @@ export type TestOptions = {
 export async function testCoercion<T>(config: TestArgs<T>) {
   /* istanbul ignore next */
   try {
+    const pathParams: PathParameterValues = {};
+
     const req = givenRequest();
     const spec = givenOperationWithParameters([config.paramSpec]);
-    const route = givenResolvedRoute(spec, {aparameter: config.rawValue});
+    const route = givenResolvedRoute(spec, pathParams);
+
+    switch (config.paramSpec.in) {
+      case 'path':
+        pathParams.aparameter = config.rawValue;
+        break;
+      case 'query':
+        const q = qs.stringify(
+          {aparameter: config.rawValue},
+          {encodeValuesOnly: true},
+        );
+        req.url += `?${q}`;
+        break;
+      case 'header':
+      case 'cookie':
+        throw new Error(
+          `testCoercion does not yet support in:${config.paramSpec.in}`,
+        );
+      default:
+        // An invalid param spec. Pass it through as an empty request
+        // to allow the tests to verify how invalid param spec is handled
+        break;
+    }
 
     if (config.expectError) {
       await expect(parseOperationArgs(req, route)).to.be.rejectedWith(
@@ -77,8 +101,7 @@ export function test<T>(
   opts?: TestOptions,
 ) {
   const caller: string = new Error().stack!;
-  const DEFAULT_TEST_NAME = `convert request raw value ${rawValue} to ${expectedResult}`;
-  const testName = (opts && opts.testName) || DEFAULT_TEST_NAME;
+  const testName = buildTestName(rawValue, expectedResult, opts);
 
   it(testName, async () => {
     await testCoercion({
@@ -90,4 +113,27 @@ export function test<T>(
       opts: opts || {},
     });
   });
+}
+
+function buildTestName<T>(
+  rawValue: string | undefined | object,
+  expectedResult: T,
+  opts?: TestOptions,
+): string {
+  if (opts && opts.testName) return opts.testName;
+
+  const inputString = getPrettyString(rawValue);
+  if (expectedResult instanceof HttpErrors.HttpError)
+    return `rejects request raw value ${inputString}`;
+  const expectedString = getPrettyString(expectedResult);
+  return `converts request raw value ${inputString} to ${expectedString}`;
+}
+
+function getPrettyString<T>(value: T) {
+  switch (typeof value) {
+    case 'string':
+      return JSON.stringify(value);
+    default:
+      return format(value);
+  }
 }


### PR DESCRIPTION
Introduce a new decorator `@param.query.object` allowing controller methods to describe a parameter as an object and optionally provide the schema for the accepted values.

Improve `parseParams` action to correctly parse and coerce object values coming from query strings, supporting the following two flavours:

- "deepObject" encoding as described by OpenAPI Spec v3:

      GET /api/products?filter[where][name]=Pen&filter[limit]=10

- JSON-based encoding for compatibility with LoopBack 3.x:

      GET /api/products?filter={"where":{"name":"Pen"},"limit":10}

See #100 

While working on these changes, I discovered and fixed a bug in openapiv3-ts, see https://github.com/metadevpro/openapi3-ts/pull/28.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated