### PR TITLE
ci: enable windows on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
       # using the default script to build & run the tests
 
     - node_js: "12"
+      os: windows
+      # using the default script to build & run the tests
+
+    - node_js: "12"
       os: linux
       env: TASK=code-lint
       # Running Code Linter -- Requires @loopback/build so it's bootstrapped


### PR DESCRIPTION
Travis added experimental (beta) windows support. Testing it to see how it fares in comparison to AppVeyor. 

https://docs.travis-ci.com/user/reference/windows/

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
