### PR TITLE
docs: add link to cloudant dashboard

### DIFF
--- a/docs/site/Deploying-to-IBM-Cloud.md
+++ b/docs/site/Deploying-to-IBM-Cloud.md
@@ -70,8 +70,9 @@ docker run \
       ibmcom/cloudant-developer
 ```
 
-3.  Log on to the local Cloudant Dashboard using `admin`:`pass` as the
-    crendentials.
+3.  Log on to the local Cloudant
+    [Dashboard](http://localhost:8080/dashboard.html) using `admin`:`pass` as
+    the crendentials.
 4.  Create a database named `todo`.
 
 ### Updates to the app


### PR DESCRIPTION
Add link to cloudant dashboard in example. I had to google how to access the dashboard so
having the link would be useful.

## Checklist

- [X] `npm test` passes on your machine
- [X] Documentation in [/docs/site](../tree/master/docs/site) was updated
