### PR TITLE
test(rest): fix connection reset errors in tests

### DIFF
--- a/packages/rest/test/integration/http-handler.integration.ts
+++ b/packages/rest/test/integration/http-handler.integration.ts
@@ -333,7 +333,7 @@ describe('HttpHandler', () => {
     });
 
     /**
-     * Ignore the EPIPE error
+     * Ignore the EPIPE and ECONNRESET errors.
      * See https://github.com/nodejs/node/issues/12339
      * @param err
      */
@@ -341,8 +341,9 @@ describe('HttpHandler', () => {
       // The server side can close the socket before the client
       // side can send out all data. For example, `response.end()`
       // is called before all request data has been processed due
-      // to size limit
-      if (err && err.code !== 'EPIPE') throw err;
+      // to size limit.
+      // On Windows, ECONNRESET is sometimes emitted instead of EPIPE.
+      if (err && err.code !== 'EPIPE' && err.code !== 'ECONNRESET') throw err;
     }
 
     function givenLargeRequest() {


### PR DESCRIPTION
Based on a test failure reported for https://github.com/strongloop/loopback-next/pull/1955 by AppVeyor in https://ci.appveyor.com/project/strongloop/loopback-next/builds/19978953/job/nioktpbi7frhc0xx, it looks like Windows can emit `ECONNRESET` instead of `EPIPE`.

This commit is fixing our test implementation to treat `ECONNRESET` the same way as `EPIPE` and ignore it in the relevant tests.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated