### PR TITLE
chore: update juggler to 4.0

### DIFF
--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -30,7 +30,7 @@
     "@types/debug": "0.0.30",
     "debug": "^4.0.1",
     "lodash": "^4.17.10",
-    "loopback-datasource-juggler": "^3.23.0"
+    "loopback-datasource-juggler": "^4.0.0"
   },
   "files": [
     "README.md",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@loopback/context": "^0.13.1",
     "@loopback/core": "^0.11.16",
-    "loopback-datasource-juggler": "^3.23.0"
+    "loopback-datasource-juggler": "^4.0.0"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Upgrade `@loopback/repository` and `@loopback/service-proxy` to use v4 of loopback-datasource-juggler.

This is a preparation of 4.0 GA release, see https://github.com/strongloop/loopback-next/issues/1744

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated