### PR TITLE
perf(repository): prevent multiple array allocation

### DIFF
--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -583,17 +583,21 @@ export class FilterBuilder<MT extends object = AnyObject> {
     } else {
       if (isFilter(constraint)) {
         // throw error if imposed Filter has non-where fields
-        Object.keys(constraint).forEach(key => {
-          if (
-            ['fields', 'order', 'limit', 'skip', 'offset', 'include'].includes(
-              key,
-            )
-          ) {
+        const nonWhereFields = [
+          'fields',
+          'order',
+          'limit',
+          'skip',
+          'offset',
+          'include',
+        ];
+        for (const key of Object.keys(constraint)) {
+          if (nonWhereFields.includes(key)) {
             throw new Error(
               'merging strategy for selection, pagination, and sorting not implemented',
             );
           }
-        });
+        }
       }
       this.filter.where = isFilter(constraint)
         ? new WhereBuilder(this.filter.where).impose(constraint.where!).build()


### PR DESCRIPTION
An improvement I found possible while looking at the code :)

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
