### PR TITLE
update the broken link

### DIFF
--- a/docs/site/todo-tutorial-geocoding-service.md
+++ b/docs/site/todo-tutorial-geocoding-service.md
@@ -14,7 +14,7 @@ To call other APIs and web services from LoopBack applications, we recommend to
 use Service Proxies as a design pattern for encapsulating low-level
 implementation details of communication with 3rd-party services and providing
 JavaScript/TypeScript API that's easy to consume e.g. from Controllers. See
-[Calling other APIs and web services](./Calling-other-APIs-and-web-services.md)
+[Calling other APIs and web services](https://loopback.io/doc/en/lb4/Calling-other-APIs-and-web-services.html)
 for more details.
 
 In LoopBack, each service proxy is backed by a


### PR DESCRIPTION
the original link is wrong. the new link should be  https://loopback.io/doc/en/lb4/Calling-other-APIs-and-web-services.html

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
