### PR TITLE
fix(cli): add more exit checks to fail fast

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -62,6 +62,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
   }
 
   checkLoopBackProject() {
+    if (this.shouldExit()) return;
     return super.checkLoopBackProject();
   }
 

--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -68,6 +68,7 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
    * Ensure CLI is being run in a LoopBack 4 project.
    */
   checkLoopBackProject() {
+    if (this.shouldExit()) return;
     return super.checkLoopBackProject();
   }
 

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -83,6 +83,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
   }
 
   checkLoopBackProject() {
+    if (this.shouldExit()) return;
     return super.checkLoopBackProject();
   }
 
@@ -95,6 +96,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
   // Ask for Model base class
   async promptModelBaseClassName() {
+    if (this.shouldExit()) return;
     const availableModelBaseClasses = [];
 
     availableModelBaseClasses.push(...BASE_MODELS);

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -139,6 +139,7 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
   }
 
   checkLoopBackProject() {
+    if (this.shouldExit()) return;
     return super.checkLoopBackProject();
   }
 

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -59,6 +59,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
   }
 
   checkLoopBackProject() {
+    if (this.shouldExit()) return;
     return super.checkLoopBackProject();
   }
 

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -65,7 +65,7 @@ describe('lb4 model integration', () => {
       testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: true}),
+          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: false}),
         )
         .withArguments('myNewModel --base InvalidModel'),
     ).to.be.rejectedWith(/Model was not found in/);

--- a/packages/cli/test/integration/lib/base-generator.js
+++ b/packages/cli/test/integration/lib/base-generator.js
@@ -66,6 +66,14 @@ module.exports = function(generator) {
         assert.equal(gen.options.name, 'abc');
         assert.equal(gen.options.description, 'Test');
       });
+
+      it('fails fast if --config has invalid value', async () => {
+        const gen = testUtils.testSetUpGen(generator, {
+          args: ['--config', path.join(__dirname, 'base-config-invalid.json')],
+        });
+        await gen.setOptions();
+        assert(gen.exitGeneration instanceof Error);
+      });
     });
 
     describe('config from json value', () => {
@@ -73,6 +81,12 @@ module.exports = function(generator) {
         "name": "xyz",
         "description": "Test"
       }`;
+
+      const invalidJsonValue = `{
+        name: "xyz",
+        "description": "Test"
+      }`;
+
       it('accepts --config', async () => {
         const gen = testUtils.testSetUpGen(generator, {
           args: ['--config', jsonValue],
@@ -90,6 +104,14 @@ module.exports = function(generator) {
         assert.equal(gen.options['config'], jsonValue);
         assert.equal(gen.options.name, 'abc');
         assert.equal(gen.options.description, 'Test');
+      });
+
+      it('fails fast if --config has invalid value', async () => {
+        const gen = testUtils.testSetUpGen(generator, {
+          args: ['--config', invalidJsonValue],
+        });
+        await gen.setOptions();
+        assert(gen.exitGeneration instanceof Error);
       });
     });
 


### PR DESCRIPTION
Add more checks to make sure CLI fails fast. For example, if `--config` has an invalid value/file, we should abort before further prompting.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
