### PR TITLE
fix(rest): coerce string parameters (reject object values)

### DIFF
--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -67,9 +67,18 @@ export function coerceParameter(
       return coerceObject(data, spec);
     case 'string':
     case 'password':
+      return coerceString(data, spec);
     default:
       return data;
   }
+}
+
+function coerceString(data: string | object, spec: ParameterObject) {
+  if (typeof data !== 'string')
+    throw RestHttpErrors.invalidData(data, spec.name);
+
+  debug('data of type string is coerced to %s', data);
+  return data;
 }
 
 function coerceBuffer(data: string | object, spec: ParameterObject) {

--- a/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/test/acceptance/coercion/coercion.acceptance.ts
@@ -17,7 +17,9 @@ describe('Coercion', () => {
     await app.stop();
   });
 
-  afterEach(() => spy.restore());
+  afterEach(() => {
+    if (spy) spy.restore();
+  });
 
   class MyController {
     @get('/create-number-from-path/{num}')
@@ -33,6 +35,11 @@ describe('Coercion', () => {
     @get('/create-number-from-header')
     createNumberFromHeader(@param.header.number('num') num: number) {
       return num;
+    }
+
+    @get('/string-from-query')
+    getStringFromQuery(@param.query.string('where') where: string) {
+      return where;
     }
 
     @get('/object-from-query')
@@ -93,6 +100,17 @@ describe('Coercion', () => {
         active: 'true',
       },
     });
+  });
+
+  it('rejects object value constructed by qs for string parameter', async () => {
+    await client
+      .get('/string-from-query')
+      .query({
+        'where[id]': 1,
+        'where[name]': 'Pen',
+        'where[active]': true,
+      })
+      .expect(400);
   });
 
   async function givenAClient() {

--- a/packages/rest/test/unit/coercion/paramStringToString.unit.ts
+++ b/packages/rest/test/unit/coercion/paramStringToString.unit.ts
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ParameterObject} from '@loopback/openapi-v3-types';
+import {RestHttpErrors} from '../../..';
+import {test} from './utils';
+
+const OPTIONAL_STRING_PARAM: ParameterObject = {
+  in: 'path',
+  name: 'aparameter',
+  schema: {type: 'string'},
+};
+
+const REQUIRED_STRING_PARAM = {
+  ...OPTIONAL_STRING_PARAM,
+  required: true,
+};
+
+describe('coerce param from string to string - required', () => {
+  context('valid values', () => {
+    test(REQUIRED_STRING_PARAM, 'text', 'text');
+  });
+
+  context('empty values trigger ERROR_BAD_REQUEST', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(
+      REQUIRED_STRING_PARAM,
+      '',
+      RestHttpErrors.missingRequired(REQUIRED_STRING_PARAM.name),
+    );
+  });
+});
+
+describe('coerce param from string to string - optional', () => {
+  context('valid values', () => {
+    test(OPTIONAL_STRING_PARAM, 'text', 'text');
+  });
+
+  context('number-like strings are preserved as strings', () => {
+    // octal (base 8)
+    test(OPTIONAL_STRING_PARAM, '0664', '0664');
+
+    // integers that cannot be repesented by JavaScript's number
+    test(
+      OPTIONAL_STRING_PARAM,
+      '2343546576878989879789',
+      '2343546576878989879789',
+    );
+    test(
+      OPTIONAL_STRING_PARAM,
+      '-2343546576878989879789',
+      '-2343546576878989879789',
+    );
+
+    // scientific notation
+    test(OPTIONAL_STRING_PARAM, '1.234e+30', '1.234e+30');
+    test(OPTIONAL_STRING_PARAM, '-1.234e+30', '-1.234e+30');
+  });
+
+  context('empty collection converts to undefined', () => {
+    // [], {} sent from request are converted to raw value undefined
+    test(OPTIONAL_STRING_PARAM, undefined, undefined);
+  });
+
+  context('empty values are allowed', () => {
+    // null, '' sent from request are converted to raw value ''
+    test(OPTIONAL_STRING_PARAM, '', '');
+    test(OPTIONAL_STRING_PARAM, 'null', 'null');
+    test(OPTIONAL_STRING_PARAM, 'undefined', 'undefined');
+  });
+
+  context('object values trigger ERROR_BAD_REQUEST', () => {
+    test(
+      OPTIONAL_STRING_PARAM,
+      {a: true},
+      RestHttpErrors.invalidData({a: true}, OPTIONAL_STRING_PARAM.name),
+    );
+
+    test(
+      OPTIONAL_STRING_PARAM,
+      [1, 2, 3],
+      RestHttpErrors.invalidData([1, 2, 3], OPTIONAL_STRING_PARAM.name),
+    );
+  });
+});


### PR DESCRIPTION
Add a missing coercion step for string parameters and prevent the situation when a string value provided by the HTTP client and converted into an object or an array by query-string parser is passed as-is to the controller method, violating the endpoint contract and TypeScript declaration.

I discovered this problem while working on #1679. Without this change, endpoints like `TodoListController#count` are incorrectly accepting object values for their `where` parameter described as `type: string`. 

https://github.com/strongloop/loopback-next/blob/d65a17fab7ce44b7977e9c03388f5684558475f2/examples/todo-list/src/controllers/todo-list.controller.ts#L37-L39

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated