### PR TITLE
feat: add 'x-visibility' extension property to OpenAPI spec

### DIFF
--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -156,6 +156,7 @@ export class RoutingTable {
     const paths: PathObject = {};
 
     for (const route of this._router.list()) {
+      if (route.spec['x-visibility'] === 'undocumented') continue;
       if (!paths[route.path]) {
         paths[route.path] = {};
       }


### PR DESCRIPTION
Add `x-visibility` extension property to OpenAPI spec.

Addresses https://github.com/strongloop/loopback-next/issues/1874.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
