### PR TITLE
Remove nsp

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,6 +9,7 @@
   ],
   "command": {
     "bootstrap": {
+      "concurrency": 8,
       "ci": false
     },
     "version": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,6 @@
     "mem-fs": "^1.1.3",
     "mem-fs-editor": "^4.0.0",
     "mock-stdin": "^0.3.1",
-    "nsp": "^3.2.1",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5",
     "rimraf": "^2.6.2",
@@ -62,7 +61,6 @@
     "yeoman-generator": "^3.1.1"
   },
   "scripts": {
-    "preversion": "nsp check",
     "build": "node ./bin/download-connector-list.js",
     "build:all-dist": "npm run build",
     "test": "lb-mocha \"test/**/*.js\"",


### PR DESCRIPTION
Remove dependency on `nsp` which is deprecated and will be shutdown soon.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
