### PR TITLE
refactor: simplify and organize imports

### DIFF
--- a/packages/boot/test/fixtures/application.ts
+++ b/packages/boot/test/fixtures/application.ts
@@ -7,7 +7,7 @@ import {ApplicationConfig} from '@loopback/core';
 import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
 import {ServiceMixin} from '@loopback/service-proxy';
-import {BootMixin} from '../../index';
+import {BootMixin} from '../..';
 
 export class BooterApp extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),

--- a/packages/boot/test/unit/booters/base-artifact.booter.unit.ts
+++ b/packages/boot/test/unit/booters/base-artifact.booter.unit.ts
@@ -3,10 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BaseArtifactBooter} from '../../../index';
 import {expect} from '@loopback/testlab';
 import {resolve} from 'path';
-import {ArtifactOptions} from '../../../src';
+import {ArtifactOptions, BaseArtifactBooter} from '../../..';
 
 describe('base-artifact booter unit tests', () => {
   const TEST_OPTIONS = {

--- a/packages/boot/test/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/test/unit/booters/booter-utils.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {discoverFiles, isClass, loadClassesFromFiles} from '../../../index';
+import {expect, TestSandbox} from '@loopback/testlab';
 import {resolve} from 'path';
-import {TestSandbox, expect} from '@loopback/testlab';
+import {discoverFiles, isClass, loadClassesFromFiles} from '../../..';
 
 describe('booter-utils unit tests', () => {
   const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');

--- a/packages/boot/test/unit/booters/controller.booter.unit.ts
+++ b/packages/boot/test/unit/booters/controller.booter.unit.ts
@@ -3,10 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect, TestSandbox} from '@loopback/testlab';
 import {Application} from '@loopback/core';
-import {ControllerBooter, ControllerDefaults} from '../../../index';
+import {expect, TestSandbox} from '@loopback/testlab';
 import {resolve} from 'path';
+import {ControllerBooter, ControllerDefaults} from '../../..';
 
 describe('controller booter unit tests', () => {
   const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');

--- a/packages/boot/test/unit/booters/datasource.booter.unit.ts
+++ b/packages/boot/test/unit/booters/datasource.booter.unit.ts
@@ -3,14 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect, TestSandbox, sinon} from '@loopback/testlab';
-import {resolve} from 'path';
+import {Application} from '@loopback/core';
 import {
   ApplicationWithRepositories,
   RepositoryMixin,
 } from '@loopback/repository';
-import {DataSourceBooter, DataSourceDefaults} from '../../../src';
-import {Application} from '@loopback/core';
+import {expect, sinon, TestSandbox} from '@loopback/testlab';
+import {resolve} from 'path';
+import {DataSourceBooter, DataSourceDefaults} from '../../..';
 
 describe('datasource booter unit tests', () => {
   const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');

--- a/packages/boot/test/unit/booters/repository.booter.unit.ts
+++ b/packages/boot/test/unit/booters/repository.booter.unit.ts
@@ -3,14 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect, TestSandbox, sinon} from '@loopback/testlab';
 import {Application} from '@loopback/core';
 import {
-  RepositoryMixin,
   ApplicationWithRepositories,
+  RepositoryMixin,
 } from '@loopback/repository';
-import {RepositoryBooter, RepositoryDefaults} from '../../../index';
+import {expect, sinon, TestSandbox} from '@loopback/testlab';
 import {resolve} from 'path';
+import {RepositoryBooter, RepositoryDefaults} from '../../..';
 
 describe('repository booter unit tests', () => {
   const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');

--- a/packages/boot/test/unit/booters/service.booter.unit.ts
+++ b/packages/boot/test/unit/booters/service.booter.unit.ts
@@ -3,11 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect, TestSandbox, sinon} from '@loopback/testlab';
-import {resolve} from 'path';
-import {ApplicationWithServices, ServiceMixin} from '@loopback/service-proxy';
-import {ServiceBooter, ServiceDefaults} from '../../../src';
 import {Application} from '@loopback/core';
+import {ApplicationWithServices, ServiceMixin} from '@loopback/service-proxy';
+import {expect, sinon, TestSandbox} from '@loopback/testlab';
+import {resolve} from 'path';
+import {ServiceBooter, ServiceDefaults} from '../../..';
 
 describe('service booter unit tests', () => {
   const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');

--- a/packages/boot/test/unit/bootstrapper.unit.ts
+++ b/packages/boot/test/unit/bootstrapper.unit.ts
@@ -3,10 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
 import {Application} from '@loopback/core';
-import {Bootstrapper, Booter, BootBindings, BootMixin} from '../../index';
 import {RepositoryMixin} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import {BootBindings, Booter, BootMixin, Bootstrapper} from '../..';
 
 describe('boot-strapper unit tests', () => {
   // RepositoryMixin is added to avoid warning message printed logged to console

--- a/packages/core/test/unit/application.unit.ts
+++ b/packages/core/test/unit/application.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Constructor, Context} from '@loopback/context';
 import {expect} from '@loopback/testlab';
-import {Application, Server, Component} from '../../index';
-import {Context, Constructor} from '@loopback/context';
+import {Application, Component, Server} from '../..';
 
 describe('Application', () => {
   describe('controller binding', () => {

--- a/packages/openapi-v3-types/test/unit/type-guards.unit.ts
+++ b/packages/openapi-v3-types/test/unit/type-guards.unit.ts
@@ -5,11 +5,11 @@
 
 import {expect} from '@loopback/testlab';
 import {
-  SchemaObject,
+  isReferenceObject,
   isSchemaObject,
   ReferenceObject,
-  isReferenceObject,
-} from '../../src';
+  SchemaObject,
+} from '../..';
 
 describe('type-guards unit tests', () => {
   describe('isSchemaObject()', () => {

--- a/packages/repository-json-schema/test/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/test/unit/filter-json-schema.unit.ts
@@ -6,7 +6,7 @@
 import {Entity, Filter, hasMany, model, property} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
 import * as Ajv from 'ajv';
-import {JsonSchema} from '../../src';
+import {JsonSchema} from '../..';
 import {
   getFilterJsonSchemaFor,
   getWhereJsonSchemaFor,

--- a/packages/repository-json-schema/test/unit/json-schema.unit.ts
+++ b/packages/repository-json-schema/test/unit/json-schema.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {JsonSchema} from '../../src';
+import {JsonSchema} from '../..';
 
 describe('JSON Schema type', () => {
   describe('JsonSchema interface', () => {

--- a/packages/repository/test/acceptance/repository.acceptance.ts
+++ b/packages/repository/test/acceptance/repository.acceptance.ts
@@ -3,17 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {expect} from '@loopback/testlab';
 import {DataSource} from 'loopback-datasource-juggler';
+import {AnyObject, DefaultCrudRepository, Entity, model, property} from '../..';
 import {Product} from '../fixtures/models/product.model';
 import {ProductRepository} from '../fixtures/repositories/product.repository';
-import {expect} from '@loopback/testlab';
-import {
-  Entity,
-  model,
-  DefaultCrudRepository,
-  property,
-  AnyObject,
-} from '../../src';
 
 // This test shows the recommended way how to use @loopback/repository
 // together with existing connectors when building LoopBack applications

--- a/packages/repository/test/unit/decorator/metadata.unit.ts
+++ b/packages/repository/test/unit/decorator/metadata.unit.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ModelMetadataHelper} from '../../../src';
+import {MetadataInspector} from '@loopback/context';
+import {expect} from '@loopback/testlab';
 import {
-  property,
   model,
   ModelDefinition,
+  ModelMetadataHelper,
   MODEL_KEY,
   MODEL_WITH_PROPERTIES_KEY,
+  property,
 } from '../../..';
-import {expect} from '@loopback/testlab';
-import {MetadataInspector} from '@loopback/context';
 
 describe('Repository', () => {
   describe('getAllClassMetadata', () => {

--- a/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -4,15 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-
 import {
-  juggler,
   bindModel,
   DefaultCrudRepository,
   Entity,
+  EntityNotFoundError,
+  juggler,
   ModelDefinition,
-} from '../../../';
-import {EntityNotFoundError} from '../../../src';
+} from '../../..';
 
 describe('legacy loopback-datasource-juggler', () => {
   let ds: juggler.DataSource;

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -17,7 +17,7 @@ import {IncomingMessage, ServerResponse} from 'http';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
 import * as fs from 'fs';
-import {RestServerConfig} from '../../src';
+import {RestServerConfig} from '../..';
 
 describe('RestServer (integration)', () => {
   it('exports url property', async () => {

--- a/packages/rest/test/unit/parser.unit.ts
+++ b/packages/rest/test/unit/parser.unit.ts
@@ -10,18 +10,18 @@ import {
   SchemaObject,
 } from '@loopback/openapi-v3-types';
 import {
-  ShotRequestOptions,
   expect,
+  ShotRequestOptions,
   stubExpressContext,
 } from '@loopback/testlab';
 import {
-  PathParameterValues,
-  Request,
-  Route,
   createResolvedRoute,
   parseOperationArgs,
+  PathParameterValues,
+  Request,
+  RestHttpErrors,
+  Route,
 } from '../..';
-import {RestHttpErrors} from '../../src';
 
 describe('operationArgsParser', () => {
   it('parses path parameters', async () => {


### PR DESCRIPTION
Simplify import paths ending with `../src` or `../index` by leaving out the last part which is not needed.

Run VSCode's "Organize Import" command in the modified files to keep import statements organized in a deterministic way.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated
