### PR TITLE
docs: update LB4 status

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -8,8 +8,9 @@ permalink: /doc/en/lb4/index.html
 summary: LoopBack is a platform for building APIs and microservices in Node.js
 ---
 
-{% include important.html content="LoopBack 4 is the next step in the evolution
-of LoopBack. It is still in early development and is not yet released.
+{% include important.html content="LoopBack 4 GA (General Availability) has been released in
+October 2018, read more in the
+[announcement post](http://strongloop.com/strongblog/loopback-4-ga)
 " %}
 
 {% include see-also.html title="GitHub Repo" content=' LoopBack 4 framework code


### PR DESCRIPTION
In the [LB4 docs main page](https://loopback.io/doc/en/lb4/), remove the note about LB4 is still in early development and is not yet released.
