### PR TITLE
build(docs): include READMEs from all packages at publish time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ benchmark/dist
 **/package
 .sandbox
 packages/cli/generators/datasource/connectors.json
+docs/site/readmes
 
 # Exclude all files under sandbox except README.md and example
 /sandbox/*

--- a/bin/build-docs-site.sh
+++ b/bin/build-docs-site.sh
@@ -21,6 +21,9 @@ DIR=`dirname $0`
 REPO_ROOT=$DIR/..
 pushd $REPO_ROOT >/dev/null
 
+# Update README duplicates inside docs/site/readmes
+node docs/bin/copy-readmes.js
+
 # Clean up sandbox/loopback.io directory
 rm -rf sandbox/loopback.io/
 

--- a/docs/bin/copy-readmes.js
+++ b/docs/bin/copy-readmes.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+/*
+ * This is an internal script to gather READMEs of all packages
+ * in our monorepo and copy them to `site/readmes` for consumption
+ * from the docs.
+ */
+
+const Project = require('@lerna/project');
+const fs = require('fs-extra');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const DEST_ROOT = path.resolve(__dirname, '../site/readmes/loopback-next');
+
+copyReadmes().catch(err => {
+  console.error('Unhandled error.', err);
+  process.exit(1);
+});
+
+async function copyReadmes() {
+  // Remove the original folder so we remove files from deleted packages
+  fs.removeSync(DEST_ROOT);
+
+  const project = new Project(REPO_ROOT);
+  const allPackages = await project.getPackages();
+
+  const packages = allPackages.filter(isDocumented).map(pkg => ({
+    name: pkg.name,
+    location: path.relative(REPO_ROOT, pkg.location),
+  }));
+
+  for (const {location} of packages) {
+    const src = path.join(REPO_ROOT, location, 'README.md');
+    const dest = path.join(DEST_ROOT, location, 'README.md');
+    await fs.copy(src, dest, {overwrite: true});
+  }
+}
+
+function isDocumented(pkg) {
+  return (
+    !pkg.name.startsWith('@loopback/sandbox-') &&
+    pkg.name !== '@loopback/docs' &&
+    pkg.name !== '@loopback/benchmark'
+  );
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build:apidocs": "lb-apidocs --html-file=index.html",
-    "clean": "lb-clean loopback-docs*.tgz package api-docs"
+    "prepublishOnly": "node ./bin/copy-readmes",
+    "clean": "lb-clean loopback-docs*.tgz package api-docs site/readmes"
   },
   "devDependencies": {
     "@loopback/build": "^1.0.1"
@@ -31,5 +32,8 @@
     "url": "https://github.com/strongloop/loopback-next"
   },
   "copyright.owner": "IBM Corp.",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "fs-extra": "^7.0.1"
+  }
 }


### PR DESCRIPTION
Add a script to copy per-package README files `docs/site/readmes`, run it as part of the release process.

This enhancement simplifies the process of including new READMEs in the documentation rendered at https://loopback.io, supersedes https://github.com/strongloop/loopback.io/pull/767 and makes loopback.io's script `update-v4-readmes.sh` pretty much obsolete.

To keep things simple, I am copying READMEs from almost all packages, even though those READMEs are not used yet. Skipped packages:
- `@loopback/docs`
- `@loopback/benchmark`
- everything starting with `@loopback/sandbox-`

See also https://github.com/strongloop/loopback-next/pull/2014 which will greatly benefit from this change.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated