### PR TITLE
feat(cli): check project deps against cli template

### DIFF
--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -54,10 +54,12 @@ module.exports = class AppGenerator extends ProjectGenerator {
   }
 
   promptProjectName() {
+    if (this.shouldExit()) return;
     return super.promptProjectName();
   }
 
   promptProjectDir() {
+    if (this.shouldExit()) return;
     return super.promptProjectDir();
   }
 
@@ -83,6 +85,7 @@ module.exports = class AppGenerator extends ProjectGenerator {
   }
 
   promptOptions() {
+    if (this.shouldExit()) return;
     return super.promptOptions();
   }
 

--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -66,11 +66,13 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
   }
 
   promptArtifactName() {
+    if (this.shouldExit()) return;
     return super.promptArtifactName();
   }
 
   promptArtifactType() {
     debug('Prompting for controller type');
+    if (this.shouldExit()) return;
     return this.prompt([
       {
         type: 'list',
@@ -92,6 +94,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
   }
 
   async promptArtifactCrudVars() {
+    if (this.shouldExit()) return;
     if (
       !this.artifactInfo.controllerType ||
       this.artifactInfo.controllerType === ControllerGenerator.BASIC

--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -99,6 +99,7 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
    */
   promptConnector() {
     debug('prompting for datasource connector');
+    if (this.shouldExit()) return;
     const prompts = [
       {
         name: 'connector',
@@ -123,6 +124,7 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
    * `npm` module name for the connector.
    */
   promptCustomConnectorInfo() {
+    if (this.shouldExit()) return;
     if (this.artifactInfo.connector !== 'other') {
       debug('custom connector option was not selected');
       return;
@@ -149,6 +151,7 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
    */
   promptConnectorConfig() {
     debug('prompting for connector config');
+    if (this.shouldExit()) return;
     // Check to make sure connector is from connectors list (not custom)
     const settings =
       (connectors[this.artifactInfo.connector] &&

--- a/packages/cli/generators/example/index.js
+++ b/packages/cli/generators/example/index.js
@@ -54,6 +54,7 @@ module.exports = class extends BaseGenerator {
   _describeExamples() {}
 
   promptExampleName() {
+    if (this.shouldExit()) return;
     if (this.options['example-name']) {
       this.exampleName = this.options['example-name'];
       return;
@@ -80,6 +81,7 @@ module.exports = class extends BaseGenerator {
   }
 
   validateExampleName() {
+    if (this.shouldExit()) return;
     if (this.exampleName in EXAMPLES) return;
     this.exit(
       `Invalid example name: ${this.exampleName}\n` +

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -67,6 +67,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
   // Prompt a user for Model Name
   async promptArtifactName() {
+    if (this.shouldExit()) return;
     await super.promptArtifactName();
     this.artifactInfo.className = utils.toClassName(this.artifactInfo.name);
     this.log();
@@ -77,6 +78,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
   // Prompt for a Property Name
   async promptPropertyName() {
+    if (this.shouldExit()) return;
     this.log(`Enter an empty property name when done`);
     this.log();
 

--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -46,6 +46,7 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
   }
 
   async askForSpecUrlOrPath() {
+    if (this.shouldExit()) return;
     const prompts = [
       {
         name: 'url',
@@ -64,6 +65,7 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
   }
 
   async loadAndBuildApiSpec() {
+    if (this.shouldExit()) return;
     try {
       const result = await loadAndBuildSpec(this.url, {
         log: this.log,

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -177,7 +177,12 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
     return super.setOptions();
   }
 
+  checkLoopBackProject() {
+    return super.checkLoopBackProject();
+  }
+
   async checkPaths() {
+    if (this.shouldExit()) return;
     // check for datasources
     if (!fs.existsSync(this.artifactInfo.datasourcesDir)) {
       return this.exit(

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -58,7 +58,12 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     return super.setOptions();
   }
 
+  checkLoopBackProject() {
+    return super.checkLoopBackProject();
+  }
+
   async checkPaths() {
+    if (this.shouldExit()) return;
     // check for datasources
     if (!fs.existsSync(this.artifactInfo.datasourcesDir)) {
       new Error(
@@ -76,6 +81,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
    */
   async promptArtifactName() {
     debug('Prompting for service name');
+    if (this.shouldExit()) return;
 
     if (this.options.name) {
       Object.assign(this.artifactInfo, {name: this.options.name});
@@ -99,6 +105,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
 
   async promptDataSourceName() {
     debug('Prompting for a datasource ');
+    if (this.shouldExit()) return;
     let cmdDatasourceName;
     let datasourcesList;
 
@@ -186,6 +193,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
    * strongly-typed service proxies and corresponding model definitions.
    */
   async inferInterfaces() {
+    if (this.shouldExit()) return;
     let connectorType = utils.getDataSourceConnectorName(
       this.artifactInfo.datasourcesDir,
       this.artifactInfo.dataSourceClass,


### PR DESCRIPTION
Sometimes a user try to run newer version of `lb4` against existing
applications. This feature will prompt users to confirm if some of
the project deps do not satisify the cli template.

It also checks exit status to avoid unnessary prompts.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
