### PR TITLE
docs: use https for apidocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ by using it for your next project. Start by having a look at
 [Getting Started](https://loopback.io/doc/en/lb4/Getting-started.html).
 
 Check the
-[API documentation](http://apidocs.loopback.io/@loopback%2fdocs/apidocs.html)
+[API documentation](https://apidocs.loopback.io/@loopback%2fdocs/apidocs.html)
 for all the API usages in each package.
 
 [LoopBack 3](https://loopback.io/doc/en/lb3/) became active LTS version, and

--- a/docs/apidocs.html
+++ b/docs/apidocs.html
@@ -3,9 +3,9 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>LoopBack API Documentation (local)</title>
-  <link rel="stylesheet" href="http://apidocs.loopback.io/css/bootstrap.min.css">
-  <link rel="stylesheet" href="http://apidocs.loopback.io/css/code-themes/sl-theme.css">
-  <link rel="stylesheet" href="http://apidocs.loopback.io/css/main.css">
+  <link rel="stylesheet" href="https://apidocs.loopback.io/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://apidocs.loopback.io/css/code-themes/sl-theme.css">
+  <link rel="stylesheet" href="https://apidocs.loopback.io/css/main.css">
 </head>
 <body>
   <div class="col-lg-9 reset-home-content">


### PR DESCRIPTION
Use `https` for apidocs assets

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
