### PR TITLE
refactor(cli): use options to specify port and OpenAPI server url

### DIFF
--- a/examples/hello-world/index.js
+++ b/examples/hello-world/index.js
@@ -9,7 +9,17 @@ module.exports = application;
 
 if (require.main === module) {
   // Run the application
-  application.main().catch(err => {
+  const config = {
+    rest: {
+      port: +process.env.PORT || 3000,
+      host: process.env.HOST || 'localhost',
+      openApiSpec: {
+        // useful when used with OASGraph to locate your application
+        setServersFromRequest: true,
+      },
+    },
+  };
+  application.main(config).catch(err => {
     console.error('Cannot start the application.', err);
     process.exit(1);
   });

--- a/examples/soap-calculator/index.js
+++ b/examples/soap-calculator/index.js
@@ -4,7 +4,17 @@ module.exports = application;
 
 if (require.main === module) {
   // Run the application
-  application.main().catch(err => {
+  const config = {
+    rest: {
+      port: +process.env.PORT || 3000,
+      host: process.env.HOST || 'localhost',
+      openApiSpec: {
+        // useful when used with OASGraph to locate your application
+        setServersFromRequest: true,
+      },
+    },
+  };
+  application.main(config).catch(err => {
     console.error('Cannot start the application.', err);
     process.exit(1);
   });

--- a/examples/todo-list/index.js
+++ b/examples/todo-list/index.js
@@ -9,6 +9,16 @@ module.exports = application;
 
 if (require.main === module) {
   // Run the application
+  const config = {
+    rest: {
+      port: +process.env.PORT || 3000,
+      host: process.env.HOST || 'localhost',
+      openApiSpec: {
+        // useful when used with OASGraph to locate your application
+        setServersFromRequest: true,
+      },
+    },
+  };
   application.main().catch(err => {
     console.error('Cannot start the application.', err);
     process.exit(1);

--- a/examples/todo/index.js
+++ b/examples/todo/index.js
@@ -9,7 +9,17 @@ module.exports = application;
 
 if (require.main === module) {
   // Run the application
-  application.main().catch(err => {
+  const config = {
+    rest: {
+      port: +process.env.PORT || 3000,
+      host: process.env.HOST || 'localhost',
+      openApiSpec: {
+        // useful when used with OASGraph to locate your application
+        setServersFromRequest: true,
+      },
+    },
+  };
+  application.main(config).catch(err => {
     console.error('Cannot start the application.', err);
     process.exit(1);
   });

--- a/packages/cli/generators/app/templates/index.js.ejs
+++ b/packages/cli/generators/app/templates/index.js.ejs
@@ -4,7 +4,17 @@ module.exports = application;
 
 if (require.main === module) {
   // Run the application
-  application.main().catch(err => {
+  const config = {
+    rest: {
+      port: +process.env.PORT || 3000,
+      host: process.env.HOST || 'localhost',
+      openApiSpec: {
+        // useful when used with OASGraph to locate your application
+        setServersFromRequest: true,
+      },
+    },
+  };
+  application.main(config).catch(err => {
     console.error('Cannot start the application.', err);
     process.exit(1);
   });

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -40,6 +40,10 @@ describe('app-generator specific files', () => {
     assert.fileContent('src/application.ts', /constructor\(/);
     assert.fileContent('src/application.ts', /this.projectRoot = __dirname/);
 
+    assert.file('index.js');
+    assert.fileContent('index.js', /openApiSpec: {/);
+    assert.fileContent('index.js', /setServersFromRequest: true/);
+
     assert.file('src/index.ts');
     assert.fileContent('src/index.ts', /new MyAppApplication/);
     assert.fileContent('src/index.ts', /await app.start\(\);/);


### PR DESCRIPTION
This PR only applies the options object in the application to benefit the app developer in two areas:

1. For new developers change the application port number with ease
2. Avoid the step to specify the server url + port number when used by OASGraph _(if not used, then I believe it won't hurt? )_

This pull request supersedes #1900.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated