### PR TITLE
refactor(repository): rename DefaultHasManyEntityCrudRepository

### DIFF
--- a/examples/todo-list/test/unit/controllers/todo-list-todo.controller.unit.ts
+++ b/examples/todo-list/test/unit/controllers/todo-list-todo.controller.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  DefaultHasManyEntityCrudRepository,
+  DefaultHasManyRepository,
   HasManyRepository,
 } from '@loopback/repository';
 import {
@@ -122,7 +122,7 @@ describe('TodoController', () => {
   function resetRepositories() {
     todoListRepo = createStubInstance(TodoListRepository);
     constrainedTodoRepo = createStubInstance<HasManyRepository<Todo>>(
-      DefaultHasManyEntityCrudRepository,
+      DefaultHasManyRepository,
     );
 
     aTodoListWithId = givenTodoList({

--- a/packages/repository/src/repositories/relation.factory.ts
+++ b/packages/repository/src/repositories/relation.factory.ts
@@ -14,7 +14,7 @@ import {
 import {Entity} from '../model';
 import {
   DefaultBelongsToRepository,
-  DefaultHasManyEntityCrudRepository,
+  DefaultHasManyRepository,
   Getter,
   HasManyRepository,
 } from './relation.repository';
@@ -56,7 +56,7 @@ export function createHasManyRepositoryFactory<
   return function(fkValue: ForeignKeyType) {
     // tslint:disable-next-line:no-any
     const constraint: any = {[meta.keyTo]: fkValue};
-    return new DefaultHasManyEntityCrudRepository<
+    return new DefaultHasManyRepository<
       Target,
       TargetID,
       EntityCrudRepository<Target, TargetID>

--- a/packages/repository/src/repositories/relation.repository.ts
+++ b/packages/repository/src/repositories/relation.repository.ts
@@ -71,7 +71,7 @@ export interface BelongsToRepository<Target extends Entity> {
   get(options?: Options): Promise<Target>;
 }
 
-export class DefaultHasManyEntityCrudRepository<
+export class DefaultHasManyRepository<
   TargetEntity extends Entity,
   TargetID,
   TargetRepository extends EntityCrudRepository<TargetEntity, TargetID>

--- a/packages/repository/test/unit/repositories/relation.repository.unit.ts
+++ b/packages/repository/test/unit/repositories/relation.repository.unit.ts
@@ -15,7 +15,7 @@ import {
   Count,
   DataObject,
   DefaultCrudRepository,
-  DefaultHasManyEntityCrudRepository,
+  DefaultHasManyRepository,
   Entity,
   EntityCrudRepository,
   Filter,
@@ -74,8 +74,8 @@ describe('relation repository', () => {
   context('DefaultHasManyEntityCrudRepository', () => {
     it('can create related model instance', async () => {
       const constraint: Partial<Customer> = {age: 25};
-      const HasManyCrudInstance = givenDefaultHasManyCrudInstance(constraint);
-      await HasManyCrudInstance.create({id: 1, name: 'Joe'});
+      const hasManyCrudInstance = givenDefaultHasManyInstance(constraint);
+      await hasManyCrudInstance.create({id: 1, name: 'Joe'});
       sinon.assert.calledWithMatch(customerRepo.stubs.create, {
         id: 1,
         name: 'Joe',
@@ -85,8 +85,8 @@ describe('relation repository', () => {
 
     it('can find related model instance', async () => {
       const constraint: Partial<Customer> = {name: 'Jane'};
-      const HasManyCrudInstance = givenDefaultHasManyCrudInstance(constraint);
-      await HasManyCrudInstance.find({where: {id: 3}});
+      const hasManyCrudInstance = givenDefaultHasManyInstance(constraint);
+      await hasManyCrudInstance.find({where: {id: 3}});
       sinon.assert.calledWithMatch(customerRepo.stubs.find, {
         where: {id: 3, name: 'Jane'},
       });
@@ -95,8 +95,8 @@ describe('relation repository', () => {
     context('patch', async () => {
       it('can patch related model instance', async () => {
         const constraint: Partial<Customer> = {name: 'Jane'};
-        const HasManyCrudInstance = givenDefaultHasManyCrudInstance(constraint);
-        await HasManyCrudInstance.patch({country: 'US'}, {id: 3});
+        const hasManyCrudInstance = givenDefaultHasManyInstance(constraint);
+        await hasManyCrudInstance.patch({country: 'US'}, {id: 3});
         sinon.assert.calledWith(
           customerRepo.stubs.updateAll,
           {country: 'US', name: 'Jane'},
@@ -106,17 +106,17 @@ describe('relation repository', () => {
 
       it('cannot override the constrain data', async () => {
         const constraint: Partial<Customer> = {name: 'Jane'};
-        const HasManyCrudInstance = givenDefaultHasManyCrudInstance(constraint);
+        const hasManyCrudInstance = givenDefaultHasManyInstance(constraint);
         await expect(
-          HasManyCrudInstance.patch({name: 'Joe'}),
+          hasManyCrudInstance.patch({name: 'Joe'}),
         ).to.be.rejectedWith(/Property "name" cannot be changed!/);
       });
     });
 
     it('can delete related model instance', async () => {
       const constraint: Partial<Customer> = {name: 'Jane'};
-      const HasManyCrudInstance = givenDefaultHasManyCrudInstance(constraint);
-      await HasManyCrudInstance.delete({id: 3});
+      const hasManyCrudInstance = givenDefaultHasManyInstance(constraint);
+      await hasManyCrudInstance.delete({id: 3});
       sinon.assert.calledWith(customerRepo.stubs.deleteAll, {
         id: 3,
         name: 'Jane',
@@ -146,8 +146,8 @@ describe('relation repository', () => {
     customerRepo = createStubInstance(CustomerRepository);
   }
 
-  function givenDefaultHasManyCrudInstance(constraint: DataObject<Customer>) {
-    return new DefaultHasManyEntityCrudRepository<
+  function givenDefaultHasManyInstance(constraint: DataObject<Customer>) {
+    return new DefaultHasManyRepository<
       Customer,
       typeof Customer.prototype.id,
       CustomerRepository


### PR DESCRIPTION
Rename DefaultHasManyEntityCrudRepository to DefaultHasManyRepository.

1. HasMany relation works only with Entities backed by a CRUD
   repository. Since there will be no other forms of the default
   implementation of HasManyRepository, there is no need to explicitly
   state HasMany requirements in the class name.

2. All other HasMany-related classes are already using this shorter
   form, e.g. the interface HasManyRepository.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
