### PR TITLE
chore(cli): make typescript required dep

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -26,7 +26,7 @@
     "source-map-support": "^0.5.5",
     "strong-docs": "^4.0.0",
     "tslint": "^5.9.1",
-    "typescript": "^3.0.1"
+    "typescript": "^3.1.1"
   },
   "bin": {
     "lb-tsc": "./bin/compile-package.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,6 @@
     "request-promise-native": "^1.0.5",
     "rimraf": "^2.6.2",
     "sinon": "^6.3.4",
-    "typescript": "^3.1.1",
     "yeoman-assert": "^3.1.1",
     "yeoman-environment": "^2.0.6",
     "yeoman-test": "^1.7.0"
@@ -57,6 +56,7 @@
     "semver": "^5.5.0",
     "swagger-parser": "^5.0.0",
     "swagger2openapi": "^3.2.10",
+    "typescript": "^3.1.1",
     "unicode-10.0.0": "^0.7.4",
     "update-notifier": "^2.5.0",
     "url-slug": "^2.0.0",


### PR DESCRIPTION
I ran into an issue where I didn't have `typescript` installed and ran `lb4 repository`. 
```
___________________    | ~/todo-list @ biniams-mbp (badmike)
| => npm un -g typescript
removed 1 package in 0.111s
___________________    | ~/todo-list @ biniams-mbp (badmike)
| => lb4 repository
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module 'typescript'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/badmike/n/lib/node_modules/@loopback/cli/node_modules/@phenomnomnominal/tsquery/dist/src/ast.js:4:20)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
___________________    | ~/todo-list @ biniams-mbp (badmike)
| => lb4 modl
^C
___________________    | ~/todo-list @ biniams-mbp (badmike)
| => lb4 model
? Model class name:
___________________    | ~/todo-list @ biniams-mbp (badmike)
| => lb4 datasource
? Datasource name:
___________________    | ~/todo-list @ biniams-mbp (badmike)
| => lb4 app
? Project name: (todo list)
```

From @bajtos:
```
We need TypeScript to parse TS files to infer id property type. IMO TypeScript should come as a dependency of our CLI package to avoid the problem you described.
```
I am not aware of any side effects this change can bring. I think @raymondfeng agrees.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
