### PR TITLE
fix(rest): make sure the sorting test pass for node 11

### DIFF
--- a/packages/rest/test/unit/router/route-sort.unit.ts
+++ b/packages/rest/test/unit/router/route-sort.unit.ts
@@ -13,19 +13,37 @@ describe('route sorter', () => {
     const sortedEndpoints = Object.entries(routes).sort((a, b) =>
       compareRoute(a[1], b[1]),
     );
-    expect(sortedEndpoints).to.eql([
-      ['count', {verb: 'get', path: '/orders/count'}],
-      ['exists', {verb: 'get', path: '/orders/{id}/exists'}],
-      ['replaceById', {verb: 'put', path: '/orders/{id}'}],
-      ['updateById', {verb: 'patch', path: '/orders/{id}'}],
-      ['findById', {verb: 'get', path: '/orders/{id}'}],
-      ['removeById', {verb: 'delete', path: '/orders/{id}'}],
-      ['deleteById', {verb: 'delete', path: '/orders/{id}'}],
-      ['create', {verb: 'post', path: '/orders'}],
-      ['updateAll', {verb: 'patch', path: '/orders'}],
-      ['findAll', {verb: 'get', path: '/orders'}],
-      ['deleteAll', {verb: 'delete', path: '/orders'}],
-    ]);
+    if (sortedEndpoints[5][0] === 'removeById') {
+      expect(sortedEndpoints).to.eql([
+        ['count', {verb: 'get', path: '/orders/count'}],
+        ['exists', {verb: 'get', path: '/orders/{id}/exists'}],
+        ['replaceById', {verb: 'put', path: '/orders/{id}'}],
+        ['updateById', {verb: 'patch', path: '/orders/{id}'}],
+        ['findById', {verb: 'get', path: '/orders/{id}'}],
+        ['removeById', {verb: 'delete', path: '/orders/{id}'}],
+        ['deleteById', {verb: 'delete', path: '/orders/{id}'}],
+        ['create', {verb: 'post', path: '/orders'}],
+        ['updateAll', {verb: 'patch', path: '/orders'}],
+        ['findAll', {verb: 'get', path: '/orders'}],
+        ['deleteAll', {verb: 'delete', path: '/orders'}],
+      ]);
+    } else {
+      // Node 11.x and above. The sort is now stable
+      // https://bugs.chromium.org/p/v8/issues/detail?id=90
+      expect(sortedEndpoints).to.eql([
+        ['count', {verb: 'get', path: '/orders/count'}],
+        ['exists', {verb: 'get', path: '/orders/{id}/exists'}],
+        ['replaceById', {verb: 'put', path: '/orders/{id}'}],
+        ['updateById', {verb: 'patch', path: '/orders/{id}'}],
+        ['findById', {verb: 'get', path: '/orders/{id}'}],
+        ['deleteById', {verb: 'delete', path: '/orders/{id}'}],
+        ['removeById', {verb: 'delete', path: '/orders/{id}'}],
+        ['create', {verb: 'post', path: '/orders'}],
+        ['updateAll', {verb: 'patch', path: '/orders'}],
+        ['findAll', {verb: 'get', path: '/orders'}],
+        ['deleteAll', {verb: 'delete', path: '/orders'}],
+      ]);
+    }
   });
 
   function givenRoutes() {


### PR DESCRIPTION
See https://bugs.chromium.org/p/v8/issues/detail?id=90

It replaces https://github.com/strongloop/loopback-next/pull/1985

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
