### PR TITLE
fix(cli): fixes final datasource class name on repository and service

### DIFF
--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -86,7 +86,7 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
     );
 
     this.artifactInfo.dataSourceClassName =
-      this.artifactInfo.dataSourceName + 'DataSource';
+      utils.toClassName(this.artifactInfo.dataSourceName) + 'DataSource';
   }
 
   /**

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -205,7 +205,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     );
 
     this.artifactInfo.dataSourceClassName =
-      this.artifactInfo.dataSourceName + 'DataSource';
+      utils.toClassName(this.artifactInfo.dataSourceName) + 'DataSource';
 
     // Setting up data for templates
     this.artifactInfo.className = utils.toClassName(this.artifactInfo.name);

--- a/packages/cli/test/integration/generators/service.integration.js
+++ b/packages/cli/test/integration/generators/service.integration.js
@@ -86,7 +86,7 @@ describe('lb4 service', () => {
       );
       assert.fileContent(
         expectedFile,
-        /protected datasource: mydsDataSource = new mydsDataSource\(\),/,
+        /protected datasource: mydsDataSource = new MydsDataSource\(\),/,
       );
       assert.fileContent(
         expectedFile,


### PR DESCRIPTION
It now runs utils.toClassName on datasource name to pass over the template generators correctly.  That function only converts the initial character of artifact name to uppercase.

closes #1771
 
## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
