### PR TITLE
revert: revert "ci: enable Node.js 11.x on Travis CI"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "11"
 
 os:
   - linux


### PR DESCRIPTION
Revert "ci: enable Node.js 11.x on Travis CI". This reverts commit 81c85d3659b7009f4437ab2795379ac2e38db19f.

Have to do this because the router sorting function is broken in Node.js 11, need more time to figure what's going on.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
