### PR TITLE
feat(testlab): set port to zero in givenHttpServerConfig

### DIFF
--- a/examples/hello-world/test/acceptance/application.acceptance.ts
+++ b/examples/hello-world/test/acceptance/application.acceptance.ts
@@ -31,9 +31,7 @@ describe('Application', () => {
 
   function givenAnApplication() {
     app = new HelloWorldApplication({
-      rest: givenHttpServerConfig({
-        port: 0,
-      }),
+      rest: givenHttpServerConfig(),
       disableConsoleLog: true,
     });
   }

--- a/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
@@ -124,9 +124,7 @@ describe('TodoListApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: givenHttpServerConfig({
-        port: 0,
-      }),
+      rest: givenHttpServerConfig(),
     });
 
     await app.boot();

--- a/examples/todo-list/test/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list.acceptance.ts
@@ -145,9 +145,7 @@ describe('TodoListApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: givenHttpServerConfig({
-        port: 0,
-      }),
+      rest: givenHttpServerConfig(),
     });
 
     await app.boot();

--- a/examples/todo-list/test/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo.acceptance.ts
@@ -143,9 +143,7 @@ describe('TodoListApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: givenHttpServerConfig({
-        port: 0,
-      }),
+      rest: givenHttpServerConfig(),
     });
 
     await app.boot();

--- a/examples/todo/test/acceptance/todo.acceptance.ts
+++ b/examples/todo/test/acceptance/todo.acceptance.ts
@@ -175,9 +175,7 @@ describe('TodoApplication', () => {
 
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
-      rest: givenHttpServerConfig({
-        port: 0,
-      }),
+      rest: givenHttpServerConfig(),
     });
 
     await app.boot();

--- a/packages/boot/test/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/test/acceptance/controller.booter.acceptance.ts
@@ -41,7 +41,7 @@ describe('controller booter acceptance tests', () => {
 
     const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
     app = new MyApp({
-      rest: givenHttpServerConfig({port: 0}),
+      rest: givenHttpServerConfig(),
     });
   }
 

--- a/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
+++ b/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
@@ -30,9 +30,7 @@ describe('PingController', () => {
 
   function givenAnApplication() {
     app = new <%= project.applicationName %>({
-      rest: givenHttpServerConfig({
-        port: 0,
-      }),
+      rest: givenHttpServerConfig(),
     });
   }
 });

--- a/packages/http-server/test/integration/http-server.integration.ts
+++ b/packages/http-server/test/integration/http-server.integration.ts
@@ -158,9 +158,9 @@ describe('HttpServer (integration)', () => {
   });
 
   it('supports HTTPS protocol with a pfx file', async () => {
-    const options = {usePfx: true};
-    const serverOptions = givenHttpServerConfig();
-    Object.assign(serverOptions, options);
+    const serverOptions = givenHttpServerConfig({
+      usePfx: true,
+    });
     const httpsServer: HttpServer = givenHttpsServer(serverOptions);
     await httpsServer.start();
     const response = await httpsGetAsync(httpsServer.url);

--- a/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
@@ -96,7 +96,7 @@ describe('Coercion', () => {
   });
 
   async function givenAClient() {
-    app = new RestApplication({rest: givenHttpServerConfig({port: 0})});
+    app = new RestApplication({rest: givenHttpServerConfig()});
     app.controller(MyController);
     await app.start();
     client = createRestAppClient(app);

--- a/packages/rest/test/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/test/acceptance/validation/validation.acceptance.ts
@@ -156,7 +156,7 @@ describe('Validation at REST level', () => {
   }
 
   async function givenAnAppAndAClient(controller: ControllerClass) {
-    app = new RestApplication({rest: givenHttpServerConfig({port: 0})});
+    app = new RestApplication({rest: givenHttpServerConfig()});
     app.controller(controller);
     await app.start();
 

--- a/packages/testlab/src/http-server-config.ts
+++ b/packages/testlab/src/http-server-config.ts
@@ -4,10 +4,16 @@
 // License text available at https://opensource.org/licenses/MIT
 
 /**
- * Helper function for generating Travis-friendly host (127.0.0.1)
- * @param options Optional defaults
+ * Create an HTTP-server configuration that works well in test environments.
+ *  - Ask the operating system to assign a free (ephemeral) port.
+ *  - Use IPv4 localhost `127.0.0.1` on Travis-CI to avoid known IPv6 issues.
+ *
+ * @param customConfig Additional configuration options to apply.
  */
-export function givenHttpServerConfig<T>(options?: T): T & {host?: string} {
-  const defaults = process.env.TRAVIS ? {host: '127.0.0.1'} : {};
-  return Object.assign(defaults, options);
+export function givenHttpServerConfig<T extends object>(
+  customConfig?: T,
+): T & {host?: string; port: number} {
+  const defaults = {port: 0};
+  const hostConfig = process.env.TRAVIS ? {host: '127.0.0.1'} : {};
+  return Object.assign(defaults, hostConfig, customConfig);
 }


### PR DESCRIPTION
Modify the test helper `givenHttpServerConfig` to explicitly set the port to zero. With this change in place, applications can use this helper in acceptation tests without having to explicitly specify `{port: 0}` to override RestServer's default port 3000.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
