### PR TITLE
fix(cli): allow other connectors to be used for repositories

### DIFF
--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -134,7 +134,7 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
       const prompts = [
         {
           name: 'customConnector',
-          message: "Enter the connector's module name",
+          message: "Enter the connector's package name:",
           validate: utils.validate,
         },
       ];
@@ -309,6 +309,10 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
       }
 
       debug(`npmModule - ${pkgs[0]}`);
+    } else {
+      const connectorName = this.artifactInfo.connector;
+      // Other connectors
+      if (!deps[connectorName]) pkgs.push(connectorName);
     }
 
     if (!deps['@loopback/repository']) {

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -206,7 +206,7 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
         this.artifactInfo.datasourcesDir,
         item,
       );
-      return result;
+      return result !== false;
     });
 
     debug(`artifactInfo.dataSourceClass ${this.artifactInfo.dataSourceClass}`);

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -11,7 +11,6 @@ const path = require('path');
 const util = require('util');
 const stream = require('stream');
 const readline = require('readline');
-const chalk = require('chalk');
 var semver = require('semver');
 const regenerate = require('regenerate');
 const _ = require('lodash');
@@ -443,7 +442,6 @@ exports.isConnectorOfType = function(
 ) {
   debug(`calling isConnectorType ${connectorType}`);
   let jsonFileContent = '';
-  let result = false;
 
   if (!dataSourceClass) {
     return false;
@@ -467,13 +465,11 @@ exports.isConnectorOfType = function(
       jsonFileContent.connector === connector.name ||
       jsonFileContent.connector === `loopback-connector-${connector.name}`;
 
-    if (matchedConnector && connectorType.includes(connector.baseModel)) {
-      result = true;
-      break;
-    }
+    if (matchedConnector) return connectorType.includes(connector.baseModel);
   }
 
-  return result;
+  // Maybe for other connectors that are not in the supported list
+  return null;
 };
 
 /**

--- a/packages/cli/test/fixtures/repository/index.js
+++ b/packages/cli/test/fixtures/repository/index.js
@@ -57,6 +57,19 @@ exports.SANDBOX_FILES = [
   },
   {
     path: DATASOURCE_APP_PATH,
+    file: 'sqlite-3.datasource.json',
+    content: JSON.stringify({
+      name: 'sqlite3',
+      connector: 'loopback-connector-sqlite3',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'sqlite-3.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
     file: 'restdb.datasource.ts',
     content: DUMMY_CONTENT,
   },

--- a/packages/cli/test/integration/generators/datasource.integration.js
+++ b/packages/cli/test/integration/generators/datasource.integration.js
@@ -13,8 +13,6 @@ const testlab = require('@loopback/testlab');
 const expect = testlab.expect;
 const TestSandbox = testlab.TestSandbox;
 
-const debug = require('../../../lib/debug')('lb4:datasource:test');
-const DataSourceGenerator = require('../../../generators/datasource');
 const generator = path.join(__dirname, '../../../generators/datasource');
 const tests = require('../lib/artifact-generator')(generator);
 const baseTests = require('../lib/base-generator')(generator);

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -31,7 +31,7 @@ describe('lb4 repository', function() {
 
   // special cases regardless of the repository type
   describe('generate repositories on special conditions', () => {
-    it('generates multipe crud repositories', async () => {
+    it('generates multiple crud repositories', async () => {
       const multiItemPrompt = {
         dataSourceClass: 'DbmemDatasource',
         modelNameList: ['MultiWord', 'Defaultmodel'],
@@ -287,6 +287,33 @@ describe('lb4 repository', function() {
         INDEX_FILE,
         /export \* from '.\/defaultmodel.repository';/,
       );
+    });
+
+    it('allows other connectors', async () => {
+      const files = SANDBOX_FILES.filter(
+        e =>
+          e.path !== 'src/datasources' ||
+          e.file.includes('sqlite-3.datasource.'),
+      );
+      const basicPrompt = {
+        dataSourceClass: 'Sqlite_3Datasource',
+      };
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            // Only use the sqlite3 datasource
+            additionalFiles: files,
+          }),
+        )
+        .withPrompts(basicPrompt)
+        .withArguments(' --model Defaultmodel');
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        REPOSITORY_APP_PATH,
+        'defaultmodel.repository.ts',
+      );
+      assert.file(expectedFile);
     });
 
     it('generates a crud repository from hyphened model file name', async () => {


### PR DESCRIPTION
The problem was reported by Sam Ruby.

1. `lb4 datasource` to add a DS with `loopback-connector-sqlite3`
2. `lb4 repository` fails to list `loopback-connector-sqlite3` as it's NOT on the list of connectors we pull from `loopback-workspace`

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
