### PR TITLE
Add property description to JSON schema

### DIFF
--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -121,6 +121,12 @@ export function metaToJsonProperty(meta: PropertyDefinition): JSONSchema {
     Object.assign(propDef, {$ref: `#/definitions/${resolvedType.name}`});
   }
 
+  if (meta.description) {
+    Object.assign(propDef, {
+      description: meta.description,
+    });
+  }
+
   return result;
 }
 

--- a/packages/repository-json-schema/test/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/test/unit/build-schema.unit.ts
@@ -162,5 +162,12 @@ describe('build-schema', () => {
         items: {$ref: '#/definitions/CustomType'},
       });
     });
+
+    it('keeps description on property', () => {
+      expect(metaToJsonProperty({type: String, description: 'test'})).to.eql({
+        type: 'string',
+        description: 'test',
+      });
+    });
   });
 });


### PR DESCRIPTION
Working on improving the JSON schema output in general, but just commiting a simple first fix to see how the contributor process is.

Fixing the missing "description" property on the property level (it's already supported on the model level)

## Checklist

- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)