### PR TITLE
feat(repository): rework *ById methods to throw if id not found

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -138,13 +138,13 @@ export class TodoController {
   async updateById(
     @param.path.number('id') id: number,
     @requestBody() obj: Todo,
-  ): Promise<boolean> {
-    return await this.todoRepository.updateById(id, obj);
+  ): Promise<void> {
+    await this.todoRepository.updateById(id, obj);
   }
 
   @del('/todos/{id}')
-  async deleteById(@param.path.number('id') id: number): Promise<boolean> {
-    return await this.todoRepository.deleteById(id);
+  async deleteById(@param.path.number('id') id: number): Promise<void> {
+    await this.todoRepository.deleteById(id);
   }
 }
 ```

--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -146,14 +146,6 @@ class MyFlexibleModel extends Entity {
 }
 ```
 
-The default response for a delete request to a non-existent resource is a `404`.
-You can change this behavior to `200` by setting `strictDelete` to `false`.
-
-```ts
-@model({settings: {strictDelete: false}})
-class Todo extends Entity { ... }
-```
-
 ### Model Decorator
 
 The model decorator can be used without any additional parameters, or can be

--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -157,13 +157,13 @@ export class TodoController {
   async updateTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
-  ): Promise<boolean> {
-    return await this.todoRepo.updateById(id, todo);
+  ): Promise<void> {
+    await this.todoRepo.updateById(id, todo);
   }
 
   @del('/todos/{id}')
-  async deleteTodo(@param.path.number('id') id: number): Promise<boolean> {
-    return await this.todoRepo.deleteById(id);
+  async deleteTodo(@param.path.number('id') id: number): Promise<void> {
+    await this.todoRepo.deleteById(id);
   }
 }
 ```

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -81,28 +81,26 @@ export class TodoListController {
 
   @patch('/todo-lists/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'TodoList PATCH success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
   async updateById(
     @param.path.number('id') id: number,
     @requestBody() obj: TodoList,
-  ): Promise<boolean> {
-    return await this.todoListRepository.updateById(id, obj);
+  ): Promise<void> {
+    await this.todoListRepository.updateById(id, obj);
   }
 
   @del('/todo-lists/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'TodoList DELETE success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
-  async deleteById(@param.path.number('id') id: number): Promise<boolean> {
-    return await this.todoListRepository.deleteById(id);
+  async deleteById(@param.path.number('id') id: number): Promise<void> {
+    await this.todoListRepository.deleteById(id);
   }
 }

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -56,43 +56,40 @@ export class TodoController {
 
   @put('/todos/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'Todo PUT success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
   async replaceTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
-  ): Promise<boolean> {
-    return await this.todoRepo.replaceById(id, todo);
+  ): Promise<void> {
+    await this.todoRepo.replaceById(id, todo);
   }
 
   @patch('/todos/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'Todo PATCH success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
   async updateTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
-  ): Promise<boolean> {
-    return await this.todoRepo.updateById(id, todo);
+  ): Promise<void> {
+    await this.todoRepo.updateById(id, todo);
   }
 
   @del('/todos/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'Todo DELETE success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
-  async deleteTodo(@param.path.number('id') id: number): Promise<boolean> {
-    return await this.todoRepo.deleteById(id);
+  async deleteTodo(@param.path.number('id') id: number): Promise<void> {
+    await this.todoRepo.deleteById(id);
   }
 }

--- a/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
@@ -9,7 +9,7 @@ import {Todo, TodoList} from '../../src/models/';
 import {TodoRepository, TodoListRepository} from '../../src/repositories/';
 import {givenTodo, givenTodoList} from '../helpers';
 
-describe('Application', () => {
+describe('TodoListApplication', () => {
   let app: TodoListApplication;
   let client: supertest.SuperTest<supertest.Test>;
   let todoRepo: TodoRepository;

--- a/examples/todo-list/test/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list.acceptance.ts
@@ -10,7 +10,7 @@ import {TodoList} from '../../src/models/';
 import {TodoListRepository} from '../../src/repositories/';
 import {givenTodoList} from '../helpers';
 
-describe('Application', () => {
+describe('TodoListApplication', () => {
   let app: TodoListApplication;
   let client: supertest.SuperTest<supertest.Test>;
   let todoListRepo: TodoListRepository;
@@ -92,7 +92,7 @@ describe('Application', () => {
       expect(result.body).to.deepEqual(expected);
     });
 
-    it('returns 404 when a todo does not exist', () => {
+    it('returns 404 when getting a todo-list that does not exist', () => {
       return client.get('/todo-lists/99999').expect(404);
     });
 
@@ -103,16 +103,23 @@ describe('Application', () => {
       await client
         .patch(`/todo-lists/${persistedTodoList.id}`)
         .send(updatedTodoList)
-        .expect(200);
+        .expect(204);
       const result = await todoListRepo.findById(persistedTodoList.id);
       expect(result).to.containEql(updatedTodoList);
+    });
+
+    it('returns 404 when updating a todo-list that does not exist', () => {
+      return client
+        .patch('/todos/99999')
+        .send(givenTodoList())
+        .expect(404);
     });
 
     it('deletes a todoList by ID', async () => {
       await client
         .del(`/todo-lists/${persistedTodoList.id}`)
         .send()
-        .expect(200);
+        .expect(204);
       await expect(
         todoListRepo.findById(persistedTodoList.id),
       ).to.be.rejectedWith(EntityNotFoundError);

--- a/examples/todo-list/test/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo.acceptance.ts
@@ -10,7 +10,7 @@ import {Todo} from '../../src/models/';
 import {TodoRepository} from '../../src/repositories/';
 import {givenTodo} from '../helpers';
 
-describe('Application', () => {
+describe('TodoListApplication', () => {
   let app: TodoListApplication;
   let client: supertest.SuperTest<supertest.Test>;
   let todoRepo: TodoRepository;
@@ -64,7 +64,7 @@ describe('Application', () => {
       expect(result.body).to.deepEqual(expected);
     });
 
-    it('returns 404 when a todo does not exist', () => {
+    it('returns 404 when getting a todo that does not exist', () => {
       return client.get('/todos/99999').expect(404);
     });
 
@@ -77,9 +77,16 @@ describe('Application', () => {
       await client
         .put(`/todos/${persistedTodo.id}`)
         .send(updatedTodo)
-        .expect(200);
+        .expect(204);
       const result = await todoRepo.findById(persistedTodo.id);
       expect(result).to.containEql(updatedTodo);
+    });
+
+    it('returns 404 when replacing a todo that does not exist', () => {
+      return client
+        .put('/todos/99999')
+        .send(givenTodo())
+        .expect(404);
     });
 
     it('updates the todo by ID ', async () => {
@@ -90,19 +97,30 @@ describe('Application', () => {
       await client
         .patch(`/todos/${persistedTodo.id}`)
         .send(updatedTodo)
-        .expect(200);
+        .expect(204);
       const result = await todoRepo.findById(persistedTodo.id);
       expect(result).to.containEql(updatedTodo);
+    });
+
+    it('returns 404 when updating a todo that does not exist', () => {
+      return client
+        .patch('/todos/99999')
+        .send(givenTodo())
+        .expect(404);
     });
 
     it('deletes the todo', async () => {
       await client
         .del(`/todos/${persistedTodo.id}`)
         .send()
-        .expect(200);
+        .expect(204);
       await expect(todoRepo.findById(persistedTodo.id)).to.be.rejectedWith(
         EntityNotFoundError,
       );
+    });
+
+    it('returns 404 when deleting a todo that does not exist', async () => {
+      await client.del(`/todos/99999`).expect(404);
     });
   });
 

--- a/examples/todo-list/test/unit/controllers/todo-list.controller.unit.ts
+++ b/examples/todo-list/test/unit/controllers/todo-list.controller.unit.ts
@@ -100,13 +100,11 @@ describe('TodoController', () => {
 
   describe('updateById', () => {
     it('successfully updates existing items', async () => {
-      updateById.resolves(true);
-      expect(
-        await controller.updateById(
-          aTodoListWithId.id as number,
-          aTodoListToPatchTo,
-        ),
-      ).to.eql(true);
+      updateById.resolves();
+      await controller.updateById(
+        aTodoListWithId.id as number,
+        aTodoListToPatchTo,
+      );
       sinon.assert.calledWith(
         updateById,
         aTodoListWithId.id,
@@ -117,10 +115,8 @@ describe('TodoController', () => {
 
   describe('deleteById', () => {
     it('successfully deletes existing items', async () => {
-      deleteById.resolves(true);
-      expect(await controller.deleteById(aTodoListWithId.id as number)).to.eql(
-        true,
-      );
+      deleteById.resolves();
+      await controller.deleteById(aTodoListWithId.id as number);
       sinon.assert.calledWith(deleteById, aTodoListWithId.id);
     });
   });

--- a/examples/todo-list/test/unit/controllers/todo.controller.unit.ts
+++ b/examples/todo-list/test/unit/controllers/todo.controller.unit.ts
@@ -82,30 +82,24 @@ describe('TodoController', () => {
 
   describe('replaceTodo', () => {
     it('successfully replaces existing items', async () => {
-      replaceById.resolves(true);
-      expect(
-        await controller.replaceTodo(aTodoWithId.id as number, aChangedTodo),
-      ).to.eql(true);
+      replaceById.resolves();
+      await controller.replaceTodo(aTodoWithId.id as number, aChangedTodo);
       sinon.assert.calledWith(replaceById, aTodoWithId.id, aChangedTodo);
     });
   });
 
   describe('updateTodo', () => {
     it('successfully updates existing items', async () => {
-      updateById.resolves(true);
-      expect(
-        await controller.updateTodo(aTodoWithId.id as number, aChangedTodo),
-      ).to.eql(true);
+      updateById.resolves();
+      await controller.updateTodo(aTodoWithId.id as number, aChangedTodo);
       sinon.assert.calledWith(updateById, aTodoWithId.id, aChangedTodo);
     });
   });
 
   describe('deleteTodo', () => {
     it('successfully deletes existing items', async () => {
-      deleteById.resolves(true);
-      expect(await controller.deleteTodo(aTodoWithId.id as number)).to.eql(
-        true,
-      );
+      deleteById.resolves();
+      await controller.deleteTodo(aTodoWithId.id as number);
       sinon.assert.calledWith(deleteById, aTodoWithId.id);
     });
   });

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -69,43 +69,40 @@ export class TodoController {
 
   @put('/todos/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'Todo PUT success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
   async replaceTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
-  ): Promise<boolean> {
-    return await this.todoRepo.replaceById(id, todo);
+  ): Promise<void> {
+    await this.todoRepo.replaceById(id, todo);
   }
 
   @patch('/todos/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'Todo PATCH success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
   async updateTodo(
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
-  ): Promise<boolean> {
-    return await this.todoRepo.updateById(id, todo);
+  ): Promise<void> {
+    await this.todoRepo.updateById(id, todo);
   }
 
   @del('/todos/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: 'Todo DELETE success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
-  async deleteTodo(@param.path.number('id') id: number): Promise<boolean> {
-    return await this.todoRepo.deleteById(id);
+  async deleteTodo(@param.path.number('id') id: number): Promise<void> {
+    await this.todoRepo.deleteById(id);
   }
 }

--- a/examples/todo/test/acceptance/todo.acceptance.ts
+++ b/examples/todo/test/acceptance/todo.acceptance.ts
@@ -16,7 +16,7 @@ import {
   HttpCachingProxy,
 } from '../helpers';
 
-describe('Application', () => {
+describe('TodoApplication', () => {
   let app: TodoListApplication;
   let client: supertest.SuperTest<supertest.Test>;
   let todoRepo: TodoRepository;
@@ -96,7 +96,7 @@ describe('Application', () => {
       expect(result.body).to.deepEqual(expected);
     });
 
-    it('returns 404 when a todo does not exist', () => {
+    it('returns 404 when getting a todo that does not exist', () => {
       return client.get('/todos/99999').expect(404);
     });
 
@@ -109,9 +109,16 @@ describe('Application', () => {
       await client
         .put(`/todos/${persistedTodo.id}`)
         .send(updatedTodo)
-        .expect(200);
+        .expect(204);
       const result = await todoRepo.findById(persistedTodo.id);
       expect(result).to.containEql(updatedTodo);
+    });
+
+    it('returns 404 when replacing a todo that does not exist', () => {
+      return client
+        .put('/todos/99999')
+        .send(givenTodo())
+        .expect(404);
     });
 
     it('updates the todo by ID ', async () => {
@@ -122,19 +129,30 @@ describe('Application', () => {
       await client
         .patch(`/todos/${persistedTodo.id}`)
         .send(updatedTodo)
-        .expect(200);
+        .expect(204);
       const result = await todoRepo.findById(persistedTodo.id);
       expect(result).to.containEql(updatedTodo);
+    });
+
+    it('returns 404 when updating a todo that does not exist', () => {
+      return client
+        .patch('/todos/99999')
+        .send(givenTodo({isComplete: true}))
+        .expect(404);
     });
 
     it('deletes the todo', async () => {
       await client
         .del(`/todos/${persistedTodo.id}`)
         .send()
-        .expect(200);
+        .expect(204);
       await expect(todoRepo.findById(persistedTodo.id)).to.be.rejectedWith(
         EntityNotFoundError,
       );
+    });
+
+    it('returns 404 when deleting a todo that does not exist', async () => {
+      await client.del(`/todos/99999`).expect(404);
     });
   });
 

--- a/examples/todo/test/unit/controllers/todo.controller.unit.ts
+++ b/examples/todo/test/unit/controllers/todo.controller.unit.ts
@@ -103,30 +103,24 @@ describe('TodoController', () => {
 
   describe('replaceTodo', () => {
     it('successfully replaces existing items', async () => {
-      replaceById.resolves(true);
-      expect(
-        await controller.replaceTodo(aTodoWithId.id as number, aChangedTodo),
-      ).to.eql(true);
+      replaceById.resolves();
+      await controller.replaceTodo(aTodoWithId.id as number, aChangedTodo);
       sinon.assert.calledWith(replaceById, aTodoWithId.id, aChangedTodo);
     });
   });
 
   describe('updateTodo', () => {
     it('successfully updates existing items', async () => {
-      updateById.resolves(true);
-      expect(
-        await controller.updateTodo(aTodoWithId.id as number, aChangedTodo),
-      ).to.eql(true);
+      updateById.resolves();
+      await controller.updateTodo(aTodoWithId.id as number, aChangedTodo);
       sinon.assert.calledWith(updateById, aTodoWithId.id, aChangedTodo);
     });
   });
 
   describe('deleteTodo', () => {
     it('successfully deletes existing items', async () => {
-      deleteById.resolves(true);
-      expect(await controller.deleteTodo(aTodoWithId.id as number)).to.eql(
-        true,
-      );
+      deleteById.resolves();
+      await controller.deleteTodo(aTodoWithId.id as number);
       sinon.assert.calledWith(deleteById, aTodoWithId.id);
     });
   });

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -88,28 +88,26 @@ export class <%= className %>Controller {
 
   @patch('<%= httpPathName %>/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: '<%= modelName %> PATCH success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
   async updateById(
     @param.path.<%= idType %>('id') id: <%= idType %>,
     @requestBody() <%= name %>: <%= modelName %>
-  ): Promise<boolean> {
-    return await this.<%= repositoryNameCamel %>.updateById(id, <%= name %>);
+  ): Promise<void> {
+    await this.<%= repositoryNameCamel %>.updateById(id, <%= name %>);
   }
 
   @del('<%= httpPathName %>/{id}', {
     responses: {
-      '200': {
+      '204': {
         description: '<%= modelName %> DELETE success',
-        content: {'application/json': {'x-ts-type': Boolean}},
       },
     },
   })
-  async deleteById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<boolean> {
-    return await this.<%= repositoryNameCamel %>.deleteById(id);
+  async deleteById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<void> {
+    await this.<%= repositoryNameCamel %>.deleteById(id);
   }
 }

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -310,9 +310,8 @@ function checkRestCrudContents() {
   const patchUpdateByIdRegEx = [
     /\@patch\('\/product-reviews\/{id}'/,
     /responses: {/,
-    /'200': {/,
+    /'204': {/,
     /description: 'ProductReview PATCH success'/,
-    /content: {'application\/json': {'x-ts-type': Boolean}},\s{1,}},\s{1,}},\s{1,}}\)/,
     /async updateById\(\s{1,}\@param.path.number\('id'\) id: number,\s{1,}\@requestBody\(\)/,
   ];
   patchUpdateByIdRegEx.forEach(regex => {
@@ -323,9 +322,8 @@ function checkRestCrudContents() {
   const deleteByIdRegEx = [
     /\@del\('\/product-reviews\/{id}', {/,
     /responses: {/,
-    /'200': {/,
+    /'204': {/,
     /description: 'ProductReview DELETE success'/,
-    /content: {'application\/json': {'x-ts-type': Boolean}},\s{1,}},\s{1,}},\s{1,}}\)/,
     /async deleteById\(\@param.path.number\('id'\) id: number\)/,
   ];
   deleteByIdRegEx.forEach(regex => {

--- a/packages/repository/test/acceptance/repository.acceptance.ts
+++ b/packages/repository/test/acceptance/repository.acceptance.ts
@@ -71,36 +71,6 @@ describe('Repository in Thinking in LoopBack', () => {
     expect(stored).to.containDeep({extra: 'additional data'});
   });
 
-  it('enables strict delete by default', async () => {
-    await repo.create({slug: 'pencil'});
-    await expect(repo.deleteById(10000)).to.be.rejectedWith(
-      /No instance with id/,
-    );
-  });
-
-  it('disables strict delete via configuration', async () => {
-    @model({settings: {strictDelete: false}})
-    class Pencil extends Entity {
-      @property({id: true})
-      id: number;
-      @property({type: 'string'})
-      name: string;
-    }
-
-    const pencilRepo = new DefaultCrudRepository<
-      Pencil,
-      typeof Pencil.prototype.id
-    >(Pencil, new DataSource({connector: 'memory'}));
-
-    await pencilRepo.create({
-      name: 'Green Pencil',
-    });
-
-    // When `strictDelete` is set to `false`, `deleteById()` on a non-existing
-    // resource is resolved with `false`, instead of being rejected.
-    await expect(pencilRepo.deleteById(10000)).to.be.fulfilledWith(false);
-  });
-
   function givenProductRepository() {
     const db = new DataSource({
       connector: 'memory',

--- a/packages/rest/src/writer.ts
+++ b/packages/rest/src/writer.ts
@@ -19,34 +19,37 @@ export function writeResultToResponse(
   // result returned back from invoking controller method
   result: OperationRetval,
 ): void {
-  if (result) {
-    if (result instanceof Readable || typeof result.pipe === 'function') {
-      response.setHeader('Content-Type', 'application/octet-stream');
-      // Stream
-      result.pipe(response);
-      return;
-    }
-    switch (typeof result) {
-      case 'object':
-      case 'boolean':
-      case 'number':
-        if (Buffer.isBuffer(result)) {
-          // Buffer for binary data
-          response.setHeader('Content-Type', 'application/octet-stream');
-        } else {
-          // TODO(ritch) remove this, should be configurable
-          // See https://github.com/strongloop/loopback-next/issues/436
-          response.setHeader('Content-Type', 'application/json');
-          // TODO(bajtos) handle errors - JSON.stringify can throw
-          result = JSON.stringify(result);
-        }
-        break;
-      default:
-        response.setHeader('Content-Type', 'text/plain');
-        result = result.toString();
-        break;
-    }
-    response.write(result);
+  if (!result) {
+    response.statusCode = 204;
+    response.end();
+    return;
   }
-  response.end();
+
+  if (result instanceof Readable || typeof result.pipe === 'function') {
+    response.setHeader('Content-Type', 'application/octet-stream');
+    // Stream
+    result.pipe(response);
+    return;
+  }
+  switch (typeof result) {
+    case 'object':
+    case 'boolean':
+    case 'number':
+      if (Buffer.isBuffer(result)) {
+        // Buffer for binary data
+        response.setHeader('Content-Type', 'application/octet-stream');
+      } else {
+        // TODO(ritch) remove this, should be configurable
+        // See https://github.com/strongloop/loopback-next/issues/436
+        response.setHeader('Content-Type', 'application/json');
+        // TODO(bajtos) handle errors - JSON.stringify can throw
+        result = JSON.stringify(result);
+      }
+      break;
+    default:
+      response.setHeader('Content-Type', 'text/plain');
+      result = result.toString();
+      break;
+  }
+  response.end(result);
 }

--- a/packages/rest/test/unit/writer.unit.ts
+++ b/packages/rest/test/unit/writer.unit.ts
@@ -68,6 +68,15 @@ describe('writer', () => {
     expect(result.payload).to.equal('ABC123');
   });
 
+  it('sends 204 No Content when the response is undefined', async () => {
+    writeResultToResponse(response, undefined);
+    const result = await observedResponse;
+
+    expect(result.statusCode).to.equal(204);
+    expect(result.headers).to.not.have.property('content-type');
+    expect(result.payload).to.equal('');
+  });
+
   function setupResponseMock() {
     const responseMock = stubExpressContext();
     response = responseMock.response;


### PR DESCRIPTION
_This is a follow-up for #1658 related to #1469._

Rework Repository interface and implementations to throw EntityNotFound error from `updateById`, `replaceById` and `deleteById` when there is no entity with the provided id. 

Update related controller methods to return 204 No Content on success, because there is no boolean flag to indicate success anymore. Clients should check the response status code instead (204 vs 404).

Improve our REST layer to set the response status code to 204 when body is undefined.

This patch is reverting the implementation details of #1621 while keeping the observed REST API behavior.

See the discussion in #1658 and https://github.com/strongloop/loopback-next/pull/1658#issuecomment-421966796 in particular to better understand the reasoning for this change. Also note that soon we will add a new Repository implementation that will provide `*ById` variant using a a special return value to indicate "not found" case. 

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated