### PR TITLE
fix(cli): fixed ds names that were hyphened, uses utils functions

### DIFF
--- a/packages/cli/test/fixtures/repository/index.js
+++ b/packages/cli/test/fixtures/repository/index.js
@@ -36,6 +36,14 @@ exports.SANDBOX_FILES = [
   },
   {
     path: DATASOURCE_APP_PATH,
+    file: 'my-ds.datasource.json',
+    content: JSON.stringify({
+      name: 'MyDS',
+      connector: 'memory',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
     file: 'dbmem.datasource.ts',
     content: DUMMY_CONTENT,
   },

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -289,6 +289,45 @@ describe('lb4 repository', function() {
       );
     });
 
+    it('generates a crud repository from hyphened model file name', async () => {
+      const basicPrompt = {
+        dataSourceClass: 'MyDsDatasource',
+      };
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(basicPrompt)
+        .withArguments(' --model Defaultmodel');
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        REPOSITORY_APP_PATH,
+        'defaultmodel.repository.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /import {MyDSDataSource} from '..\/datasources';/,
+      );
+      assert.fileContent(
+        expectedFile,
+        /\@inject\('datasources.MyDS'\) protected datasource: MyDSDataSource,/,
+      );
+      assert.fileContent(
+        expectedFile,
+        /export class DefaultmodelRepository extends DefaultCrudRepository\</,
+      );
+      assert.fileContent(expectedFile, /typeof Defaultmodel.prototype.id/);
+      assert.file(INDEX_FILE);
+      assert.fileContent(
+        INDEX_FILE,
+        /export \* from '.\/defaultmodel.repository';/,
+      );
+    });
+
     it('generates a crud repository from decorator defined model', async () => {
       await testUtils
         .executeGenerator(generator)


### PR DESCRIPTION
Now uses the functions created at utils to refer properly to the src/datasources file name. We fixed `lb4 services` but forgot about `lb4 repository` on this issue. Now I removed the function that was being duplicated in `lb4 repository` and use the one in utils which contains a fix for this problem.

close #1791 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
