### PR TITLE
fix(cli): removed unused dependencies from project template

### DIFF
--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -95,13 +95,6 @@
   "devDependencies": {
     "@loopback/build": "<%= project.dependencies['@loopback/build'] -%>",
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
-<% if (project.mocha) { -%>
-    "@types/mocha": "<%= project.dependencies['@types/mocha'] -%>",
-<% } -%>
-    "@types/node": "<%= project.dependencies['@types/node'] -%>"<% if (project.mocha) { -%>,<% } %>
-<% if (project.mocha) { -%>
-    "mocha": "<%= project.dependencies['mocha'] -%>",
-    "source-map-support": "<%= project.dependencies['source-map-support'] -%>"
-<% } -%>
+    "@types/node": "<%= project.dependencies['@types/node'] -%>"
   }
 }


### PR DESCRIPTION
Remove the following dependencie:
  - `mocha`
  - `@types/mocha`
  - `source-map-support`

These dependencies are not needed because `mocha` is invoked via `lb-mocha` from `@loopback/build`.

As a nice side effect, when a new application is scaffolded via `lb4 app` into loopback-next's `sandbox` folder, then `lerna bootstrap` does not need to install any 3rd party dependencies for this new project, everything is resolved locally from loopback-next packages.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
