### PR TITLE
feat: add 'x-internal' extension property to OpenAPI spec

### DIFF
--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -156,11 +156,13 @@ export class RoutingTable {
     const paths: PathObject = {};
 
     for (const route of this._router.list()) {
-      if (!paths[route.path]) {
-        paths[route.path] = {};
-      }
+      if (!route.spec['x-internal']) {
+        if (!paths[route.path]) {
+          paths[route.path] = {};
+        }
 
-      paths[route.path][route.verb] = route.spec;
+        paths[route.path][route.verb] = route.spec;
+      }
     }
 
     return paths;
@@ -187,6 +189,10 @@ export class RoutingTable {
   }
 }
 
+export interface LB4OperationObject extends OperationObject {
+  readonly 'x-internal'?: boolean;
+}
+
 /**
  * An entry in the routing table
  */
@@ -202,7 +208,7 @@ export interface RouteEntry {
   /**
    * OpenAPI operation spec
    */
-  readonly spec: OperationObject;
+  readonly spec: LB4OperationObject;
 
   /**
    * Update bindings for the request context


### PR DESCRIPTION
Add `x-internal` extension property to OpenAPI spec.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
