### PR TITLE
feat(http-server): exposes underlying http server before start

### DIFF
--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -75,7 +75,7 @@ export class HttpServer {
   private _protocol: HttpProtocol;
   private _address: AddressInfo;
   private requestListener: RequestListener;
-  private server: http.Server | https.Server;
+  readonly server: http.Server | https.Server;
   private serverOptions?: HttpServerOptions;
 
   /**
@@ -91,12 +91,6 @@ export class HttpServer {
     this._port = serverOptions ? serverOptions.port || 0 : 0;
     this._host = serverOptions ? serverOptions.host : undefined;
     this._protocol = serverOptions ? serverOptions.protocol || 'http' : 'http';
-  }
-
-  /**
-   * Starts the HTTP / HTTPS server
-   */
-  public async start() {
     if (this._protocol === 'https') {
       this.server = https.createServer(
         this.serverOptions as https.ServerOptions,
@@ -105,6 +99,12 @@ export class HttpServer {
     } else {
       this.server = http.createServer(this.requestListener);
     }
+  }
+
+  /**
+   * Starts the HTTP / HTTPS server
+   */
+  public async start() {
     this.server.listen(this._port, this._host);
     await pEvent(this.server, 'listening');
     this._listening = true;

--- a/packages/http-server/test/integration/http-server.integration.ts
+++ b/packages/http-server/test/integration/http-server.integration.ts
@@ -12,7 +12,7 @@ import {
   givenHttpServerConfig,
 } from '@loopback/testlab';
 import * as makeRequest from 'request-promise-native';
-import {IncomingMessage, ServerResponse} from 'http';
+import {IncomingMessage, ServerResponse, Server} from 'http';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -119,6 +119,11 @@ describe('HttpServer (integration)', () => {
     expect(server)
       .to.have.property('address')
       .which.is.an.Object();
+  });
+
+  it('exports server before start', async () => {
+    server = new HttpServer(dummyRequestHandler);
+    expect(server.server).to.be.instanceOf(Server);
   });
 
   it('resets address when server is stopped', async () => {


### PR DESCRIPTION
To create a sockio server from the HttpServer, we need to access the
underlying http/https server.

See https://github.com/raymondfeng/loopback4-example-websocket/blob/master/src/websocket.server.ts
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
