### PR TITLE
refactor(cli): update the response OAS for ping controller

### DIFF
--- a/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
+++ b/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
@@ -16,10 +16,10 @@ const PING_RESPONSE: ResponseObject = {
           url: {type: 'string'},
           headers: {
             type: 'object',
-            patternProperties: {
-              '^.*$': {type: 'string'},
+            properties: {
+              'Content-Type': {type: 'string'},
             },
-            additionalProperties: false,
+            additionalProperties: true,
           },
         },
       },


### PR DESCRIPTION
This PR removes the invalid headers sent from ping controller related to OAS Graph.

@raymondfeng ,  I am not sure why we had to place headers in the response object the first time. I think they are needed for custom headers only.  we placed a basic header for content-type and additionalProperties set to true.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
