### PR TITLE
chore: add node version check to fail gracefully

### DIFF
--- a/packages/cli/bin/cli-main.js
+++ b/packages/cli/bin/cli-main.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const checkNodeVersion = require('@loopback/dist-util').checkNodeVersion;
+
+try {
+  const range = require('../package.json').engines.node;
+  checkNodeVersion(range);
+} catch (e) {
+  console.error(e.message);
+  process.exit(1);
+}
+
+// Intentionally have a separate `main.js` which can use JS features
+// supported by required version of Node
+const minimist = require('minimist');
+const main = require('../lib/cli');
+const opts = minimist(process.argv.slice(2), {
+  alias: {
+    version: 'v', // --version or -v: print versions
+    commands: 'l', // --commands or -l: print commands
+  },
+});
+main(opts);

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/cli
 // This file is licensed under the MIT License.
@@ -6,10 +5,8 @@
 
 'use strict';
 
-const assert = require('assert');
 const camelCaseKeys = require('camelcase-keys');
-const debug = require('../lib/debug')();
-const minimist = require('minimist');
+const debug = require('./debug')();
 const path = require('path');
 const yeoman = require('yeoman-environment');
 const PREFIX = 'loopback4:';
@@ -125,13 +122,3 @@ function main(opts, log, dryRun) {
 }
 
 module.exports = main;
-
-if (require.main === module) {
-  const opts = minimist(process.argv.slice(2), {
-    alias: {
-      version: 'v', // --version or -v: print versions
-      commands: 'l', // --commands or -l: print commands
-    },
-  });
-  main(opts);
-}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "generators"
   ],
   "bin": {
-    "lb4": "bin/cli.js"
+    "lb4": "bin/cli-main.js"
   },
   "main": "generators/app/index.js",
   "keywords": [
@@ -42,6 +42,7 @@
     "yeoman-test": "^1.7.0"
   },
   "dependencies": {
+    "@loopback/dist-util": "^0.3.6",
     "camelcase-keys": "^4.2.0",
     "chalk": "^2.3.2",
     "change-case": "^3.0.2",

--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -7,7 +7,7 @@
 
 const expect = require('@loopback/testlab').expect;
 const util = require('util');
-const main = require('../../../bin/cli');
+const main = require('../../../lib/cli');
 
 function getLog(buffer) {
   buffer = buffer || [];

--- a/packages/dist-util/index.js
+++ b/packages/dist-util/index.js
@@ -6,15 +6,28 @@
 'use strict';
 
 const path = require('path');
+const util = require('util');
+const semver = require('semver');
+
+/**
+ * Make sure node version meets the requirement. This file intentionally
+ * only uses ES5 features so that it can be run with lower versions of Node
+ * to report the version requirement.
+ */
+function checkNodeVersion(range) {
+  const nodeVer = process.versions.node;
+  const requiredVer = range || require('./package.json').engines.node;
+  const ok = semver.satisfies(nodeVer, requiredVer);
+  if (!ok) {
+    const format = 'Node.js %s is not supported. Please use a version %s.';
+    const msg = util.format(format, nodeVer, requiredVer);
+    throw new Error(msg);
+  }
+}
 
 function getDist() {
+  checkNodeVersion();
   const nodeMajorVersion = +process.versions.node.split('.')[0];
-  if (nodeMajorVersion < 8) {
-    throw new Error(
-      `Node.js version ${process.versions.node} is not supported.` +
-        'Please use Node.js 8.9 or newer.',
-    );
-  }
   return nodeMajorVersion >= 10 ? './dist10' : './dist8';
 }
 
@@ -23,4 +36,4 @@ function loadDist(projectRootDir) {
   return require(path.join(projectRootDir, dist));
 }
 
-module.exports = {getDist, loadDist};
+module.exports = {getDist, loadDist, checkNodeVersion};

--- a/packages/dist-util/package.json
+++ b/packages/dist-util/package.json
@@ -9,6 +9,9 @@
   "engines": {
     "node": ">=8.9"
   },
+  "dependencies": {
+    "semver": "^5.5.1"
+  },
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
Check required Node.js versions and print out meaningful error message if fails.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
