### PR TITLE
docs: fix compile errors; rename variables to match impl

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -119,7 +119,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {'x-ts-type': Todo}},
+        content: {'application/json': {schema: {'x-ts-type': Todo}}},
       },
     },
   })
@@ -131,7 +131,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: {'x-ts-type': Number}}},
       },
     },
   })
@@ -163,7 +163,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo PATCH success count',
-        content: {'application/json': {'x-ts-type': Number}},
+        content: {'application/json': {schema: {'x-ts-type': Number}}},
       },
     },
   })
@@ -178,7 +178,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {'x-ts-type': Todo}},
+        content: {'application/json': {schema: {'x-ts-type': Todo}}},
       },
     },
   })

--- a/docs/site/Decorators_openapi.md
+++ b/docs/site/Decorators_openapi.md
@@ -392,10 +392,10 @@ const schemaWithObjectPropOfMyModel = {
 export class SomeController {
   @post('/my-controller')
   greetObjectProperty(
-      @requestBody({
-        content: {'application/json': {schema: schemaWithObjectPropOfMyModel}},
-      })
-          body: { myModel: MyModel },
+    @requestBody({
+      content: {'application/json': {schema: schemaWithObjectPropOfMyModel}},
+    })
+    body: { myModel: MyModel },
   ): string {
     return `hello ${body.myModel.name}!`;
   }
@@ -414,13 +414,14 @@ export class SomeController {
 
   @post('/my-controllers')
   greetEveryone(
-      @requestBody({
-        content: {'application/json': {schema: schemaDeepArrayOfMyModel}},
-      })
-          body: MyModel[][],
+    @requestBody({
+      content: {'application/json': {schema: schemaDeepArrayOfMyModel}},
+    })
+    body: MyModel[][],
   ): string {
     return `hello ${body.map(objs => objs.map(m => m.name))}`;
   }
+}
 ```
 
 When the OpenAPI spec is generated, the `xs-ts-type` is mapped to

--- a/docs/site/Decorators_openapi.md
+++ b/docs/site/Decorators_openapi.md
@@ -335,7 +335,7 @@ class MyModel {
   name: string;
 }
 
-class MyController {
+export class MyController {
   @get('/', {
     responses: {
       '200': {
@@ -351,7 +351,7 @@ class MyController {
   @post('/')
   greet(
     @requestBody({
-      content: {'application/json': {{'x-ts-type': MyModel}}},
+      content: {'application/json': {schema: {'x-ts-type': MyModel}}},
     })
     body: MyModel,
   ) {
@@ -363,7 +363,14 @@ class MyController {
 The `x-ts-type` can be used for array and object properties too:
 
 ```ts
-const schemaWithArray = {
+const schemaWithArrayOfMyModel = {
+  type: 'array',
+  items: {
+    'x-ts-type': MyModel,
+  }
+};
+
+const schemaDeepArrayOfMyModel = {
   type: 'array',
   items: {
     type: 'array',
@@ -373,7 +380,7 @@ const schemaWithArray = {
   },
 };
 
-const schema = {
+const schemaWithObjectPropOfMyModel = {
   type: 'object',
   properties: {
     myModel: {
@@ -381,6 +388,39 @@ const schema = {
     },
   },
 };
+
+export class SomeController {
+  @post('/my-controller')
+  greetObjectProperty(
+      @requestBody({
+        content: {'application/json': {schema: schemaWithObjectPropOfMyModel}},
+      })
+          body: { myModel: MyModel },
+  ): string {
+    return `hello ${body.myModel.name}!`;
+  }
+
+  @get('/my-controllers', {
+    responses: {
+      '200': {
+        description: 'hello world',
+        content: {'application/json': {schema: schemaWithArrayOfMyModel}},
+      },
+    },
+  })
+  everyone(): MyModel[] {
+    return [{name: 'blue'}, {name: 'red'}];
+  }
+
+  @post('/my-controllers')
+  greetEveryone(
+      @requestBody({
+        content: {'application/json': {schema: schemaDeepArrayOfMyModel}},
+      })
+          body: MyModel[][],
+  ): string {
+    return `hello ${body.map(objs => objs.map(m => m.name))}`;
+  }
 ```
 
 When the OpenAPI spec is generated, the `xs-ts-type` is mapped to

--- a/docs/site/Decorators_openapi.md
+++ b/docs/site/Decorators_openapi.md
@@ -367,7 +367,7 @@ const schemaWithArrayOfMyModel = {
   type: 'array',
   items: {
     'x-ts-type': MyModel,
-  }
+  },
 };
 
 const schemaDeepArrayOfMyModel = {
@@ -391,12 +391,12 @@ const schemaWithObjectPropOfMyModel = {
 
 export class SomeController {
   @post('/my-controller')
-  greetObjectProperty(
-    @requestBody({
-      content: {'application/json': {schema: schemaWithObjectPropOfMyModel}},
-    })
-    body: { myModel: MyModel },
-  ): string {
+  greetObjectProperty(@requestBody({
+    content: {'application/json': {schema: schemaWithObjectPropOfMyModel}},
+  })
+  body: {
+    myModel: MyModel;
+  }): string {
     return `hello ${body.myModel.name}!`;
   }
 

--- a/docs/site/todo-list-tutorial-controller.md
+++ b/docs/site/todo-list-tutorial-controller.md
@@ -131,7 +131,7 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList model instance',
-        content: {'application/json': {'x-ts-type': TodoList}},
+        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
       },
     },
   })
@@ -157,7 +157,7 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'Array of TodoList model instances',
-        content: {'application/json': {'x-ts-type': TodoList}},
+        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
       },
     },
   })
@@ -186,7 +186,7 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList model instance',
-        content: {'application/json': {'x-ts-type': TodoList}},
+        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
       },
     },
   })

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -31,7 +31,7 @@ export class TodoListTodoController {
     responses: {
       '200': {
         description: 'TodoList.Todo model instance',
-        content: {'application/json': {'x-ts-type': Todo}},
+        content: {'application/json': {schema: {'x-ts-type': Todo}}},
       },
     },
   })

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -33,7 +33,7 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList model instance',
-        content: {'application/json': {'x-ts-type': TodoList}},
+        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
       },
     },
   })
@@ -59,7 +59,7 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'Array of TodoList model instances',
-        content: {'application/json': {'x-ts-type': TodoList}},
+        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
       },
     },
   })
@@ -88,7 +88,7 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList model instance',
-        content: {'application/json': {'x-ts-type': TodoList}},
+        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
       },
     },
   })

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -24,7 +24,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {'x-ts-type': Todo}},
+        content: {'application/json': {schema: {'x-ts-type': Todo}}},
       },
     },
   })
@@ -36,7 +36,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {'x-ts-type': Todo}},
+        content: {'application/json': {schema: {'x-ts-type': Todo}}},
       },
     },
   })
@@ -108,7 +108,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'TodoList model instance',
-        content: {'application/json': {'x-ts-type': TodoList}},
+        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
       },
     },
   })

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -29,7 +29,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {'x-ts-type': Todo}},
+        content: {'application/json': {schema: {'x-ts-type': Todo}}},
       },
     },
   })
@@ -49,7 +49,7 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {'x-ts-type': Todo}},
+        content: {'application/json': {schema: {'x-ts-type': Todo}}},
       },
     },
   })

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -28,7 +28,7 @@ export class <%= className %>Controller {
     responses: {
       '200': {
         description: '<%= modelName %> model instance',
-        content: {'application/json': {'x-ts-type': <%= modelName %>}},
+        content: {'application/json': {schema: {'x-ts-type': <%= modelName %>}}},
       },
     },
   })
@@ -87,7 +87,7 @@ export class <%= className %>Controller {
     responses: {
       '200': {
         description: '<%= modelName %> model instance',
-        content: {'application/json': {'x-ts-type': <%= modelName %>}},
+        content: {'application/json': {schema: {'x-ts-type': <%= modelName %>}}},
       },
     },
   })

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -247,7 +247,7 @@ function checkRestCrudContents() {
     /responses: {/,
     /'200': {/,
     /description: 'ProductReview model instance'/,
-    /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /content: {'application\/json': {schema: {'x-ts-type': ProductReview}}},\s{1,}},\s{1,}},\s{1,}}\)/,
     /async create\(\@requestBody\(\) productReview: ProductReview\)/,
   ];
   postCreateRegEx.forEach(regex => {
@@ -273,7 +273,7 @@ function checkRestCrudContents() {
     /responses: {/,
     /'200': {/,
     /description: 'Array of ProductReview model instances'/,
-    /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /content: {'application\/json': {schema: {'x-ts-type': ProductReview}}},\s{1,}},\s{1,}},\s{1,}}\)/,
     /async find\(\s*\@param\.query\.object\('filter', getFilterSchemaFor\(ProductReview\)\) filter\?: Filter(|,\s+)\)/,
   ];
   getFindRegEx.forEach(regex => {
@@ -299,7 +299,7 @@ function checkRestCrudContents() {
     /responses: {/,
     /'200': {/,
     /description: 'ProductReview model instance'/,
-    /content: {'application\/json': {'x-ts-type': ProductReview}},\s{1,}},\s{1,}},\s{1,}}\)/,
+    /content: {'application\/json': {schema: {'x-ts-type': ProductReview}}},\s{1,}},\s{1,}},\s{1,}}\)/,
     /async findById\(\@param.path.number\('id'\)/,
   ];
   getFindByIdRegEx.forEach(regex => {


### PR DESCRIPTION
- exported the controller class
- the `schema:` prop was missing
- the variable names were mismatched with types declared and 
  exposed through openapi/swagger/explorer thingie
