### PR TITLE
feat(cli) add basic lb4 service 

### DIFF
--- a/docs/site/Service-generator.md
+++ b/docs/site/Service-generator.md
@@ -1,0 +1,66 @@
+---
+lang: en
+title: 'Service generator'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Service-generator.html
+---
+
+{% include content/generator-create-app.html lang=page.lang %}
+
+### Synopsis
+
+Adds a new Service class to a LoopBack application with one single command.
+
+```sh
+lb4 service [options] [<name>]
+```
+
+### Options
+
+`--datasource` : _(Optional)_ name of a valid REST or SOAP datasource already
+created in src/datasources
+
+### Configuration file
+
+This generator supports a config file with the following format, see the
+Standard options below to see different ways you can supply this configuration
+file.
+
+```ts
+{
+  "name": "serviceNameToBeGenerated",
+  "datasource": "validDataSourceName",
+}
+```
+
+### Notes
+
+There should be at least one valid _(REST or SOAP)_ data source created already
+in the `src/datasources` directory.
+
+{% include_relative includes/CLI-std-options.md %}
+
+### Arguments
+
+`<name>` - Optional argument specifyng the service name to be generated.
+
+### Interactive Prompts
+
+The tool will prompt you for:
+
+- **Service name.** _(name)_ If the name of the service to be generated had been
+  supplied from the command line, the prompt is skipped.
+
+- **Please select the datasource.** _(datasource)_ If the name of the datasource
+  had been supplied from the command line with `--datasource` option and it is a
+  valid one, then the prompt is skipped, otherwise it will present you the list
+  of all valid datasources from the `src/datasources` directory.
+
+### Output
+
+Once all the prompts have been answered, the **CLI** will generate a basic
+skeleton for your service.
+
+- Create a Service class as follows: `/src/services/${name}.service.ts`
+- Update `/src/services/index.ts` to export the newly created Service class.

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -227,6 +227,10 @@ children:
     url: Repository-generator.html
     output: 'web, pdf'
 
+  - title: 'Service generator'
+    url: Service-generator.html
+    output: 'web, pdf'
+
   - title: 'OpenAPI generator'
     url: OpenAPI-generator.html
     output: 'web, pdf'

--- a/docs/site/tables/lb4-artifact-commands.html
+++ b/docs/site/tables/lb4-artifact-commands.html
@@ -36,6 +36,12 @@
     </tr>
 
     <tr>
+      <td><code>lb4 service</code></td>
+      <td>Add new service for a selected datasource to a LoopBack 4 application</td>
+      <td><a href="Service-generator.html">Service generator</a></td>
+    </tr>
+
+    <tr>
       <td><code>lb4 openapi</code></td>
       <td>Generate controllers and models from OpenAPI specs</td>
       <td><a href="OpenAPI-generator.html">OpenAPI generator</a></td>

--- a/packages/cli/generators/datasource/templates/datasource.ts.ejs
+++ b/packages/cli/generators/datasource/templates/datasource.ts.ejs
@@ -7,7 +7,7 @@ export class <%= className %>DataSource extends juggler.DataSource {
 
   constructor(
     @inject('datasources.config.<%= name %>', {optional: true})
-    dsConfig: AnyObject = config
+    dsConfig: AnyObject = config,
   ) {
     super(dsConfig);
   }

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -80,23 +80,13 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
       this.artifactInfo.defaultTemplate = REPOSITORY_CRUD_TEMPLATE;
     }
 
-    // assign the data source name to the information artifact
-    let dataSourceName = this.artifactInfo.dataSourceClass
-      .replace('Datasource', '')
-      .toLowerCase();
-
-    let dataSourceClassName = this.artifactInfo.dataSourceClass.replace(
-      'Datasource',
-      'DataSource',
+    this.artifactInfo.dataSourceName = utils.getDataSourceName(
+      this.artifactInfo.datasourcesDir,
+      this.artifactInfo.dataSourceClass,
     );
 
-    Object.assign(this.artifactInfo, {
-      dataSourceClassName: dataSourceClassName,
-    });
-
-    Object.assign(this.artifactInfo, {
-      dataSourceName: dataSourceName,
-    });
+    this.artifactInfo.dataSourceClassName =
+      this.artifactInfo.dataSourceName + 'DataSource';
   }
 
   /**

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -80,13 +80,14 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     if (this.options.name) {
       Object.assign(this.artifactInfo, {name: this.options.name});
     }
+
     const prompts = [
       {
         type: 'input',
         name: 'name',
         // capitalization
         message: utils.toClassName(this.artifactInfo.type) + ' name:',
-        when: this.artifactInfo.name === undefined,
+        when: !this.artifactInfo.name,
         validate: utils.validateClassName,
       },
     ];
@@ -198,14 +199,13 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
   scaffold() {
     if (this.shouldExit()) return false;
 
-    this.artifactInfo.dataSourceClassName = this.artifactInfo.dataSourceClass.replace(
-      'Datasource',
-      'DataSource',
+    this.artifactInfo.dataSourceName = utils.getDataSourceName(
+      this.artifactInfo.datasourcesDir,
+      this.artifactInfo.dataSourceClass,
     );
 
-    this.artifactInfo.dataSourceName = utils.lowerCase(
-      this.artifactInfo.dataSourceClass.replace('Datasource', ''),
-    );
+    this.artifactInfo.dataSourceClassName =
+      this.artifactInfo.dataSourceName + 'DataSource';
 
     // Setting up data for templates
     this.artifactInfo.className = utils.toClassName(this.artifactInfo.name);

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -77,7 +77,6 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
    * Ask for Service Name
    */
   async promptArtifactName() {
-    if (this.shouldExit()) return false;
     debug('Prompting for service name');
 
     if (this.options.name) {
@@ -100,8 +99,6 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
   }
 
   async promptDataSourceName() {
-    if (this.shouldExit()) return false;
-
     debug('Prompting for a datasource ');
     let cmdDatasourceName;
     let datasourcesList;

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -63,10 +63,11 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     if (!fs.existsSync(this.artifactInfo.datasourcesDir)) {
       return this.exit(
         new Error(
-          `${ERROR_NO_DATA_SOURCES_FOUND} ${this.artifactInfo.datasourcesDir}.
-        ${chalk.yellow(
-          'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
-        )}`,
+          `${ERROR_NO_DATA_SOURCES_FOUND} ${
+            this.artifactInfo.datasourcesDir
+          }.${chalk.yellow(
+            'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
+          )}`,
         ),
       );
     }
@@ -142,10 +143,11 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     if (availableDatasources.length === 0) {
       return this.exit(
         new Error(
-          `${ERROR_NO_DATA_SOURCES_FOUND} ${this.artifactInfo.datasourcesDir}.
-        ${chalk.yellow(
-          'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
-        )}`,
+          `${ERROR_NO_DATA_SOURCES_FOUND} ${
+            this.artifactInfo.datasourcesDir
+          }.${chalk.yellow(
+            'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
+          )}`,
         ),
       );
     }
@@ -183,7 +185,9 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
   /**
    * this method will be in charge of inferring and create
    * the remote interfaces from either SOAP wsdl or REST openApi json
-   * TODO: @marioestradarosa
+   *
+   * TODO: add functionality to inspect service specs to generate
+   * strongly-typed service proxies and corresponding model definitions.
    */
   async inferInterfaces() {
     let connectorType = utils.getDataSourceConnectorName(

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -61,14 +61,12 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
   async checkPaths() {
     // check for datasources
     if (!fs.existsSync(this.artifactInfo.datasourcesDir)) {
-      return this.exit(
-        new Error(
-          `${ERROR_NO_DATA_SOURCES_FOUND} ${
-            this.artifactInfo.datasourcesDir
-          }.${chalk.yellow(
-            'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
-          )}`,
-        ),
+      new Error(
+        `${ERROR_NO_DATA_SOURCES_FOUND} ${
+          this.artifactInfo.datasourcesDir
+        }. ${chalk.yellow(
+          'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
+        )}`,
       );
     }
   }
@@ -142,7 +140,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
         new Error(
           `${ERROR_NO_DATA_SOURCES_FOUND} ${
             this.artifactInfo.datasourcesDir
-          }.${chalk.yellow(
+          }. ${chalk.yellow(
             'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
           )}`,
         ),
@@ -223,10 +221,9 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
       path.join(this.artifactInfo.outDir, this.artifactInfo.outFile),
     );
 
-    if (debug.enabled) {
-      debug(`artifactInfo: ${inspect(this.artifactInfo)}`);
-      debug(`Copying artifact to: ${dest}`);
-    }
+    debug(`artifactInfo: ${inspect(this.artifactInfo)}`);
+    debug(`Copying artifact to: ${dest}`);
+
     this.fs.copyTpl(
       source,
       dest,
@@ -235,6 +232,19 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
       {globOptions: {dot: true}},
     );
     return;
+  }
+
+  install() {
+    if (this.shouldExit()) return false;
+    debug('install npm dependencies');
+    const pkgJson = this.packageJson || {};
+    const deps = pkgJson.dependencies || {};
+    const pkgs = [];
+
+    if (!deps['@loopback/service-proxy']) {
+      pkgs.push('@loopback/service-proxy');
+    }
+    if (pkgs.length) this.npmInstall(pkgs, {save: true});
   }
 
   async end() {

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -79,6 +79,9 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     if (this.shouldExit()) return false;
     debug('Prompting for service name');
 
+    if (this.options.name) {
+      Object.assign(this.artifactInfo, {name: this.options.name});
+    }
     const prompts = [
       {
         type: 'input',

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -1,0 +1,239 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const _ = require('lodash');
+const ArtifactGenerator = require('../../lib/artifact-generator');
+const fs = require('fs');
+const debug = require('../../lib/debug')('service-generator');
+const inspect = require('util').inspect;
+const path = require('path');
+const chalk = require('chalk');
+const utils = require('../../lib/utils');
+
+const VALID_CONNECTORS_FOR_SERVICE = ['Model'];
+
+const SERVICE_TEMPLATE = 'service-template.ts.ejs';
+
+const PROMPT_MESSAGE_DATA_SOURCE = 'Please select the datasource';
+
+const ERROR_NO_DATA_SOURCES_FOUND = 'No datasources found at';
+
+module.exports = class ServiceGenerator extends ArtifactGenerator {
+  // Note: arguments and options should be defined in the constructor.
+  constructor(args, opts) {
+    super(args, opts);
+  }
+
+  _setupGenerator() {
+    this.artifactInfo = {
+      type: 'service',
+      rootDir: utils.sourceRootDir,
+    };
+
+    this.artifactInfo.outDir = path.resolve(
+      this.artifactInfo.rootDir,
+      utils.servicesDir,
+    );
+
+    this.artifactInfo.datasourcesDir = path.resolve(
+      this.artifactInfo.rootDir,
+      utils.datasourcesDir,
+    );
+
+    this.artifactInfo.defaultTemplate = SERVICE_TEMPLATE;
+
+    this.option('datasource', {
+      type: String,
+      required: false,
+      description: 'A valid datasource name',
+    });
+
+    return super._setupGenerator();
+  }
+
+  setOptions() {
+    return super.setOptions();
+  }
+
+  async checkPaths() {
+    // check for datasources
+    if (!fs.existsSync(this.artifactInfo.datasourcesDir)) {
+      return this.exit(
+        new Error(
+          `${ERROR_NO_DATA_SOURCES_FOUND} ${this.artifactInfo.datasourcesDir}.
+        ${chalk.yellow(
+          'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
+        )}`,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Ask for Service Name
+   */
+  async promptArtifactName() {
+    if (this.shouldExit()) return false;
+    debug('Prompting for service name');
+
+    const prompts = [
+      {
+        type: 'input',
+        name: 'name',
+        // capitalization
+        message: utils.toClassName(this.artifactInfo.type) + ' name:',
+        when: this.artifactInfo.name === undefined,
+        validate: utils.validateClassName,
+      },
+    ];
+    return this.prompt(prompts).then(props => {
+      Object.assign(this.artifactInfo, props);
+      return props;
+    });
+  }
+
+  async promptDataSourceName() {
+    if (this.shouldExit()) return false;
+
+    debug('Prompting for a datasource ');
+    let cmdDatasourceName;
+    let datasourcesList;
+
+    // grab the datasourcename from the command line
+    cmdDatasourceName = this.options.datasource
+      ? utils.toClassName(this.options.datasource) + 'Datasource'
+      : '';
+
+    debug(`command line datasource is  ${cmdDatasourceName}`);
+
+    try {
+      datasourcesList = await utils.getArtifactList(
+        this.artifactInfo.datasourcesDir,
+        'datasource',
+        true,
+      );
+      debug(
+        `datasourcesList from ${utils.sourceRootDir}/${
+          utils.datasourcesDir
+        } : ${datasourcesList}`,
+      );
+    } catch (err) {
+      return this.exit(err);
+    }
+
+    const availableDatasources = datasourcesList.filter(item => {
+      debug(
+        `inspecting datasource: ${item} for basemodel: ${VALID_CONNECTORS_FOR_SERVICE}`,
+      );
+      const result = utils.isConnectorOfType(
+        VALID_CONNECTORS_FOR_SERVICE,
+        this.artifactInfo.datasourcesDir,
+        item,
+      );
+      return result;
+    });
+
+    if (availableDatasources.length === 0) {
+      return this.exit(
+        new Error(
+          `${ERROR_NO_DATA_SOURCES_FOUND} ${this.artifactInfo.datasourcesDir}.
+        ${chalk.yellow(
+          'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
+        )}`,
+        ),
+      );
+    }
+
+    if (availableDatasources.includes(cmdDatasourceName)) {
+      Object.assign(this.artifactInfo, {
+        dataSourceClass: cmdDatasourceName,
+      });
+    }
+
+    debug(`artifactInfo.dataSourceClass ${this.artifactInfo.dataSourceClass}`);
+
+    return this.prompt([
+      {
+        type: 'list',
+        name: 'dataSourceClass',
+        message: PROMPT_MESSAGE_DATA_SOURCE,
+        choices: availableDatasources,
+        when: !this.artifactInfo.dataSourceClass,
+        default: availableDatasources[0],
+        validate: utils.validateClassName,
+      },
+    ])
+      .then(props => {
+        Object.assign(this.artifactInfo, props);
+        debug(`props after datasource prompt: ${inspect(props)}`);
+        return props;
+      })
+      .catch(err => {
+        debug(`Error during datasource prompt: ${err}`);
+        return this.exit(err);
+      });
+  }
+
+  /**
+   * this method will be in charge of inferring and create
+   * the remote interfaces from either SOAP wsdl or REST openApi json
+   * TODO: @marioestradarosa
+   */
+  async inferInterfaces() {
+    let connectorType = utils.getDataSourceConnectorName(
+      this.artifactInfo.datasourcesDir,
+      this.artifactInfo.dataSourceClass,
+    );
+
+    // connectorType should output soap or rest in this case
+    // The base an further work for inferring remote methods
+    debug(`connectorType: ${connectorType}`);
+  }
+
+  scaffold() {
+    if (this.shouldExit()) return false;
+
+    this.artifactInfo.dataSourceClassName = this.artifactInfo.dataSourceClass.replace(
+      'Datasource',
+      'DataSource',
+    );
+
+    this.artifactInfo.dataSourceName = utils.lowerCase(
+      this.artifactInfo.dataSourceClass.replace('Datasource', ''),
+    );
+
+    // Setting up data for templates
+    this.artifactInfo.className = utils.toClassName(this.artifactInfo.name);
+    this.artifactInfo.fileName = utils.kebabCase(this.artifactInfo.name);
+
+    Object.assign(this.artifactInfo, {
+      outFile: utils.getServiceFileName(this.artifactInfo.name),
+    });
+
+    const source = this.templatePath(this.artifactInfo.defaultTemplate);
+
+    const dest = this.destinationPath(
+      path.join(this.artifactInfo.outDir, this.artifactInfo.outFile),
+    );
+
+    if (debug.enabled) {
+      debug(`artifactInfo: ${inspect(this.artifactInfo)}`);
+      debug(`Copying artifact to: ${dest}`);
+    }
+    this.fs.copyTpl(
+      source,
+      dest,
+      this.artifactInfo,
+      {},
+      {globOptions: {dot: true}},
+    );
+    return;
+  }
+
+  async end() {
+    await super.end();
+  }
+};

--- a/packages/cli/generators/service/templates/service-template.ts.ejs
+++ b/packages/cli/generators/service/templates/service-template.ts.ejs
@@ -1,4 +1,4 @@
-import {getService, juggler} from '@loopback/service-proxy';
+import {getService} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
 import {<%= dataSourceClassName %>} from '../datasources';
 
@@ -12,7 +12,7 @@ export class <%= className %>ServiceProvider implements Provider<<%= className %
   constructor(
     // <%= dataSourceName %> must match the name property in the datasource json file
     @inject('datasources.<%= dataSourceName %>')
-    protected datasource: <%= dataSourceClassName %> = new <%= dataSourceClassName %>(),
+    protected datasource: <%= dataSourceName %>DataSource = new <%= dataSourceClassName %>(),
   ) {}
 
   value(): Promise<<%= className %>Service> {

--- a/packages/cli/generators/service/templates/service-template.ts.ejs
+++ b/packages/cli/generators/service/templates/service-template.ts.ejs
@@ -1,0 +1,24 @@
+import {getService, juggler} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {<%= dataSourceClassName %>} from '../datasources';
+
+/**
+ * this is where you define the Node.js methods that will be
+ * mapped to the SOAP operations as stated in the datasource
+ * json file.
+ */
+export interface <%= className %>Service {
+
+}
+
+export class <%= className %>ServiceProvider implements Provider<<%= className %>Service> {
+  constructor(
+    // <%= dataSourceName %> must match the name property in the datasource json file
+    @inject('datasources.<%= dataSourceName %>')
+    protected datasource: <%= dataSourceClassName %> = new <%= dataSourceClassName %>(),
+  ) {}
+
+  value(): Promise<<%= className %>Service> {
+    return getService(this.datasource);
+  }
+}

--- a/packages/cli/generators/service/templates/service-template.ts.ejs
+++ b/packages/cli/generators/service/templates/service-template.ts.ejs
@@ -2,13 +2,10 @@ import {getService, juggler} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
 import {<%= dataSourceClassName %>} from '../datasources';
 
-/**
- * this is where you define the Node.js methods that will be
- * mapped to the SOAP operations as stated in the datasource
- * json file.
- */
 export interface <%= className %>Service {
-
+  // this is where you define the Node.js methods that will be
+  // mapped to the SOAP operations as stated in the datasource
+  // json file.
 }
 
 export class <%= className %>ServiceProvider implements Provider<<%= className %>Service> {

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -68,6 +68,10 @@ function setupGenerators() {
     PREFIX + 'repository',
   );
   env.register(
+    path.join(__dirname, '../generators/service'),
+    PREFIX + 'service',
+  );
+  env.register(
     path.join(__dirname, '../generators/example'),
     PREFIX + 'example',
   );

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -411,7 +411,7 @@ exports.getDataSourceConnectorName = function(datasourcesDir, dataSourceClass) {
 
   let datasourceJSONFile = path.join(
     datasourcesDir,
-    dataSourceClass.replace('Datasource', '.datasource.json').toLowerCase(),
+    exports.dataSourceToJSONFileName(dataSourceClass),
   );
 
   debug(`reading ${datasourceJSONFile}`);
@@ -448,9 +448,10 @@ exports.isConnectorOfType = function(
   if (!dataSourceClass) {
     return false;
   }
+
   let datasourceJSONFile = path.join(
     datasourcesDir,
-    dataSourceClass.replace('Datasource', '.datasource.json').toLowerCase(),
+    exports.dataSourceToJSONFileName(dataSourceClass),
   );
 
   debug(`reading ${datasourceJSONFile}`);
@@ -473,6 +474,44 @@ exports.isConnectorOfType = function(
   }
 
   return result;
+};
+
+/**
+ *
+ * returns the name property inside the datasource json file
+ * @param {string} datasourcesDir path for sources
+ * @param {string} dataSourceClass class name for the datasoure
+ */
+exports.getDataSourceName = function(datasourcesDir, dataSourceClass) {
+  if (!dataSourceClass) {
+    return false;
+  }
+  let result;
+  let jsonFileContent;
+
+  let datasourceJSONFile = path.join(
+    datasourcesDir,
+    exports.dataSourceToJSONFileName(dataSourceClass),
+  );
+
+  debug(`reading ${datasourceJSONFile}`);
+  try {
+    jsonFileContent = JSON.parse(fs.readFileSync(datasourceJSONFile, 'utf8'));
+  } catch (err) {
+    debug(`Error reading file ${datasourceJSONFile}: ${err.message}`);
+    throw err;
+  }
+
+  if (jsonFileContent.name) {
+    result = jsonFileContent.name;
+  }
+  return result;
+};
+
+exports.dataSourceToJSONFileName = function(dataSourceClass) {
+  return path.join(
+    _.kebabCase(dataSourceClass.replace('Datasource', '')) + '.datasource.json',
+  );
 };
 
 // literal strings with artifacts directory locations

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -419,7 +419,7 @@ exports.getDataSourceConnectorName = function(datasourcesDir, dataSourceClass) {
     jsonFileContent = JSON.parse(fs.readFileSync(datasourceJSONFile, 'utf8'));
   } catch (err) {
     debug(`Error reading file ${datasourceJSONFile}: ${err.message}`);
-    throw new Error(err);
+    throw err;
   }
 
   if (jsonFileContent.connector) {
@@ -458,7 +458,7 @@ exports.isConnectorOfType = function(
     jsonFileContent = JSON.parse(fs.readFileSync(datasourceJSONFile, 'utf8'));
   } catch (err) {
     debug(`Error reading file ${datasourceJSONFile}: ${err.message}`);
-    throw new Error(err);
+    throw err;
   }
 
   for (let connector of Object.values(connectors)) {

--- a/packages/cli/test/fixtures/repository/index.js
+++ b/packages/cli/test/fixtures/repository/index.js
@@ -1,0 +1,89 @@
+const DATASOURCE_APP_PATH = 'src/datasources';
+const MODEL_APP_PATH = 'src/models';
+const CONFIG_PATH = '.';
+const DUMMY_CONTENT = '--DUMMY VALUE--';
+const fs = require('fs');
+
+exports.SANDBOX_FILES = [
+  {
+    path: CONFIG_PATH,
+    file: 'myconfig.json',
+    content: JSON.stringify({
+      datasource: 'dbmem',
+      model: 'decoratordefined',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbkv.datasource.json',
+    content: JSON.stringify({
+      name: 'dbkv',
+      connector: 'kv-redis',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbkv.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.json',
+    content: JSON.stringify({
+      name: 'dbmem',
+      connector: 'memory',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.json',
+    content: JSON.stringify({
+      name: 'restdb',
+      connector: 'rest',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'decoratordefined.model.ts',
+    content: fs.readFileSync(
+      require.resolve('./models/decoratordefined.model.txt'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'defaultmodel.model.ts',
+    content: fs.readFileSync(
+      require.resolve('./models/defaultmodel.model.txt'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'multi-word.model.ts',
+    content: fs.readFileSync(require.resolve('./models/multi-word.model.txt'), {
+      encoding: 'utf-8',
+    }),
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'invalid-id.model.ts',
+    content: fs.readFileSync(require.resolve('./models/invalid-id.model.txt'), {
+      encoding: 'utf-8',
+    }),
+  },
+];

--- a/packages/cli/test/fixtures/repository/models/decoratordefined.model.txt
+++ b/packages/cli/test/fixtures/repository/models/decoratordefined.model.txt
@@ -1,0 +1,17 @@
+import {Entity, model} from '@loopback/repository';
+
+    @model({
+      name: 'Product',
+      properties: {
+        thePK: {type: 'number', id: true},
+        name: {type: 'string', required: true},
+      },
+    })
+    export class DecoratorDefined extends Entity {
+      thePK: number;
+      name: string;
+
+      constructor(data?: Partial<DecoratorDefined>) {
+        super(data);
+      }
+    }

--- a/packages/cli/test/fixtures/repository/models/defaultmodel.model.txt
+++ b/packages/cli/test/fixtures/repository/models/defaultmodel.model.txt
@@ -1,0 +1,26 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class DefaultModel extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  desc?: string;
+
+  @property({
+    type: 'number',
+    default: 0,
+  })
+  balance?: number;
+
+  constructor(data?: Partial<DefaultModel>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/repository/models/invalid-id.model.txt
+++ b/packages/cli/test/fixtures/repository/models/invalid-id.model.txt
@@ -1,0 +1,20 @@
+ import {Entity, model, property} from '@loopback/repository';
+
+    @model()
+    export class InvalidID extends Entity {
+      @property({
+        type: 'string',
+        required: true,
+        default: 0,
+      })
+      id: string;
+
+      @property({
+        type: 'string',
+      })
+      desc?: string;
+
+      constructor(data?: Partial<InvalidID>) {
+        super(data);
+      }
+    }

--- a/packages/cli/test/fixtures/repository/models/multi-word.model.txt
+++ b/packages/cli/test/fixtures/repository/models/multi-word.model.txt
@@ -1,0 +1,20 @@
+import {Entity, model, property} from '@loopback/repository';
+
+    @model()
+    export class MultiWord extends Entity {
+      @property({
+        type: 'string',
+        id: true,
+        default: 0,
+      })
+      pk?: string;
+
+      @property({
+        type: 'string',
+      })
+      desc?: string;
+
+      constructor(data?: Partial<MultiWord>) {
+        super(data);
+      }
+    }

--- a/packages/cli/test/fixtures/service/index.js
+++ b/packages/cli/test/fixtures/service/index.js
@@ -1,0 +1,61 @@
+const DATASOURCE_APP_PATH = 'src/datasources';
+const CONFIG_PATH = '.';
+const DUMMY_CONTENT = '--DUMMY VALUE--';
+
+exports.SANDBOX_FILES = [
+  {
+    path: CONFIG_PATH,
+    file: 'mysoapconfig.json',
+    content: JSON.stringify({
+      name: 'MultiWordService',
+      datasource: 'myds',
+    }),
+  },
+  {
+    path: CONFIG_PATH,
+    file: 'myrestconfig.json',
+    content: JSON.stringify({
+      name: 'myservice',
+      datasource: 'restdb',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'myds.datasource.json',
+    content: JSON.stringify({
+      name: 'myds',
+      connector: 'soap',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'myds.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.json',
+    content: JSON.stringify({
+      name: 'dbmem',
+      connector: 'memory',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.json',
+    content: JSON.stringify({
+      name: 'restdb',
+      connector: 'rest',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+];

--- a/packages/cli/test/fixtures/service/index.js
+++ b/packages/cli/test/fixtures/service/index.js
@@ -29,6 +29,14 @@ exports.SANDBOX_FILES = [
   },
   {
     path: DATASOURCE_APP_PATH,
+    file: 'map-ds.datasource.json',
+    content: JSON.stringify({
+      name: 'MapDS',
+      connector: 'soap',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
     file: 'myds.datasource.ts',
     content: DUMMY_CONTENT,
   },

--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -24,7 +24,7 @@ describe('cli', () => {
     expect(entries).to.eql([
       'Available commands: ',
       '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
-        'lb4 model\n  lb4 repository\n  lb4 example\n  lb4 openapi',
+        'lb4 model\n  lb4 repository\n  lb4 service\n  lb4 example\n  lb4 openapi',
     ]);
   });
 
@@ -42,7 +42,7 @@ describe('cli', () => {
     expect(entries).to.containEql('Available commands: ');
     expect(entries).to.containEql(
       '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
-        'lb4 model\n  lb4 repository\n  lb4 example\n  lb4 openapi',
+        'lb4 model\n  lb4 repository\n  lb4 service\n  lb4 example\n  lb4 openapi',
     );
   });
 

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -40,7 +40,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withPrompts(multiItemPrompt);
 
@@ -96,7 +98,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withPrompts(multiItemPrompt);
 
@@ -123,7 +127,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('myrepo --datasource dbmem --model MultiWord');
       const expectedFile = path.join(
@@ -146,7 +152,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('--config myconfig.json');
       const expectedFile = path.join(
@@ -180,7 +188,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withPrompts(multiItemPrompt);
 
@@ -213,7 +223,9 @@ describe('lb4 repository', function() {
         testUtils
           .executeGenerator(generator)
           .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+            testUtils.givenLBProject(SANDBOX_PATH, {
+              additionalFiles: SANDBOX_FILES,
+            }),
           )
           .withPrompts(basicPrompt)
           .withArguments(' --model InvalidModel'),
@@ -228,7 +240,9 @@ describe('lb4 repository', function() {
         testUtils
           .executeGenerator(generator)
           .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+            testUtils.givenLBProject(SANDBOX_PATH, {
+              additionalFiles: SANDBOX_FILES,
+            }),
           )
           .withPrompts(basicPrompt),
       ).to.be.rejectedWith(/You did not select a valid model/);
@@ -251,7 +265,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withPrompts(basicPrompt)
         .withArguments(' --model Defaultmodel');
@@ -277,7 +293,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('--datasource dbmem --model decoratordefined');
       const expectedFile = path.join(
@@ -307,7 +325,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('--datasource dbkv --model Defaultmodel');
       const expectedFile = path.join(
@@ -334,7 +354,9 @@ describe('lb4 repository', function() {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withPrompts(basicPrompt)
         .withArguments('--model decoratordefined');
@@ -359,6 +381,5 @@ describe('lb4 repository', function() {
 });
 
 // Sandbox constants
-
 const REPOSITORY_APP_PATH = 'src/repositories';
 const INDEX_FILE = path.join(SANDBOX_PATH, REPOSITORY_APP_PATH, 'index.ts');

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -36,9 +36,12 @@ describe('lb4 repository', () => {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withPrompts(multiItemPrompt);
 
@@ -93,9 +96,12 @@ describe('lb4 repository', () => {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withPrompts(multiItemPrompt);
 
@@ -121,9 +127,12 @@ describe('lb4 repository', () => {
     it('generates a custom name repository', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withArguments('myrepo --datasource dbmem --model MultiWord');
       const expectedFile = path.join(
@@ -145,9 +154,12 @@ describe('lb4 repository', () => {
     it('generates a crud repository from a config file', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withArguments('--config myconfig.json');
       const expectedFile = path.join(
@@ -180,9 +192,12 @@ describe('lb4 repository', () => {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withPrompts(multiItemPrompt);
 
@@ -214,9 +229,12 @@ describe('lb4 repository', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(
-            SANDBOX_PATH,
-            async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+          .inDir(SANDBOX_PATH, () =>
+            testUtils.givenLBProject(
+              SANDBOX_PATH,
+              {includeSandboxFilesFixtures: true},
+              SANDBOX_FILES,
+            ),
           )
           .withPrompts(basicPrompt)
           .withArguments(' --model InvalidModel'),
@@ -230,9 +248,12 @@ describe('lb4 repository', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(
-            SANDBOX_PATH,
-            async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+          .inDir(SANDBOX_PATH, () =>
+            testUtils.givenLBProject(
+              SANDBOX_PATH,
+              {includeSandboxFilesFixtures: true},
+              SANDBOX_FILES,
+            ),
           )
           .withPrompts(basicPrompt),
       ).to.be.rejectedWith(/You did not select a valid model/);
@@ -240,13 +261,15 @@ describe('lb4 repository', () => {
 
     it('does not run with empty datasource list', async () => {
       return expect(
-        testUtils.executeGenerator(generator).inDir(
-          SANDBOX_PATH,
-          async () =>
-            await prepareGeneratorForRepository(SANDBOX_PATH, {
-              noFixtures: true,
-            }),
-        ),
+        testUtils
+          .executeGenerator(generator)
+          .inDir(SANDBOX_PATH, () =>
+            testUtils.givenLBProject(
+              SANDBOX_PATH,
+              {includeSandboxFilesFixtures: false},
+              SANDBOX_FILES,
+            ),
+          ),
       ).to.be.rejectedWith(/No datasources found/);
     });
   });
@@ -258,9 +281,12 @@ describe('lb4 repository', () => {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withPrompts(basicPrompt)
         .withArguments(' --model Defaultmodel');
@@ -285,9 +311,12 @@ describe('lb4 repository', () => {
     it('generates a crud repository from decorator defined model', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withArguments('--datasource dbmem --model decoratordefined');
       const expectedFile = path.join(
@@ -316,9 +345,12 @@ describe('lb4 repository', () => {
     it('generates a kv repository from default model', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withArguments('--datasource dbkv --model Defaultmodel');
       const expectedFile = path.join(
@@ -344,9 +376,12 @@ describe('lb4 repository', () => {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(
-          SANDBOX_PATH,
-          async () => await prepareGeneratorForRepository(SANDBOX_PATH),
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(
+            SANDBOX_PATH,
+            {includeSandboxFilesFixtures: true},
+            SANDBOX_FILES,
+          ),
         )
         .withPrompts(basicPrompt)
         .withArguments('--model decoratordefined');
@@ -534,53 +569,3 @@ const SANDBOX_FILES = [
     `,
   },
 ];
-
-async function prepareGeneratorForRepository(rootDir, options) {
-  options = options || {};
-  const content = {};
-  if (!options.excludeKeyword) {
-    content.keywords = ['loopback'];
-  }
-
-  if (!options.excludePackageJSON) {
-    fs.writeFileSync(
-      path.join(rootDir, 'package.json'),
-      JSON.stringify(content),
-    );
-  }
-
-  if (!options.excludeYoRcJSON) {
-    fs.writeFileSync(path.join(rootDir, '.yo-rc.json'), JSON.stringify({}));
-  }
-
-  fs.mkdirSync(path.join(rootDir, 'src'));
-
-  if (!options.excludeControllersDir) {
-    fs.mkdirSync(path.join(rootDir, 'src', 'controllers'));
-  }
-
-  if (!options.excludeModelsDir) {
-    fs.mkdirSync(path.join(rootDir, 'src', 'models'));
-  }
-
-  if (!options.excludeRepositoriesDir) {
-    fs.mkdirSync(path.join(rootDir, 'src', 'repositories'));
-  }
-
-  if (!options.excludeDataSourcesDir) {
-    fs.mkdirSync(path.join(rootDir, 'src', 'datasources'));
-  }
-
-  if (!options.noFixtures) {
-    copyFixtures();
-  }
-}
-
-function copyFixtures() {
-  for (let theFile of SANDBOX_FILES) {
-    const fullPath = path.join(SANDBOX_PATH, theFile.path, theFile.file);
-    if (!fs.existsSync(fullPath)) {
-      fs.writeFileSync(fullPath, theFile.content);
-    }
-  }
-}

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -14,14 +14,17 @@ const expect = testlab.expect;
 const TestSandbox = testlab.TestSandbox;
 
 const generator = path.join(__dirname, '../../../generators/repository');
-
+const SANDBOX_FILES = require('../../fixtures/repository').SANDBOX_FILES;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
 const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 const sandbox = new TestSandbox(SANDBOX_PATH);
 
-describe('lb4 repository', () => {
+describe('lb4 repository', function() {
+  // tslint:disable-next-line:no-invalid-this
+  this.timeout(30000);
+
   beforeEach('reset sandbox', async () => {
     await sandbox.reset();
   });
@@ -37,11 +40,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withPrompts(multiItemPrompt);
 
@@ -97,11 +96,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withPrompts(multiItemPrompt);
 
@@ -128,11 +123,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('myrepo --datasource dbmem --model MultiWord');
       const expectedFile = path.join(
@@ -155,11 +146,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('--config myconfig.json');
       const expectedFile = path.join(
@@ -193,11 +180,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withPrompts(multiItemPrompt);
 
@@ -230,11 +213,7 @@ describe('lb4 repository', () => {
         testUtils
           .executeGenerator(generator)
           .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(
-              SANDBOX_PATH,
-              {includeSandboxFilesFixtures: true},
-              SANDBOX_FILES,
-            ),
+            testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
           )
           .withPrompts(basicPrompt)
           .withArguments(' --model InvalidModel'),
@@ -249,11 +228,7 @@ describe('lb4 repository', () => {
         testUtils
           .executeGenerator(generator)
           .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(
-              SANDBOX_PATH,
-              {includeSandboxFilesFixtures: true},
-              SANDBOX_FILES,
-            ),
+            testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
           )
           .withPrompts(basicPrompt),
       ).to.be.rejectedWith(/You did not select a valid model/);
@@ -263,13 +238,7 @@ describe('lb4 repository', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(
-              SANDBOX_PATH,
-              {includeSandboxFilesFixtures: false},
-              SANDBOX_FILES,
-            ),
-          ),
+          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
       ).to.be.rejectedWith(/No datasources found/);
     });
   });
@@ -282,11 +251,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withPrompts(basicPrompt)
         .withArguments(' --model Defaultmodel');
@@ -312,11 +277,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('--datasource dbmem --model decoratordefined');
       const expectedFile = path.join(
@@ -346,11 +307,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('--datasource dbkv --model Defaultmodel');
       const expectedFile = path.join(
@@ -377,11 +334,7 @@ describe('lb4 repository', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withPrompts(basicPrompt)
         .withArguments('--model decoratordefined');
@@ -406,166 +359,6 @@ describe('lb4 repository', () => {
 });
 
 // Sandbox constants
-const DATASOURCE_APP_PATH = 'src/datasources';
-const MODEL_APP_PATH = 'src/models';
-const CONFIG_PATH = '.';
+
 const REPOSITORY_APP_PATH = 'src/repositories';
 const INDEX_FILE = path.join(SANDBOX_PATH, REPOSITORY_APP_PATH, 'index.ts');
-const DUMMY_CONTENT = '--DUMMY VALUE--';
-
-const SANDBOX_FILES = [
-  {
-    path: CONFIG_PATH,
-    file: 'myconfig.json',
-    content: `{
-      "datasource": "dbmem",
-      "model": "decoratordefined"
-    }`,
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'dbkv.datasource.json',
-    content: JSON.stringify({
-      name: 'dbkv',
-      connector: 'kv-redis',
-    }),
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'dbkv.datasource.ts',
-    content: DUMMY_CONTENT,
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'dbmem.datasource.json',
-    content: JSON.stringify({
-      name: 'dbmem',
-      connector: 'memory',
-    }),
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'dbmem.datasource.ts',
-    content: DUMMY_CONTENT,
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'restdb.datasource.json',
-    content: JSON.stringify({
-      name: 'restdb',
-      connector: 'rest',
-    }),
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'restdb.datasource.ts',
-    content: DUMMY_CONTENT,
-  },
-  {
-    path: MODEL_APP_PATH,
-    file: 'decoratordefined.model.ts',
-    content: `
-    import {Entity, model} from '@loopback/repository';
-
-    @model({
-      name: 'Product',
-      properties: {
-        thePK: {type: 'number', id: true},
-        name: {type: 'string', required: true},
-      },
-    })
-    export class DecoratorDefined extends Entity {
-      thePK: number;
-      name: string;
-
-      constructor(data?: Partial<DecoratorDefined>) {
-        super(data);
-      }
-    }
-    `,
-  },
-  {
-    path: MODEL_APP_PATH,
-    file: 'defaultmodel.model.ts',
-    content: `
-    import {Entity, model, property} from '@loopback/repository';
-
-    @model()
-    export class DefaultModel extends Entity {
-      @property({
-        type: 'number',
-        id: true,
-        default: 0,
-      })
-      id?: number;
-
-      @property({
-        type: 'string',
-      })
-      desc?: string;
-
-      @property({
-        type: 'number',
-        default: 0,
-      })
-      balance?: number;
-
-      constructor(data?: Partial<DefaultModel>) {
-        super(data);
-      }
-    }
-    `,
-  },
-  {
-    path: MODEL_APP_PATH,
-    file: 'multi-word.model.ts',
-    content: `
-    import {Entity, model, property} from '@loopback/repository';
-
-    @model()
-    export class MultiWord extends Entity {
-      @property({
-        type: 'string',
-        id: true,
-        default: 0,
-      })
-      pk?: string;
-
-      @property({
-        type: 'string',
-      })
-      desc?: string;
-
-      constructor(data?: Partial<MultiWord>) {
-        super(data);
-      }
-    }
-    `,
-  },
-  {
-    path: MODEL_APP_PATH,
-    file: 'invalid-id.model.ts',
-    content: `
-    import {Entity, model, property} from '@loopback/repository';
-
-    @model()
-    export class InvalidID extends Entity {
-      @property({
-        type: 'string',
-        required: true,
-        default: 0,
-      })
-      id: string;
-
-      @property({
-        type: 'string',
-      })
-      desc?: string;
-
-      constructor(data?: Partial<InvalidID>) {
-        super(data);
-      }
-    }
-    `,
-  },
-];

--- a/packages/cli/test/integration/generators/service.integration.js
+++ b/packages/cli/test/integration/generators/service.integration.js
@@ -40,7 +40,9 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('myService --datasource myds');
       const expectedFile = path.join(
@@ -67,7 +69,9 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('--config mysoapconfig.json');
       const expectedFile = path.join(
@@ -103,7 +107,9 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withPrompts(multiItemPrompt);
 
@@ -136,7 +142,9 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withPrompts(multiItemPrompt);
 
@@ -163,7 +171,9 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('--config myrestconfig.json');
       const expectedFile = path.join(
@@ -189,7 +199,9 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
         )
         .withArguments('myservice --datasource restdb');
       const expectedFile = path.join(

--- a/packages/cli/test/integration/generators/service.integration.js
+++ b/packages/cli/test/integration/generators/service.integration.js
@@ -1,0 +1,250 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const testlab = require('@loopback/testlab');
+const fs = require('fs');
+
+const expect = testlab.expect;
+const TestSandbox = testlab.TestSandbox;
+
+const generator = path.join(__dirname, '../../../generators/service');
+
+const testUtils = require('../../test-utils');
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+
+describe('lb4 service', () => {
+  beforeEach('reset sandbox', async () => {
+    await sandbox.reset();
+  });
+
+  describe('invalid generation of services', () => {
+    it('does not run with empty datasource list', async () => {
+      return expect(
+        testUtils.executeGenerator(generator).inDir(
+          SANDBOX_PATH,
+          async () =>
+            await prepareGeneratorForServices(SANDBOX_PATH, {
+              noFixtures: true,
+            }),
+        ),
+      ).to.be.rejectedWith(/No datasources found/);
+    });
+  });
+
+  describe('valid generation of services', () => {
+    it('generates a basic soap service from command line arguments', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(
+          SANDBOX_PATH,
+          async () => await prepareGeneratorForServices(SANDBOX_PATH),
+        )
+        .withArguments('myService --datasource myds');
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        SERVICE_APP_PATH,
+        'my-service.service.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /export class MyServiceServiceProvider implements Provider<MyServiceService> {/,
+      );
+      assert.fileContent(expectedFile, /export interface MyServiceService {/);
+      assert.fileContent(expectedFile, /\@inject\('datasources.myds'\)/);
+      assert.fileContent(
+        expectedFile,
+        /value\(\): Promise\<MyServiceService\> {/,
+      );
+      assert.file(INDEX_FILE);
+      assert.fileContent(INDEX_FILE, /export \* from '.\/my-service.service';/);
+    });
+
+    it('generates a basic rest service from the prompts', async () => {
+      const multiItemPrompt = {
+        name: 'myservice',
+        dataSourceClass: 'RestdbDatasource',
+      };
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(
+          SANDBOX_PATH,
+          async () => await prepareGeneratorForServices(SANDBOX_PATH),
+        )
+        .withPrompts(multiItemPrompt);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        SERVICE_APP_PATH,
+        'myservice.service.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /export class MyserviceServiceProvider implements Provider<MyserviceService> {/,
+      );
+      assert.fileContent(expectedFile, /export interface MyserviceService {/);
+      assert.fileContent(expectedFile, /\@inject\('datasources.restdb'\)/);
+      assert.fileContent(
+        expectedFile,
+        /value\(\): Promise\<MyserviceService\> {/,
+      );
+      assert.file(INDEX_FILE);
+      assert.fileContent(INDEX_FILE, /export \* from '.\/myservice.service';/);
+    });
+  });
+
+  it('generates a soap service from a config file', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(
+        SANDBOX_PATH,
+        async () => await prepareGeneratorForServices(SANDBOX_PATH),
+      )
+      .withArguments('--config myconfig.json');
+    const expectedFile = path.join(
+      SANDBOX_PATH,
+      SERVICE_APP_PATH,
+      'multi-word-service.service.ts',
+    );
+    assert.file(expectedFile);
+    assert.fileContent(
+      expectedFile,
+      /export class MultiWordServiceServiceProvider implements Provider\<MultiWordServiceService\> {/,
+    );
+    assert.fileContent(
+      expectedFile,
+      /protected datasource: MydsDataSource = new MydsDataSource\(\),/,
+    );
+    assert.fileContent(
+      expectedFile,
+      /value\(\): Promise\<MultiWordServiceService\> {/,
+    );
+    assert.file(INDEX_FILE);
+    assert.fileContent(
+      INDEX_FILE,
+      /export \* from '.\/multi-word-service.service';/,
+    );
+  });
+});
+
+// Sandbox constants
+const DATASOURCE_APP_PATH = 'src/datasources';
+const CONFIG_PATH = '.';
+const SERVICE_APP_PATH = 'src/services';
+const INDEX_FILE = path.join(SANDBOX_PATH, SERVICE_APP_PATH, 'index.ts');
+const DUMMY_CONTENT = '--DUMMY VALUE--';
+
+const SANDBOX_FILES = [
+  {
+    path: CONFIG_PATH,
+    file: 'myconfig.json',
+    content: `{
+      "name": "MultiWordService",
+      "datasource": "myds"
+    }`,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'myds.datasource.json',
+    content: JSON.stringify({
+      name: 'myds',
+      connector: 'soap',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'myds.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.json',
+    content: JSON.stringify({
+      name: 'dbmem',
+      connector: 'memory',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.json',
+    content: JSON.stringify({
+      name: 'restdb',
+      connector: 'rest',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+];
+
+async function prepareGeneratorForServices(rootDir, options) {
+  options = options || {};
+  const content = {};
+  if (!options.excludeKeyword) {
+    content.keywords = ['loopback'];
+  }
+
+  if (!options.excludePackageJSON) {
+    fs.writeFileSync(
+      path.join(rootDir, 'package.json'),
+      JSON.stringify(content),
+    );
+  }
+
+  if (!options.excludeYoRcJSON) {
+    fs.writeFileSync(path.join(rootDir, '.yo-rc.json'), JSON.stringify({}));
+  }
+
+  fs.mkdirSync(path.join(rootDir, 'src'));
+
+  if (!options.excludeControllersDir) {
+    fs.mkdirSync(path.join(rootDir, 'src', 'controllers'));
+  }
+
+  if (!options.excludeModelsDir) {
+    fs.mkdirSync(path.join(rootDir, 'src', 'models'));
+  }
+
+  if (!options.excludeRepositoriesDir) {
+    fs.mkdirSync(path.join(rootDir, 'src', 'repositories'));
+  }
+
+  if (!options.excludeDataSourcesDir) {
+    fs.mkdirSync(path.join(rootDir, 'src', 'datasources'));
+  }
+
+  if (!options.excludeDataSourcesDir) {
+    fs.mkdirSync(path.join(rootDir, 'src', 'services'));
+  }
+
+  if (!options.noFixtures) {
+    copyFixtures();
+  }
+}
+
+function copyFixtures() {
+  for (let theFile of SANDBOX_FILES) {
+    const fullPath = path.join(SANDBOX_PATH, theFile.path, theFile.file);
+    if (!fs.existsSync(fullPath)) {
+      fs.writeFileSync(fullPath, theFile.content);
+    }
+  }
+}

--- a/packages/cli/test/integration/generators/service.integration.js
+++ b/packages/cli/test/integration/generators/service.integration.js
@@ -13,7 +13,7 @@ const expect = testlab.expect;
 const TestSandbox = testlab.TestSandbox;
 
 const generator = path.join(__dirname, '../../../generators/service');
-
+const SANDBOX_FILES = require('../../fixtures/service').SANDBOX_FILES;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
@@ -30,9 +30,7 @@ describe('lb4 service', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
-          ),
+          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
       ).to.be.rejectedWith(/No datasources found/);
     });
   });
@@ -42,11 +40,7 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('myService --datasource myds');
       const expectedFile = path.join(
@@ -73,11 +67,7 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('--config mysoapconfig.json');
       const expectedFile = path.join(
@@ -113,11 +103,7 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withPrompts(multiItemPrompt);
 
@@ -150,11 +136,7 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withPrompts(multiItemPrompt);
 
@@ -181,11 +163,7 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('--config myrestconfig.json');
       const expectedFile = path.join(
@@ -211,11 +189,7 @@ describe('lb4 service', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(
-            SANDBOX_PATH,
-            {includeSandboxFilesFixtures: true},
-            SANDBOX_FILES,
-          ),
+          testUtils.givenLBProject(SANDBOX_PATH, {}, SANDBOX_FILES),
         )
         .withArguments('myservice --datasource restdb');
       const expectedFile = path.join(
@@ -241,66 +215,5 @@ describe('lb4 service', () => {
 });
 
 // Sandbox constants
-const DATASOURCE_APP_PATH = 'src/datasources';
-const CONFIG_PATH = '.';
 const SERVICE_APP_PATH = 'src/services';
 const INDEX_FILE = path.join(SANDBOX_PATH, SERVICE_APP_PATH, 'index.ts');
-const DUMMY_CONTENT = '--DUMMY VALUE--';
-
-const SANDBOX_FILES = [
-  {
-    path: CONFIG_PATH,
-    file: 'mysoapconfig.json',
-    content: `{
-      "name": "MultiWordService",
-      "datasource": "myds"
-    }`,
-  },
-  {
-    path: CONFIG_PATH,
-    file: 'myrestconfig.json',
-    content: `{
-      "name": "myservice",
-      "datasource": "restdb"
-    }`,
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'myds.datasource.json',
-    content: JSON.stringify({
-      name: 'myds',
-      connector: 'soap',
-    }),
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'myds.datasource.ts',
-    content: DUMMY_CONTENT,
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'dbmem.datasource.json',
-    content: JSON.stringify({
-      name: 'dbmem',
-      connector: 'memory',
-    }),
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'dbmem.datasource.ts',
-    content: DUMMY_CONTENT,
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'restdb.datasource.json',
-    content: JSON.stringify({
-      name: 'restdb',
-      connector: 'rest',
-    }),
-  },
-  {
-    path: DATASOURCE_APP_PATH,
-    file: 'restdb.datasource.ts',
-    content: DUMMY_CONTENT,
-  },
-];

--- a/packages/cli/test/integration/generators/service.integration.js
+++ b/packages/cli/test/integration/generators/service.integration.js
@@ -86,7 +86,7 @@ describe('lb4 service', () => {
       );
       assert.fileContent(
         expectedFile,
-        /protected datasource: MydsDataSource = new MydsDataSource\(\),/,
+        /protected datasource: mydsDataSource = new mydsDataSource\(\),/,
       );
       assert.fileContent(
         expectedFile,
@@ -216,6 +216,50 @@ describe('lb4 service', () => {
       );
       assert.fileContent(expectedFile, /export interface MyserviceService {/);
       assert.fileContent(expectedFile, /\@inject\('datasources.restdb'\)/);
+      assert.fileContent(
+        expectedFile,
+        /value\(\): Promise\<MyserviceService\> {/,
+      );
+      assert.file(INDEX_FILE);
+      assert.fileContent(INDEX_FILE, /export \* from '.\/myservice.service';/);
+    });
+
+    it('generates a basic soap service with capital datasource name', async () => {
+      const multiItemPrompt = {
+        name: 'myservice',
+        dataSourceClass: 'MapDsDatasource',
+      };
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(multiItemPrompt);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        SERVICE_APP_PATH,
+        'myservice.service.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /export class MyserviceServiceProvider implements Provider<MyserviceService> {/,
+      );
+      assert.fileContent(expectedFile, /export interface MyserviceService {/);
+      assert.fileContent(
+        expectedFile,
+        /import {MapDSDataSource} from '..\/datasources';/,
+      );
+      assert.fileContent(
+        expectedFile,
+        /protected datasource: MapDSDataSource = new MapDSDataSource()/,
+      );
+
+      assert.fileContent(expectedFile, /\@inject\('datasources.MapDS'\)/);
       assert.fileContent(
         expectedFile,
         /value\(\): Promise\<MyserviceService\> {/,

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -64,11 +64,11 @@ exports.executeGenerator = function(GeneratorOrNamespace, settings) {
  * @property {boolean} includeDummyModel Creates a dummy model file in /src/models/product-review.model.ts
  * @property {boolean} includeDummyRepository Creates a dummy repository file in /src/repositories/bar.repository.ts
  * @property {boolean} includeSandboxFilesFixtures creates files specified in SANDBOX_FILES array
- * @param {Object[]} sandBoxFiles specify files, directories and their content to be included as fixtures
+ * @param {array} additionalFiles specify files, directories and their content to be included as fixtures
  */
-exports.givenLBProject = function(rootDir, options, sandBoxFiles) {
+exports.givenLBProject = function(rootDir, options) {
   options = options || {};
-  sandBoxFiles = sandBoxFiles || [];
+  const sandBoxFiles = options.additionalFiles || [];
 
   const content = {};
   if (!options.excludeKeyword) {

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -63,10 +63,13 @@ exports.executeGenerator = function(GeneratorOrNamespace, settings) {
  * @property {boolean} excludeDataSourcesDir Excludes the datasources directory
  * @property {boolean} includeDummyModel Creates a dummy model file in /src/models/product-review.model.ts
  * @property {boolean} includeDummyRepository Creates a dummy repository file in /src/repositories/bar.repository.ts
+ * @property {boolean} includeSandboxFilesFixtures creates files specified in SANDBOX_FILES array
+ * @param {Object[]} sandBoxFiles specify files, directories and their content to be included as fixtures
  */
-exports.givenLBProject = function(rootDir, options) {
+exports.givenLBProject = function(rootDir, options, sandBoxFiles) {
   options = options || {};
-  const context = {};
+  sandBoxFiles = sandBoxFiles || [];
+
   const content = {};
   if (!options.excludeKeyword) {
     content.keywords = ['loopback'];
@@ -109,5 +112,14 @@ exports.givenLBProject = function(rootDir, options) {
   if (options.includeDummyRepository) {
     const repoPath = path.join(rootDir, '/src/repositories/bar.repository.ts');
     fs.writeFileSync(repoPath, '--DUMMY VALUE--');
+  }
+
+  if (options.includeSandboxFilesFixtures && sandBoxFiles.length > 0) {
+    for (let theFile of sandBoxFiles) {
+      const fullPath = path.join(rootDir, theFile.path, theFile.file);
+      if (!fs.existsSync(fullPath)) {
+        fs.writeFileSync(fullPath, theFile.content);
+      }
+    }
   }
 };

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -114,7 +114,7 @@ exports.givenLBProject = function(rootDir, options, sandBoxFiles) {
     fs.writeFileSync(repoPath, '--DUMMY VALUE--');
   }
 
-  if (options.includeSandboxFilesFixtures && sandBoxFiles.length > 0) {
+  if (sandBoxFiles.length > 0) {
     for (let theFile of sandBoxFiles) {
       const fullPath = path.join(rootDir, theFile.path, theFile.file);
       if (!fs.existsSync(fullPath)) {

--- a/packages/cli/test/unit/utils.unit.js
+++ b/packages/cli/test/unit/utils.unit.js
@@ -380,4 +380,40 @@ describe('Utils', () => {
       expect(utils.validateStringObject('array')('[1, 2, 3]')).to.be.True();
     });
   });
+
+  describe('getDataSourceName', () => {
+    it('returns false on missing dataSourceClass parameter', () => {
+      expect(utils.getDataSourceName('src/datasources')).to.be.False();
+    });
+  });
+
+  describe('getDataSourceConnectorName', () => {
+    it('returns false on missing dataSourceClass parameter', () => {
+      expect(utils.getDataSourceConnectorName('src/datasources')).to.be.False();
+    });
+  });
+
+  describe('isConnectorOfType', () => {
+    it('returns false on missing dataSourceClass parameter', () => {
+      expect(
+        utils.isConnectorOfType('src/datasources', 'PersistedModel'),
+      ).to.be.False();
+    });
+  });
+
+  describe('getServiceFileName', () => {
+    it('returns the file class name', () => {
+      expect(utils.getServiceFileName('MyService')).to.equal(
+        'my-service.service.ts',
+      );
+    });
+  });
+
+  describe('dataSourceToJSONFileName', () => {
+    it('returns the datasource json file name', () => {
+      expect(utils.dataSourceToJSONFileName('MapDS')).to.equal(
+        'map-ds.datasource.json',
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR implements the basic generation of a service class, as discussed in https://github.com/strongloop/loopback-next/issues/1312#issuecomment-423224230.  

## Done 
- **Generates** a **basic** _service class_
- Add **Integration test** 
- Add **Documentation**  for `lb4 service`
- **Move** the datasource file inspector to the utils library to be consumed by other artifacts such as lb4 repository, _this way we don't duplicate code_
- **Add* a function to return the connector type, which is basic for future inferring of remote methods, so the function returns soap or rest based on the DS name.
- **Share** `addGivenLB4Project` now with repository and service generators. This way we separate concerns and make the code reading and reviewing more efficient
- **Move** the fixtures to their respective `fixtures` directory for both `repository` and `service` generators
- **Install** the @loopback/proxy-service package if missing from package.json

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
