### PR TITLE
feat(rest): push route(verb, path, spec, fn) down to RestServer

### DIFF
--- a/packages/rest/test/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/test/acceptance/routing/routing.acceptance.ts
@@ -6,7 +6,6 @@
 import {
   Request,
   Response,
-  Route,
   RestBindings,
   RestServer,
   RestComponent,
@@ -408,8 +407,7 @@ describe('Routing', () => {
       return `hello ${name}`;
     }
 
-    const route = new Route('get', '/greet', routeSpec, greet);
-    server.route(route);
+    server.route('get', '/greet', routeSpec, greet);
 
     const client = whenIMakeRequestTo(server);
     await client.get('/greet?name=world').expect(200, 'hello world');
@@ -609,8 +607,7 @@ describe('Routing', () => {
         return `hello ${name}`;
       }
 
-      const route = new Route('get', '/greet', routeSpec, greet);
-      app.route(route);
+      app.route('get', '/greet', routeSpec, greet);
 
       await whenIMakeRequestTo(app)
         .get('/greet?name=world')

--- a/packages/rest/test/integration/rest.server.integration.ts
+++ b/packages/rest/test/integration/rest.server.integration.ts
@@ -12,7 +12,7 @@ import {
   httpsGetAsync,
   givenHttpServerConfig,
 } from '@loopback/testlab';
-import {Route, RestBindings, RestServer, RestComponent} from '../..';
+import {RestBindings, RestServer, RestComponent} from '../..';
 import {IncomingMessage, ServerResponse} from 'http';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
@@ -238,7 +238,7 @@ describe('RestServer (integration)', () => {
         },
       },
     };
-    server.route(new Route('get', '/greet', greetSpec, function greet() {}));
+    server.route('get', '/greet', greetSpec, function greet() {});
 
     const response = await createClientForHandler(server.requestHandler).get(
       '/openapi.json',
@@ -330,7 +330,7 @@ describe('RestServer (integration)', () => {
         },
       },
     };
-    server.route(new Route('get', '/greet', greetSpec, function greet() {}));
+    server.route('get', '/greet', greetSpec, function greet() {});
 
     const response = await createClientForHandler(server.requestHandler).get(
       '/openapi.yaml',
@@ -372,7 +372,7 @@ paths:
         },
       },
     };
-    server.route(new Route('get', '/greet', greetSpec, function greet() {}));
+    server.route('get', '/greet', greetSpec, function greet() {});
 
     const response = await createClientForHandler(server.requestHandler).get(
       '/explorer',

--- a/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -7,7 +7,6 @@ import {expect, validateApiSpec} from '@loopback/testlab';
 import {Application} from '@loopback/core';
 import {
   RestServer,
-  Route,
   RestComponent,
   createControllerFactoryForClass,
 } from '../../..';
@@ -51,9 +50,7 @@ describe('RestServer.getApiSpec()', () => {
 
   it('binds a route via app.route(route)', () => {
     function greet() {}
-    const binding = server.route(
-      new Route('get', '/greet', {responses: {}}, greet),
-    );
+    const binding = server.route('get', '/greet', {responses: {}}, greet);
     expect(binding.key).to.eql('routes.get %2Fgreet');
     expect(binding.tagNames).containEql('route');
   });
@@ -77,7 +74,7 @@ describe('RestServer.getApiSpec()', () => {
 
   it('returns routes registered via app.route(route)', () => {
     function greet() {}
-    server.route(new Route('get', '/greet', {responses: {}}, greet));
+    server.route('get', '/greet', {responses: {}}, greet);
 
     const spec = server.getApiSpec();
     expect(spec.paths).to.eql({
@@ -195,7 +192,7 @@ describe('RestServer.getApiSpec()', () => {
     );
 
     function greet() {}
-    server.route(new Route('get', '/greet', {responses: {}}, greet));
+    server.route('get', '/greet', {responses: {}}, greet);
 
     const spec = server.getApiSpec();
     expect(spec.paths).to.eql({


### PR DESCRIPTION
Move the implementation of 4-arg version of "route` method from RestApplication to RestServer, simplify RestApplication's "route" to delegate the implementation to RestServer.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated
