### PR TITLE
feat(cli): add update notifier to remind cli upgrade

### DIFF
--- a/packages/cli/bin/cli-main.js
+++ b/packages/cli/bin/cli-main.js
@@ -8,8 +8,9 @@
 
 const checkNodeVersion = require('@loopback/dist-util').checkNodeVersion;
 
+const pkg = require('../package.json');
 try {
-  const range = require('../package.json').engines.node;
+  const range = pkg.engines.node;
   checkNodeVersion(range);
 } catch (e) {
   console.error(e.message);
@@ -26,4 +27,13 @@ const opts = minimist(process.argv.slice(2), {
     commands: 'l', // --commands or -l: print commands
   },
 });
+
+const updateNotifier = require('update-notifier');
+// Force version check with `lb4 --version`
+const interval = opts.version ? 0 : undefined;
+updateNotifier({
+  pkg: pkg,
+  updateCheckInterval: interval,
+}).notify({isGlobal: true});
+
 main(opts);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,6 +58,7 @@
     "swagger-parser": "^5.0.0",
     "swagger2openapi": "^2.11.16",
     "unicode-10.0.0": "^0.7.4",
+    "update-notifier": "^2.5.0",
     "url-slug": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
     "yeoman-generator": "^3.1.1"


### PR DESCRIPTION
Add [update-notifier](https://github.com/yeoman/update-notifier) to remind users of newer CLI versions.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
