### PR TITLE
fix(repository): build relations based on their names

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -130,7 +130,7 @@ export class OrderRepository extends DefaultCrudRepository<
   ) {
     super(Order, db);
     this.customer = this._createBelongsToAccessorFor(
-      'customerId',
+      'customer',
       customerRepositoryGetter,
     );
   }

--- a/examples/todo-list/src/repositories/todo.repository.ts
+++ b/examples/todo-list/src/repositories/todo.repository.ts
@@ -30,7 +30,7 @@ export class TodoRepository extends DefaultCrudRepository<
     super(Todo, dataSource);
 
     this.todoList = this._createBelongsToAccessorFor(
-      'todoListId',
+      'todoList',
       todoListRepositoryGetter,
     );
   }

--- a/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
@@ -39,13 +39,13 @@ export function belongsTo<T extends Entity>(
       // default values, can be customized by the caller
       {
         keyFrom: decoratedKey,
+        name: relationName,
       },
       // properties provided by the caller
       definition,
       // properties enforced by the decorator
       {
         type: RelationType.belongsTo,
-        name: relationName,
         source: decoratedTarget.constructor,
         target: targetResolver,
       },

--- a/packages/repository/src/relations/has-many/has-many.decorator.ts
+++ b/packages/repository/src/relations/has-many/has-many.decorator.ts
@@ -25,13 +25,12 @@ export function hasMany<T extends Entity>(
 
     const meta: HasManyDefinition = Object.assign(
       // default values, can be customized by the caller
-      {},
+      {name: key},
       // properties provided by the caller
       definition,
       // properties enforced by the decorator
       {
         type: RelationType.hasMany,
-        name: key,
         source: decoratedTarget.constructor,
         target: targetResolver,
       },

--- a/packages/repository/src/relations/relation.decorator.ts
+++ b/packages/repository/src/relations/relation.decorator.ts
@@ -6,6 +6,7 @@
 import {PropertyDecoratorFactory} from '@loopback/context';
 import {Model, RelationDefinitionMap} from '../model';
 import {RelationType} from './relation.types';
+import {buildModelDefinition} from '../decorators';
 
 export const RELATIONS_KEY = 'loopback:relations';
 
@@ -28,7 +29,9 @@ export function relation(definition?: Object) {
 export function getModelRelations(
   modelCtor: typeof Model,
 ): RelationDefinitionMap {
-  return (modelCtor.definition && modelCtor.definition.relations) || {};
+  // Build model definitions if `@model` is missing
+  const modelDef = buildModelDefinition(modelCtor);
+  return (modelDef && modelDef.relations) || {};
 }
 
 //

--- a/packages/repository/test/fixtures/repositories/order.repository.ts
+++ b/packages/repository/test/fixtures/repositories/order.repository.ts
@@ -29,7 +29,7 @@ export class OrderRepository extends DefaultCrudRepository<
   ) {
     super(Order, db);
     this.customer = this._createBelongsToAccessorFor(
-      'customerId',
+      'customer',
       customerRepositoryGetter,
     );
   }

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -29,6 +29,7 @@ describe('relation decorator', () => {
         addressBookId: number;
       }
 
+      @model()
       class AddressBook extends Entity {
         id: number;
 
@@ -56,6 +57,15 @@ describe('relation decorator', () => {
       expect(jugglerMeta).to.eql({
         type: Array,
         itemType: () => Address,
+      });
+
+      expect(AddressBook.definition.relations).to.eql({
+        addresses: {
+          type: RelationType.hasMany,
+          name: 'addresses',
+          source: AddressBook,
+          target: () => Address,
+        },
       });
     });
 
@@ -126,6 +136,7 @@ describe('relation decorator', () => {
         @property({id: true})
         id: number;
       }
+      @model()
       class Address extends Entity {
         @belongsTo(() => AddressBook)
         addressBookId: number;
@@ -137,6 +148,13 @@ describe('relation decorator', () => {
       expect(jugglerMeta).to.eql({
         addressBookId: {
           type: Number,
+        },
+      });
+      expect(Address.definition.relations).to.containDeep({
+        addressBook: {
+          keyFrom: 'addressBookId',
+          name: 'addressBook',
+          type: 'belongsTo',
         },
       });
     });
@@ -170,6 +188,7 @@ describe('relation decorator', () => {
     });
 
     it('accepts explicit keyFrom and keyTo', () => {
+      @model()
       class Address extends Entity {
         addressId: number;
         street: string;
@@ -177,6 +196,7 @@ describe('relation decorator', () => {
         @belongsTo(() => AddressBook, {
           keyFrom: 'aForeignKey',
           keyTo: 'aPrimaryKey',
+          name: 'address-book',
         })
         addressBookId: number;
       }
@@ -193,6 +213,13 @@ describe('relation decorator', () => {
       expect(meta).to.containEql({
         keyFrom: 'aForeignKey',
         keyTo: 'aPrimaryKey',
+      });
+      expect(Address.definition.relations).to.containDeep({
+        'address-book': {
+          type: 'belongsTo',
+          keyFrom: 'aForeignKey',
+          keyTo: 'aPrimaryKey',
+        },
       });
     });
   });


### PR DESCRIPTION
The current implementation uses property names as the key of
relations and it's not compatible with legacy juggler.

See https://github.com/strongloop/loopback-next/issues/1909

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
