### PR TITLE
fix: limit concurrent processes to prevent them from being killed by travis

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "3.1.4",
+  "lerna": "3.3.0",
   "packages": [
     "benchmark",
     "docs",
@@ -21,7 +21,9 @@
     "run": {
       "prefix": false,
       "loglevel": "silent",
-      "parallel": true
+      "stream": true,
+      "concurrency": 8,
+      "sort": false
     },
     "clean": {
       "loglevel": "silent",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^0.14.3",
-    "lerna": "^3.1.4"
+    "lerna": "^3.3.0"
   },
   "scripts": {
     "postinstall": "lerna bootstrap",

--- a/packages/build/bin/utils.js
+++ b/packages/build/bin/utils.js
@@ -177,6 +177,19 @@ function runShell(command, args, options) {
   );
   child.on('close', (code, signal) => {
     debug('%s exits: %d', command, code);
+    if (code > 0 || signal) {
+      console.warn(
+        'Command aborts (code %d signal %s): %s %s.',
+        code,
+        signal,
+        command,
+        args.join(' '),
+      );
+    }
+    if (signal === 'SIGKILL' && code === 0) {
+      // Travis might kill processes under resource pressure
+      code = 128;
+    }
     process.exitCode = code;
   });
   return child;


### PR DESCRIPTION
For some reason, the `tsc` process exits before the `outDir` is created. This PR adds some logic to detect such cases and limit concurrency to 16 to prevent processes from being killed by travis.

See  https://docs.travis-ci.com/user/common-build-problems/#my-build-script-is-killed-without-any-error.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
