### PR TITLE
refactor(build): honors project mocha.opts file

### DIFF
--- a/packages/build/bin/run-mocha.js
+++ b/packages/build/bin/run-mocha.js
@@ -17,25 +17,19 @@ Usage:
 
 function run(argv, options) {
   const utils = require('./utils');
-  const path = require('path');
 
   // Substitute the dist variable with the dist folder
   const dist = utils.getDistribution();
   const mochaOpts = argv.slice(2).map(a => a.replace(/\bDIST\b/g, dist));
 
-  // Add default options
-  if (mochaOpts.indexOf('--opts') === -1) {
-    const optsPath = require.resolve('../mocha.opts');
-    mochaOpts.unshift('--opts', optsPath);
-  }
+  const setMochaOpts =
+    !utils.isOptionSet(mochaOpts, '--opts') &&
+    !utils.mochaOptsFileProjectExists();
 
-  // Add source map support
-  if (mochaOpts.indexOf('source-map-support/register') === -1) {
-    // Resolve source-map-support so that the path can be used by mocha
-    const sourceMapRegisterPath = require.resolve(
-      'source-map-support/register',
-    );
-    mochaOpts.unshift('--require', sourceMapRegisterPath);
+  // Add default options
+  if (setMochaOpts) {
+    const mochaOptsFile = utils.getConfigFile('mocha.opts');
+    mochaOpts.unshift('--opts', mochaOptsFile);
   }
 
   const allowConsoleLogsIx = mochaOpts.indexOf('--allow-console-logs');

--- a/packages/build/bin/utils.js
+++ b/packages/build/bin/utils.js
@@ -207,6 +207,11 @@ function isOptionSet(opts, ...optionNames) {
   );
 }
 
+function mochaOptsFileProjectExists() {
+  const configFile = path.join(getPackageDir(), 'test/mocha.opts');
+  return fs.existsSync(configFile);
+}
+
 exports.getCompilationTarget = getCompilationTarget;
 exports.getDistribution = getDistribution;
 exports.getRootDir = getRootDir;
@@ -216,3 +221,4 @@ exports.resolveCLI = resolveCLI;
 exports.runCLI = runCLI;
 exports.runShell = runShell;
 exports.isOptionSet = isOptionSet;
+exports.mochaOptsFileProjectExists = mochaOptsFileProjectExists;

--- a/packages/build/config/mocha.opts
+++ b/packages/build/config/mocha.opts
@@ -1,0 +1,4 @@
+--require source-map-support/register
+--recursive
+--exit
+--reporter dot

--- a/packages/build/mocha.opts
+++ b/packages/build/mocha.opts
@@ -1,3 +1,0 @@
---recursive
---exit
---reporter dot

--- a/packages/build/test/integration/scripts.integration.js
+++ b/packages/build/test/integration/scripts.integration.js
@@ -357,3 +357,63 @@ describe('build', function() {
     after(() => delete process.env.LERNA_ROOT_PATH);
   });
 });
+
+describe('mocha', function() {
+  this.timeout(30000);
+  var cwd = process.cwd();
+  var projectDir = path.resolve(__dirname, './fixtures');
+
+  function cleanup() {
+    var run = require('../../bin/run-clean');
+    run(['node', 'bin/run-clean', 'test/mocha.opts']);
+  }
+
+  beforeEach(() => {
+    process.chdir(projectDir);
+    cleanup();
+  });
+
+  afterEach(() => {
+    cleanup();
+    process.chdir(cwd);
+  });
+
+  it('loads built-in mocha.opts file', () => {
+    var run = require('../../bin/run-mocha');
+    var command = run(['node', 'bin/run-mocha', '"dist/test"'], true);
+    const builtInMochaOptsFile = path.join(
+      __dirname,
+      '../../config/mocha.opts',
+    );
+    assert(
+      command.indexOf(builtInMochaOptsFile) !== -1,
+      '--opts should be set by default',
+    );
+  });
+
+  it('honors --opts option', () => {
+    var run = require('../../bin/run-mocha');
+    var command = run(
+      ['node', 'bin/run-mocha', '--opts custom/mocha.opts', '"dist/test"'],
+      true,
+    );
+    assert(
+      command.indexOf('--opts custom/mocha.opts') !== -1,
+      '--opts custom/mocha.opts should be honored',
+    );
+  });
+
+  it('loads mocha.opts specific project file', () => {
+    var run = require('../../bin/run-mocha');
+    const buitInMochaOptsPath = path.join(__dirname, '../../config/mocha.opts');
+    const destPath = path.join(__dirname, './fixtures/test/mocha.opts');
+
+    fs.copyFileSync(buitInMochaOptsPath, destPath);
+
+    var command = run(['node', 'bin/run-mocha', '"dist/test"'], true);
+    assert(
+      command.indexOf('--opts') === -1,
+      'should skip built-in mocha.opts file when specific project file exist',
+    );
+  });
+});


### PR DESCRIPTION
After generating a new loopback 4 project with cli generator, a new `mocha.opts` file is created by default. When I run the `npm test` command, all options defined in the `mocha.opts` file should be loaded. This PR loads your default built-in mocha options only if the corresponding parameter `--use-default-options` is added to the `npm test` command.

If this logic is accepted, all affected packages should be modified accordingly. I look forward to knowing from you which of them should I update.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
