### PR TITLE
perf(repository): prevent multiple array allocation

### DIFF
--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -13,6 +13,17 @@ import * as assert from 'assert';
 
 // tslint:disable:no-any
 
+const nonWhereFields = [
+  'fields',
+  'order',
+  'limit',
+  'skip',
+  'offset',
+  'include',
+];
+
+const filterFields = ['where', ...nonWhereFields];
+
 /**
  * Operators for where clauses
  */
@@ -208,15 +219,6 @@ export function isFilter<MT extends object>(
   candidate: any,
 ): candidate is Filter<MT> {
   if (typeof candidate !== 'object') return false;
-  const filterFields = [
-    'where',
-    'fields',
-    'order',
-    'limit',
-    'skip',
-    'offset',
-    'include',
-  ];
   for (const key in candidate) {
     if (!filterFields.includes(key)) {
       return false;
@@ -583,14 +585,6 @@ export class FilterBuilder<MT extends object = AnyObject> {
     } else {
       if (isFilter(constraint)) {
         // throw error if imposed Filter has non-where fields
-        const nonWhereFields = [
-          'fields',
-          'order',
-          'limit',
-          'skip',
-          'offset',
-          'include',
-        ];
         for (const key of Object.keys(constraint)) {
           if (nonWhereFields.includes(key)) {
             throw new Error(


### PR DESCRIPTION
This comes after the observation of @bajtos in my previous PR : https://github.com/strongloop/loopback-next/pull/1865#issuecomment-430974581

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
