### PR TITLE
docs: change ParsedRequest to Request on documentation

### DIFF
--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -144,13 +144,11 @@ resolve them automatically.
 
 ```ts
 import {Provider} from '@loopback/context';
-import {ParsedRequest, RestBindings} from '@loopback/rest';
+import {Request, RestBindings} from '@loopback/rest';
 const uuid = require('uuid/v4');
 
 class CorrelationIdProvider implements Provider<string> {
-  constructor(
-    @inject(RestBindings.Http.REQUEST) private request: ParsedRequest,
-  ) {}
+  constructor(@inject(RestBindings.Http.REQUEST) private request: Request) {}
 
   value() {
     return this.request.headers['X-Correlation-Id'] || uuid();

--- a/docs/site/Dependency-injection.md
+++ b/docs/site/Dependency-injection.md
@@ -34,7 +34,7 @@ class AuthenticateActionProvider {
   }
 
   // this is the function invoked by "authenticate()" sequence action
-  action(request: ParsedRequest) {
+  action(request: Request) {
     const adapter = new StrategyAdapter(this.strategy);
     const user = await adapter.authenticate(request);
     return user;

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -136,11 +136,7 @@ function upon injection.
 ```ts
 import {Send, Response} from '@loopback/rest';
 import {Provider, BoundValue, inject} from '@loopback/context';
-import {
-  writeResultToResponse,
-  RestBindings,
-  ParsedRequest,
-} from '@loopback/rest';
+import {writeResultToResponse, RestBindings, Request} from '@loopback/rest';
 
 // Note: This is an example class; we do not provide this for you.
 import {Formatter} from '../utils';
@@ -149,7 +145,7 @@ export class CustomSendProvider implements Provider<Send> {
   // In this example, the injection key for formatter is simple
   constructor(
     @inject('utils.formatter') public formatter: Formatter,
-    @inject(RestBindings.Http.REQUEST) public request: ParsedRequest,
+    @inject(RestBindings.Http.REQUEST) public request: Request,
   ) {}
 
   value() {

--- a/examples/log-extension/README.md
+++ b/examples/log-extension/README.md
@@ -123,14 +123,14 @@ Now we define TypeScript type definitions / interfaces for complex types and
 functions here.
 
 ```ts
-import {ParsedRequest, OperationArgs} from '@loopback/rest';
+import {Request, OperationArgs} from '@loopback/rest';
 
 /**
  * A function to perform REST req/res logging action
  */
 export interface LogFn {
   (
-    req: ParsedRequest,
+    req: Request,
     args: OperationArgs,
     // tslint:disable-next-line:no-any
     result: any,
@@ -287,7 +287,7 @@ when called. The action provider will look as follows:
 ```ts
 import {inject, Provider, Constructor, Getter} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
-import {OperationArgs, ParsedRequest} from '@loopback/rest';
+import {OperationArgs, Request} from '@loopback/rest';
 import {getLogMetadata} from '../decorators/log.decorator';
 import {EXAMPLE_LOG_BINDINGS, LOG_LEVEL} from '../keys';
 import {
@@ -317,7 +317,7 @@ export class LogActionProvider implements Provider<LogFn> {
 
   value(): LogFn {
     const fn = <LogFn>((
-      req: ParsedRequest,
+      req: Request,
       args: OperationArgs,
       // tslint:disable-next-line:no-any
       result: any,
@@ -334,7 +334,7 @@ export class LogActionProvider implements Provider<LogFn> {
   }
 
   private async action(
-    req: ParsedRequest,
+    req: Request,
     args: OperationArgs,
     // tslint:disable-next-line:no-any
     result: any,


### PR DESCRIPTION
this PR replaces **ParsedRequest** by **Request**.

four (4) files were mentioning an import for **ParsedRequest** class/interface, however, I couldn't find any reference for this object in @loopback/rest package. I am not sure about the **ParsedRequest**, so please discard this PR and provide a solution if this object is meant to be there in this part of the documentation. 

closes #1690


- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
