### PR TITLE
feat: deprecate dist-util package

### DIFF
--- a/packages/cli/bin/cli-main.js
+++ b/packages/cli/bin/cli-main.js
@@ -6,14 +6,18 @@
 
 'use strict';
 
-const checkNodeVersion = require('@loopback/dist-util').checkNodeVersion;
-
 const pkg = require('../package.json');
-try {
-  const range = pkg.engines.node;
-  checkNodeVersion(range);
-} catch (e) {
-  console.error(e.message);
+const semver = require('semver');
+
+// Make sure node version meets the requirement. This code intentionally only
+// uses ES5 features so that it can be run with lower versions of Node
+// to report the version requirement.
+const nodeVer = process.versions.node;
+const requiredVer = pkg.engines.node;
+const ok = semver.satisfies(nodeVer, requiredVer);
+if (!ok) {
+  const format = 'Node.js %s is not supported. Please use a version %s.';
+  console.error(format, nodeVer, requiredVer);
   process.exit(1);
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,6 @@
     "yeoman-test": "^1.7.0"
   },
   "dependencies": {
-    "@loopback/dist-util": "^0.3.7",
     "@phenomnomnominal/tsquery": "^2.1.1",
     "camelcase-keys": "^4.2.0",
     "chalk": "^2.3.2",

--- a/packages/dist-util/README.md
+++ b/packages/dist-util/README.md
@@ -1,5 +1,20 @@
 # @loopback/dist-util
 
+**This package is no longer actively maintained.**
+
+Please upgrade your project to use a single compilation target, for example by
+changing your `build` script in `package.json` as follows:
+
+```json
+{
+  "scripts": {
+    "build": "lb-tsc es2017 --outDir dist"
+  }
+}
+```
+
+## Overview
+
 Utilities to work with `dist` folders used by different Node.js versions.
 
 | version | directory       |

--- a/sandbox/example/index.js
+++ b/sandbox/example/index.js
@@ -3,5 +3,5 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-const distUtilPkg = require('@loopback/dist-util/package.json');
-console.log('Resolved dependency: %s@%s', distUtilPkg.name, distUtilPkg.version);
+const package = require('./package.json');
+console.log('Welcome to %s@%s', package.name, package.version);


### PR DESCRIPTION
As a follow-up for  #1803 and #1809, this pull request is removing remaining usages of dist-util package and marking the package as deprecated. My intention is to remove dist-util from loopback-next *before* 4.0 GA.

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated