### PR TITLE
feat(cli): add lb4 model option to select base model class

### DIFF
--- a/docs/site/Model-generator.md
+++ b/docs/site/Model-generator.md
@@ -18,6 +18,10 @@ lb4 model [options] [<name>]
 
 ### Options
 
+`--base` : _(Optional)_ a valid model already created in src/models or any of
+the core based class models Entity or Model. Your new model will extend this
+selected base model class.
+
 {% include_relative includes/CLI-std-options.md %}
 
 ### Arguments
@@ -32,6 +36,11 @@ The tool will prompt you for:
 - **Name of the model.** _(modelName)_ If the name had been supplied from the
   command line, the prompt is skipped and the datasource is built with the name
   from the command-line argument.
+
+- **Model base class.** _(modelBaseClass)_ If the command line option --base had
+  been supplied with a valid model class name, the prompt is skipped. It will
+  present you with a list of available models from `src/models` including the
+  **Entity** and **Model** at the top of the list.
 
 The tool will next recursively prompt you for the model's properties until a
 blank one is entered. Properties will be prompted for as follows:

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -14,7 +14,11 @@ const path = require('path');
 
 const PROMPT_BASE_MODEL_CLASS = 'Please select the model base class';
 const ERROR_NO_MODELS_FOUND = 'Model was not found in';
-const BASE_MODELS = ['Entity', 'Model'];
+const BASE_MODELS = [
+  'Entity',
+  'Model',
+  {type: 'separator', line: '----- Custom Models -----'},
+];
 const MODEL_TEMPLATE_PATH = 'model.ts.ejs';
 
 /**
@@ -286,9 +290,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
     this.artifactInfo.isModelBaseBuiltin = BASE_MODELS.includes(
       this.artifactInfo.modelBaseClass,
-    )
-      ? true
-      : false;
+    );
 
     // Set up types for Templating
     const TS_TYPES = ['string', 'number', 'object', 'boolean', 'any'];

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -1,7 +1,12 @@
-import {Entity, model, property} from '@loopback/repository';
+<% if (isModelBaseBuiltin) { -%>
+import {<%= modelBaseClass %>, model, property} from '@loopback/repository';
+<% } else { -%>
+import {model, property} from '@loopback/repository';
+import {<%= modelBaseClass %>} from '.';
+<% } -%>
 
 @model()
-export class <%= className %> extends Entity {
+export class <%= className %> extends <%= modelBaseClass %> {
 <% Object.entries(properties).forEach(([key, val]) => { -%>
   @property({
   <%_ Object.entries(val).forEach(([propKey, propVal]) => { -%>

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -60,6 +60,17 @@ describe('lb4 model integration', () => {
     ).to.be.rejectedWith(/No `loopback` keyword found in/);
   });
 
+  it('does not run if passed an invalid model from command line', () => {
+    return expect(
+      testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: true}),
+        )
+        .withArguments('myNewModel --base InvalidModel'),
+    ).to.be.rejectedWith(/Model was not found in/);
+  });
+
   describe('model generator', () => {
     it('scaffolds correct files with input', async () => {
       await testUtils
@@ -71,6 +82,58 @@ describe('lb4 model integration', () => {
         });
 
       basicModelFileChecks();
+    });
+
+    it('scaffolds correct files with model base class', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withPrompts({
+          name: 'test',
+          propName: null,
+          modelBaseClass: 'Model',
+        });
+
+      assert.file(expectedModelFile);
+      assert.file(expectedIndexFile);
+
+      // Actual Model File
+      assert.fileContent(
+        expectedModelFile,
+        /import {Model, model, property} from '@loopback\/repository';/,
+      );
+      assert.fileContent(expectedModelFile, /@model()/);
+      assert.fileContent(
+        expectedModelFile,
+        /export class Test extends Model {/,
+      );
+    });
+
+    it('scaffolds correct files with model custom class', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {includeDummyModel: true}),
+        )
+        .withPrompts({
+          name: 'test',
+          propName: null,
+          modelBaseClass: 'ProductReview',
+        });
+
+      assert.file(expectedModelFile);
+      assert.file(expectedIndexFile);
+
+      // Actual Model File
+      assert.fileContent(
+        expectedModelFile,
+        /import {model, property} from '@loopback\/repository';/,
+      );
+      assert.fileContent(expectedModelFile, /@model()/);
+      assert.fileContent(
+        expectedModelFile,
+        /export class Test extends ProductReview {/,
+      );
     });
 
     it('scaffolds correct files with args', async () => {


### PR DESCRIPTION
This PR adds the option to select a base model class to `lb4 model` **CLI** command.

**Done** 
- User can specify --base command line option with either Entity , Model or any valid model  custom class name. The command will validate if any custom class provided exists in `src/models`
- User is presented a list of options including Entity, Model and any valid model already created in `src/models` directory
- The **CLI** command will generate the file from the appropriate model template.
- Tests with invalid model name and valid model names were added
- Add documentation about the new option
- Thanks to @raymondfeng  suggestion the separator (base classes and custom one) was added in the model list.

**Excluded**
- `lb4 repository` update to filter models based on the baseModel  type 
   - PersistedModel works with Entity 
   - KeyValueModel works with Entity and Model
   - The reason is that this addition can make this PR more complex to digest for review
      - We have to navigate from child to father models to find out if it is Entity or Model for filtering, whenver an extended model from a custom model is selected.

close #1698

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
