### PR TITLE
feat(rest): set port from env by default

### DIFF
--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -155,8 +155,9 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
     // Can't check falsiness, 0 is a valid port.
     if (config.port == null) {
-      config.port = 3000;
+      config.port = process.env.PORT ? +process.env.PORT : 3000;
     }
+
     if (config.host == null) {
       // Set it to '' so that the http server will listen on all interfaces
       config.host = undefined;


### PR DESCRIPTION
Based on a discussion with @rmg and the experience of deploying the app to cloud, I think we should offer a default based on the `env`. Most cloud providers set `$PORT` as the environment variable. 

Users can still override if needed. 

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
