### PR TITLE
Easy-to-use database migrations at application level

### DIFF
--- a/docs/site/Database-migrations.md
+++ b/docs/site/Database-migrations.md
@@ -20,123 +20,111 @@ LoopBack offers two ways to do this:
 - **Auto-update**: Change database schema objects if there is a difference
   between the objects and model definitions. Existing data will be kept.
 
-## Implementation Example
+{% include warning.html content="Auto-update will attempt to preserve data while
+updating the schema in your target database, but this is not guaranteed to be
+safe.
 
-Below is an example of how to implement
-[automigrate()](http://apidocs.loopback.io/loopback-datasource-juggler/#datasource-prototype-automigrate)
-and
-[autoupdate()](http://apidocs.loopback.io/loopback-datasource-juggler/#datasource-prototype-autoupdate),
-shown with the
-[TodoList](https://loopback.io/doc/en/lb4/todo-list-tutorial.html) example.
+Please check the documentation for your specific connector(s) for a detailed
+breakdown of behaviors for automigrate! " %}
 
-Create a new file **src/migrate.ts** and add the following import statement:
+## Examples
 
-```ts
-import {DataSource, Repository} from '@loopback/repository';
-```
+LoopBack applications are typically using `RepositoryMixin` to enhance the core
+`Application` class with additional repository-related APIs. One of such methods
+is `migrateSchema`, which iterates over all registered repositories and asks
+them to migrate their schema. Repositories that do not support schema migrations
+are silently skipped.
 
-Import your application and your repositories:
+In the future, we would like to provide finer-grained control of database schema
+updates, learn more in the GitHub issue
+[#487 Database Migration Management Framework](https://github.com/strongloop/loopback-next/issues/487)
 
-```ts
-import {TodoListApplication} from './index';
-import {TodoRepository, TodoListRepository} from './repositories';
-```
+### Auto-update database at start
 
-Create a function called _dsMigrate()_:
+To automatically update the database schema whenever the application is started,
+modify your main script to execute `app.migrateSchema()` after the application
+was bootstrapped (all repositories were registered) but before it is actually
+started.
 
-```ts
-export async function dsMigrate(app: TodoListApplication) {}
-```
-
-In the _dsMigrate()_ function, get your datasource and instantiate your
-repositories by retrieving them, so that the models are attached to the
-corresponding datasource:
+{% include code-caption.html content="src/index.ts" %}
 
 ```ts
-const ds = await app.get<DataSource>('datasources.db');
-const todoRepo = await app.getRepository(TodoRepository);
-const todoListRepo = await app.getRepository(TodoListRepository);
-```
-
-Then, in the same function, call _automigrate()_:
-
-```ts
-await ds.automigrate();
-```
-
-This call to automigrate will migrate all the models attached to the datasource
-db. However if you want to only migrate some of your models, add the names of
-the classes in the first parameter:
-
-```ts
-// Migrate a single model
-ds.automigrate('Todo');
-```
-
-```ts
-// Migrate multiple models
-ds.automigrate(['Todo', 'TodoList']);
-```
-
-The implementation for _autoupdate()_ is similar. Create a new function
-_dsUpdate()_:
-
-```ts
-export async function dsUpdate(app: TodoListApplication) {
-  const ds = await app.get<DataSource>('datasources.db');
-  const todoRepo = await app.getRepository(TodoRepository);
-  const todoListRepo = await app.getRepository(TodoListRepository);
-
-  await ds.autoupdate();
-}
-```
-
-The completed **src/migrate.ts** should look similar to this:
-
-```ts
-import {DataSource, Repository} from '@loopback/repository';
-import {TodoListApplication} from './index';
-import {TodoRepository, TodoListRepository} from './repositories';
-
-export async function dsMigrate(app: TodoListApplication) {
-  const ds = await app.get<DataSource>('datasources.db');
-  const todoRepo = await app.getRepository(TodoRepository);
-  const todoListRepo = await app.getRepository(TodoListRepository);
-
-  await ds.automigrate();
-}
-
-export async function dsUpdate(app: TodoListApplication) {
-  const ds = await app.get<DataSource>('datasources.db');
-  const todoRepo = await app.getRepository(TodoRepository);
-  const todoListRepo = await app.getRepository(TodoListRepository);
-
-  await ds.autoupdate();
-}
-```
-
-Finally, in **src/index.ts**, import and call the _dsMigrate()_ or _dsUpdate()_
-function:
-
-```ts
-import {TodoListApplication} from './application';
-import {ApplicationConfig} from '@loopback/core';
-
-// Import the functions from src/migrate.ts
-import {dsMigrate, dsUpdate} from './migrate';
-
-export {TodoListApplication};
-
 export async function main(options: ApplicationConfig = {}) {
   const app = new TodoListApplication(options);
   await app.boot();
+  await app.migrateSchema();
   await app.start();
 
   const url = app.restServer.url;
   console.log(`Server is running at ${url}`);
 
-  // The call to dsMigrate(), or replace with dsUpdate()
-  await dsMigrate(app);
   return app;
+}
+```
+
+### Auto-update the database explicitly
+
+It's usually better to have more control about the database migration and
+trigger the updates explicitly. To do so, you can implement a custom script as
+shown below.
+
+{% include code-caption.html content="src/migrate.ts" %}
+
+```ts
+import {TodoListApplication} from './application';
+
+export async function migrate(args: string[]) {
+  const dropExistingTables = args.includes('--rebuild');
+  console.log('Migrating schemas (%s)', rebuild ? 'rebuild' : 'update');
+
+  const app = new TodoListApplication();
+  await app.boot();
+  await app.migrateSchema({dropExistingTables});
+}
+
+migrate(process.argv).catch(err => {
+  console.error('Cannot migrate database schema', err);
+  process.exit(1);
+});
+```
+
+After you have compiled your application via `npm run build`, you can update
+your database by running `node dist/src/migrate` and rebuild it from scratch by
+running `node dist/src/migrate --rebuild`. It is also possible to save this
+commands as `npm` scripts in your `package.json` file.
+
+### Implement additional migration steps
+
+In some scenarios, the application may need to define additional schema
+constraints or seed the database with predefined model instances. This can be
+achieved by overriding the `migrateSchema` method provided by the mixin.
+
+The example below shows how to do so in our Todo example application.
+
+{% include code-caption.html content="src/application.ts" %}
+
+```ts
+import {TodoRepository} from './repositories';
+// skipped: other imports
+
+export class TodoListApplication extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  // skipped: the constructor, etc.
+
+  async migrateSchema(options?: SchemaMigrationOptions) {
+    // 1. Run migration scripts provided by connectors
+    await super.migrateSchema(options);
+
+    // 2. Make further changes. When creating predefined model instances,
+    // handle the case when these instances already exist.
+    const todoRepo = await this.getRepository(TodoRepository);
+    const found = await todoRepo.findOne({where: {title: 'welcome'}});
+    if (found) {
+      todoRepo.updateById(found.id, {isComplete: false});
+    } else {
+      await todoRepo.create({title: 'welcome', isComplete: false});
+    }
+  }
 }
 ```

--- a/examples/todo/src/migrate.ts
+++ b/examples/todo/src/migrate.ts
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {TodoListApplication} from './application';
+
+export async function migrate(args: string[]) {
+  const existingSchema = args.includes('--rebuild') ? 'drop' : 'alter';
+  console.log('Migrating schemas (%s existing schema)', existingSchema);
+
+  const app = new TodoListApplication();
+  await app.boot();
+  await app.migrateSchema({existingSchema});
+
+  // Connectors usually keep a pool of opened connections,
+  // this keeps the process running even after all work is done.
+  // We need to exit explicitly.
+  process.exit(0);
+}
+
+migrate(process.argv).catch(err => {
+  console.error('Cannot migrate database schema', err);
+  process.exit(1);
+});

--- a/packages/repository/src/datasource.ts
+++ b/packages/repository/src/datasource.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {AnyObject} from './common-types';
+import {AnyObject, Options} from './common-types';
 import {Connector} from './connectors';
 
 /**
@@ -16,4 +16,22 @@ export interface DataSource {
   settings: AnyObject; // Settings
   // tslint:disable-next-line:no-any
   [property: string]: any; // Other properties that vary by connectors
+}
+
+export interface SchemaMigrationOptions extends Options {
+  /**
+   * When set to 'drop', schema migration will drop existing tables and recreate
+   * them from scratch, removing any existing data along the way.
+   *
+   * When set to 'alter', schema migration will try to preserve current schema
+   * and data, and perform a non-destructive incremental update.
+   */
+  existingSchema?: 'drop' | 'alter';
+
+  /**
+   * List of model names to migrate.
+   *
+   * By default, all models are migrated.
+   */
+  models?: string[];
 }


### PR DESCRIPTION
I find the current instructions for database migration as too involved for practical use, for example when running our example applications against a real database (SQL, MongoDB). I would like to propose a better user experience as a short-term solution to scratch this itch. Please see https://github.com/strongloop/loopback-next/issues/487 for the discussion about a more comprehensive solution for long term.

In this pull request, I am introducing new APIs to simplify database migrations:

- ~~A new interface `MigrateableRepository` describing repositores that know how to migrate their database schema.~~

- A new Application-level method `app.migrateSchema()` provided by `RepositoryMixin` and running schema migration provided by all registered ~~repositories~~ datasources under the hood.

Using these two new APIs, I also

- ~~Implement `MigrateableRepository` in `DefaultCrudRepository` using autoupdate/automigrate APIs provided by legacy-juggler's  DataSource class.~~

- Simplify the instructions shown in `Database-migrations.db`

- Add an example `migrate.ts` script to our Todo example to verify that the code snippet shown in the docs works as intended.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- out of scope: Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated