### PR TITLE
docs(repository): fix tsdoc

### DIFF
--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -95,8 +95,8 @@ export class ModelDefinition {
 
   /**
    * Add a property
-   * @param property Property definition or name (string)
-   * @param type Property type
+   * @param name Property definition or name (string)
+   * @param definitionOrType Definition or property type
    */
   addProperty(
     name: string,

--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -6,11 +6,6 @@
 import {AnyObject} from './common-types';
 import * as assert from 'assert';
 
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: @loopback/repository
-// This file is licensed under the MIT License.
-// License text available at https://opensource.org/licenses/MIT
-
 // tslint:disable:no-any
 
 /**
@@ -501,7 +496,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
   /**
    * Describe the sorting order
-   * @param f A field name with optional direction, an array of field names,
+   * @param o A field name with optional direction, an array of field names,
    * or an Order object for the field/direction pairs
    */
   order(...o: (string | string[] | Order<MT>)[]): this {

--- a/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
@@ -11,6 +11,7 @@ import {BelongsToDefinition, RelationType} from '../relation.types';
 
 /**
  * Decorator for belongsTo
+ * @param targetResolver
  * @param definition
  * @returns {(target: Object, key:string)}
  */

--- a/packages/repository/src/relations/has-many/has-many.decorator.ts
+++ b/packages/repository/src/relations/has-many/has-many.decorator.ts
@@ -8,7 +8,7 @@ import {Entity, EntityResolver} from '../../model';
 import {relation} from '../relation.decorator';
 import {HasManyDefinition, RelationType} from '../relation.types';
 
-/*
+/**
  * Decorator for hasMany
  * Calls property.array decorator underneath the hood and infers foreign key
  * name from target model name unless explicitly specified

--- a/packages/repository/src/relations/has-many/has-many.repository.ts
+++ b/packages/repository/src/relations/has-many/has-many.repository.ts
@@ -30,7 +30,7 @@ export interface HasManyRepository<Target extends Entity> {
   ): Promise<Target>;
   /**
    * Find target model instance(s)
-   * @param Filter A filter object for where, order, limit, etc.
+   * @param filter A filter object for where, order, limit, etc.
    * @param options Options for the operation
    * @returns A promise which resolves with the found target instance(s)
    */

--- a/packages/repository/src/repositories/kv.repository.ts
+++ b/packages/repository/src/repositories/kv.repository.ts
@@ -61,6 +61,7 @@ export interface KeyValueRepository<T extends Model> extends Repository<T> {
    * Set up ttl for an entry by key
    *
    * @param key Key for the entry
+   * @param ttl Ttl for the entry
    * @param options Options for the operation
    */
   expire(key: string, ttl: number, options?: Options): Promise<void>;

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -80,7 +80,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
 
   /**
    * Constructor of DefaultCrudRepository
-   * @param modelClass Legacy model class
+   * @param entityClass Legacy entity class
    * @param dataSource Legacy data source
    */
   constructor(

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -150,8 +150,8 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Update an entity by id with property/value pairs in the data object
-   * @param data Data attributes to be updated
    * @param id Value for the entity id
+   * @param data Data attributes to be updated
    * @param options Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.
@@ -160,8 +160,8 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Replace an entity by id
-   * @param data Data attributes to be replaced
    * @param id Value for the entity id
+   * @param data Data attributes to be replaced
    * @param options Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.


### PR DESCRIPTION
This PR fix typos, missing parameters or bad names in the tsdoc of the repository package :smiley: 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
