### PR TITLE
docs: Fix "Page Not Found" error when going to the Glossary page

### DIFF
--- a/docs/site/Glossary.md
+++ b/docs/site/Glossary.md
@@ -1,3 +1,12 @@
+---
+lang: en
+title: 'Glossary'
+keywords: LoopBack 4.0, LoopBack 4
+toc_level: 1
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Glossary.html
+---
+
 **Action**: JavaScript functions that only accept or return Elements. Since the
 input of one action (an Element) is the output of another action (Element) they
 are easily composed.


### PR DESCRIPTION
Currently from the LB4 docs sidebar, when clicking on Reference > Glossary, it says "Page Not Found".  