### PR TITLE
fix(repository): return an object for count and updateAll

### DIFF
--- a/docs/site/todo-list-tutorial-controller.md
+++ b/docs/site/todo-list-tutorial-controller.md
@@ -137,13 +137,13 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList model count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async count(
     @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.todoListRepository.count(where);
   }
 
@@ -165,14 +165,14 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList PATCH success count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async updateAll(
     @requestBody() obj: Partial<TodoList>,
     @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.todoListRepository.updateAll(obj, where);
   }
 

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Filter, repository, Where} from '@loopback/repository';
+import {
+  Count,
+  CountSchema,
+  Filter,
+  repository,
+  Where,
+} from '@loopback/repository';
 import {
   del,
   get,
@@ -59,7 +65,7 @@ export class TodoListTodoController {
     responses: {
       '200': {
         description: 'TodoList.Todo PATCH success count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
@@ -67,7 +73,7 @@ export class TodoListTodoController {
     @param.path.number('id') id: number,
     @requestBody() todo: Partial<Todo>,
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.todoListRepo.todos(id).patch(todo, where);
   }
 
@@ -75,14 +81,14 @@ export class TodoListTodoController {
     responses: {
       '200': {
         description: 'TodoList.Todo DELETE success count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async delete(
     @param.path.number('id') id: number,
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.todoListRepo.todos(id).delete(where);
   }
 }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Filter, repository, Where} from '@loopback/repository';
+import {
+  Count,
+  CountSchema,
+  Filter,
+  repository,
+  Where,
+} from '@loopback/repository';
 import {
   del,
   get,
@@ -39,13 +45,13 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList model count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async count(
     @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.todoListRepository.count(where);
   }
 
@@ -67,14 +73,14 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList PATCH success count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async updateAll(
     @requestBody() obj: Partial<TodoList>,
     @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.todoListRepository.updateAll(obj, where);
   }
 

--- a/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list-todo.acceptance.ts
@@ -84,7 +84,7 @@ describe('TodoListApplication', () => {
         .send(patchedIsCompleteTodo)
         .expect(200);
 
-      expect(response.body).to.eql(myTodos.length);
+      expect(response.body.count).to.eql(myTodos.length);
       const updatedTodos = await todoListRepo
         .todos(persistedTodoList.id)
         .find();
@@ -111,7 +111,7 @@ describe('TodoListApplication', () => {
         .query({where: {isComplete: false}})
         .send({desc: 'work in progress'})
         .expect(200);
-      expect(response.body).to.equal(1);
+      expect(response.body.count).to.equal(1);
 
       // the matched Todo was updated
       expect(await todoRepo.findById(wip.id)).to.have.property(
@@ -156,7 +156,7 @@ describe('TodoListApplication', () => {
         .query({where: {isComplete: true}})
         .expect(200);
 
-      expect(response.body).to.equal(1);
+      expect(response.body.count).to.equal(1);
 
       const allRemainingTodos = await todoRepo.find();
       expect(allRemainingTodos.map(t => t.title).sort()).to.deepEqual(

--- a/examples/todo-list/test/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/test/acceptance/todo-list.acceptance.ts
@@ -56,7 +56,7 @@ describe('TodoListApplication', () => {
         .get('/todo-lists/count')
         .send()
         .expect(200);
-      expect(response.body).to.eql(persistedTodoLists.length);
+      expect(response.body.count).to.eql(persistedTodoLists.length);
     });
 
     it('counts a subset of todoLists', async () => {
@@ -64,7 +64,7 @@ describe('TodoListApplication', () => {
         .get('/todo-lists/count')
         .query({where: {title: 'so many things to do wow'}})
         .expect(200);
-      expect(response.body).to.equal(1);
+      expect(response.body.count).to.equal(1);
     });
 
     it('finds all todoLists', async () => {
@@ -81,7 +81,7 @@ describe('TodoListApplication', () => {
         .patch('/todo-lists')
         .send(patchedColorTodo)
         .expect(200);
-      expect(response.body).to.eql(persistedTodoLists.length);
+      expect(response.body.count).to.eql(persistedTodoLists.length);
       const updatedTodoLists = await todoListRepo.find();
       for (const todoList of updatedTodoLists) {
         expect(todoList.color).to.eql(patchedColorTodo.color);
@@ -98,7 +98,7 @@ describe('TodoListApplication', () => {
         .query({where: {color: 'red'}})
         .send({color: 'purple'})
         .expect(200);
-      expect(response.body).to.eql(1);
+      expect(response.body.count).to.eql(1);
 
       // the matched TodoList was updated
       expect(await todoListRepo.findByTitle('red-list')).to.have.property(

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -1,4 +1,10 @@
-import {Filter, repository, Where} from '@loopback/repository';
+import {
+  Count,
+  CountSchema,
+  Filter,
+  repository,
+  Where,
+} from '@loopback/repository';
 import {
   post,
   param,
@@ -34,13 +40,13 @@ export class <%= className %>Controller {
     responses: {
       '200': {
         description: '<%= modelName %> model count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async count(
     @param.query.object('where', getWhereSchemaFor(<%= modelName %>)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.<%= repositoryNameCamel %>.count(where);
   }
 
@@ -66,14 +72,14 @@ export class <%= className %>Controller {
     responses: {
       '200': {
         description: '<%= modelName %> PATCH success count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async updateAll(
     @requestBody() <%= modelVariableName %>: <%= modelName %>,
     @param.query.object('where', getWhereSchemaFor(<%= modelName %>)) where?: Where,
-  ): Promise<number> {
+  ): Promise<Count> {
     return await this.<%= repositoryNameCamel %>.updateAll(<%= modelVariableName %>, where);
   }
 

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -260,7 +260,7 @@ function checkRestCrudContents() {
     /responses: {/,
     /'200': {/,
     /description: 'ProductReview model count'/,
-    /content: {'application\/json': {'x-ts-type': Number}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /content: {'application\/json': {schema: CountSchema}},\s{1,}},\s{1,}},\s{1,}}\)/,
     /async count\(\s+\@param\.query\.object\('where', getWhereSchemaFor\(ProductReview\)\) where\?: Where(|,\s+)\)/,
   ];
   getCountRegEx.forEach(regex => {
@@ -286,7 +286,7 @@ function checkRestCrudContents() {
     /responses: {/,
     /'200': {/,
     /description: 'ProductReview PATCH success count'/,
-    /content: {'application\/json': {'x-ts-type': Number}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /content: {'application\/json': {schema: CountSchema}},\s{1,}},\s{1,}},\s{1,}}\)/,
     /async updateAll\(\s{1,}\@requestBody\(\) productReview: ProductReview,\s{1,} @param\.query\.object\('where', getWhereSchemaFor\(ProductReview\)\) where\?: Where(|,\s+)\)/,
   ];
   patchUpdateAllRegEx.forEach(regex => {

--- a/packages/repository/src/common-types.ts
+++ b/packages/repository/src/common-types.ts
@@ -82,3 +82,20 @@ export type NamedParameters = AnyObject;
  */
 // tslint:disable-next-line:no-any
 export type PositionalParameters = any[];
+
+/**
+ * Count of Model instances that were successful for methods like `updateAll`,
+ * `deleteAll`, etc.
+ */
+export interface Count {
+  count: number;
+}
+
+/**
+ * JSON Schema describing the Count interface. It's the response type for
+ * REST calls to APIs which return Count
+ */
+export const CountSchema = {
+  type: 'object',
+  properties: {count: {type: 'number'}},
+};

--- a/packages/repository/src/connectors/crud.connector.ts
+++ b/packages/repository/src/connectors/crud.connector.ts
@@ -6,7 +6,7 @@
 import {Connector} from './connector';
 import {Entity, EntityData} from '../model';
 import {Filter, Where} from '../query';
-import {Class, Options} from '../common-types';
+import {Class, Options, Count} from '../common-types';
 
 /**
  * CRUD operations for connector implementations
@@ -118,7 +118,7 @@ export interface CrudConnector extends Connector {
     data: EntityData,
     where?: Where,
     options?: Options,
-  ): Promise<number>;
+  ): Promise<Count>;
 
   /**
    * Update an entity by id
@@ -163,7 +163,7 @@ export interface CrudConnector extends Connector {
     modelClass: Class<Entity>,
     where?: Where,
     options?: Options,
-  ): Promise<number>;
+  ): Promise<Count>;
 
   /**
    * Delete an entity by id
@@ -190,7 +190,7 @@ export interface CrudConnector extends Connector {
     modelClass: Class<Entity>,
     where?: Where,
     options?: Options,
-  ): Promise<number>;
+  ): Promise<Count>;
 
   /**
    * Check if an entity exists for the id

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -13,6 +13,7 @@ import {
   NamedParameters,
   Options,
   PositionalParameters,
+  Count,
 } from '../common-types';
 import {HasManyDefinition} from '../decorators/relation.decorator';
 import {EntityNotFoundError} from '../errors';
@@ -229,15 +230,16 @@ export class DefaultCrudRepository<T extends Entity, ID>
     return this.deleteById(entity.getId(), options);
   }
 
-  updateAll(
+  async updateAll(
     data: DataObject<T>,
     where?: Where,
     options?: Options,
-  ): Promise<number> {
+  ): Promise<Count> {
     where = where || {};
-    return ensurePromise(this.modelClass.updateAll(where, data, options)).then(
-      result => result.count,
+    const result = await ensurePromise(
+      this.modelClass.updateAll(where, data, options),
     );
+    return {count: result.count};
   }
 
   async updateById(
@@ -248,8 +250,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
     const idProp = this.modelClass.definition.idName();
     const where = {} as Where;
     where[idProp] = id;
-    const count = await this.updateAll(data, where, options);
-    if (count === 0) {
+    const result = await this.updateAll(data, where, options);
+    if (result.count === 0) {
       throw new EntityNotFoundError(this.entityClass, id);
     }
   }
@@ -269,10 +271,11 @@ export class DefaultCrudRepository<T extends Entity, ID>
     }
   }
 
-  deleteAll(where?: Where, options?: Options): Promise<number> {
-    return ensurePromise(this.modelClass.deleteAll(where, options)).then(
-      result => result.count,
+  async deleteAll(where?: Where, options?: Options): Promise<Count> {
+    const result = await ensurePromise(
+      this.modelClass.deleteAll(where, options),
     );
+    return {count: result.count};
   }
 
   async deleteById(id: ID, options?: Options): Promise<void> {
@@ -282,8 +285,9 @@ export class DefaultCrudRepository<T extends Entity, ID>
     }
   }
 
-  count(where?: Where, options?: Options): Promise<number> {
-    return ensurePromise(this.modelClass.count(where, options));
+  async count(where?: Where, options?: Options): Promise<Count> {
+    const result = await ensurePromise(this.modelClass.count(where, options));
+    return {count: result};
   }
 
   exists(id: ID, options?: Options): Promise<boolean> {

--- a/packages/repository/src/repositories/relation.repository.ts
+++ b/packages/repository/src/repositories/relation.repository.ts
@@ -9,7 +9,7 @@ import {
   constrainFilter,
   constrainWhere,
 } from './constraint-utils';
-import {DataObject, Options} from '../common-types';
+import {DataObject, Options, Count} from '../common-types';
 import {Entity} from '../model';
 import {Filter, Where} from '../query';
 
@@ -40,7 +40,7 @@ export interface HasManyRepository<Target extends Entity> {
    * @param options
    * @returns A promise which resolves the deleted target model instances
    */
-  delete(where?: Where, options?: Options): Promise<number>;
+  delete(where?: Where, options?: Options): Promise<Count>;
   /**
    * Patch multiple target model instances
    * @param dataObject The fields and their new values to patch
@@ -52,7 +52,7 @@ export interface HasManyRepository<Target extends Entity> {
     dataObject: DataObject<Target>,
     where?: Where,
     options?: Options,
-  ): Promise<number>;
+  ): Promise<Count>;
 }
 
 export class DefaultHasManyEntityCrudRepository<
@@ -88,7 +88,7 @@ export class DefaultHasManyEntityCrudRepository<
     );
   }
 
-  async delete(where?: Where, options?: Options): Promise<number> {
+  async delete(where?: Where, options?: Options): Promise<Count> {
     return await this.targetRepository.deleteAll(
       constrainWhere(where, this.constraint),
       options,
@@ -99,8 +99,8 @@ export class DefaultHasManyEntityCrudRepository<
     dataObject: DataObject<TargetEntity>,
     where?: Where,
     options?: Options,
-  ): Promise<number> {
-    return await this.targetRepository.updateAll(
+  ): Promise<Count> {
+    return this.targetRepository.updateAll(
       constrainDataObject(dataObject, this.constraint),
       constrainWhere(where, this.constraint),
       options,

--- a/packages/repository/test/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many.relation.acceptance.ts
@@ -87,7 +87,7 @@ describe('HasMany relation', () => {
       existingCustomerId,
       patchObject,
     );
-    expect(arePatched).to.equal(2);
+    expect(arePatched.count).to.equal(2);
     const patchedData = _.map(
       await controller.findCustomerOrders(existingCustomerId),
       d => _.pick(d, ['customerId', 'description', 'isDelivered']),
@@ -124,7 +124,7 @@ describe('HasMany relation', () => {
     const deletedOrders = await controller.deleteCustomerOrders(
       existingCustomerId,
     );
-    expect(deletedOrders).to.equal(2);
+    expect(deletedOrders.count).to.equal(2);
     const relatedOrders = await controller.findCustomerOrders(
       existingCustomerId,
     );

--- a/packages/repository/test/acceptance/repository.acceptance.ts
+++ b/packages/repository/test/acceptance/repository.acceptance.ts
@@ -22,7 +22,7 @@ describe('Repository in Thinking in LoopBack', () => {
   beforeEach(givenProductRepository);
 
   it('counts models in empty database', async () => {
-    expect(await repo.count()).to.equal(0);
+    expect(await repo.count()).to.deepEqual({count: 0});
   });
 
   it('creates a new model', async () => {

--- a/packages/repository/test/unit/repositories/crud.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/crud.repository.unit.ts
@@ -17,6 +17,7 @@ import {
   Options,
   CrudConnector,
   AnyObject,
+  Count,
 } from '../../..';
 
 /**
@@ -60,30 +61,30 @@ class CrudConnectorStub implements CrudConnector {
     data: EntityData,
     where?: Where,
     options?: Options,
-  ): Promise<number> {
+  ): Promise<Count> {
     for (const p in data) {
       for (const e of this.entities) {
         (e as AnyObject)[p] = (data as AnyObject)[p];
       }
     }
-    return Promise.resolve(this.entities.length);
+    return Promise.resolve({count: this.entities.length});
   }
 
   deleteAll(
     modelClass: Class<Entity>,
     where?: Where,
     options?: Options,
-  ): Promise<number> {
+  ): Promise<Count> {
     const items = this.entities.splice(0, this.entities.length);
-    return Promise.resolve(items.length);
+    return Promise.resolve({count: items.length});
   }
 
   count(
     modelClass: Class<Entity>,
     where?: Where,
     options?: Options,
-  ): Promise<number> {
-    return Promise.resolve(this.entities.length);
+  ): Promise<Count> {
+    return Promise.resolve({count: this.entities.length});
   }
 }
 
@@ -131,8 +132,8 @@ describe('CrudRepositoryImpl', () => {
   it('updates all entities', async () => {
     await repo.create({id: 1, email: 'john@example.com'});
     await repo.create({id: 2, email: 'mary@example.com'});
-    const count = await repo.updateAll({email: 'xyz@example.com'});
-    expect(count).to.be.eql(2);
+    const result = await repo.updateAll({email: 'xyz@example.com'});
+    expect(result.count).to.be.eql(2);
   });
 
   it('find all entities', async () => {
@@ -145,13 +146,13 @@ describe('CrudRepositoryImpl', () => {
   it('delete all entities', async () => {
     await repo.create({id: 1, email: 'john@example.com'});
     await repo.create({id: 2, email: 'mary@example.com'});
-    const count = await repo.deleteAll();
-    expect(count).to.be.eql(2);
+    const result = await repo.deleteAll();
+    expect(result.count).to.be.eql(2);
   });
 
   it('count all entities', async () => {
     await repo.create({id: 1, email: 'john@example.com'});
-    const count = await repo.count();
-    expect(count).to.be.eql(1);
+    const result = await repo.count();
+    expect(result.count).to.be.eql(1);
   });
 });

--- a/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -228,7 +228,7 @@ describe('DefaultCrudRepository', () => {
     await repo.create({title: 't3', content: 'c3'});
     await repo.create({title: 't4', content: 'c4'});
     const result = await repo.deleteAll({title: 't3'});
-    expect(result).to.eql(1);
+    expect(result.count).to.eql(1);
   });
 
   it('implements Repository.updateById()', async () => {
@@ -255,7 +255,7 @@ describe('DefaultCrudRepository', () => {
     await repo.create({title: 't3', content: 'c3'});
     await repo.create({title: 't4', content: 'c4'});
     const result = await repo.updateAll({content: 'c5'}, {});
-    expect(result).to.eql(2);
+    expect(result.count).to.eql(2);
     const notes = await repo.find({where: {title: 't3'}});
     expect(notes[0].content).to.eql('c5');
   });
@@ -265,7 +265,7 @@ describe('DefaultCrudRepository', () => {
     await repo.create({title: 't3', content: 'c3'});
     await repo.create({title: 't4', content: 'c4'});
     const result = await repo.updateAll({content: 'c5'});
-    expect(result).to.eql(2);
+    expect(result.count).to.eql(2);
     const notes = await repo.find();
     const titles = notes.map(n => `${n.title}:${n.content}`);
     expect(titles).to.deepEqual(['t3:c5', 't4:c5']);
@@ -276,7 +276,7 @@ describe('DefaultCrudRepository', () => {
     await repo.create({title: 't3', content: 'c3'});
     await repo.create({title: 't4', content: 'c4'});
     const result = await repo.count();
-    expect(result).to.eql(2);
+    expect(result.count).to.eql(2);
   });
 
   it('implements Repository.save() without id', async () => {

--- a/packages/repository/test/unit/repositories/relation.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/relation.repository.unit.ts
@@ -16,6 +16,7 @@ import {
   Options,
   DataObject,
   Where,
+  Count,
 } from '../../..';
 
 describe('relation repository', () => {
@@ -45,7 +46,7 @@ describe('relation repository', () => {
         /* istanbul ignore next */
         throw new Error('Method not implemented.');
       }
-      async delete(where?: Where, options?: Options): Promise<number> {
+      async delete(where?: Where, options?: Options): Promise<Count> {
         /* istanbul ignore next */
         throw new Error('Method not implemented.');
       }
@@ -53,7 +54,7 @@ describe('relation repository', () => {
         dataObject: DataObject<T>,
         where?: Where,
         options?: Options,
-      ): Promise<number> {
+      ): Promise<Count> {
         /* istanbul ignore next */
         throw new Error('Method not implemented.');
       }


### PR DESCRIPTION
fixes https://github.com/strongloop/loopback-next/issues/1471

- update repository to return a {count: number} instead of just a `number`
- update `@responses`, examples, cli, docs.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
