### PR TITLE
refactor(repository): introduce InvalidRelationError

### DIFF
--- a/packages/repository/src/errors/index.ts
+++ b/packages/repository/src/errors/index.ts
@@ -4,3 +4,4 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from './entity-not-found.error';
+export * from './invalid-relation.error';

--- a/packages/repository/src/errors/invalid-relation.error.ts
+++ b/packages/repository/src/errors/invalid-relation.error.ts
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {RelationType, RelationMetadata} from '../decorators/relation.decorator';
+
+export class InvalidRelationError<Props extends object = {}> extends Error {
+  code: string;
+  reason: string;
+  relationName: string;
+  relationType: RelationType;
+  sourceModelName: string;
+
+  constructor(
+    reason: string,
+    relationMeta: RelationMetadata,
+    extraProperties?: Props,
+  ) {
+    const {name, type, source} = relationMeta;
+    const model = (source && source.modelName) || '<Unknown Model>';
+    const message = `Invalid ${type} definition for ${model}#${name}: ${reason}`;
+    super(message);
+
+    Error.captureStackTrace(this, this.constructor);
+
+    this.code = 'INVALID_RELATION_DEFINITION';
+    this.relationName = name;
+    this.relationType = type;
+    this.sourceModelName = model;
+
+    Object.assign(this, extraProperties);
+  }
+}
+
+// tslint:disable-next-line:no-any
+export function isInvalidRelationError(e: any): e is InvalidRelationError<any> {
+  return e instanceof InvalidRelationError;
+}

--- a/packages/repository/test/unit/errors/invalid-relation-error.test.ts
+++ b/packages/repository/test/unit/errors/invalid-relation-error.test.ts
@@ -1,0 +1,54 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  Entity,
+  InvalidRelationError,
+  isInvalidRelationError,
+  RelationType,
+} from '../../..';
+
+describe('InvalidRelationDefinitionError', () => {
+  it('inherits from Error correctly', () => {
+    const err = givenAnErrorInstance();
+    expect(err).to.be.instanceof(InvalidRelationError);
+    expect(err).to.be.instanceof(Error);
+    expect(err.stack)
+      .to.be.String()
+      // NOTE(bajtos) We cannot assert using __filename because stack traces
+      // are typically converted from JS paths to TS paths using source maps.
+      .and.match(/invalid-relation-error\.test\.(ts|js)/);
+  });
+
+  it('sets code to "INVALID_RELATION_DEFINITION"', () => {
+    const err = givenAnErrorInstance();
+    expect(err.code).to.equal('INVALID_RELATION_DEFINITION');
+  });
+});
+
+describe('isInvalidRelationError', () => {
+  it('returns true for an instance of EntityNotFoundError', () => {
+    const error = givenAnErrorInstance();
+    expect(isInvalidRelationError(error)).to.be.true();
+  });
+
+  it('returns false for an instance of Error', () => {
+    const error = new Error('A generic error');
+    expect(isInvalidRelationError(error)).to.be.false();
+  });
+});
+
+function givenAnErrorInstance() {
+  class Category extends Entity {}
+  class Product extends Entity {}
+
+  return new InvalidRelationError('a reason', {
+    name: 'products',
+    type: RelationType.hasMany,
+    source: Category,
+    target: () => Product,
+  });
+}


### PR DESCRIPTION
Introduce a new error class InvalidRelationError to simplify the code dealing with validation of relation definitions.

As a nice bonus, errors reported for invalid relations come with `code` property set to `INVALID_RELATION_DEFINITION` now.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated