### PR TITLE
chore: update prettier to 1.15.1

### DIFF
--- a/bin/update-template-deps.js
+++ b/bin/update-template-deps.js
@@ -19,10 +19,12 @@ async function updateTemplateDeps() {
   const project = new Project(process.cwd());
   const packages = await project.getPackages();
 
-  const pkgs = packages.filter(pkg => !pkg.private).map(pkg => ({
-    name: pkg.name,
-    version: pkg.version,
-  }));
+  const pkgs = packages
+    .filter(pkg => !pkg.private)
+    .map(pkg => ({
+      name: pkg.name,
+      version: pkg.version,
+    }));
 
   const lbModules = {};
   for (const p of pkgs) {

--- a/packages/build/bin/utils.js
+++ b/packages/build/bin/utils.js
@@ -19,8 +19,8 @@ function getCompilationTarget() {
   return nodeMajorVersion >= 10
     ? 'es2018'
     : nodeMajorVersion >= 7
-      ? 'es2017'
-      : 'es2015';
+    ? 'es2017'
+    : 'es2015';
 }
 
 /**

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -21,7 +21,7 @@
     "glob": "^7.1.2",
     "mocha": "^5.1.1",
     "nyc": "^13.0.1",
-    "prettier": "^1.14.0",
+    "prettier": "^1.15.1",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.5",
     "strong-docs": "^4.0.0",

--- a/packages/context/test/unit/value-promise.unit.ts
+++ b/packages/context/test/unit/value-promise.unit.ts
@@ -132,18 +132,16 @@ describe('resolveList', () => {
 
   it('resolves an array of promises or values', async () => {
     const source = ['a', 'b'];
-    const result = await resolveList(
-      source,
-      v => (v === 'a' ? 'A' : Promise.resolve(v.toUpperCase())),
+    const result = await resolveList(source, v =>
+      v === 'a' ? 'A' : Promise.resolve(v.toUpperCase()),
     );
     expect(result).to.eql(['A', 'B']);
   });
 
   it('resolves an array of promises or values with index', async () => {
     const source = ['a', 'b'];
-    const result = await resolveList(
-      source,
-      (v, i) => (v === 'a' ? 'A' + i : Promise.resolve(v.toUpperCase() + i)),
+    const result = await resolveList(source, (v, i) =>
+      v === 'a' ? 'A' + i : Promise.resolve(v.toUpperCase() + i),
     );
     expect(result).to.eql(['A0', 'B1']);
   });
@@ -189,18 +187,16 @@ describe('resolveMap', () => {
 
   it('resolves an object of promises or values', async () => {
     const source = {a: 'x', b: 'y'};
-    const result = await resolveMap(
-      source,
-      v => (v === 'x' ? 'X' : Promise.resolve(v.toUpperCase())),
+    const result = await resolveMap(source, v =>
+      v === 'x' ? 'X' : Promise.resolve(v.toUpperCase()),
     );
     expect(result).to.eql({a: 'X', b: 'Y'});
   });
 
   it('resolves an object of promises or values with key', async () => {
     const source = {a: 'x', b: 'y'};
-    const result = await resolveMap(
-      source,
-      (v, p) => (v === 'x' ? 'X' + p : Promise.resolve(v.toUpperCase() + p)),
+    const result = await resolveMap(source, (v, p) =>
+      v === 'x' ? 'X' + p : Promise.resolve(v.toUpperCase() + p),
     );
     expect(result).to.eql({a: 'Xa', b: 'Yb'});
   });

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -147,13 +147,15 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
        *   }
        * ```
        */
-      operationSpec.parameters = params.filter(p => p != null).map(p => {
-        // Per OpenAPI spec, `required` must be `true` for path parameters
-        if (p.in === 'path') {
-          p.required = true;
-        }
-        return p;
-      });
+      operationSpec.parameters = params
+        .filter(p => p != null)
+        .map(p => {
+          // Per OpenAPI spec, `required` must be `true` for path parameters
+          if (p.in === 'path') {
+            p.required = true;
+          }
+          return p;
+        });
     }
 
     debug('  processing requestBody for method %s', op);


### PR DESCRIPTION
Update prettier to 1.15.1

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
