### PR TITLE
Docs: Break cyclic dependency for hasMany

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -87,9 +87,10 @@ repository, the following are required:
 - In the constructor of your source repository class, use
   [Dependency Injection](Dependency-injection.md) to receive a getter function
   for obtaining an instance of the target repository. _Note: We need a getter
-  function instead of a repository instance in order to break a cyclic
-  dependency between a repository with a belongsTo relation and a repository
-  with the matching hasMany relation._
+  function, accepting a string repository name instead of a repository
+  constructor, or a repository instance, in order to break a cyclic dependency
+  between a repository with a belongsTo relation and a repository with the
+  matching hasMany relation._
 - Declare a property with the factory function type
   `BelongsToAccessor<targetModel, typeof sourceModel.prototype.id>` on the
   source repository class.

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -100,9 +100,11 @@ repository, the following are required:
 - In the constructor of your source repository class, use
   [Dependency Injection](Dependency-injection.md) to receive a getter function
   for obtaining an instance of the target repository. _Note: We need a getter
-  function instead of a repository instance in order to break a cyclic
-  dependency between a repository with a hasMany relation and a repository with
-  the matching belongsTo relation._
+  function, accepting a string repository name instead of a repository
+  constructor, or a repository instance, in order to break a cyclic dependency
+  between a repository with a hasMany relation and a repository with the
+  matching belongsTo relation._
+
 - Declare a property with the factory function type
   `HasManyRepositoryFactory<targetModel, typeof sourceModel.prototype.id>` on
   the source repository class.
@@ -137,7 +139,7 @@ export class CustomerRepository extends DefaultCrudRepository<
   >;
   constructor(
     @inject('datasources.db') protected db: juggler.DataSource,
-    @repository.getter(OrderRepository)
+    @repository.getter('OrderRepository')
     getOrderRepository: Getter<OrderRepository>,
   ) {
     super(Customer, db);


### PR DESCRIPTION
This brings the documentation inline with the https://loopback.io/doc/en/lb4/BelongsTo-relation.html. 

When using `hasMany` and `belongsTo` together, it's important to use string based class names to break the cyclic dependency. 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
