### PR TITLE
fix(docs): fix incorrect soap url

### DIFF
--- a/docs/site/soap-calculator-tutorial-add-datasource.md
+++ b/docs/site/soap-calculator-tutorial-add-datasource.md
@@ -40,12 +40,12 @@ by StrongLoop) connector from the list as shown below:
 #### Specify the SOAP web service endpoint
 
 Now we must tell **CLI** about the full URL path for our web service. In this
-case, let's type `http://lb4ws.eycgrupo.com/calculator` for the URL and
+case, let's type `http://lb4ws.eycgrupo.com/calculator/` for the URL and
 `http://lb4ws.eycgrupo.com/calculator/?wsdl` for the WSDL path.
 
 ```sh
 ? Select the connector for calculator: SOAP webservices (supported by StrongLoop)
-? URL to the SOAP web service endpoint: http://lb4ws.eycgrupo.com/calculator
+? URL to the SOAP web service endpoint: http://lb4ws.eycgrupo.com/calculator/
 ? HTTP URL or local file system path to the WSDL file: http://lb4ws.eycgrupo.com/calculator/?wsdl
 ```
 


### PR DESCRIPTION
without trailing slash response will be empty

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
