### PR TITLE
fix(cli): allow `*` for version range

### DIFF
--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -343,8 +343,12 @@ module.exports = class BaseGenerator extends Generator {
     const incompatibleDeps = {};
     for (const d in templateDeps) {
       const versionRange = projectDeps[d] || projectDevDeps[d];
-      if (!versionRange || semver.intersects(versionRange, templateDeps[d]))
-        continue;
+      if (!versionRange) continue;
+      // https://github.com/strongloop/loopback-next/issues/2028
+      // https://github.com/npm/node-semver/pull/238
+      // semver.intersects does not like `*`, `x`, or `X`
+      if (versionRange.match(/^\*|x|X/)) continue;
+      if (semver.intersects(versionRange, templateDeps[d])) continue;
       incompatibleDeps[d] = [versionRange, templateDeps[d]];
     }
 

--- a/packages/cli/test/integration/lib/artifact-generator.js
+++ b/packages/cli/test/integration/lib/artifact-generator.js
@@ -94,6 +94,19 @@ module.exports = function(artiGenerator) {
         /Incompatible dependencies/,
       );
 
+      testCheckLoopBack(
+        'allows */x/X for version range',
+        {
+          keywords: ['loopback'],
+          devDependencies: {'@types/node': '*'},
+          dependencies: {
+            '@loopback/context': 'x.x',
+            '@loopback/core': 'X.*',
+          },
+        },
+        // No expected error here
+      );
+
       it('passes if "keywords" maps to "loopback"', async () => {
         gen.fs.readJSON.returns({keywords: ['test', 'loopback']});
         await gen.checkLoopBackProject();
@@ -110,6 +123,10 @@ module.exports = function(artiGenerator) {
           });
           gen.fs.readJSON.returns(obj);
           await gen.checkLoopBackProject();
+          if (!expected) {
+            assert(gen.exitGeneration == null);
+            return;
+          }
           assert(gen.exitGeneration instanceof Error);
           assert(gen.exitGeneration.message.match(expected));
           gen.end();


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/2028

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
