### PR TITLE
feat(core): improve component bindings

### DIFF
--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -24,8 +24,8 @@ export class MyComponent implements Component {
       'my-validator': MyValidator,
     };
 
-    const bindingX = new Binding('x').to('Value X');
-    const bindingY = new Binding('y').toClass(ClassY);
+    const bindingX = Binding.bind('x').to('Value X');
+    const bindingY = Binding.bind('y').toClass(ClassY);
     this.bindings = [bindingX, bindingY];
   }
 }
@@ -45,7 +45,7 @@ Please note that `providers` and `classes` are shortcuts for provider and class
 `bindings`.
 
 The example `MyComponent` above will add `MyController` to application's API and
-create the following bindings to the application context:
+create the following bindings in the application context:
 
 - `my-value` -> `MyValueProvider` (provider)
 - `my-validator` -> `MyValidator` (class)

--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -20,6 +20,13 @@ export class MyComponent implements Component {
     this.providers = {
       'my-value': MyValueProvider,
     };
+    this.classes = {
+      'my-validator': MyValidator,
+    };
+
+    const bindingX = new Binding('x').to('Value X');
+    const bindingY = new Binding('y').toClass(ClassY);
+    this.bindings = [bindingX, bindingY];
   }
 }
 ```
@@ -28,10 +35,22 @@ When a component is mounted to an application, a new instance of the component
 class is created and then:
 
 - Each Controller class is registered via `app.controller()`,
-- Each Provider is bound to its key in `providers` object.
+- Each Provider is bound to its key in `providers` object via
+  `app.bind(key).toProvider(providerClass)`
+- Each Class is bound to its key in `classes` object via
+  `app.bind(key).toClass(cls)`
+- Each Binding is added via `app.add(binding)`
+
+Please note that `providers` and `classes` are shortcuts for provider and class
+`bindings`.
 
 The example `MyComponent` above will add `MyController` to application's API and
-create a new binding `my-value` that will be resolved using `MyValueProvider`.
+create the following bindings to the application context:
+
+- `my-value` -> `MyValueProvider` (provider)
+- `my-validator` -> `MyValidator` (class)
+- `x` -> `'Value X'` (value)
+- `y` -> `ClassY` (class)
 
 ## Providers
 

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -383,7 +383,7 @@ export class Binding<T = BoundValue> {
    *
    * @param provider The value provider to use.
    */
-  public toProvider(providerClass: Constructor<Provider<T>>): this {
+  toProvider(providerClass: Constructor<Provider<T>>): this {
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Bind %s to provider %s', this.key, providerClass.name);
@@ -435,5 +435,15 @@ export class Binding<T = BoundValue> {
       json.type = this.type;
     }
     return json;
+  }
+
+  /**
+   * A static method to create a binding so that we can do
+   * `Binding.bind('foo').to('bar');` as `new Binding('foo').to('bar')` is not
+   * easy to read.
+   * @param key Binding key
+   */
+  static bind(key: string): Binding {
+    return new Binding(key);
   }
 }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -42,16 +42,26 @@ export class Context {
    * Create a binding with the given key in the context. If a locked binding
    * already exists with the same key, an error will be thrown.
    *
-   * @param key Binding key
+   * @param keyOrBinding Binding key or a binding
    */
   bind<ValueType = BoundValue>(
-    key: BindingAddress<ValueType>,
+    keyOrBinding: BindingAddress<ValueType> | Binding,
   ): Binding<ValueType> {
+    let key: string;
+    let binding: Binding<ValueType>;
+    if (keyOrBinding instanceof Binding) {
+      key = keyOrBinding.key;
+      binding = keyOrBinding;
+    } else {
+      key = keyOrBinding.toString();
+      binding = new Binding<ValueType>(key);
+    }
+
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Adding binding: %s', key);
     }
-    key = BindingKey.validate(key);
+
     const keyExists = this.registry.has(key);
     if (keyExists) {
       const existingBinding = this.registry.get(key);
@@ -59,8 +69,6 @@ export class Context {
       if (bindingIsLocked)
         throw new Error(`Cannot rebind key "${key}" to a locked binding`);
     }
-
-    const binding = new Binding<ValueType>(key);
     this.registry.set(key, binding);
     return binding;
   }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -42,21 +42,23 @@ export class Context {
    * Create a binding with the given key in the context. If a locked binding
    * already exists with the same key, an error will be thrown.
    *
-   * @param keyOrBinding Binding key or a binding
+   * @param key Binding key
    */
   bind<ValueType = BoundValue>(
-    keyOrBinding: BindingAddress<ValueType> | Binding,
+    key: BindingAddress<ValueType>,
   ): Binding<ValueType> {
-    let key: string;
-    let binding: Binding<ValueType>;
-    if (keyOrBinding instanceof Binding) {
-      key = keyOrBinding.key;
-      binding = keyOrBinding;
-    } else {
-      key = keyOrBinding.toString();
-      binding = new Binding<ValueType>(key);
-    }
+    const binding = new Binding<ValueType>(key.toString());
+    this.add(binding);
+    return binding;
+  }
 
+  /**
+   * Add a binding to the context. If a locked binding already exists with the
+   * same key, an error will be thrown.
+   * @param binding The configured binding to be added
+   */
+  add<ValueType = BoundValue>(binding: Binding<ValueType>): this {
+    const key = binding.key;
     /* istanbul ignore if */
     if (debug.enabled) {
       debug('Adding binding: %s', key);
@@ -70,7 +72,7 @@ export class Context {
         throw new Error(`Cannot rebind key "${key}" to a locked binding`);
     }
     this.registry.set(key, binding);
-    return binding;
+    return this;
   }
 
   /**

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -57,7 +57,7 @@ export class Context {
    * same key, an error will be thrown.
    * @param binding The configured binding to be added
    */
-  add<ValueType = BoundValue>(binding: Binding<ValueType>): this {
+  add(binding: Binding<unknown>): this {
     const key = binding.key;
     /* istanbul ignore if */
     if (debug.enabled) {
@@ -85,7 +85,7 @@ export class Context {
    * @param key Binding key
    * @returns true if the binding key is found and removed from this context
    */
-  unbind<ValueType = BoundValue>(key: BindingAddress<ValueType>): boolean {
+  unbind(key: BindingAddress<unknown>): boolean {
     key = BindingKey.validate(key);
     const binding = this.registry.get(key);
     if (binding == null) return false;
@@ -99,7 +99,7 @@ export class Context {
    * delegating to the parent context
    * @param key Binding key
    */
-  contains<ValueType = BoundValue>(key: BindingAddress<ValueType>): boolean {
+  contains(key: BindingAddress<unknown>): boolean {
     key = BindingKey.validate(key);
     return this.registry.has(key);
   }
@@ -108,7 +108,7 @@ export class Context {
    * Check if a key is bound in the context or its ancestors
    * @param key Binding key
    */
-  isBound<ValueType = BoundValue>(key: BindingAddress<ValueType>): boolean {
+  isBound(key: BindingAddress<unknown>): boolean {
     if (this.contains(key)) return true;
     if (this._parent) {
       return this._parent.isBound(key);
@@ -120,9 +120,7 @@ export class Context {
    * Get the owning context for a binding key
    * @param key Binding key
    */
-  getOwnerContext<ValueType = BoundValue>(
-    key: BindingAddress<ValueType>,
-  ): Context | undefined {
+  getOwnerContext(key: BindingAddress<unknown>): Context | undefined {
     if (this.contains(key)) return this;
     if (this._parent) {
       return this._parent.getOwnerContext(key);

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -71,13 +71,6 @@ describe('Context', () => {
       expect(result).to.be.true();
     });
 
-    it('accepts a binding', () => {
-      const binding = new Binding('foo').to('bar');
-      expect(ctx.bind(binding)).to.be.exactly(binding);
-      const result = ctx.contains('foo');
-      expect(result).to.be.true();
-    });
-
     it('returns a binding', () => {
       const binding = ctx.bind('foo');
       expect(binding).to.be.instanceOf(Binding);
@@ -86,6 +79,30 @@ describe('Context', () => {
     it('rejects a key containing property separator', () => {
       const key = 'a' + BindingKey.PROPERTY_SEPARATOR + 'b';
       expect(() => ctx.bind(key)).to.throw(/Binding key .* cannot contain/);
+    });
+
+    it('rejects rebinding of a locked key', () => {
+      ctx.bind('foo').lock();
+      expect(() => ctx.bind('foo')).to.throw(
+        'Cannot rebind key "foo" to a locked binding',
+      );
+    });
+  });
+
+  describe('add', () => {
+    it('accepts a binding', () => {
+      const binding = new Binding('foo').to('bar');
+      ctx.add(binding);
+      expect(ctx.getBinding(binding.key)).to.be.exactly(binding);
+      const result = ctx.contains('foo');
+      expect(result).to.be.true();
+    });
+
+    it('rejects rebinding of a locked key', () => {
+      ctx.bind('foo').lock();
+      expect(() => ctx.add(new Binding('foo'))).to.throw(
+        'Cannot rebind key "foo" to a locked binding',
+      );
     });
   });
 

--- a/packages/context/test/unit/context.unit.ts
+++ b/packages/context/test/unit/context.unit.ts
@@ -71,6 +71,13 @@ describe('Context', () => {
       expect(result).to.be.true();
     });
 
+    it('accepts a binding', () => {
+      const binding = new Binding('foo').to('bar');
+      expect(ctx.bind(binding)).to.be.exactly(binding);
+      const result = ctx.contains('foo');
+      expect(result).to.be.true();
+    });
+
     it('returns a binding', () => {
       const binding = ctx.bind('foo');
       expect(binding).to.be.instanceOf(Binding);

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -3,15 +3,22 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor, Provider, BoundValue} from '@loopback/context';
+import {Constructor, Provider, BoundValue, Binding} from '@loopback/context';
 import {Server} from './server';
 import {Application, ControllerClass} from './application';
 
 /**
- * A map of name/class pairs for binding providers
+ * A map of provider classes to be bound to a context
  */
 export interface ProviderMap {
   [key: string]: Constructor<Provider<BoundValue>>;
+}
+
+/**
+ * A map of classes to be bound to a context
+ */
+export interface ClassMap {
+  [key: string]: Constructor<BoundValue>;
 }
 
 /**
@@ -23,16 +30,45 @@ export interface Component {
    * An array of controller classes
    */
   controllers?: ControllerClass[];
+
   /**
-   * A map of name/class pairs for binding providers
+   * A map of providers to be bound to the application context
+   * * For example:
+   * ```ts
+   * {
+   *   'authentication.strategies.ldap': LdapStrategyProvider
+   * }
+   * ```
    */
   providers?: ProviderMap;
+
+  /**
+   * A map of classes to be bound to the application context.
+   *
+   * For example:
+   * ```ts
+   * {
+   *   'rest.body-parsers.xml': XmlBodyParser
+   * }
+   * ```
+   */
+  classes?: ClassMap;
+
   /**
    * A map of name/class pairs for servers
    */
   servers?: {
     [name: string]: Constructor<Server>;
   };
+
+  /**
+   * An array of bindings to be aded to the application context. For example,
+   * ```ts
+   * const bindingX = new Binding('x').to('Value X');
+   * this.bindings = [bindingX]
+   * ```
+   */
+  bindings?: Binding[];
 
   /**
    * Other properties
@@ -49,15 +85,27 @@ export interface Component {
  * @param {Component} component
  */
 export function mountComponent(app: Application, component: Component) {
-  if (component.controllers) {
-    for (const controllerCtor of component.controllers) {
-      app.controller(controllerCtor);
+  if (component.classes) {
+    for (const classKey in component.classes) {
+      app.bind(classKey).toClass(component.classes[classKey]);
     }
   }
 
   if (component.providers) {
     for (const providerKey in component.providers) {
       app.bind(providerKey).toProvider(component.providers[providerKey]);
+    }
+  }
+
+  if (component.bindings) {
+    for (const binding of component.bindings) {
+      app.add(binding);
+    }
+  }
+
+  if (component.controllers) {
+    for (const controllerCtor of component.controllers) {
+      app.controller(controllerCtor);
     }
   }
 

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -64,7 +64,7 @@ export interface Component {
   /**
    * An array of bindings to be aded to the application context. For example,
    * ```ts
-   * const bindingX = new Binding('x').to('Value X');
+   * const bindingX = Binding.bind('x').to('Value X');
    * this.bindings = [bindingX]
    * ```
    */

--- a/packages/core/test/unit/application.unit.ts
+++ b/packages/core/test/unit/application.unit.ts
@@ -74,7 +74,7 @@ describe('Application', () => {
     });
 
     it('binds bindings from a component', () => {
-      const binding = new Binding('foo');
+      const binding = Binding.bind('foo');
       class MyComponentWithBindings implements Component {
         bindings = [binding];
       }


### PR DESCRIPTION
Reactivation of https://github.com/strongloop/loopback-next/pull/929

- Improve the component design to allow contribution of various bindings
- Introduce a `@component` decorator to mark a component class (inspired by https://docs.nestjs.com/modules)

A component class can be declared as follows:
```ts
     @component({
      controllers: [MyController],
      bindings: [binding],
      classes: {'my-class': MyClass},
      providers: {'my-provider': MyProvider},
    })
    class MyComponent implements Component {
      bindings = [];
      constructor() {
        // Dynamically add more bindings
        this.bindings.push(...);
      }
    }
```
## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
