### PR TITLE
refactor: set default for optional options argument

### DIFF
--- a/examples/hello-world/src/application.ts
+++ b/examples/hello-world/src/application.ts
@@ -7,7 +7,7 @@ import {ApplicationConfig} from '@loopback/core';
 import {RestApplication, RestServer} from '@loopback/rest';
 
 export class HelloWorldApplication extends RestApplication {
-  constructor(options?: ApplicationConfig) {
+  constructor(options: ApplicationConfig = {}) {
     super(options);
 
     // In this example project, we configure a sequence that always

--- a/examples/rpc-server/src/application.ts
+++ b/examples/rpc-server/src/application.ts
@@ -9,12 +9,11 @@ import {GreetController} from './controllers';
 
 export class MyApplication extends Application {
   options: ApplicationConfig;
-  constructor(options?: ApplicationConfig) {
+  constructor(options: ApplicationConfig = {}) {
     // Allow options to replace the defined components array, if desired.
     super(options);
     this.controller(GreetController);
     this.server(RPCServer);
-    this.options = options || {};
     this.options.port = this.options.port || 3000;
     this.bind('rpcServer.config').to(this.options);
   }

--- a/examples/rpc-server/src/index.ts
+++ b/examples/rpc-server/src/index.ts
@@ -6,7 +6,7 @@
 import {MyApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 
-export async function main(options?: ApplicationConfig) {
+export async function main(options: ApplicationConfig = {}) {
   const app = new MyApplication(options);
 
   await app.start();

--- a/examples/soap-calculator/src/application.ts
+++ b/examples/soap-calculator/src/application.ts
@@ -8,7 +8,7 @@ import {MySequence} from './sequence';
 export class SoapCalculatorApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
 ) {
-  constructor(options?: ApplicationConfig) {
+  constructor(options: ApplicationConfig = {}) {
     super(options);
 
     // Set up the custom sequence

--- a/examples/soap-calculator/src/index.ts
+++ b/examples/soap-calculator/src/index.ts
@@ -1,7 +1,7 @@
 import {SoapCalculatorApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 
-export async function main(options?: ApplicationConfig) {
+export async function main(options: ApplicationConfig = {}) {
   const app = new SoapCalculatorApplication(options);
   await app.boot();
   await app.start();

--- a/examples/todo-list/src/application.ts
+++ b/examples/todo-list/src/application.ts
@@ -12,7 +12,7 @@ import {MySequence} from './sequence';
 export class TodoListApplication extends BootMixin(
   RepositoryMixin(RestApplication),
 ) {
-  constructor(options?: ApplicationConfig) {
+  constructor(options: ApplicationConfig = {}) {
     super(options);
 
     // Set up the custom sequence

--- a/examples/todo-list/src/index.ts
+++ b/examples/todo-list/src/index.ts
@@ -6,7 +6,7 @@
 import {TodoListApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 
-export async function main(options?: ApplicationConfig) {
+export async function main(options: ApplicationConfig = {}) {
   const app = new TodoListApplication(options);
   await app.boot();
   await app.start();

--- a/examples/todo/src/application.ts
+++ b/examples/todo/src/application.ts
@@ -13,7 +13,7 @@ import {MySequence} from './sequence';
 export class TodoListApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
 ) {
-  constructor(options?: ApplicationConfig) {
+  constructor(options: ApplicationConfig = {}) {
     super(options);
 
     // Set up the custom sequence

--- a/examples/todo/src/index.ts
+++ b/examples/todo/src/index.ts
@@ -6,7 +6,7 @@
 import {TodoListApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 
-export async function main(options?: ApplicationConfig) {
+export async function main(options: ApplicationConfig = {}) {
   const app = new TodoListApplication(options);
   await app.boot();
   await app.start();

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -34,7 +34,8 @@ export class Bootstrapper {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     private app: Application & Bootable,
     @inject(BootBindings.PROJECT_ROOT) private projectRoot: string,
-    @inject(BootBindings.BOOT_OPTIONS) private bootOptions: BootOptions = {},
+    @inject(BootBindings.BOOT_OPTIONS, {optional: true})
+    private bootOptions: BootOptions = {},
   ) {
     // Resolve path to projectRoot and re-bind
     this.projectRoot = resolve(this.projectRoot);

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -18,7 +18,7 @@ export class <%= project.applicationName %> extends BootMixin(
 -%>
 export class <%= project.applicationName %> extends BootMixin(RestApplication) {
 <% } -%>
-  constructor(options?: ApplicationConfig) {
+  constructor(options: ApplicationConfig = {}) {
     super(options);
 
     // Set up the custom sequence

--- a/packages/cli/generators/app/templates/src/index.ts.ejs
+++ b/packages/cli/generators/app/templates/src/index.ts.ejs
@@ -3,7 +3,7 @@ import {ApplicationConfig} from '@loopback/core';
 
 export {<%= project.applicationName %>};
 
-export async function main(options?: ApplicationConfig) {
+export async function main(options: ApplicationConfig = {}) {
   const app = new <%= project.applicationName %>(options);
   await app.boot();
   await app.start();

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -14,12 +14,10 @@ import {CoreBindings} from './keys';
  * and models.
  */
 export class Application extends Context {
-  constructor(public options?: ApplicationConfig) {
+  constructor(public options: ApplicationConfig = {}) {
     super();
-    if (!options) options = {};
 
-    // Bind to self to allow injection of application context in other
-    // modules.
+    // Bind to self to allow injection of application context in other modules.
     this.bind(CoreBindings.APPLICATION_INSTANCE).to(this);
     // Make options available to other modules as well.
     this.bind(CoreBindings.APPLICATION_CONFIG).to(options);

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -65,8 +65,8 @@ export class RestApplication extends Application implements HttpServerLike {
     return this.restServer.requestHandler;
   }
 
-  constructor(config?: ApplicationConfig) {
-    super(Object.assign({}, config));
+  constructor(config: ApplicationConfig = {}) {
+    super(config);
     this.component(RestComponent);
   }
 

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -147,11 +147,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
    */
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) app: Application,
-    @inject(RestBindings.CONFIG) config?: RestServerConfig,
+    @inject(RestBindings.CONFIG, {optional: true})
+    config: RestServerConfig = {},
   ) {
     super(app);
-
-    config = config || {};
 
     // Can't check falsiness, 0 is a valid port.
     if (config.port == null) {


### PR DESCRIPTION
`options` is an optional argument. Causes us to introduce unnecessary checks to see if it exists in the deploy workflow. This PR proposes making the argument optional by setting a default value instead of marking it as optional.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
