### PR TITLE
fix(rest): don't rely on transitive dependencies from express

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -43,6 +43,7 @@
     "parseurl": "^1.3.2",
     "path-to-regexp": "^2.2.0",
     "qs": "^6.5.2",
+    "serve-static": "^1.13.2",
     "strong-error-handler": "^3.2.0",
     "validator": "^10.4.0"
   },
@@ -54,7 +55,9 @@
     "@types/debug": "0.0.30",
     "@types/js-yaml": "^3.11.1",
     "@types/lodash": "^4.14.106",
-    "@types/node": "^10.11.2"
+    "@types/node": "^10.11.2",
+    "@types/express-serve-static-core": "^4.16.0",
+    "@types/serve-static": "1.13.2"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Fixes #1917

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

Blank items above because there are no code changes in this PR

Ideally would like this to say, logically, "pull in whatever version of `serve-static` is used by `express`", but I'm not sure how to do that.

I've tried to verify this with my problem project where I found the issue, but I can't get `pnpm` to play nice with linked packages in the context of the rush monorepo.  That said, the imports I've added here are exactly the same ones I added to that parent project as a workaround, so I'm _reasonably_ confident this should work.

Note that only including `@types/express-serve-static-core` and not the base `express-serve-static-core` is quite intentional and a bit important -- see the issue report for why.