### PR TITLE
feat(testlab): add createRestAppClient(), simplify usage in tests

### DIFF
--- a/docs/site/Implementing-features.shelved.md
+++ b/docs/site/Implementing-features.shelved.md
@@ -40,11 +40,11 @@ Create `test/acceptance/product.acceptance.ts` with the following contents:
 ```ts
 import {HelloWorldApp} from '../..';
 import {RestBindings, RestServer} from '@loopback/rest';
-import {expect, supertest} from '@loopback/testlab';
+import {Client, expect, supertest} from '@loopback/testlab';
 
 describe('Product (acceptance)', () => {
   let app: HelloWorldApp;
-  let request: supertest.SuperTest<supertest.Test>;
+  let request: Client;
 
   before(givenEmptyDatabase);
   before(givenRunningApp);
@@ -84,13 +84,13 @@ describe('Product (acceptance)', () => {
   }
 
   async function givenRunningApp() {
-    app = new HelloWorldApp();
-    const server = await app.getServer(RestServer);
-    server.bind(RestBindings.PORT).to(0);
+    app = new HelloWorldApp({
+      rest: {
+        port: 0,
+      },
+    });
     await app.start();
-
-    const port: number = await server.get(RestBindings.PORT);
-    request = supertest(`http://127.0.0.1:${port}`);
+    request = supertest(app.restServer.url);
   }
 
   async function givenProduct(data: Object) {

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -833,7 +833,7 @@ Here is an example of an acceptance test:
 
 ```ts
 import {HelloWorldApplication} from '../..';
-import {expect, createClientForHandler, Client} from '@loopback/testlab';
+import {Client, createRestAppClient, expect} from '@loopback/testlab';
 import {givenEmptyDatabase, givenProduct} from '../helpers/database.helpers';
 import {RestServer, RestBindings} from '@loopback/rest';
 import {testdb} from '../fixtures/datasources/testdb.datasource';
@@ -870,14 +870,16 @@ describe('Product (acceptance)', () => {
   });
 
   async function givenRunningApp() {
-    app = new HelloWorldApplication();
+    app = new HelloWorldApplication({
+      rest: {
+        port: 0,
+      },
+    });
     app.dataSource(testdb);
-    const server = await app.getServer(RestServer);
-    server.bind(RestBindings.PORT).to(0);
     await app.boot();
     await app.start();
 
-    client = createClientForHandler(server.handleHttp);
+    client = createRestAppClient(app);
   }
 });
 ```

--- a/examples/hello-world/test/acceptance/application.acceptance.ts
+++ b/examples/hello-world/test/acceptance/application.acceptance.ts
@@ -3,23 +3,22 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {createClientForHandler, expect, supertest} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
+import {
+  Client,
+  createRestAppClient,
+  expect,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
 import {HelloWorldApplication} from '../../src/application';
 
 describe('Application', () => {
   let app: HelloWorldApplication;
-  let client: supertest.SuperTest<supertest.Test>;
-  let server: RestServer;
+  let client: Client;
 
   before(givenAnApplication);
   before(async () => {
     await app.start();
-    server = await app.getServer(RestServer);
-  });
-
-  before(() => {
-    client = createClientForHandler(server.requestHandler);
+    client = createRestAppClient(app);
   });
   after(async () => {
     await app.stop();
@@ -32,9 +31,9 @@ describe('Application', () => {
 
   function givenAnApplication() {
     app = new HelloWorldApplication({
-      rest: {
+      rest: givenHttpServerConfig({
         port: 0,
-      },
+      }),
       disableConsoleLog: true,
     });
   }

--- a/examples/soap-calculator/test/acceptance/application.acceptance.ts
+++ b/examples/soap-calculator/test/acceptance/application.acceptance.ts
@@ -1,10 +1,9 @@
-import {supertest} from '@loopback/testlab';
+import {Client, createRestAppClient, expect} from '@loopback/testlab';
 import {SoapCalculatorApplication} from '../../src/application';
-import {expect} from '@loopback/testlab';
 
 describe('Application', function() {
   let app: SoapCalculatorApplication;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
 
   // tslint:disable-next-line:no-invalid-this
   this.timeout(30000);
@@ -14,7 +13,7 @@ describe('Application', function() {
   before(async () => {
     await app.boot();
     await app.start();
-    client = supertest(app.restServer.url);
+    client = createRestAppClient(app);
   });
 
   after(async () => {

--- a/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
@@ -3,15 +3,20 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {createClientForHandler, expect, supertest} from '@loopback/testlab';
+import {
+  Client,
+  createRestAppClient,
+  expect,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {Todo, TodoList} from '../../src/models/';
-import {TodoRepository, TodoListRepository} from '../../src/repositories/';
+import {TodoListRepository, TodoRepository} from '../../src/repositories/';
 import {givenTodo, givenTodoList} from '../helpers';
 
 describe('TodoListApplication', () => {
   let app: TodoListApplication;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
   let todoRepo: TodoRepository;
   let todoListRepo: TodoListRepository;
 
@@ -23,7 +28,7 @@ describe('TodoListApplication', () => {
   before(givenTodoRepository);
   before(givenTodoListRepository);
   before(() => {
-    client = createClientForHandler(app.requestHandler);
+    client = createRestAppClient(app);
   });
 
   beforeEach(async () => {
@@ -119,9 +124,9 @@ describe('TodoListApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: {
+      rest: givenHttpServerConfig({
         port: 0,
-      },
+      }),
     });
 
     await app.boot();

--- a/examples/todo-list/test/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list.acceptance.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {EntityNotFoundError} from '@loopback/repository';
-import {createClientForHandler, expect, supertest} from '@loopback/testlab';
+import {
+  Client,
+  createRestAppClient,
+  expect,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {TodoList} from '../../src/models/';
 import {TodoListRepository} from '../../src/repositories/';
@@ -12,7 +17,7 @@ import {givenTodoList} from '../helpers';
 
 describe('TodoListApplication', () => {
   let app: TodoListApplication;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
   let todoListRepo: TodoListRepository;
 
   before(givenRunningApplicationWithCustomConfiguration);
@@ -20,7 +25,7 @@ describe('TodoListApplication', () => {
 
   before(givenTodoListRepository);
   before(() => {
-    client = createClientForHandler(app.requestHandler);
+    client = createRestAppClient(app);
   });
 
   beforeEach(async () => {
@@ -140,9 +145,9 @@ describe('TodoListApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: {
+      rest: givenHttpServerConfig({
         port: 0,
-      },
+      }),
     });
 
     await app.boot();

--- a/examples/todo-list/test/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo.acceptance.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {EntityNotFoundError} from '@loopback/repository';
-import {createClientForHandler, expect, supertest} from '@loopback/testlab';
+import {
+  Client,
+  createRestAppClient,
+  expect,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {Todo} from '../../src/models/';
 import {TodoRepository} from '../../src/repositories/';
@@ -12,7 +17,7 @@ import {givenTodo} from '../helpers';
 
 describe('TodoListApplication', () => {
   let app: TodoListApplication;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
   let todoRepo: TodoRepository;
 
   before(givenRunningApplicationWithCustomConfiguration);
@@ -20,7 +25,7 @@ describe('TodoListApplication', () => {
 
   before(givenTodoRepository);
   before(() => {
-    client = createClientForHandler(app.requestHandler);
+    client = createRestAppClient(app);
   });
 
   beforeEach(async () => {
@@ -138,9 +143,9 @@ describe('TodoListApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: {
+      rest: givenHttpServerConfig({
         port: 0,
-      },
+      }),
     });
 
     await app.boot();

--- a/examples/todo/test/acceptance/todo.acceptance.ts
+++ b/examples/todo/test/acceptance/todo.acceptance.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {EntityNotFoundError} from '@loopback/repository';
-import {createClientForHandler, expect, supertest} from '@loopback/testlab';
+import {
+  Client,
+  createRestAppClient,
+  expect,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
 import {TodoListApplication} from '../../src/application';
 import {Todo} from '../../src/models/';
 import {TodoRepository} from '../../src/repositories/';
@@ -18,7 +23,7 @@ import {
 
 describe('TodoApplication', () => {
   let app: TodoListApplication;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
   let todoRepo: TodoRepository;
 
   let cachingProxy: HttpCachingProxy;
@@ -30,7 +35,7 @@ describe('TodoApplication', () => {
 
   before(givenTodoRepository);
   before(() => {
-    client = createClientForHandler(app.requestHandler);
+    client = createRestAppClient(app);
   });
 
   beforeEach(async () => {
@@ -170,9 +175,9 @@ describe('TodoApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: {
+      rest: givenHttpServerConfig({
         port: 0,
-      },
+      }),
     });
 
     await app.boot();

--- a/packages/boot/test/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/test/acceptance/controller.booter.acceptance.ts
@@ -3,8 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Client, createClientForHandler, TestSandbox} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
+import {
+  createRestAppClient,
+  givenHttpServerConfig,
+  TestSandbox,
+} from '@loopback/testlab';
 import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
@@ -22,8 +25,7 @@ describe('controller booter acceptance tests', () => {
     await app.boot();
     await app.start();
 
-    const server: RestServer = await app.getServer(RestServer);
-    const client: Client = createClientForHandler(server.requestHandler);
+    const client = createRestAppClient(app);
 
     // Default Controllers = /controllers with .controller.js ending (nested = true);
     await client.get('/one').expect(200, 'ControllerOne.one()');
@@ -38,7 +40,9 @@ describe('controller booter acceptance tests', () => {
     );
 
     const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
-    app = new MyApp();
+    app = new MyApp({
+      rest: givenHttpServerConfig({port: 0}),
+    });
   }
 
   async function stopApp() {

--- a/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
+++ b/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
@@ -1,15 +1,15 @@
-import {createClientForHandler, supertest} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
+import {
+  Client,
+  createRestAppClient,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
 import {<%= project.applicationName %>} from '../..';
 
 describe('PingController', () => {
   let app: <%= project.applicationName %>;
-  let server: RestServer;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
 
   before(givenAnApplication);
-
-  before(givenARestServer);
 
   before(async () => {
     await app.boot();
@@ -17,7 +17,7 @@ describe('PingController', () => {
   });
 
   before(() => {
-    client = createClientForHandler(server.requestHandler);
+    client = createRestAppClient(app);
   });
 
   after(async () => {
@@ -30,13 +30,9 @@ describe('PingController', () => {
 
   function givenAnApplication() {
     app = new <%= project.applicationName %>({
-      rest: {
+      rest: givenHttpServerConfig({
         port: 0,
-      },
+      }),
     });
-  }
-
-  async function givenARestServer() {
-    server = await app.getServer(RestServer);
   }
 });

--- a/packages/rest/test/acceptance/bootstrapping/rest.acceptance.ts
+++ b/packages/rest/test/acceptance/bootstrapping/rest.acceptance.ts
@@ -56,7 +56,7 @@ describe('Starting the application', () => {
 
   it('starts an HTTP server (using RestApplication)', async () => {
     const app = new RestApplication();
-    app.bind(RestBindings.PORT).to(0);
+    app.restServer.bind(RestBindings.PORT).to(0);
     app.handler(sequenceHandler);
     await startServerCheck(app);
   });

--- a/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
@@ -1,9 +1,14 @@
-import {supertest, createClientForHandler, sinon} from '@loopback/testlab';
-import {RestApplication, get, param} from '../../..';
+import {
+  Client,
+  createRestAppClient,
+  givenHttpServerConfig,
+  sinon,
+} from '@loopback/testlab';
+import {get, param, RestApplication} from '../../..';
 
 describe('Coercion', () => {
   let app: RestApplication;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
   let spy: sinon.SinonSpy;
 
   before(givenAClient);
@@ -91,9 +96,9 @@ describe('Coercion', () => {
   });
 
   async function givenAClient() {
-    app = new RestApplication();
+    app = new RestApplication({rest: givenHttpServerConfig({port: 0})});
     app.controller(MyController);
     await app.start();
-    client = createClientForHandler(app.requestHandler);
+    client = createRestAppClient(app);
   }
 });

--- a/packages/rest/test/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/test/acceptance/validation/validation.acceptance.ts
@@ -5,20 +5,24 @@
 
 import {ControllerClass} from '@loopback/core';
 import {model, property} from '@loopback/repository';
-import {createClientForHandler, supertest} from '@loopback/testlab';
 import {
-  RestApplication,
+  Client,
+  createRestAppClient,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
+import {
   api,
   getJsonSchema,
   jsonToSchemaObject,
   post,
   requestBody,
+  RestApplication,
 } from '../../..';
 import {aBodySpec} from '../../helpers';
 
 describe('Validation at REST level', () => {
   let app: RestApplication;
-  let client: supertest.SuperTest<supertest.Test>;
+  let client: Client;
 
   @model()
   class Product {
@@ -152,10 +156,10 @@ describe('Validation at REST level', () => {
   }
 
   async function givenAnAppAndAClient(controller: ControllerClass) {
-    app = new RestApplication();
+    app = new RestApplication({rest: givenHttpServerConfig({port: 0})});
     app.controller(controller);
     await app.start();
 
-    client = createClientForHandler(app.requestHandler);
+    client = createRestAppClient(app);
   }
 });

--- a/packages/testlab/README.md
+++ b/packages/testlab/README.md
@@ -48,6 +48,8 @@ Table of contents:
 - [shot](#shot) - HTTP Request/Response stubs.
 - [validateApiSpec](#validateapispec) - Open API Spec validator.
 - [itSkippedOnTravis](#itskippedontravis) - Skip tests on Travis env.
+- [createRestAppClient](#createrestappclient) - Create a supertest client
+  connected to a running RestApplication.
 - [givenHttpServerConfig](#givenhttpserverconfig) - Generate HTTP server config.
 - [httpGetAsync](#httpgetasync) - Async wrapper for HTTP GET requests.
 - [httpsGetAsync](#httpsgetasync) - Async wrapper for HTTPS GET requests.
@@ -81,6 +83,33 @@ by Shot in your unit tests:
 
 Helper function for skipping tests on Travis environment. If you need to skip
 testing on Travis for any reason, use this instead of Mocha's `it`.
+
+### `createRestAppClient`
+
+Helper function to create a `supertest` client connected to a running
+RestApplication. It is the responsibility of the caller to ensure that the app
+is running and to stop the application after all tests are done.
+
+Example use:
+
+```ts
+import {Client, createRestAppClient} from '@loopback/testlab';
+
+describe('My application', () => {
+  app: MyApplication; // extends RestApplication
+  client: Client;
+
+  before(givenRunningApplication);
+  before(() => {
+    client = createRestAppClient(app);
+  });
+  after(() => app.stop());
+
+  it('invokes GET /ping', async () => {
+    await client.get('/ping?msg=world').expect(200);
+  });
+});
+```
 
 ### `givenhttpserverconfig`
 

--- a/packages/testlab/src/client.ts
+++ b/packages/testlab/src/client.ts
@@ -26,23 +26,31 @@ export function createClientForHandler(
   return supertest(server);
 }
 
-export async function createClientForRestServer(
-  server: RestServer,
-): Promise<Client> {
-  await server.start();
-  const port =
-    server.options && server.options.http ? server.options.http.port : 3000;
-  const url = `http://127.0.0.1:${port}`;
-  // TODO(bajtos) Find a way how to stop the server after all tests are done
+/**
+ * Create a SuperTest client for a running RestApplication instance.
+ * It is the responsibility of the caller to ensure that the app
+ * is running and to stop the application after all tests are done.
+ * @param app A running (listening) instance of a RestApplication.
+ */
+export function createRestAppClient(app: RestApplicationLike) {
+  const url = app.restServer.url;
+  if (!url) {
+    throw new Error(
+      `Cannot create client for ${app.constructor.name}, it is not listening.`,
+    );
+  }
   return supertest(url);
 }
 
-// These interfaces are meant to partially mirror the formats provided
-// in our other libraries to avoid circular imports.
-export interface RestServer {
-  start(): Promise<void>;
-  options?: {
-    // tslint:disable-next-line:no-any
-    [prop: string]: any;
-  };
+/*
+ * These interfaces are meant to partially mirror the formats provided
+ * in our other libraries to avoid circular imports.
+ */
+
+export interface RestApplicationLike {
+  restServer: RestServerLike;
+}
+
+export interface RestServerLike {
+  url?: string;
 }


### PR DESCRIPTION
While reviewing https://github.com/strongloop/loopback4-example-shopping/pull/12, I noticed the test code is depending on low-level types from `supertest` that are difficult to discover (in my experience). I decided to fix this and introduce a type alias, only to find that we already have `Client` alias defined! As I was replacing supertest type with `Client` alias,  I found few places calling `supertest` directly instead of using our `createClient*` helper APIs and decided to improve that too. Here is the outcome:

- Clean up all test code (including examples in the documentation) to use `Client` instead of `supertest.SuperTest<supertest.Test>`.
- Remove `createClientForRestServer` because it was not used anywhere and had the issue of leaking a listening server (not stopping the server after the test is done).
- Add a new helper `createRestAppClient` instead, rework acceptance tests (including the templates) to use this new helper.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in ~~[/docs/site](../tree/master/docs/site)~~ testlab's README was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated