### PR TITLE
fix(cli): remove dist-util from project templates

### DIFF
--- a/packages/cli/generators/app/templates/index.js.ejs
+++ b/packages/cli/generators/app/templates/index.js.ejs
@@ -1,8 +1,4 @@
-<% if (project.loopbackBuild) { -%>
-const application = require('@loopback/dist-util').loadDist(__dirname);
-<% } else { -%>
 const application = require('./dist');
-<% } -%>
 
 module.exports = application;
 

--- a/packages/cli/generators/extension/templates/index.js.ejs
+++ b/packages/cli/generators/extension/templates/index.js.ejs
@@ -1,5 +1,1 @@
-<% if (project.loopbackBuild) { -%>
-module.exports = require('@loopback/dist-util').loadDist(__dirname);
-<% } else { -%>
-  module.exports = require('./dist');
-<% } -%>
+module.exports = require('./dist');

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -73,7 +73,6 @@
     "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",
 <% if (project.projectType === 'application') { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
-    "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>",
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
 <% if (project.repositories) { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
@@ -85,8 +84,7 @@
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>"
 <% } -%>
 <% } else { /* NOT AN APPLICATION */-%>
-    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
-    "@loopback/dist-util": "<%= project.dependencies['@loopback/dist-util'] -%>"
+    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>"
 <% } -%>
   },
   "devDependencies": {


### PR DESCRIPTION
This is a follow-up for https://github.com/strongloop/loopback-next/pull/1803 fixing few places using dist-util that I did not notice.


## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated