### PR TITLE
chore(rest-explorer): set rest-explorer version to 1.0.0

### DIFF
--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -43,7 +43,7 @@
     "@loopback/boot": "^1.0.4",
     "@loopback/context": "^1.1.0",
     "@loopback/core": "^1.1.0",
-    "@loopback/rest-explorer": "^0.1.0",
+    "@loopback/rest-explorer": "^1.0.0",
     "@loopback/openapi-v3": "^1.1.1",
     "@loopback/repository": "^1.0.4",
     "@loopback/rest": "^1.3.0",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -37,7 +37,7 @@
     "@loopback/boot": "^1.0.4",
     "@loopback/context": "^1.1.0",
     "@loopback/core": "^1.1.0",
-    "@loopback/rest-explorer": "^0.1.0",
+    "@loopback/rest-explorer": "^1.0.0",
     "@loopback/openapi-v3": "^1.1.1",
     "@loopback/openapi-v3-types": "^1.0.1",
     "@loopback/repository": "^1.0.4",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -37,7 +37,7 @@
     "@loopback/boot": "^1.0.4",
     "@loopback/context": "^1.1.0",
     "@loopback/core": "^1.1.0",
-    "@loopback/rest-explorer": "^0.1.0",
+    "@loopback/rest-explorer": "^1.0.0",
     "@loopback/openapi-v3": "^1.1.1",
     "@loopback/openapi-v3-types": "^1.0.1",
     "@loopback/repository": "^1.0.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -112,7 +112,7 @@
       "@loopback/http-server": "^1.0.2",
       "@loopback/example-todo-list": "^1.1.1",
       "@loopback/dist-util": "^0.4.0",
-      "@loopback/rest-explorer": "^0.1.0"
+      "@loopback/rest-explorer": "^1.0.0"
     }
   },
   "copyright.owner": "IBM Corp.",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/rest-explorer",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "LoopBack's API Explorer",
   "engines": {
     "node": ">=8.9"
@@ -21,7 +21,7 @@
     "@loopback/core": "^1.0.1",
     "@loopback/rest": "^1.2.0",
     "ejs": "^2.6.1",
-    "swagger-ui-dist": "^3.18.2"
+    "swagger-ui-dist": "^3.20.0"
   },
   "devDependencies": {
     "@loopback/build": "^1.0.1",


### PR DESCRIPTION
Set `rest-explorer` version to `1.0.0` so that we can publish its 1st release.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
