### PR TITLE
chore(rest): switch to /explorer with explorer.loopback.io

### DIFF
--- a/docs/site/Deploying-to-IBM-Cloud.md
+++ b/docs/site/Deploying-to-IBM-Cloud.md
@@ -164,8 +164,8 @@ $ npm run build
 $ npm start
 ```
 
-5.  Go to http://localhost:3000/swagger-ui to load API Explorer and add a todo
-    or two.
+5.  Go to http://localhost:3000/explorer to load API Explorer and add a todo or
+    two.
 
 6.  Go to http://localhost:3000/todos to see the todos.
 
@@ -211,8 +211,8 @@ npm run build
 cf push mylb4app
 ```
 
-3.  Go to https://mylb4app.eu-gb.mybluemix.net/swagger-ui to load the API
-    Explorer and add a todo or two. The host `mylb4app.eu-gb.mybluemix.net` is
-    derived from the `name` and `domain` values in the `manifest.yml` file.
+3.  Go to https://mylb4app.eu-gb.mybluemix.net/explorer to load the API Explorer
+    and add a todo or two. The host `mylb4app.eu-gb.mybluemix.net` is derived
+    from the `name` and `domain` values in the `manifest.yml` file.
 
 4.  Go to https://mylb4app.eu-gb.mybluemix.net/todos to see the todos.

--- a/docs/site/Preparing-the-API-for-consumption.shelved.md
+++ b/docs/site/Preparing-the-API-for-consumption.shelved.md
@@ -27,7 +27,7 @@ cd loopback4-example-todo
 npm start
 ```
 
-Open <http://localhost:3000/swagger-ui> to see the API endpoints defined by
+Open <http://localhost:3000/explorer> to see the API endpoints defined by
 `swagger.json`.
 
 {% include note.html content="

--- a/docs/site/todo-tutorial-putting-it-together.md
+++ b/docs/site/todo-tutorial-putting-it-together.md
@@ -81,7 +81,7 @@ $ npm start
 Server is running on port 3000
 ```
 
-Next, you can use the [API Explorer](http://localhost:3000/swagger-ui) to browse
+Next, you can use the [API Explorer](http://localhost:3000/explorer) to browse
 your API and make requests!
 
 Here are some requests you can try:

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -166,13 +166,14 @@ export class RestServer extends Context implements Server, HttpServerLike {
       config.openApiSpec.endpointMapping || OPENAPI_SPEC_MAPPING;
     config.apiExplorer = config.apiExplorer || {};
 
-    config.apiExplorer.url =
-      config.apiExplorer.url || 'https://loopback.io/api-explorer';
+    const url = config.apiExplorer.url || 'https://explorer.loopback.io';
 
     config.apiExplorer.httpUrl =
       config.apiExplorer.httpUrl ||
       config.apiExplorer.url ||
-      'https://loopback.io/api-explorer';
+      'http://explorer.loopback.io';
+
+    config.apiExplorer.url = url;
 
     this.config = config;
     this.bind(RestBindings.PORT).to(config.port);
@@ -245,7 +246,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   }
 
   /**
-   * Mount /openapi.json, /openapi.yaml for specs and /swagger-ui, /api-explorer
+   * Mount /openapi.json, /openapi.yaml for specs and /swagger-ui, /explorer
    * to redirect to externally hosted API explorer
    */
   protected _setupOpenApiSpecEndpoints() {
@@ -263,7 +264,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
         this._serveOpenApiSpec(req, res, mapping[p]),
       );
     }
-    this._expressApp.get(['/swagger-ui', '/api-explorer'], (req, res) =>
+    this._expressApp.get(['/swagger-ui', '/explorer'], (req, res) =>
       this._redirectToSwaggerUI(req, res),
     );
   }

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -358,7 +358,7 @@ paths:
     expect(response.get('Access-Control-Allow-Credentials')).to.equal('true');
   });
 
-  it('exposes "GET /swagger-ui" endpoint', async () => {
+  it('exposes "GET /explorer" endpoint', async () => {
     const app = new Application();
     app.component(RestComponent);
     const server = await app.getServer(RestServer);
@@ -373,12 +373,12 @@ paths:
     server.route(new Route('get', '/greet', greetSpec, function greet() {}));
 
     const response = await createClientForHandler(server.requestHandler).get(
-      '/swagger-ui',
+      '/explorer',
     );
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'https://loopback.io/api-explorer',
+        'http://explorer.loopback.io',
         '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/openapi.json',
       ].join(''),
     );
@@ -393,14 +393,14 @@ paths:
     const server = await app.getServer(RestServer);
 
     const response = await createClientForHandler(server.requestHandler)
-      .get('/swagger-ui')
+      .get('/explorer')
       .set('x-forwarded-proto', 'https')
       .set('x-forwarded-host', 'example.com')
       .set('x-forwarded-port', '8080');
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'https://loopback.io/api-explorer',
+        'https://explorer.loopback.io',
         '\\?url=https://example.com:8080/openapi.json',
       ].join(''),
     );
@@ -413,13 +413,13 @@ paths:
     const server = await app.getServer(RestServer);
 
     const response = await createClientForHandler(server.requestHandler)
-      .get('/swagger-ui')
+      .get('/explorer')
       .set('x-forwarded-proto', 'http')
       .set('x-forwarded-host', 'example.com:8080,my.example.com:9080');
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'https://loopback.io/api-explorer',
+        'http://explorer.loopback.io',
         '\\?url=http://example.com:8080/openapi.json',
       ].join(''),
     );
@@ -432,21 +432,21 @@ paths:
     const server = await app.getServer(RestServer);
 
     const response = await createClientForHandler(server.requestHandler)
-      .get('/swagger-ui')
+      .get('/explorer')
       .set('x-forwarded-proto', 'https')
       .set('x-forwarded-host', 'example.com')
       .set('x-forwarded-port', '443');
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'https://loopback.io/api-explorer',
+        'https://explorer.loopback.io',
         '\\?url=https://example.com/openapi.json',
       ].join(''),
     );
     expect(response.get('Location')).match(expectedUrl);
   });
 
-  it('exposes "GET /swagger-ui" endpoint with apiExplorer.url', async () => {
+  it('exposes "GET /explorer" endpoint with apiExplorer.url', async () => {
     const server = await givenAServer({
       rest: {
         apiExplorer: {
@@ -456,7 +456,7 @@ paths:
     });
 
     const response = await createClientForHandler(server.requestHandler).get(
-      '/swagger-ui',
+      '/explorer',
     );
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
@@ -468,7 +468,7 @@ paths:
     expect(response.get('Location')).match(expectedUrl);
   });
 
-  it('exposes "GET /swagger-ui" endpoint with apiExplorer.urlForHttp', async () => {
+  it('exposes "GET /explorer" endpoint with apiExplorer.urlForHttp', async () => {
     const server = await givenAServer({
       rest: {
         apiExplorer: {
@@ -479,7 +479,7 @@ paths:
     });
 
     const response = await createClientForHandler(server.requestHandler).get(
-      '/swagger-ui',
+      '/explorer',
     );
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
@@ -565,12 +565,12 @@ paths:
     const serverUrl = server.getSync(RestBindings.URL);
 
     // The `Location` header should be something like
-    // https://loopback.io/api-explorer?url=https://[::1]:58470/openapi.json
-    const res = await httpsGetAsync(serverUrl + '/swagger-ui');
+    // https://explorer.loopback.io?url=https://[::1]:58470/openapi.json
+    const res = await httpsGetAsync(serverUrl + '/explorer');
     const location = res.headers['location'];
     expect(location).to.match(/\[\:\:1\]\:\d+\/openapi.json/);
     expect(location).to.equal(
-      `https://loopback.io/api-explorer?url=${serverUrl}/openapi.json`,
+      `https://explorer.loopback.io?url=${serverUrl}/openapi.json`,
     );
     await server.stop();
   });


### PR DESCRIPTION
Switch to https://explorer.loopback.io and http://explorer.loopback.io for hosted API explorer
Switch to `/explorer` for the mount path for the UI

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
