### PR TITLE
chore: add home page controller to examples

### DIFF
--- a/examples/soap-calculator/public/index.html
+++ b/examples/soap-calculator/public/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>@loopback/example-soap-calculator</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" type="image/x-icon" href="//v4.loopback.io/favicon.ico">
+
+  <style>
+    h3 {
+      margin-left: 25px;
+      text-align: center;
+    }
+
+    a, a:visited {
+      color: #3f5dff;
+    }
+
+    h3 a {
+      margin-left: 10px;
+    }
+
+    a:hover, a:focus, a:active {
+      color: #001956;
+    }
+
+    .power {
+      position: absolute;
+      bottom: 25px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    .info {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%)
+    }
+
+    .info h1 {
+      text-align: center;
+      margin-bottom: 0px;
+    }
+
+    .info p {
+      text-align: center;
+      margin-bottom: 3em;
+      margin-top: 1em;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="info">
+    <h1>@loopback/example-soap-calculator</h1>
+
+    <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h4>
+    <h3>API Explorer: <a href="/explorer">/explorer</a></h4>
+  </div>
+
+  <footer class="power">
+    <a href="https://v4.loopback.io" target="_blank">
+      <img src="https://loopback.io/images/branding/powered-by-loopback/blue/powered-by-loopback-sm.png" />
+    </a>
+  </footer>
+</body>
+
+</html>
+

--- a/examples/soap-calculator/src/controllers/home-page.controller.ts
+++ b/examples/soap-calculator/src/controllers/home-page.controller.ts
@@ -1,0 +1,31 @@
+import {get} from '@loopback/openapi-v3';
+import * as fs from 'fs';
+import * as path from 'path';
+import {inject} from '@loopback/context';
+import {RestBindings, Response} from '@loopback/rest';
+
+export class HomePageController {
+  private html: string;
+  constructor(@inject(RestBindings.Http.RESPONSE) private response: Response) {
+    this.html = fs.readFileSync(
+      path.join(__dirname, '../../../public/index.html'),
+      'utf-8',
+    );
+  }
+
+  @get('/', {
+    responses: {
+      '200': {
+        description: 'Home Page',
+        content: {'text/html': {schema: {type: 'string'}}},
+      },
+    },
+  })
+  homePage() {
+    this.response
+      .status(200)
+      .contentType('html')
+      .send(this.html);
+    return this.response;
+  }
+}

--- a/examples/soap-calculator/src/index.ts
+++ b/examples/soap-calculator/src/index.ts
@@ -1,6 +1,8 @@
 import {SoapCalculatorApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 
+export {SoapCalculatorApplication};
+
 export async function main(options: ApplicationConfig = {}) {
   const app = new SoapCalculatorApplication(options);
   await app.boot();

--- a/examples/soap-calculator/test/acceptance/home-page.controller.acceptance.ts
+++ b/examples/soap-calculator/test/acceptance/home-page.controller.acceptance.ts
@@ -1,0 +1,31 @@
+import {get} from '@loopback/openapi-v3';
+import * as fs from 'fs';
+import * as path from 'path';
+import {inject} from '@loopback/context';
+import {RestBindings, Response} from '@loopback/rest';
+
+export class HomePageController {
+  private html: string;
+  constructor(@inject(RestBindings.Http.RESPONSE) private response: Response) {
+    this.html = fs.readFileSync(
+      path.join(__dirname, '../../../public/index.html'),
+      'utf-8',
+    );
+  }
+
+  @get('/', {
+    responses: {
+      '200': {
+        description: 'Home Page',
+        content: {'text/html': {schema: {type: 'string'}}},
+      },
+    },
+  })
+  homePage() {
+    this.response
+      .status(200)
+      .contentType('html')
+      .send(this.html);
+    return this.response;
+  }
+}

--- a/examples/soap-calculator/test/acceptance/test-helper.ts
+++ b/examples/soap-calculator/test/acceptance/test-helper.ts
@@ -1,0 +1,24 @@
+import {SoapCalculatorApplication} from '../..';
+import {
+  createRestAppClient,
+  givenHttpServerConfig,
+  Client,
+} from '@loopback/testlab';
+
+export async function setupApplication(): Promise<AppWithClient> {
+  const app = new SoapCalculatorApplication({
+    rest: givenHttpServerConfig(),
+  });
+
+  await app.boot();
+  await app.start();
+
+  const client = createRestAppClient(app);
+
+  return {app, client};
+}
+
+export interface AppWithClient {
+  app: SoapCalculatorApplication;
+  client: Client;
+}

--- a/examples/todo-list/public/index.html
+++ b/examples/todo-list/public/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>myapp</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" type="image/x-icon" href="//v4.loopback.io/favicon.ico">
+
+  <style>
+    h3 {
+      margin-left: 25px;
+      text-align: center;
+    }
+
+    a, a:visited {
+      color: #3f5dff;
+    }
+
+    h3 a {
+      margin-left: 10px;
+    }
+
+    a:hover, a:focus, a:active {
+      color: #001956;
+    }
+
+    .power {
+      position: absolute;
+      bottom: 25px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    .info {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%)
+    }
+
+    .info h1 {
+      text-align: center;
+      margin-bottom: 0px;
+    }
+
+    .info p {
+      text-align: center;
+      margin-bottom: 3em;
+      margin-top: 1em;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="info">
+    <h1>@loopback/example-todo-list</h1>
+
+    <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h4>
+    <h3>API Explorer: <a href="/explorer">/explorer</a></h4>
+  </div>
+
+  <footer class="power">
+    <a href="https://v4.loopback.io" target="_blank">
+      <img src="https://loopback.io/images/branding/powered-by-loopback/blue/powered-by-loopback-sm.png" />
+    </a>
+  </footer>
+</body>
+
+</html>

--- a/examples/todo-list/src/controllers/home-page.controller.ts
+++ b/examples/todo-list/src/controllers/home-page.controller.ts
@@ -1,0 +1,31 @@
+import {get} from '@loopback/openapi-v3';
+import * as fs from 'fs';
+import * as path from 'path';
+import {inject} from '@loopback/context';
+import {RestBindings, Response} from '@loopback/rest';
+
+export class HomePageController {
+  private html: string;
+  constructor(@inject(RestBindings.Http.RESPONSE) private response: Response) {
+    this.html = fs.readFileSync(
+      path.join(__dirname, '../../../public/index.html'),
+      'utf-8',
+    );
+  }
+
+  @get('/', {
+    responses: {
+      '200': {
+        description: 'Home Page',
+        content: {'text/html': {schema: {type: 'string'}}},
+      },
+    },
+  })
+  homePage() {
+    this.response
+      .status(200)
+      .contentType('html')
+      .send(this.html);
+    return this.response;
+  }
+}

--- a/examples/todo-list/src/index.ts
+++ b/examples/todo-list/src/index.ts
@@ -6,6 +6,8 @@
 import {TodoListApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 
+export {TodoListApplication};
+
 export async function main(options: ApplicationConfig = {}) {
   const app = new TodoListApplication(options);
   await app.boot();

--- a/examples/todo-list/test/acceptance/home-page.controller.acceptance.ts
+++ b/examples/todo-list/test/acceptance/home-page.controller.acceptance.ts
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Client} from '@loopback/testlab';
+import {TodoListApplication} from '../..';
+import {setupApplication} from './test-helper';
+
+describe('HomePageController', () => {
+  let app: TodoListApplication;
+  let client: Client;
+
+  before('setupApplication', async () => {
+    ({app, client} = await setupApplication());
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  it('exposes a default home page', async () => {
+    await client
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /text\/html/);
+  });
+});

--- a/examples/todo-list/test/acceptance/test-helper.ts
+++ b/examples/todo-list/test/acceptance/test-helper.ts
@@ -1,0 +1,24 @@
+import {TodoListApplication} from '../..';
+import {
+  createRestAppClient,
+  givenHttpServerConfig,
+  Client,
+} from '@loopback/testlab';
+
+export async function setupApplication(): Promise<AppWithClient> {
+  const app = new TodoListApplication({
+    rest: givenHttpServerConfig(),
+  });
+
+  await app.boot();
+  await app.start();
+
+  const client = createRestAppClient(app);
+
+  return {app, client};
+}
+
+export interface AppWithClient {
+  app: TodoListApplication;
+  client: Client;
+}

--- a/examples/todo/public/index.html
+++ b/examples/todo/public/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>@loopback/example-todo</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" type="image/x-icon" href="//v4.loopback.io/favicon.ico">
+
+  <style>
+    h3 {
+      margin-left: 25px;
+      text-align: center;
+    }
+
+    a, a:visited {
+      color: #3f5dff;
+    }
+
+    h3 a {
+      margin-left: 10px;
+    }
+
+    a:hover, a:focus, a:active {
+      color: #001956;
+    }
+
+    .power {
+      position: absolute;
+      bottom: 25px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    .info {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%)
+    }
+
+    .info h1 {
+      text-align: center;
+      margin-bottom: 0px;
+    }
+
+    .info p {
+      text-align: center;
+      margin-bottom: 3em;
+      margin-top: 1em;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="info">
+    <h1>@loopback/example-todo</h1>
+
+    <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h4>
+    <h3>API Explorer: <a href="/explorer">/explorer</a></h4>
+  </div>
+
+  <footer class="power">
+    <a href="https://v4.loopback.io" target="_blank">
+      <img src="https://loopback.io/images/branding/powered-by-loopback/blue/powered-by-loopback-sm.png" />
+    </a>
+  </footer>
+</body>
+
+</html>
+

--- a/examples/todo/src/controllers/home-page.controller.ts
+++ b/examples/todo/src/controllers/home-page.controller.ts
@@ -1,0 +1,31 @@
+import {get} from '@loopback/openapi-v3';
+import * as fs from 'fs';
+import * as path from 'path';
+import {inject} from '@loopback/context';
+import {RestBindings, Response} from '@loopback/rest';
+
+export class HomePageController {
+  private html: string;
+  constructor(@inject(RestBindings.Http.RESPONSE) private response: Response) {
+    this.html = fs.readFileSync(
+      path.join(__dirname, '../../../public/index.html'),
+      'utf-8',
+    );
+  }
+
+  @get('/', {
+    responses: {
+      '200': {
+        description: 'Home Page',
+        content: {'text/html': {schema: {type: 'string'}}},
+      },
+    },
+  })
+  homePage() {
+    this.response
+      .status(200)
+      .contentType('html')
+      .send(this.html);
+    return this.response;
+  }
+}

--- a/examples/todo/test/acceptance/home-page.controller.acceptance.ts
+++ b/examples/todo/test/acceptance/home-page.controller.acceptance.ts
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Client} from '@loopback/testlab';
+import {TodoListApplication} from '../..';
+import {setupApplication} from './test-helper';
+
+describe('HomePageController', () => {
+  let app: TodoListApplication;
+  let client: Client;
+
+  before('setupApplication', async () => {
+    ({app, client} = await setupApplication());
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  it('exposes a default home page', async () => {
+    await client
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /text\/html/);
+  });
+});

--- a/examples/todo/test/acceptance/test-helper.ts
+++ b/examples/todo/test/acceptance/test-helper.ts
@@ -1,0 +1,24 @@
+import {TodoListApplication} from '../..';
+import {
+  createRestAppClient,
+  givenHttpServerConfig,
+  Client,
+} from '@loopback/testlab';
+
+export async function setupApplication(): Promise<AppWithClient> {
+  const app = new TodoListApplication({
+    rest: givenHttpServerConfig(),
+  });
+
+  await app.boot();
+  await app.start();
+
+  const client = createRestAppClient(app);
+
+  return {app, client};
+}
+
+export interface AppWithClient {
+  app: TodoListApplication;
+  client: Client;
+}


### PR DESCRIPTION
This PR close #1806 .  

**Added home page controller to:**

- todo
- todo-list
- soap-calculator


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
