### PR TITLE
fix(cli): git-ignore all "dist*" dirs in scaffolded projects

### DIFF
--- a/packages/cli/generators/project/templates/_.gitignore
+++ b/packages/cli/generators/project/templates/_.gitignore
@@ -61,4 +61,4 @@ typings/
 api-docs/
 
 # Transpiled JavaScript files from Typescript
-dist/
+/dist*/


### PR DESCRIPTION
Fix the project template to configure Git to ignore all dist files created by the TypeScript compiler, e.g. `dist8` for Node.js 8.x and `dist10` for Node.js 10.x

Before this change, only the directory `dist` was ignored.

I discovered this problem while testing #1659 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
