### PR TITLE
docs: add configuration for CORS

### DIFF
--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -155,6 +155,38 @@ export async function main() {
 }
 ```
 
+### Customize CORS
+
+[CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) is enabled
+by default for REST servers with the following options:
+
+```ts
+{
+  origin: '*',
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+  preflightContinue: false,
+  optionsSuccessStatus: 204,
+  maxAge: 86400,
+  credentials: true,
+}
+```
+
+The application code can customize CORS via REST configuration:
+
+```ts
+export async function main() {
+  const options = {
+    rest: {
+      cors: {...},
+    },
+  };
+  const app = new RestApplication(options);
+}
+```
+
+For a complete list of CORS options, see
+https://github.com/expressjs/cors#configuration-options.
+
 ### `rest` options
 
 | Property    | Type                | Purpose                                                                                                   |
@@ -163,6 +195,7 @@ export async function main() {
 | protocol    | string (http/https) | Specify the protocol on which the RestServer will listen for traffic.                                     |
 | key         | string              | Specify the SSL private key for https.                                                                    |
 | cert        | string              | Specify the SSL certificate for https.                                                                    |
+| cors        | CorsOptions         | Specify the CORS options.                                                                                 |
 | sequence    | SequenceHandler     | Use a custom SequenceHandler to change the behavior of the RestServer for the request-response lifecycle. |
 | openApiSpec | OpenApiSpecOptions  | Customize how OpenAPI spec is served                                                                      |
 | apiExplorer | ApiExplorerOptions  | Customize how API explorer is served                                                                      |


### PR DESCRIPTION
Add docs to configure `CORS` for rest servers.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
