### PR TITLE
chore: add wildcard to ignore dist8 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@ coverage
 .nyc_output
 api-docs
 **/*.tgz
-packages/*/dist
-examples/*/dist
-benchmark/dist
+packages/*/dist*/
+examples/*/dist*/
+benchmark/dist*/
+dist
 **/package
 .sandbox
 packages/cli/generators/datasource/connectors.json


### PR DESCRIPTION
I have noted that under `packages`,  `examples` and `benchmark` , we are still generating a **dist8** directory, that caused my `git status` not to ignore these files. This PR includes a wildcard that makes the warning disappear.  

Please ignore if there is another way to make this warning disappear.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
