### PR TITLE
feat(cli): add code template for default home page controller

### DIFF
--- a/packages/cli/generators/app/templates/public/index.html.ejs
+++ b/packages/cli/generators/app/templates/public/index.html.ejs
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title><%= project.description %></title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" type="image/x-icon" href="//v4.loopback.io/favicon.ico">
+
+  <style>
+    h3 {
+      margin-left: 25px;
+      text-align: center;
+    }
+
+    a, a:visited {
+      color: #3f5dff;
+    }
+
+    h3 a {
+      margin-left: 10px;
+    }
+
+    a:hover, a:focus, a:active {
+      color: #001956;
+    }
+
+    .power {
+      position: absolute;
+      bottom: 25px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    .info {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%)
+    }
+
+    .info h1 {
+      text-align: center;
+      margin-bottom: 0px;
+    }
+
+    .info p {
+      text-align: center;
+      margin-bottom: 3em;
+      margin-top: 1em;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="info">
+    <h1><%= project.name %></h1>
+    <p>Version <%= project.version || '1.0.0' %></p>
+
+    <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h4>
+    <h3>API Explorer: <a href="/explorer">/explorer</a></h4>
+  </div>
+
+  <footer class="power">
+    <a href="https://v4.loopback.io" target="_blank">
+      <img src="https://loopback.io/images/branding/powered-by-loopback/blue/powered-by-loopback-sm.png" />
+    </a>
+  </footer>
+</body>
+
+</html>

--- a/packages/cli/generators/app/templates/src/controllers/home-page.controller.ts.ejs
+++ b/packages/cli/generators/app/templates/src/controllers/home-page.controller.ts.ejs
@@ -1,0 +1,31 @@
+import {get} from '@loopback/openapi-v3';
+import * as fs from 'fs';
+import * as path from 'path';
+import {inject} from '@loopback/context';
+import {RestBindings, Response} from '@loopback/rest';
+
+export class HomePageController {
+  private html: string;
+  constructor(@inject(RestBindings.Http.RESPONSE) private response: Response) {
+    this.html = fs.readFileSync(
+      path.join(__dirname, '../../../public/index.html'),
+      'utf-8',
+    );
+  }
+
+  @get('/', {
+    responses: {
+      '200': {
+        description: 'Home Page',
+        content: {'text/html': {schema: {type: 'string'}}},
+      },
+    },
+  })
+  homePage() {
+    this.response
+      .status(200)
+      .contentType('html')
+      .send(this.html);
+    return this.response;
+  }
+}

--- a/packages/cli/generators/app/templates/test/acceptance/home-page.controller.acceptance.ts.ejs
+++ b/packages/cli/generators/app/templates/test/acceptance/home-page.controller.acceptance.ts.ejs
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Client} from '@loopback/testlab';
+import {<%= project.applicationName %>} from '../..';
+import {setupApplication} from './test-helper';
+
+describe('HomePageController', () => {
+  let app: <%= project.applicationName %>;
+  let client: Client;
+
+  before('setupApplication', async () => {
+    ({app, client} = await setupApplication());
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  it('exposes a default home page', async () => {
+    await client
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /text\/html/);
+  });
+});

--- a/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
+++ b/packages/cli/generators/app/templates/test/acceptance/ping.controller.acceptance.ts.ejs
@@ -1,24 +1,13 @@
-import {
-  Client,
-  createRestAppClient,
-  givenHttpServerConfig,
-  expect,
-} from '@loopback/testlab';
+import {Client, expect} from '@loopback/testlab';
 import {<%= project.applicationName %>} from '../..';
+import {setupApplication} from './test-helper';
 
 describe('PingController', () => {
   let app: <%= project.applicationName %>;
   let client: Client;
 
-  before(givenAnApplication);
-
-  before(async () => {
-    await app.boot();
-    await app.start();
-  });
-
-  before(() => {
-    client = createRestAppClient(app);
+  before('setupApplication', async () => {
+    ({app, client} = await setupApplication());
   });
 
   after(async () => {
@@ -29,10 +18,4 @@ describe('PingController', () => {
     const res = await client.get('/ping?msg=world').expect(200);
     expect(res.body).to.containEql({greeting: 'Hello from LoopBack'});
   });
-
-  function givenAnApplication() {
-    app = new <%= project.applicationName %>({
-      rest: givenHttpServerConfig(),
-    });
-  }
 });

--- a/packages/cli/generators/app/templates/test/acceptance/test-helper.ts.ejs
+++ b/packages/cli/generators/app/templates/test/acceptance/test-helper.ts.ejs
@@ -1,0 +1,24 @@
+import {<%= project.applicationName %>} from '../..';
+import {
+  createRestAppClient,
+  givenHttpServerConfig,
+  Client,
+} from '@loopback/testlab';
+
+export async function setupApplication(): Promise<AppWithClient> {
+  const app = new <%= project.applicationName %>({
+    rest: givenHttpServerConfig(),
+  });
+
+  await app.boot();
+  await app.start();
+
+  const client = createRestAppClient(app);
+
+  return {app, client};
+}
+
+export interface AppWithClient {
+  app: <%= project.applicationName %>;
+  client: Client;
+}

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -257,7 +257,7 @@ exports.renameEJS = function() {
 
     // extname already contains a leading '.'
     const fileName = `${basename}${extname}`;
-    const result = fileName.match(/(.+)(.ts|.json|.js|.md)\.ejs$/);
+    const result = fileName.match(/(.+)(.ts|.json|.js|.md|.html)\.ejs$/);
     if (result) {
       extname = result[2];
       basename = result[1];

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -63,6 +63,22 @@ describe('app-generator specific files', () => {
       'test/acceptance/ping.controller.acceptance.ts',
       /describe\('PingController'/,
     );
+    assert.fileContent(
+      'src/controllers/home-page.controller.ts',
+      /export class HomePageController/,
+    );
+    assert.fileContent(
+      'src/controllers/home-page.controller.ts',
+      /homePage\(\)/,
+    );
+    assert.fileContent(
+      'test/acceptance/home-page.controller.acceptance.ts',
+      /describe\('HomePageController'/,
+    );
+    assert.fileContent(
+      'test/acceptance/test-helper.ts',
+      /export async function setupApplication/,
+    );
   });
 });
 


### PR DESCRIPTION
This PR adds code template for a default home page controller to be generated as part of `lb4 app`.

Fixes https://github.com/strongloop/loopback-next/issues/1745

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
