### PR TITLE
feat(boot): bind content of package.json to app context

### DIFF
--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -8,6 +8,8 @@ import {Booter, BootOptions, Bootable} from '../interfaces';
 import {BootComponent} from '../boot.component';
 import {Bootstrapper} from '../bootstrapper';
 import {BootBindings} from '../keys';
+import {CoreBindings} from '@loopback/core';
+import * as path from 'path';
 
 // Binding is re-exported as Binding / Booter types are needed when consuming
 // BootMixin and this allows a user to import them from the same package (UX!)
@@ -53,6 +55,11 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
       this.bind(BootBindings.BOOT_OPTIONS).toDynamicValue(
         () => this.bootOptions,
       );
+
+      this.bind(CoreBindings.APPLICATION_PACKAGE_JSON).toDynamicValue(() => {
+        const pkgFile = path.resolve(this.projectRoot, 'package.json');
+        return require(pkgFile);
+      });
     }
 
     /**

--- a/packages/boot/test/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/test/acceptance/controller.booter.acceptance.ts
@@ -7,9 +7,11 @@ import {
   createRestAppClient,
   givenHttpServerConfig,
   TestSandbox,
+  expect,
 } from '@loopback/testlab';
 import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
+import {CoreBindings} from '@loopback/core';
 
 describe('controller booter acceptance tests', () => {
   let app: BooterApp;
@@ -20,6 +22,15 @@ describe('controller booter acceptance tests', () => {
   beforeEach(getApp);
 
   afterEach(stopApp);
+
+  it('binds package.json', async () => {
+    const pkg = await app.get(CoreBindings.APPLICATION_PACKAGE_JSON);
+    expect(pkg).containEql({
+      name: 'boot-test-app',
+      version: '1.0.0',
+      description: 'boot-test-app',
+    });
+  });
 
   it('binds controllers using ControllerDefaults and REST endpoints work', async () => {
     await app.boot();
@@ -33,6 +44,7 @@ describe('controller booter acceptance tests', () => {
   });
 
   async function getApp() {
+    await sandbox.copyFile(resolve(__dirname, '../fixtures/package.json'));
     await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/multiple.artifact.js'),

--- a/packages/boot/test/fixtures/package.json
+++ b/packages/boot/test/fixtures/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "boot-test-app",
+  "version": "1.0.0",
+  "description": "boot-test-app",
+  "keywords": [
+    "loopback-application",
+    "loopback"
+  ],
+  "engines": {
+    "node": ">=8.9"
+  },
+  "scripts": {
+  },
+  "repository": {
+    "type": "git"
+  },
+  "author": "",
+  "license": ""
+}

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -192,6 +192,10 @@ export class Application extends Context {
     const instance = this.getSync<Component>(componentKey);
     mountComponent(this, instance);
   }
+
+  public packageJson(pkg: PackageJson) {
+    this.bind(CoreBindings.APPLICATION_PACKAGE_JSON).to(pkg);
+  }
 }
 
 /**
@@ -207,3 +211,14 @@ export interface ApplicationConfig {
 
 // tslint:disable-next-line:no-any
 export type ControllerClass = Constructor<any>;
+
+/**
+ * Type description for `package.json`
+ */
+export interface PackageJson {
+  name: string;
+  version: string;
+  description: string;
+  // tslint:disable-next-line:no-any
+  [name: string]: any;
+}

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingKey} from '@loopback/context';
-import {Application, ControllerClass} from './application';
+import {Application, ControllerClass, PackageJson} from './application';
 
 /**
  * Namespace for core binding keys
@@ -23,6 +23,13 @@ export namespace CoreBindings {
    */
   export const APPLICATION_CONFIG = BindingKey.create<object>(
     'application.config',
+  );
+
+  /**
+   * Binding key for the content of `package.json`
+   */
+  export const APPLICATION_PACKAGE_JSON = BindingKey.create<PackageJson>(
+    'application.package-json',
   );
 
   // server


### PR DESCRIPTION
See https://github.com/strongloop/loopback4-example-shopping/pull/16#discussion_r220140265

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
