### PR TITLE
chore(cli): upgrade tsquery that supports typescript 3.x

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@loopback/dist-util": "^0.3.7",
-    "@phenomnomnominal/tsquery": "^2.0.1",
+    "@phenomnomnominal/tsquery": "^2.1.1",
     "camelcase-keys": "^4.2.0",
     "chalk": "^2.3.2",
     "change-case": "^3.0.2",


### PR DESCRIPTION
This completes the excellent @virkt25  PR on @phenomnomnominal/tsquery , which was upgraded to tsquery@2.1.1 to include typescript 3.x as a peerDependency. Now it shouldn't display the npm warning about typescript 2.x

close #1769

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
