### PR TITLE
REST API to find models using a filter 

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -96,8 +96,17 @@ Here's an example of what the template will produce given a `Todo` model and a
 `TodoRepository`:
 
 ```ts
-import {Filter, Where, repository} from '@loopback/repository';
-import {post, param, get, patch, del, requestBody} from '@loopback/rest';
+import {Filter, repository, Where} from '@loopback/repository';
+import {
+  post,
+  param,
+  get,
+  getFilterSchemaFor,
+  getWhereSchemaFor,
+  patch,
+  del,
+  requestBody,
+} from '@loopback/rest';
 import {Todo} from '../models';
 import {TodoRepository} from '../repositories';
 
@@ -106,43 +115,98 @@ export class TodoController {
     @repository(TodoRepository) public todoRepository: TodoRepository,
   ) {}
 
-  @post('/todos')
-  async create(@requestBody() obj: Todo): Promise<Todo> {
-    return await this.todoRepository.create(obj);
+  @post('/todos', {
+    responses: {
+      '200': {
+        description: 'Todo model instance',
+        content: {'application/json': {'x-ts-type': Todo}},
+      },
+    },
+  })
+  async create(@requestBody() data: Todo): Promise<Todo> {
+    return await this.todoRepository.create(data);
   }
 
-  @get('/todos/count')
-  async count(@param.query.string('where') where?: Where): Promise<number> {
+  @get('/todos/count', {
+    responses: {
+      '200': {
+        description: 'Todo model count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
+  async count(
+    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
+  ): Promise<number> {
     return await this.todoRepository.count(where);
   }
 
-  @get('/todos')
-  async find(@param.query.string('filter') filter?: Filter): Promise<Todo[]> {
+  @get('/todos', {
+    responses: {
+      '200': {
+        description: 'Array of Todo model instances',
+        content: {
+          'application/json': {
+            schema: {type: 'array', items: {'x-ts-type': Todo}},
+          },
+        },
+      },
+    },
+  })
+  async find(
+    @param.query.object('filter', getFilterSchemaFor(Todo)) filter?: Filter,
+  ): Promise<Todo[]> {
     return await this.todoRepository.find(filter);
   }
 
-  @patch('/todos')
+  @patch('/todos', {
+    responses: {
+      '200': {
+        description: 'Todo PATCH success count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
   async updateAll(
-    @requestBody() obj: Todo,
-    @param.query.string('where') where?: Where,
+    @requestBody() data: Todo,
+    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
   ): Promise<number> {
-    return await this.todoRepository.updateAll(obj, where);
+    return await this.todoRepository.updateAll(data, where);
   }
 
-  @get('/todos/{id}')
+  @get('/todos/{id}', {
+    responses: {
+      '200': {
+        description: 'Todo model instance',
+        content: {'application/json': {'x-ts-type': Todo}},
+      },
+    },
+  })
   async findById(@param.path.number('id') id: number): Promise<Todo> {
     return await this.todoRepository.findById(id);
   }
 
-  @patch('/todos/{id}')
+  @patch('/todos/{id}', {
+    responses: {
+      '204': {
+        description: 'Todo PATCH success',
+      },
+    },
+  })
   async updateById(
     @param.path.number('id') id: number,
-    @requestBody() obj: Todo,
+    @requestBody() data: Todo,
   ): Promise<void> {
-    await this.todoRepository.updateById(id, obj);
+    await this.todoRepository.updateById(id, data);
   }
 
-  @del('/todos/{id}')
+  @del('/todos/{id}', {
+    responses: {
+      '204': {
+        description: 'Todo DELETE success',
+      },
+    },
+  })
   async deleteById(@param.path.number('id') id: number): Promise<void> {
     await this.todoRepository.deleteById(id);
   }

--- a/docs/site/todo-list-tutorial-controller.md
+++ b/docs/site/todo-list-tutorial-controller.md
@@ -98,47 +98,119 @@ Using our constraining factory as we did with the `POST` request, we'll define
 the controller methods for the rest of the HTTP verbs for the route. The
 completed controller should look as follows:
 
-#### src/controllers/todo-list-todo.controller.ts
+#### src/controllers/todo-list.controller.ts
 
 ```ts
-import {repository, Filter, Where} from '@loopback/repository';
+import {Filter, repository, Where} from '@loopback/repository';
+import {
+  del,
+  get,
+  getFilterSchemaFor,
+  getWhereSchemaFor,
+  param,
+  patch,
+  post,
+  requestBody,
+} from '@loopback/rest';
+import {TodoList} from '../models';
 import {TodoListRepository} from '../repositories';
-import {post, get, patch, del, param, requestBody} from '@loopback/rest';
-import {Todo} from '../models';
 
-export class TodoListTodoController {
+export class TodoListController {
   constructor(
-    @repository(TodoListRepository) protected todoListRepo: TodoListRepository,
+    @repository(TodoListRepository)
+    public todoListRepository: TodoListRepository,
   ) {}
 
-  @post('/todo-lists/{id}/todos')
-  async create(@param.path.number('id') id: number, @requestBody() todo: Todo) {
-    return await this.todoListRepo.todos(id).create(todo);
+  @post('/todo-lists', {
+    responses: {
+      '200': {
+        description: 'TodoList model instance',
+        content: {'application/json': {'x-ts-type': TodoList}},
+      },
+    },
+  })
+  async create(@requestBody() obj: TodoList): Promise<TodoList> {
+    return await this.todoListRepository.create(obj);
   }
 
-  @get('/todo-lists/{id}/todos')
+  @get('/todo-lists/count', {
+    responses: {
+      '200': {
+        description: 'TodoList model count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
+  async count(
+    @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
+  ): Promise<number> {
+    return await this.todoListRepository.count(where);
+  }
+
+  @get('/todo-lists', {
+    responses: {
+      '200': {
+        description: 'Array of TodoList model instances',
+        content: {'application/json': {'x-ts-type': TodoList}},
+      },
+    },
+  })
   async find(
-    @param.path.number('id') id: number,
-    @param.query.string('filter') filter?: Filter,
-  ) {
-    return await this.todoListRepo.todos(id).find(filter);
+    @param.query.object('filter', getFilterSchemaFor(TodoList)) filter?: Filter,
+  ): Promise<TodoList[]> {
+    return await this.todoListRepository.find(filter);
   }
 
-  @patch('/todo-lists/{id}/todos')
-  async patch(
-    @param.path.number('id') id: number,
-    @requestBody() todo: Partial<Todo>,
-    @param.query.string('where') where?: Where,
-  ) {
-    return await this.todoListRepo.todos(id).patch(todo, where);
+  @patch('/todo-lists', {
+    responses: {
+      '200': {
+        description: 'TodoList PATCH success count',
+        content: {'application/json': {'x-ts-type': Number}},
+      },
+    },
+  })
+  async updateAll(
+    @requestBody() obj: Partial<TodoList>,
+    @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
+  ): Promise<number> {
+    return await this.todoListRepository.updateAll(obj, where);
   }
 
-  @del('/todo-lists/{id}/todos')
-  async delete(
+  @get('/todo-lists/{id}', {
+    responses: {
+      '200': {
+        description: 'TodoList model instance',
+        content: {'application/json': {'x-ts-type': TodoList}},
+      },
+    },
+  })
+  async findById(@param.path.number('id') id: number): Promise<TodoList> {
+    return await this.todoListRepository.findById(id);
+  }
+
+  @patch('/todo-lists/{id}', {
+    responses: {
+      '204': {
+        description: 'TodoList PATCH success',
+      },
+    },
+  })
+  async updateById(
     @param.path.number('id') id: number,
-    @param.query.string('where') where?: Where,
-  ) {
-    return await this.todoListRepo.todos(id).delete(where);
+    @requestBody() obj: TodoList,
+  ): Promise<void> {
+    await this.todoListRepository.updateById(id, obj);
+  }
+
+  @del('/todo-lists/{id}', {
+    responses: {
+      '204': {
+        description: 'TodoList DELETE success',
+      },
+    },
+  })
+  async deleteById(@param.path.number('id') id: number): Promise<void> {
+    await this.todoListRepository.deleteById(id);
   }
 }
 ```

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -3,10 +3,18 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {repository, Filter, Where} from '@loopback/repository';
-import {TodoListRepository} from '../repositories';
-import {post, get, patch, del, param, requestBody} from '@loopback/rest';
+import {Filter, repository, Where} from '@loopback/repository';
+import {
+  del,
+  get,
+  getWhereSchemaFor,
+  param,
+  patch,
+  post,
+  requestBody,
+} from '@loopback/rest';
 import {Todo} from '../models';
+import {TodoListRepository} from '../repositories';
 
 export class TodoListTodoController {
   constructor(
@@ -58,7 +66,7 @@ export class TodoListTodoController {
   async patch(
     @param.path.number('id') id: number,
     @requestBody() todo: Partial<Todo>,
-    @param.query.string('where') where?: Where,
+    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
   ): Promise<number> {
     return await this.todoListRepo.todos(id).patch(todo, where);
   }
@@ -73,7 +81,7 @@ export class TodoListTodoController {
   })
   async delete(
     @param.path.number('id') id: number,
-    @param.query.string('where') where?: Where,
+    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
   ): Promise<number> {
     return await this.todoListRepo.todos(id).delete(where);
   }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -4,7 +4,16 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Filter, repository, Where} from '@loopback/repository';
-import {del, get, param, patch, post, requestBody} from '@loopback/rest';
+import {
+  del,
+  get,
+  getFilterSchemaFor,
+  getWhereSchemaFor,
+  param,
+  patch,
+  post,
+  requestBody,
+} from '@loopback/rest';
 import {TodoList} from '../models';
 import {TodoListRepository} from '../repositories';
 
@@ -34,7 +43,9 @@ export class TodoListController {
       },
     },
   })
-  async count(@param.query.string('where') where?: Where): Promise<number> {
+  async count(
+    @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
+  ): Promise<number> {
     return await this.todoListRepository.count(where);
   }
 
@@ -47,7 +58,7 @@ export class TodoListController {
     },
   })
   async find(
-    @param.query.string('filter') filter?: Filter,
+    @param.query.object('filter', getFilterSchemaFor(TodoList)) filter?: Filter,
   ): Promise<TodoList[]> {
     return await this.todoListRepository.find(filter);
   }
@@ -62,7 +73,7 @@ export class TodoListController {
   })
   async updateAll(
     @requestBody() obj: Partial<TodoList>,
-    @param.query.string('where') where?: Where,
+    @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
   ): Promise<number> {
     return await this.todoListRepository.updateAll(obj, where);
   }

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -3,8 +3,17 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {repository} from '@loopback/repository';
-import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {Filter, repository} from '@loopback/repository';
+import {
+  del,
+  get,
+  getFilterSchemaFor,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+} from '@loopback/rest';
 import {Todo} from '../models';
 import {TodoRepository} from '../repositories';
 
@@ -50,8 +59,10 @@ export class TodoController {
       },
     },
   })
-  async findTodos(): Promise<Todo[]> {
-    return await this.todoRepo.find();
+  async findTodos(
+    @param.query.object('filter', getFilterSchemaFor(Todo)) filter?: Filter,
+  ): Promise<Todo[]> {
+    return await this.todoRepo.find(filter);
   }
 
   @put('/todos/{id}', {

--- a/examples/todo-list/src/repositories/todo-list.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list.repository.ts
@@ -29,4 +29,8 @@ export class TodoListRepository extends DefaultCrudRepository<
       todoRepository,
     );
   }
+
+  public findByTitle(title: string) {
+    return this.findOne({where: {title}});
+  }
 }

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -4,8 +4,17 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {inject} from '@loopback/core';
-import {repository} from '@loopback/repository';
-import {del, get, param, patch, post, put, requestBody} from '@loopback/rest';
+import {Filter, repository} from '@loopback/repository';
+import {
+  del,
+  get,
+  getFilterSchemaFor,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+} from '@loopback/rest';
 import {Todo} from '../models';
 import {TodoRepository} from '../repositories';
 import {GeocoderService} from '../services';
@@ -63,8 +72,10 @@ export class TodoController {
       },
     },
   })
-  async findTodos(): Promise<Todo[]> {
-    return await this.todoRepo.find();
+  async findTodos(
+    @param.query.object('filter', getFilterSchemaFor(Todo)) filter?: Filter,
+  ): Promise<Todo[]> {
+    return await this.todoRepo.find(filter);
   }
 
   @put('/todos/{id}', {

--- a/examples/todo/test/acceptance/todo.acceptance.ts
+++ b/examples/todo/test/acceptance/todo.acceptance.ts
@@ -9,6 +9,7 @@ import {
   createRestAppClient,
   expect,
   givenHttpServerConfig,
+  toJSON,
 } from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {Todo} from '../../src/models/';
@@ -91,14 +92,11 @@ describe('TodoApplication', () => {
       persistedTodo = await givenTodoInstance();
     });
 
-    it('gets a todo by ID', async () => {
-      const result = await client
+    it('gets a todo by ID', () => {
+      return client
         .get(`/todos/${persistedTodo.id}`)
         .send()
-        .expect(200);
-      // Remove any undefined properties that cannot be represented in JSON/REST
-      const expected = JSON.parse(JSON.stringify(persistedTodo));
-      expect(result.body).to.deepEqual(expected);
+        .expect(200, toJSON(persistedTodo));
     });
 
     it('returns 404 when getting a todo that does not exist', () => {
@@ -159,6 +157,20 @@ describe('TodoApplication', () => {
     it('returns 404 when deleting a todo that does not exist', async () => {
       await client.del(`/todos/99999`).expect(404);
     });
+  });
+
+  it('queries todos with a filter', async () => {
+    await givenTodoInstance({title: 'wake up', isComplete: true});
+
+    const todoInProgress = await givenTodoInstance({
+      title: 'go to sleep',
+      isComplete: false,
+    });
+
+    await client
+      .get('/todos')
+      .query({filter: {where: {isComplete: false}}})
+      .expect(200, [toJSON(todoInProgress)]);
   });
 
   /*

--- a/examples/todo/test/unit/controllers/todo.controller.unit.ts
+++ b/examples/todo/test/unit/controllers/todo.controller.unit.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Filter} from '@loopback/repository';
 import {expect, sinon} from '@loopback/testlab';
 import {TodoController} from '../../../src/controllers';
 import {Todo} from '../../../src/models/index';
@@ -98,6 +99,14 @@ describe('TodoController', () => {
       find.resolves(expected);
       expect(await controller.findTodos()).to.eql(expected);
       sinon.assert.called(find);
+    });
+
+    it('uses the provided filter', async () => {
+      const filter: Filter = {where: {isCompleted: false}};
+
+      find.resolves(aListOfTodos);
+      await controller.findTodos(filter);
+      sinon.assert.calledWith(find, filter);
     });
   });
 

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -207,6 +207,10 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
       debug(`Artifact output filename set to: ${this.artifactInfo.outFile}`);
     }
 
+    this.artifactInfo.modelVariableName = utils.camelCase(
+      this.artifactInfo.modelName,
+    );
+
     // renames the file
     let template = 'controller-template.ts.ejs';
     switch (this.artifactInfo.controllerType) {

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -1,12 +1,13 @@
 import {Filter, repository, Where} from '@loopback/repository';
-
 import {
   post,
   param,
   get,
+  getFilterSchemaFor,
+  getWhereSchemaFor,
   patch,
   del,
-  requestBody
+  requestBody,
 } from '@loopback/rest';
 import {<%= modelName %>} from '../models';
 import {<%= repositoryName %>} from '../repositories';
@@ -25,9 +26,8 @@ export class <%= className %>Controller {
       },
     },
   })
-  async create(@requestBody() <%= name %>: <%= modelName %>)
-    : Promise<<%= modelName %>> {
-    return await this.<%= repositoryNameCamel %>.create(<%= name %>);
+  async create(@requestBody() <%= modelVariableName %>: <%= modelName %>): Promise<<%= modelName %>> {
+    return await this.<%= repositoryNameCamel %>.create(<%= modelVariableName %>);
   }
 
   @get('<%= httpPathName %>/count', {
@@ -38,7 +38,9 @@ export class <%= className %>Controller {
       },
     },
   })
-  async count(@param.query.string('where') where?: Where): Promise<number> {
+  async count(
+    @param.query.object('where', getWhereSchemaFor(<%= modelName %>)) where?: Where,
+  ): Promise<number> {
     return await this.<%= repositoryNameCamel %>.count(where);
   }
 
@@ -54,8 +56,9 @@ export class <%= className %>Controller {
       },
     },
   })
-  async find(@param.query.string('filter') filter?: Filter)
-    : Promise<<%= modelName %>[]> {
+  async find(
+    @param.query.object('filter', getFilterSchemaFor(<%= modelName %>)) filter?: Filter,
+  ): Promise<<%= modelName %>[]> {
     return await this.<%= repositoryNameCamel %>.find(filter);
   }
 
@@ -68,10 +71,10 @@ export class <%= className %>Controller {
     },
   })
   async updateAll(
-    @requestBody() <%= name %>: <%= modelName %>,
-    @param.query.string('where') where?: Where
+    @requestBody() <%= modelVariableName %>: <%= modelName %>,
+    @param.query.object('where', getWhereSchemaFor(<%= modelName %>)) where?: Where,
   ): Promise<number> {
-    return await this.<%= repositoryNameCamel %>.updateAll(<%= name %>, where);
+    return await this.<%= repositoryNameCamel %>.updateAll(<%= modelVariableName %>, where);
   }
 
   @get('<%= httpPathName %>/{id}', {
@@ -95,9 +98,9 @@ export class <%= className %>Controller {
   })
   async updateById(
     @param.path.<%= idType %>('id') id: <%= idType %>,
-    @requestBody() <%= name %>: <%= modelName %>
+    @requestBody() <%= modelVariableName %>: <%= modelName %>,
   ): Promise<void> {
-    await this.<%= repositoryNameCamel %>.updateById(id, <%= name %>);
+    await this.<%= repositoryNameCamel %>.updateById(id, <%= modelVariableName %>);
   }
 
   @del('<%= httpPathName %>/{id}', {

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -248,7 +248,7 @@ function checkRestCrudContents() {
     /'200': {/,
     /description: 'ProductReview model instance'/,
     /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
-    /async create\(\@requestBody\(\)/,
+    /async create\(\@requestBody\(\) productReview: ProductReview\)/,
   ];
   postCreateRegEx.forEach(regex => {
     assert.fileContent(expectedFile, regex);
@@ -261,7 +261,7 @@ function checkRestCrudContents() {
     /'200': {/,
     /description: 'ProductReview model count'/,
     /content: {'application\/json': {'x-ts-type': Number}},\s{1,}},\s{1,}},\s{1,}}\)/,
-    /async count\(\@param.query.string\('where'\)/,
+    /async count\(\s+\@param\.query\.object\('where', getWhereSchemaFor\(ProductReview\)\) where\?: Where(|,\s+)\)/,
   ];
   getCountRegEx.forEach(regex => {
     assert.fileContent(expectedFile, regex);
@@ -274,7 +274,7 @@ function checkRestCrudContents() {
     /'200': {/,
     /description: 'Array of ProductReview model instances'/,
     /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
-    /async find\(\@param.query.string\('filter'\)/,
+    /async find\(\s*\@param\.query\.object\('filter', getFilterSchemaFor\(ProductReview\)\) filter\?: Filter(|,\s+)\)/,
   ];
   getFindRegEx.forEach(regex => {
     assert.fileContent(expectedFile, regex);
@@ -287,7 +287,7 @@ function checkRestCrudContents() {
     /'200': {/,
     /description: 'ProductReview PATCH success count'/,
     /content: {'application\/json': {'x-ts-type': Number}},\s{1,}},\s{1,}},\s{1,}}\)/,
-    /async updateAll\(\s{1,}\@requestBody\(\).*,\s{1,}\@param.query.string\('where'\) where\?: Where/,
+    /async updateAll\(\s{1,}\@requestBody\(\) productReview: ProductReview,\s{1,} @param\.query\.object\('where', getWhereSchemaFor\(ProductReview\)\) where\?: Where(|,\s+)\)/,
   ];
   patchUpdateAllRegEx.forEach(regex => {
     assert.fileContent(expectedFile, regex);
@@ -312,7 +312,7 @@ function checkRestCrudContents() {
     /responses: {/,
     /'204': {/,
     /description: 'ProductReview PATCH success'/,
-    /async updateById\(\s{1,}\@param.path.number\('id'\) id: number,\s{1,}\@requestBody\(\)/,
+    /async updateById\(\s{1,}\@param.path.number\('id'\) id: number,\s{1,}\@requestBody\(\) productReview: ProductReview,\s+\)/,
   ];
   patchUpdateByIdRegEx.forEach(regex => {
     assert.fileContent(expectedFile, regex);

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -224,6 +224,7 @@ export namespace param {
         name,
         in: 'query',
         style: 'deepObject',
+        explode: true,
         schema,
       });
     },

--- a/packages/openapi-v3/src/filter-schema.ts
+++ b/packages/openapi-v3/src/filter-schema.ts
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {SchemaObject} from '@loopback/openapi-v3-types';
+import {
+  getFilterJsonSchemaFor,
+  getWhereJsonSchemaFor,
+  Model,
+} from '@loopback/repository-json-schema';
+import {jsonToSchemaObject} from './json-to-schema';
+
+/**
+ * Build an OpenAPI schema describing the format of the "filter" object
+ * used to query model instances.
+ *
+ * Note we don't take the model properties into account yet and return
+ * a generic json schema allowing any "where" condition.
+ *
+ * @param modelCtor The model constructor to build the filter schema for.
+ */
+export function getFilterSchemaFor(modelCtor: typeof Model): SchemaObject {
+  const jsonSchema = getFilterJsonSchemaFor(modelCtor);
+  const schema = jsonToSchemaObject(jsonSchema);
+  return schema;
+}
+
+/**
+ * Build a OpenAPI schema describing the format of the "where" object
+ * used to filter model instances to query, update or delete.
+ *
+ * Note we don't take the model properties into account yet and return
+ * a generic json schema allowing any "where" condition.
+ *
+ * @param modelCtor The model constructor to build the filter schema for.
+ */
+export function getWhereSchemaFor(modelCtor: typeof Model): SchemaObject {
+  const jsonSchema = getWhereJsonSchemaFor(modelCtor);
+  const schema = jsonToSchemaObject(jsonSchema);
+  return schema;
+}

--- a/packages/openapi-v3/src/index.ts
+++ b/packages/openapi-v3/src/index.ts
@@ -6,5 +6,6 @@
 export * from './decorators';
 export * from './controller-spec';
 export * from './json-to-schema';
+export * from './filter-schema';
 
 export * from '@loopback/repository-json-schema';

--- a/packages/openapi-v3/test/unit/decorators/param/param-query.decorator.unit.ts
+++ b/packages/openapi-v3/test/unit/decorators/param/param-query.decorator.unit.ts
@@ -231,6 +231,7 @@ describe('Routing metadata for parameters', () => {
         name: 'filter',
         in: 'query',
         style: 'deepObject',
+        explode: true,
         schema: {
           type: 'object',
           additionalProperties: true,
@@ -257,6 +258,7 @@ describe('Routing metadata for parameters', () => {
         name: 'filter',
         in: 'query',
         style: 'deepObject',
+        explode: true,
         schema: {
           type: 'object',
           properties: {

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository-json-schema
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Model, model, getModelRelations} from '@loopback/repository';
+import {JSONSchema6 as JsonSchema} from 'json-schema';
+
+@model({settings: {strict: false}})
+class EmptyModel extends Model {}
+
+const scopeFilter = getFilterJsonSchemaFor(EmptyModel);
+
+/**
+ * Build a JSON schema describing the format of the "filter" object
+ * used to query model instances.
+ *
+ * Note we don't take the model properties into account yet and return
+ * a generic json schema allowing any "where" condition.
+ *
+ * @param modelCtor The model constructor to build the filter schema for.
+ */
+export function getFilterJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
+  const schema: JsonSchema = {
+    properties: {
+      where: getWhereJsonSchemaFor(modelCtor),
+
+      fields: {
+        type: 'object',
+        // TODO(bajtos) enumerate "model" properties
+        // See https://github.com/strongloop/loopback-next/issues/1748
+        additionalProperties: true,
+      },
+
+      offset: {
+        type: 'integer',
+        minimum: 0,
+      },
+
+      limit: {
+        type: 'integer',
+        minimum: 0,
+      },
+
+      skip: {
+        type: 'integer',
+        minimum: 0,
+      },
+
+      order: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+      },
+    },
+  };
+
+  const modelRelations = getModelRelations(modelCtor);
+  const hasRelations = Object.keys(modelRelations).length > 0;
+
+  if (hasRelations) {
+    schema.properties!.include = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          // TODO(bajtos) restrict values to relations defined by "model"
+          relation: {type: 'string'},
+          // TODO(bajtos) describe the filter for the relation target model
+          scope: scopeFilter,
+        },
+      },
+    };
+  }
+
+  return schema;
+}
+
+/**
+ * Build a JSON schema describing the format of the "where" object
+ * used to filter model instances to query, update or delete.
+ *
+ * Note we don't take the model properties into account yet and return
+ * a generic json schema allowing any "where" condition.
+ *
+ * @param modelCtor The model constructor to build the filter schema for.
+ */
+export function getWhereJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
+  const schema: JsonSchema = {
+    type: 'object',
+    // TODO(bajtos) enumerate "model" properties and operators like "and"
+    // See https://github.com/strongloop/loopback-next/issues/1748
+    additionalProperties: true,
+  };
+  return schema;
+}

--- a/packages/repository-json-schema/src/index.ts
+++ b/packages/repository-json-schema/src/index.ts
@@ -5,6 +5,9 @@
 
 export * from './build-schema';
 export * from './keys';
+export * from './filter-json-schema';
 
 import {JSONSchema6 as JsonSchema} from 'json-schema';
 export {JsonSchema};
+
+export {Model} from '@loopback/repository';

--- a/packages/repository-json-schema/test/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/test/unit/filter-json-schema.unit.ts
@@ -1,0 +1,186 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository-json-schema
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity, Filter, hasMany, model, property} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import * as Ajv from 'ajv';
+import {JsonSchema} from '../../src';
+import {
+  getFilterJsonSchemaFor,
+  getWhereJsonSchemaFor,
+} from '../../src/filter-json-schema';
+
+describe('getFilterJsonSchemaFor', () => {
+  let ajv: Ajv.Ajv;
+  let customerFilterSchema: JsonSchema;
+  let orderFilterSchema: JsonSchema;
+
+  beforeEach(() => {
+    ajv = new Ajv();
+    customerFilterSchema = getFilterJsonSchemaFor(Customer);
+    orderFilterSchema = getFilterJsonSchemaFor(Order);
+  });
+
+  it('produces a valid schema', () => {
+    const isValid = ajv.validateSchema(customerFilterSchema);
+
+    const SUCCESS_MSG = 'Filter schema is a valid JSON Schema';
+    const result = isValid ? SUCCESS_MSG : ajv.errorsText(ajv.errors!);
+    expect(result).to.equal(SUCCESS_MSG);
+  });
+
+  it('allows an empty filter', () => {
+    expectSchemaToAllowFilter(customerFilterSchema, {});
+  });
+
+  it('allows all top-level filter properties', () => {
+    const filter: Required<Filter> = {
+      where: {id: 1},
+      fields: {id: true, name: true},
+      include: [{relation: 'orders'}],
+      offset: 0,
+      limit: 10,
+      order: ['id DESC'],
+      skip: 0,
+    };
+
+    expectSchemaToAllowFilter(customerFilterSchema, filter);
+  });
+
+  it('describes "where" as an object', () => {
+    const filter = {where: 'invalid-where'};
+    ajv.validate(customerFilterSchema, filter);
+    expect(ajv.errors || []).to.containDeep([
+      {
+        keyword: 'type',
+        dataPath: '.where',
+        message: 'should be object',
+      },
+    ]);
+  });
+
+  it('describes "fields" as an object', () => {
+    const filter = {fields: 'invalid-fields'};
+    ajv.validate(customerFilterSchema, filter);
+    expect(ajv.errors || []).to.containDeep([
+      {
+        keyword: 'type',
+        dataPath: '.fields',
+        message: 'should be object',
+      },
+    ]);
+  });
+
+  it('describes "include" as an array for models with relations', () => {
+    const filter = {include: 'invalid-include'};
+    ajv.validate(customerFilterSchema, filter);
+    expect(ajv.errors || []).to.containDeep([
+      {
+        keyword: 'type',
+        dataPath: '.include',
+        message: 'should be array',
+      },
+    ]);
+  });
+
+  it('leaves out "include" for models with no relations', () => {
+    const filterProperties = Object.keys(orderFilterSchema.properties || {});
+    expect(filterProperties).to.not.containEql('include');
+  });
+
+  it('describes "offset" as an integer', () => {
+    const filter = {offset: 'invalid-offset'};
+    ajv.validate(customerFilterSchema, filter);
+    expect(ajv.errors || []).to.containDeep([
+      {
+        keyword: 'type',
+        dataPath: '.offset',
+        message: 'should be integer',
+      },
+    ]);
+  });
+
+  it('describes "limit" as an integer', () => {
+    const filter = {limit: 'invalid-limit'};
+    ajv.validate(customerFilterSchema, filter);
+    expect(ajv.errors || []).to.containDeep([
+      {
+        keyword: 'type',
+        dataPath: '.limit',
+        message: 'should be integer',
+      },
+    ]);
+  });
+
+  it('describes "skip" as an integer', () => {
+    const filter = {skip: 'invalid-skip'};
+    ajv.validate(customerFilterSchema, filter);
+    expect(ajv.errors || []).to.containDeep([
+      {
+        keyword: 'type',
+        dataPath: '.skip',
+        message: 'should be integer',
+      },
+    ]);
+  });
+
+  it('describes "order" as an array', () => {
+    const filter = {order: 'invalid-order'};
+    ajv.validate(customerFilterSchema, filter);
+    expect(ajv.errors || []).to.containDeep([
+      {
+        keyword: 'type',
+        dataPath: '.order',
+        message: 'should be array',
+      },
+    ]);
+  });
+
+  function expectSchemaToAllowFilter<T>(schema: JsonSchema, value: T) {
+    const isValid = ajv.validate(schema, value);
+    const SUCCESS_MSG = 'Filter instance is valid according to Filter schema';
+    const result = isValid ? SUCCESS_MSG : ajv.errorsText(ajv.errors!);
+    expect(result).to.equal(SUCCESS_MSG);
+  }
+});
+
+describe('getWhereJsonSchemaFor', () => {
+  let ajv: Ajv.Ajv;
+  let customerWhereSchema: JsonSchema;
+
+  beforeEach(() => {
+    ajv = new Ajv();
+    customerWhereSchema = getWhereJsonSchemaFor(Customer);
+  });
+
+  it('produces a valid schema', () => {
+    const isValid = ajv.validateSchema(customerWhereSchema);
+
+    const SUCCESS_MSG = 'Where schema is a valid JSON Schema';
+    const result = isValid ? SUCCESS_MSG : ajv.errorsText(ajv.errors!);
+    expect(result).to.equal(SUCCESS_MSG);
+  });
+});
+
+@model()
+class Order extends Entity {
+  @property({id: true})
+  id: number;
+
+  @property()
+  customerId: number;
+}
+
+@model()
+class Customer extends Entity {
+  @property({id: true})
+  id: number;
+
+  @property()
+  name: string;
+
+  @hasMany(Order)
+  orders?: Order[];
+}

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -14,8 +14,9 @@ import {
   ModelDefinition,
   ModelDefinitionSyntax,
   PropertyDefinition,
+  RelationDefinitionMap,
 } from '../model';
-import {RELATIONS_KEY, RelationDefinitionBase} from './relation.decorator';
+import {RELATIONS_KEY} from './relation.decorator';
 
 export const MODEL_KEY = MetadataAccessor.create<
   Partial<ModelDefinitionSyntax>,
@@ -31,7 +32,6 @@ export const MODEL_WITH_PROPERTIES_KEY = MetadataAccessor.create<
 >('loopback:model-and-properties');
 
 export type PropertyMap = MetadataMap<PropertyDefinition>;
-export type RelationMap = MetadataMap<RelationDefinitionBase>;
 
 // tslint:disable:no-any
 
@@ -76,7 +76,7 @@ export function model(definition?: Partial<ModelDefinitionSyntax>) {
 
     target.definition = modelDef;
 
-    const relationMap: RelationMap =
+    const relationMap: RelationDefinitionMap =
       MetadataInspector.getAllPropertyMetadata(
         RELATIONS_KEY,
         target.prototype,

--- a/packages/repository/src/decorators/relation.decorator.ts
+++ b/packages/repository/src/decorators/relation.decorator.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Class} from '../common-types';
-import {Entity} from '../model';
+import {Entity, Model, RelationDefinitionMap} from '../model';
 import {PropertyDecoratorFactory} from '@loopback/context';
 import {property} from './model.decorator';
 import {camelCase} from 'lodash';
@@ -25,7 +24,7 @@ export const RELATIONS_KEY = 'loopback:relations';
 
 export class RelationMetadata {
   type: RelationType;
-  target: string | Class<Entity>;
+  target: string | typeof Entity;
   as: string;
 }
 
@@ -149,4 +148,16 @@ export function referencesOne(definition?: Object) {
 export function referencesMany(definition?: Object) {
   const rel = Object.assign({type: RelationType.referencesMany}, definition);
   return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel);
+}
+
+/**
+ * Get metadata of all relations defined on a given model class.
+ *
+ * @param modelCtor The model class (the constructor function).
+ * @return
+ */
+export function getModelRelations(
+  modelCtor: typeof Model,
+): RelationDefinitionMap {
+  return (modelCtor.definition && modelCtor.definition.relations) || {};
 }

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -44,7 +44,13 @@ export interface PropertyForm {
   name?: string; // Custom name for this form
 }
 
-export interface PropertyDefinitionMap {}
+/**
+ * A key-value map describing model relations.
+ * A relation name is used as the key, a relation definition is the value.
+ */
+export type RelationDefinitionMap = {
+  [relationName: string]: RelationDefinitionBase;
+};
 
 /**
  * DSL for building a model definition.
@@ -53,7 +59,7 @@ export interface ModelDefinitionSyntax {
   name: string;
   properties?: {[name: string]: PropertyDefinition | PropertyType};
   settings?: {[name: string]: any};
-  relations?: {[name: string]: RelationDefinitionBase};
+  relations?: RelationDefinitionMap;
   [attribute: string]: any;
 }
 
@@ -64,7 +70,7 @@ export class ModelDefinition {
   readonly name: string;
   properties: {[name: string]: PropertyDefinition};
   settings: {[name: string]: any};
-  relations: {[name: string]: RelationDefinitionBase};
+  relations: RelationDefinitionMap;
   // indexes: Map<string, any>;
   [attribute: string]: any; // Other attributes
 

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -6,7 +6,7 @@
 import {expect} from '@loopback/testlab';
 import {Entity, hasMany, RELATIONS_KEY, RelationType, property} from '../../..';
 import {MetadataInspector} from '@loopback/context';
-import {MODEL_PROPERTIES_KEY, model} from '../../../src';
+import {MODEL_PROPERTIES_KEY, model, getModelRelations} from '../../../src';
 
 describe('relation decorator', () => {
   context('hasMany', () => {
@@ -121,6 +121,46 @@ describe('relation decorator', () => {
           }
         }).to.throw(/Decorator cannot be applied more than once/);
       });
+    });
+  });
+});
+
+describe('getModelRelations', () => {
+  it('returns relation metadata for own and inherited properties', () => {
+    @model()
+    class AccessToken extends Entity {
+      @property({id: true})
+      userId: number;
+    }
+
+    @model()
+    class User extends Entity {
+      @hasMany(AccessToken)
+      accessTokens: AccessToken[];
+    }
+
+    @model()
+    class Order extends Entity {
+      @property({id: true})
+      customerId: number;
+    }
+
+    @model()
+    class Customer extends User {
+      @hasMany(Order)
+      orders: Order[];
+    }
+
+    const relations = getModelRelations(Customer);
+    expect(relations).to.deepEqual({
+      accessTokens: {
+        keyTo: 'userId',
+        type: 'hasMany',
+      },
+      orders: {
+        keyTo: 'customerId',
+        type: 'hasMany',
+      },
     });
   });
 });

--- a/packages/rest/test/unit/coercion/paramObject.unit.ts
+++ b/packages/rest/test/unit/coercion/paramObject.unit.ts
@@ -16,6 +16,7 @@ const OPTIONAL_ANY_OBJECT: ParameterObject = {
     additionalProperties: true,
   },
   style: 'deepObject',
+  explode: true,
 };
 
 const REQUIRED_ANY_OBJECT = {

--- a/packages/rest/test/unit/parser.unit.ts
+++ b/packages/rest/test/unit/parser.unit.ts
@@ -138,6 +138,7 @@ describe('operationArgsParser', () => {
           name,
           in: 'query',
           style: 'deepObject',
+          explode: true,
           schema,
         },
       ]);


### PR DESCRIPTION
This pull request leverages the recently added `@param.query.object()` decorator (see #1667) to add support for querying a subset of models using a Filter object.

For example:

```
GET /todos?filter[where][isCompleted]=false
```

The OpenAPI spec contains a reasonably-minimal description of the Filter object.

<img width="1113" alt="screen shot 2018-09-07 at 15 42 29" src="https://user-images.githubusercontent.com/1140553/45222377-b11b1680-b2b4-11e8-9d7b-1011c1309532.png">

**Done**
 - infrastructure to describe `filter` and `where` parameters
 - updated `todo` example 
 - update `todo-list` example
 - update CRUD Controller template in CLI
 - doc updates

See also #100

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated