### PR TITLE
Fix trie routing

### DIFF
--- a/benchmark/src/rest-routing/README.md
+++ b/benchmark/src/rest-routing/README.md
@@ -11,29 +11,39 @@ https://loopback.io/doc/en/lb4/Routing-requests.html for more information.
 
 ```sh
 npm run -s benchmark:routing // default to 1000 routes
-npm run -s benchmark:routing -- <number-of-routes>
+npm run -s benchmark:routing -- <number-of-routes> <number-of-routes>
+```
+
+For example:
+
+```
+npm run -s benchmark:routing -- 10 40 160 640 2560
 ```
 
 ## Base lines
 
 ```
 name                 duration    count    found   missed
-TrieRouter          0,1453883       10        8        2
-RegExpRouter        0,1220030       10        8        2
+TrieRouter          0,1038244       10        8        2
+RegExpRouter        0,1002559       10        8        2
+
 
 name                 duration    count    found   missed
-TrieRouter          0,2109957       40       35        5
-RegExpRouter        0,8762936       40       35        5
+TrieRouter           0,661415       40       35        5
+RegExpRouter        0,5797990       40       35        5
+
 
 name                 duration    count    found   missed
-TrieRouter          0,4895252      160      140       20
-RegExpRouter       0,52156699      160      140       20
+TrieRouter          0,2851976      160      140       20
+RegExpRouter       0,27040556      160      140       20
+
 
 name                 duration    count    found   missed
-TrieRouter         0,16065852      640      560       80
-RegExpRouter      0,304921026      640      560       80
+TrieRouter          0,8914005      640      560       80
+RegExpRouter      0,330599418      640      560       80
+
 
 name                 duration    count    found   missed
-TrieRouter         0,60165877     2560     2240      320
-RegExpRouter      4,592089555     2560     2240      320
+TrieRouter         0,45302321     2560     2240      320
+RegExpRouter      5,471787942     2560     2240      320
 ```

--- a/benchmark/src/rest-routing/routing-table.ts
+++ b/benchmark/src/rest-routing/routing-table.ts
@@ -108,4 +108,11 @@ function givenRouter(router: RestRouter, spec: OpenApiSpec, count: number) {
   };
 }
 
-runBenchmark(+process.argv[2] || 1000);
+let tests = process.argv.slice(2);
+if (!tests.length) {
+  tests = ['1000'];
+}
+tests.forEach(n => {
+  runBenchmark(+n);
+  console.log('\n');
+});

--- a/packages/rest/src/router/route-sort.ts
+++ b/packages/rest/src/router/route-sort.ts
@@ -28,41 +28,30 @@ export function compareRoute(
   route1: Pick<RouteEntry, 'verb' | 'path'>,
   route2: Pick<RouteEntry, 'verb' | 'path'>,
 ): number {
-  // First check verb
-  const verb1 = HTTP_VERBS[route1.verb.toLowerCase()] || HTTP_VERBS.get;
-  const verb2 = HTTP_VERBS[route2.verb.toLowerCase()] || HTTP_VERBS.get;
-  if (verb1 !== verb2) return verb1 - verb2;
-
-  // Then check the path tokens
+  // First check the path tokens
   const path1 = route1.path.replace(/{([^}]*)}(\/|$)/g, ':$1$2');
   const path2 = route2.path.replace(/{([^}]*)}(\/|$)/g, ':$1$2');
   const tokensForPath1: pathToRegExp.Token[] = parse(path1);
   const tokensForPath2: pathToRegExp.Token[] = parse(path2);
 
-  // Longer path comes before shorter path
-  if (tokensForPath1.length < tokensForPath2.length) {
-    return 1;
-  } else if (tokensForPath1.length > tokensForPath2.length) {
-    return -1;
-  }
+  const length =
+    tokensForPath1.length > tokensForPath2.length
+      ? tokensForPath1.length
+      : tokensForPath2.length;
 
-  // Now check token by token
-  for (let i = 0; i < tokensForPath1.length; i++) {
+  for (let i = 0; i < length; i++) {
     const token1 = tokensForPath1[i];
     const token2 = tokensForPath2[i];
-    if (typeof token1 === 'string' && typeof token2 === 'string') {
-      if (token1 < token2) return -1;
-      else if (token1 > token2) return 1;
-    } else if (typeof token1 === 'string' && typeof token2 === 'object') {
-      // token 1 is a literal while token 2 is a parameter
-      return -1;
-    } else if (typeof token1 === 'object' && typeof token2 === 'string') {
-      // token 1 is a parameter while token 2 is a literal
-      return 1;
-    } else {
-      // Both token are parameters. Treat as equal weight.
-    }
+    if (token1 === token2) continue;
+    if (token1 === undefined) return 1;
+    if (token2 === undefined) return -1;
+    if (token1 < token2) return -1;
+    if (token1 > token2) return 1;
   }
+  // Then check verb
+  const verb1 = HTTP_VERBS[route1.verb.toLowerCase()] || HTTP_VERBS.get;
+  const verb2 = HTTP_VERBS[route2.verb.toLowerCase()] || HTTP_VERBS.get;
+  if (verb1 !== verb2) return verb1 - verb2;
   return 0;
 }
 
@@ -77,7 +66,8 @@ function parse(path: string) {
       // The string can be /orders/count
       tokens.push(...p.split('/').filter(Boolean));
     } else {
-      tokens.push(p);
+      // Use `{}` for wildcard as they are larger than any other ascii chars
+      tokens.push(`{}`);
     }
   });
   return tokens;

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -138,7 +138,7 @@ export class RoutingTable {
    * @param request
    */
   find(request: Request): ResolvedRoute {
-    debug('Finding route %s for %s %s', request.method, request.path);
+    debug('Finding route for %s %s', request.method, request.path);
 
     const found = this._router.find(request);
 

--- a/packages/rest/test/unit/router/route-sort.unit.ts
+++ b/packages/rest/test/unit/router/route-sort.unit.ts
@@ -14,15 +14,15 @@ describe('route sorter', () => {
       compareRoute(a[1], b[1]),
     );
     expect(sortedEndpoints).to.eql([
-      ['create', {verb: 'post', path: '/orders'}],
+      ['count', {verb: 'get', path: '/orders/count'}],
+      ['exists', {verb: 'get', path: '/orders/{id}/exists'}],
       ['replaceById', {verb: 'put', path: '/orders/{id}'}],
       ['updateById', {verb: 'patch', path: '/orders/{id}'}],
-      ['updateAll', {verb: 'patch', path: '/orders'}],
-      ['exists', {verb: 'get', path: '/orders/{id}/exists'}],
-      ['count', {verb: 'get', path: '/orders/count'}],
       ['findById', {verb: 'get', path: '/orders/{id}'}],
-      ['findAll', {verb: 'get', path: '/orders'}],
       ['deleteById', {verb: 'delete', path: '/orders/{id}'}],
+      ['create', {verb: 'post', path: '/orders'}],
+      ['updateAll', {verb: 'patch', path: '/orders'}],
+      ['findAll', {verb: 'get', path: '/orders'}],
       ['deleteAll', {verb: 'delete', path: '/orders'}],
     ]);
   });

--- a/packages/rest/test/unit/router/route-sort.unit.ts
+++ b/packages/rest/test/unit/router/route-sort.unit.ts
@@ -19,6 +19,7 @@ describe('route sorter', () => {
       ['replaceById', {verb: 'put', path: '/orders/{id}'}],
       ['updateById', {verb: 'patch', path: '/orders/{id}'}],
       ['findById', {verb: 'get', path: '/orders/{id}'}],
+      ['removeById', {verb: 'delete', path: '/orders/{id}'}],
       ['deleteById', {verb: 'delete', path: '/orders/{id}'}],
       ['create', {verb: 'post', path: '/orders'}],
       ['updateAll', {verb: 'patch', path: '/orders'}],
@@ -58,6 +59,11 @@ describe('route sorter', () => {
         path: '/orders/{id}/exists',
       },
       deleteById: {
+        verb: 'delete',
+        path: '/orders/{id}',
+      },
+      // Add a duplicate route to test sorting
+      removeById: {
         verb: 'delete',
         path: '/orders/{id}',
       },

--- a/packages/rest/test/unit/router/trie-router.unit.ts
+++ b/packages/rest/test/unit/router/trie-router.unit.ts
@@ -56,19 +56,19 @@ describe('trie router', () => {
 
   it('lists routes by order', () => {
     expect(router.list().map(getVerbAndPath)).to.eql([
-      {verb: 'post', path: '/orders'},
+      {verb: 'get', path: '/orders/count'},
+      {verb: 'get', path: '/orders/{id}/exists'},
       {verb: 'put', path: '/orders/{id}'},
       {verb: 'patch', path: '/orders/{id}'},
+      {verb: 'get', path: '/orders/{id}'},
+      {verb: 'delete', path: '/orders/{id}'},
+      {verb: 'post', path: '/orders'},
       {verb: 'patch', path: '/orders'},
-      {verb: 'get', path: '/orders/{id}/exists'},
+      {verb: 'get', path: '/orders'},
+      {verb: 'delete', path: '/orders'},
       {verb: 'get', path: '/users/{userId}/orders'},
       {verb: 'get', path: '/users/{id}/products'},
-      {verb: 'get', path: '/orders/count'},
-      {verb: 'get', path: '/orders/{id}'},
       {verb: 'get', path: '/users/{id}'},
-      {verb: 'get', path: '/orders'},
-      {verb: 'delete', path: '/orders/{id}'},
-      {verb: 'delete', path: '/orders'},
     ]);
   });
 


### PR DESCRIPTION
1. Handle overlapping paths with different vars

For example:

- GET /users/{id}/products
- GET /users/{id}
- GET /users/{userId}/orders

The issue was discovered with https://github.com/strongloop/loopback4-example-shopping/pull/23

2. Improve route sorting to group by path and verb. 

For example:
```
      {verb: 'get', path: '/orders/count'},
      {verb: 'get', path: '/orders/{id}/exists'},
      {verb: 'put', path: '/orders/{id}'},
      {verb: 'patch', path: '/orders/{id}'},
      {verb: 'get', path: '/orders/{id}'},
      {verb: 'delete', path: '/orders/{id}'},
      {verb: 'post', path: '/orders'},
      {verb: 'patch', path: '/orders'},
      {verb: 'get', path: '/orders'},
      {verb: 'delete', path: '/orders'},
      {verb: 'get', path: '/users/{userId}/orders'},
      {verb: 'get', path: '/users/{id}/products'},
      {verb: 'get', path: '/users/{id}'},
```

We currently sort by verb/number of parts/path.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
