### PR TITLE
fix: todo-list example index.js

### DIFF
--- a/examples/todo-list/index.js
+++ b/examples/todo-list/index.js
@@ -19,7 +19,7 @@ if (require.main === module) {
       },
     },
   };
-  application.main().catch(err => {
+  application.main(config).catch(err => {
     console.error('Cannot start the application.', err);
     process.exit(1);
   });


### PR DESCRIPTION
Originated from https://github.com/strongloop/loopback-next/issues/2029#issuecomment-438806289

@dougal83 reported that the GraphQL tutorial won't work for todo-list example.  It is because the index.js in the `todo-list` example does not take in the config as parameter in https://github.com/strongloop/loopback-next/blob/master/examples/todo-list/index.js#L22

It should be the same as the index.js in the `todo` example: https://github.com/strongloop/loopback-next/blob/master/examples/todo-list/index.js#L22
