### PR TITLE
fix(cli): enforce an empty object on connectors with no settings

### DIFF
--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -150,11 +150,12 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
   promptConnectorConfig() {
     debug('prompting for connector config');
     // Check to make sure connector is from connectors list (not custom)
-    const settings = connectors[this.artifactInfo.connector]
-      ? connectors[this.artifactInfo.connector]['settings']
-      : {};
-
+    const settings =
+      (connectors[this.artifactInfo.connector] &&
+        connectors[this.artifactInfo.connector]['settings']) ||
+      {};
     const prompts = [];
+
     // Create list of questions to prompt the user
     Object.entries(settings).forEach(([key, setting]) => {
       // Set defaults and merge with `setting` to override properties


### PR DESCRIPTION
It seems that the connector in mention doesn't have a settings property, thus the code was not enforcing a {} object but rather an undefined, which caused the generator to fail. I am assuming this connector doesn't need the settings property, if that's the case , this PR successfully fixes the error. If not, then I believe we need to add the settings property also.

fix #1697



## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
