### PR TITLE
feat(repository): type-safe queries

### DIFF
--- a/packages/repository/src/repositories/constraint-utils.ts
+++ b/packages/repository/src/repositories/constraint-utils.ts
@@ -16,12 +16,12 @@ import {Entity} from '../model';
  * @returns Filter the modified filter with the constraint, otherwise
  * the original filter
  */
-export function constrainFilter(
-  originalFilter: Filter | undefined,
+export function constrainFilter<T>(
+  originalFilter: Filter<T> | undefined,
   constraint: AnyObject,
-): Filter {
+): Filter<T> {
   const filter = cloneDeep(originalFilter);
-  const builder = new FilterBuilder(filter);
+  const builder = new FilterBuilder<T>(filter);
   return builder.impose(constraint).build();
 }
 
@@ -33,12 +33,12 @@ export function constrainFilter(
  * @returns Filter the modified filter with the constraint, otherwise
  * the original filter
  */
-export function constrainWhere(
-  originalWhere: Where | undefined,
+export function constrainWhere<T>(
+  originalWhere: Where<T> | undefined,
   constraint: AnyObject,
-): Where {
+): Where<T> {
   const where = cloneDeep(originalWhere);
-  const builder = new WhereBuilder(where);
+  const builder = new WhereBuilder<T>(where);
   return builder.impose(constraint).build();
 }
 /**

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -201,20 +201,24 @@ export class DefaultCrudRepository<T extends Entity, ID>
     }
   }
 
-  async find(filter?: Filter, options?: Options): Promise<T[]> {
-    const models = await ensurePromise(this.modelClass.find(filter, options));
+  async find(filter?: Filter<T>, options?: Options): Promise<T[]> {
+    const models = await ensurePromise(
+      this.modelClass.find(filter as legacy.Filter, options),
+    );
     return this.toEntities(models);
   }
 
-  async findOne(filter?: Filter, options?: Options): Promise<T | null> {
-    const model = await ensurePromise(this.modelClass.findOne(filter, options));
+  async findOne(filter?: Filter<T>, options?: Options): Promise<T | null> {
+    const model = await ensurePromise(
+      this.modelClass.findOne(filter as legacy.Filter, options),
+    );
     if (!model) return null;
     return this.toEntity(model);
   }
 
-  async findById(id: ID, filter?: Filter, options?: Options): Promise<T> {
+  async findById(id: ID, filter?: Filter<T>, options?: Options): Promise<T> {
     const model = await ensurePromise(
-      this.modelClass.findById(id, filter, options),
+      this.modelClass.findById(id, filter as legacy.Filter, options),
     );
     if (!model) {
       throw new EntityNotFoundError(this.entityClass, id);
@@ -232,7 +236,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
 
   async updateAll(
     data: DataObject<T>,
-    where?: Where,
+    where?: Where<T>,
     options?: Options,
   ): Promise<Count> {
     where = where || {};
@@ -248,8 +252,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
     options?: Options,
   ): Promise<void> {
     const idProp = this.modelClass.definition.idName();
-    const where = {} as Where;
-    where[idProp] = id;
+    const where = {} as Where<T>;
+    (where as AnyObject)[idProp] = id;
     const result = await this.updateAll(data, where, options);
     if (result.count === 0) {
       throw new EntityNotFoundError(this.entityClass, id);
@@ -271,7 +275,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
     }
   }
 
-  async deleteAll(where?: Where, options?: Options): Promise<Count> {
+  async deleteAll(where?: Where<T>, options?: Options): Promise<Count> {
     const result = await ensurePromise(
       this.modelClass.deleteAll(where, options),
     );
@@ -285,7 +289,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
     }
   }
 
-  async count(where?: Where, options?: Options): Promise<Count> {
+  async count(where?: Where<T>, options?: Options): Promise<Count> {
     const result = await ensurePromise(this.modelClass.count(where, options));
     return {count: result};
   }

--- a/packages/repository/src/repositories/relation.repository.ts
+++ b/packages/repository/src/repositories/relation.repository.ts
@@ -33,14 +33,14 @@ export interface HasManyRepository<Target extends Entity> {
    * @param options Options for the operation
    * @returns A promise which resolves with the found target instance(s)
    */
-  find(filter?: Filter, options?: Options): Promise<Target[]>;
+  find(filter?: Filter<Target>, options?: Options): Promise<Target[]>;
   /**
    * Delete multiple target model instances
    * @param where Instances within the where scope are deleted
    * @param options
    * @returns A promise which resolves the deleted target model instances
    */
-  delete(where?: Where, options?: Options): Promise<Count>;
+  delete(where?: Where<Target>, options?: Options): Promise<Count>;
   /**
    * Patch multiple target model instances
    * @param dataObject The fields and their new values to patch
@@ -50,7 +50,7 @@ export interface HasManyRepository<Target extends Entity> {
    */
   patch(
     dataObject: DataObject<Target>,
-    where?: Where,
+    where?: Where<Target>,
     options?: Options,
   ): Promise<Count>;
 }
@@ -81,14 +81,17 @@ export class DefaultHasManyEntityCrudRepository<
     );
   }
 
-  async find(filter?: Filter, options?: Options): Promise<TargetEntity[]> {
+  async find(
+    filter?: Filter<TargetEntity>,
+    options?: Options,
+  ): Promise<TargetEntity[]> {
     return await this.targetRepository.find(
       constrainFilter(filter, this.constraint),
       options,
     );
   }
 
-  async delete(where?: Where, options?: Options): Promise<Count> {
+  async delete(where?: Where<TargetEntity>, options?: Options): Promise<Count> {
     return await this.targetRepository.deleteAll(
       constrainWhere(where, this.constraint),
       options,
@@ -97,7 +100,7 @@ export class DefaultHasManyEntityCrudRepository<
 
   async patch(
     dataObject: DataObject<TargetEntity>,
-    where?: Where,
+    where?: Where<TargetEntity>,
     options?: Options,
   ): Promise<Count> {
     return this.targetRepository.updateAll(

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -64,7 +64,7 @@ export interface CrudRepository<T extends ValueObject | Entity>
    * @param options Options for the operations
    * @returns A promise of an array of records found
    */
-  find(filter?: Filter, options?: Options): Promise<T[]>;
+  find(filter?: Filter<T>, options?: Options): Promise<T[]>;
 
   /**
    * Updating matching records with attributes from the data object
@@ -143,7 +143,7 @@ export interface EntityCrudRepository<T extends Entity, ID>
    * @param options Options for the operations
    * @returns A promise of an entity found for the id
    */
-  findById(id: ID, filter?: Filter, options?: Options): Promise<T>;
+  findById(id: ID, filter?: Filter<T>, options?: Options): Promise<T>;
 
   /**
    * Update an entity by id with property/value pairs in the data object
@@ -250,11 +250,11 @@ export class CrudRepositoryImpl<T extends Entity, ID>
     }
   }
 
-  find(filter?: Filter, options?: Options): Promise<T[]> {
+  find(filter?: Filter<T>, options?: Options): Promise<T[]> {
     return this.toModels(this.connector.find(this.model, filter, options));
   }
 
-  async findById(id: ID, filter?: Filter, options?: Options): Promise<T> {
+  async findById(id: ID, filter?: Filter<T>, options?: Options): Promise<T> {
     if (typeof this.connector.findById === 'function') {
       return this.toModel(this.connector.findById(this.model, id, options));
     }
@@ -278,7 +278,7 @@ export class CrudRepositoryImpl<T extends Entity, ID>
 
   updateAll(
     data: DataObject<T>,
-    where?: Where,
+    where?: Where<T>,
     options?: Options,
   ): Promise<Count> {
     return this.connector.updateAll(this.model, data, where, options);
@@ -323,7 +323,7 @@ export class CrudRepositoryImpl<T extends Entity, ID>
     }
   }
 
-  deleteAll(where?: Where, options?: Options): Promise<Count> {
+  deleteAll(where?: Where<T>, options?: Options): Promise<Count> {
     return this.connector.deleteAll(this.model, where, options);
   }
 
@@ -342,7 +342,7 @@ export class CrudRepositoryImpl<T extends Entity, ID>
     }
   }
 
-  count(where?: Where, options?: Options): Promise<Count> {
+  count(where?: Where<T>, options?: Options): Promise<Count> {
     return this.connector.count(this.model, where, options);
   }
 

--- a/packages/repository/test/unit/query/query-builder.unit.ts
+++ b/packages/repository/test/unit/query/query-builder.unit.ts
@@ -4,7 +4,13 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {FilterBuilder, WhereBuilder, filterTemplate, isFilter} from '../../../';
+import {
+  FilterBuilder,
+  WhereBuilder,
+  filterTemplate,
+  isFilter,
+  AnyObject,
+} from '../../../';
 
 describe('WhereBuilder', () => {
   it('builds where object', () => {
@@ -84,10 +90,14 @@ describe('WhereBuilder', () => {
       .or({x: 'x'}, {y: {gt: 1}}, [{a: 1}, {b: 2}])
       .build();
     expect(where).to.eql({
-      a: 1,
-      b: {gt: 2},
-      c: {lt: 2},
-      or: [{x: 'x'}, {y: {gt: 1}}, {a: 1}, {b: 2}],
+      and: [
+        {
+          a: 1,
+          b: {gt: 2},
+          c: {lt: 2},
+        },
+        {or: [{x: 'x'}, {y: {gt: 1}}, {a: 1}, {b: 2}]},
+      ],
     });
   });
 
@@ -100,10 +110,13 @@ describe('WhereBuilder', () => {
       .and({x: 'x'}, {y: {gt: 1}}, [{a: 1}, {b: 2}])
       .build();
     expect(where).to.eql({
-      a: 1,
-      b: {gt: 2},
-      c: {lt: 2},
-      and: [{x: 'x'}, {y: {gt: 1}}, {a: 1}, {b: 2}],
+      and: [
+        {a: 1, b: {gt: 2}, c: {lt: 2}},
+        {x: 'x'},
+        {y: {gt: 1}},
+        {a: 1},
+        {b: 2},
+      ],
     });
   });
 
@@ -115,20 +128,12 @@ describe('WhereBuilder', () => {
       .and({b: 'b'}, {c: {lt: 1}})
       .build();
     expect(where).to.eql({
-      and: [
-        {
-          a: 1,
-          and: [{x: 'x'}, {y: {gt: 1}}],
-        },
-        {
-          and: [{b: 'b'}, {c: {lt: 1}}],
-        },
-      ],
+      and: [{a: 1}, {x: 'x'}, {y: {gt: 1}}, {b: 'b'}, {c: {lt: 1}}],
     });
   });
 
   it('builds where object from an existing one', () => {
-    const whereBuilder = new WhereBuilder({y: 'y'});
+    const whereBuilder = new WhereBuilder<AnyObject>({y: 'y'});
     const where = whereBuilder
       .eq('a', 1)
       .gt('b', 2)
@@ -139,7 +144,7 @@ describe('WhereBuilder', () => {
   });
 
   it('constrains an existing where object with another where filter', () => {
-    const builder = new WhereBuilder({x: 'x'});
+    const builder = new WhereBuilder<AnyObject>({x: 'x'});
     const where = builder.impose({x: 'y', z: 'z'}).build();
     expect(where).to.be.deepEqual({and: [{x: 'x'}, {x: 'y', z: 'z'}]});
   });

--- a/packages/repository/test/unit/repositories/constraint-utils.unit.ts
+++ b/packages/repository/test/unit/repositories/constraint-utils.unit.ts
@@ -14,6 +14,7 @@ import {
   constrainDataObject,
   constrainDataObjects,
   Entity,
+  AnyObject,
 } from '../../..';
 
 describe('constraint utility functions', () => {
@@ -130,7 +131,7 @@ describe('constraint utility functions', () => {
   function whereBuilderHelper(where: Where) {
     const builder = new WhereBuilder();
     for (const key in where) {
-      builder.eq(key, where[key]);
+      builder.eq(key, (where as AnyObject)[key]);
     }
     return builder.build();
   }


### PR DESCRIPTION
add type-safety to the query definition to have
full IntelliSense and refactoring support

BREAKING CHANGE: logical and comparison conditions must be separated into different objects

fixes  #1777

### about the breaking change, or is it a fix?

To make the compiler happy I had to separate the conditions defined on
properties (see 'PredicateCondition<MT>') from the logical conditions (see first
part of the union type 'Condition<MT>')

currently, neither juggler nor lb4 has stopped us from doing wrong things like:

```TypeScript
{title: 't1', or: [{content: 'Note 2'}, {content: 'Note 3'}]}
```

which results to:

```sql
WHERE title=:1 AND (content=:2) OR (content=:3)
```

while indentional we wanted to do this:

```TypeScript
{and: [{title: 't1'}, {or: [{content: 'Note 2'}, {content: 'Note 3'}]}]}
```

which results to:

```sql
WHERE (title=:1) AND ((content=:2) OR (content=:3))
```

please see how the logical operators are supposed to be used:
https://loopback.io/doc/en/lb3/Where-filter.html#and--or

### WhereBuilder

The WhereBuilder has been changed accordingly, please see the effects in
'query-builder.unit.ts'

regarding the WhereBuilder additional tests are required!

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
