### PR TITLE
fix(rest): allow @patch update obj to be a Partial

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -168,7 +168,7 @@ export class TodoController {
     },
   })
   async updateAll(
-    @requestBody() data: Todo,
+    @requestBody() data: Partial<Todo>,
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
   ): Promise<number> {
     return await this.todoRepository.updateAll(data, where);
@@ -195,7 +195,7 @@ export class TodoController {
   })
   async updateById(
     @param.path.number('id') id: number,
-    @requestBody() data: Todo,
+    @requestBody() data: Partial<Todo>,
   ): Promise<void> {
     await this.todoRepository.updateById(id, data);
   }

--- a/docs/site/todo-list-tutorial-controller.md
+++ b/docs/site/todo-list-tutorial-controller.md
@@ -197,7 +197,7 @@ export class TodoListController {
   })
   async updateById(
     @param.path.number('id') id: number,
-    @requestBody() obj: TodoList,
+    @requestBody() obj: Partial<TodoList>,
   ): Promise<void> {
     await this.todoListRepository.updateById(id, obj);
   }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -105,7 +105,7 @@ export class TodoListController {
   })
   async updateById(
     @param.path.number('id') id: number,
-    @requestBody() obj: TodoList,
+    @requestBody() obj: Partial<TodoList>,
   ): Promise<void> {
     await this.todoListRepository.updateById(id, obj);
   }

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -88,7 +88,7 @@ export class TodoController {
   })
   async updateTodo(
     @param.path.number('id') id: number,
-    @requestBody() todo: Todo,
+    @requestBody() todo: Partial<Todo>,
   ): Promise<void> {
     await this.todoRepo.updateById(id, todo);
   }

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -101,7 +101,7 @@ export class TodoController {
   })
   async updateTodo(
     @param.path.number('id') id: number,
-    @requestBody() todo: Todo,
+    @requestBody() todo: Partial<Todo>,
   ): Promise<void> {
     await this.todoRepo.updateById(id, todo);
   }

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -77,7 +77,7 @@ export class <%= className %>Controller {
     },
   })
   async updateAll(
-    @requestBody() <%= modelVariableName %>: <%= modelName %>,
+    @requestBody() <%= modelVariableName %>: Partial<<%= modelName %>>,
     @param.query.object('where', getWhereSchemaFor(<%= modelName %>)) where?: Where,
   ): Promise<Count> {
     return await this.<%= repositoryNameCamel %>.updateAll(<%= modelVariableName %>, where);
@@ -104,7 +104,7 @@ export class <%= className %>Controller {
   })
   async updateById(
     @param.path.<%= idType %>('id') id: <%= idType %>,
-    @requestBody() <%= modelVariableName %>: <%= modelName %>,
+    @requestBody() <%= modelVariableName %>: Partial<<%= modelName %>>,
   ): Promise<void> {
     await this.<%= repositoryNameCamel %>.updateById(id, <%= modelVariableName %>);
   }


### PR DESCRIPTION
This changes the type of the `obj` argument in `@patch` endpoints from `Model` to `Partial<Model>`.

Since the route checking has become more strict, requests to patch only some fields of a document are now being rejected, because the validation expects to see _all_ required fields in the patch.

In our codebase, we have made the type of the update object `Partial<Model>` to allow partial updates, and that has been working well.

This is only a quick fix. I believe you may settle on a more comprehensive solution later, as discussed in https://github.com/strongloop/loopback-next/issues/1722

- I used `Partial<Model>` because I thought that was more appropriate than `DeepPartial<Model>` or `DataObject<Model>` but I could be wrong.

If this PR is not a step in the desired direction, then please feel free to close it.

## Checklist

- [ ] `npm test` passes on your machine
  I'm afraid the develop branch is currently failing for me with: `Conflicting definitions for 'express-serve-static-core'`
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated