### PR TITLE
 style(boot): remove workaround warning comment 

### DIFF
--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -44,6 +44,7 @@ export function isClass(target: any): target is Constructor<any> {
  * and then testing each exported member to see if it's a class or not.
  *
  * @param files An array of string of absolute file paths
+ * @param projectRootDir The project root directory
  * @returns {Constructor<{}>[]} An array of Class constructors from a file
  */
 export function loadClassesFromFiles(
@@ -54,8 +55,6 @@ export function loadClassesFromFiles(
   for (const file of files) {
     debug('Loading artifact file %j', path.relative(projectRootDir, file));
     const moduleObj = require(file);
-    // WORKAROUND: use `for in` instead of Object.values().
-    // See https://github.com/nodejs/node/issues/20278
     for (const k in moduleObj) {
       const exported = moduleObj[k];
       if (isClass(exported)) {


### PR DESCRIPTION
https://github.com/nodejs/node/issues/20278 was solved so Object.entries/values can now be used.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
