### PR TITLE
feat(http-server): add http/2 support based on spdy

### DIFF
--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -17,7 +17,9 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "p-event": "^2.0.0"
+    "@types/spdy": "^3.4.4",
+    "p-event": "^2.0.0",
+    "spdy": "^4.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^1.0.1",

--- a/packages/testlab/src/request.ts
+++ b/packages/testlab/src/request.ts
@@ -22,10 +22,15 @@ export function httpGetAsync(urlString: string): Promise<IncomingMessage> {
  * Async wrapper for making HTTPS GET requests
  * @param urlString
  */
-export function httpsGetAsync(urlString: string): Promise<IncomingMessage> {
-  const agent = new https.Agent({
-    rejectUnauthorized: false,
-  });
+export function httpsGetAsync(
+  urlString: string,
+  agent?: https.Agent,
+): Promise<IncomingMessage> {
+  agent =
+    agent ||
+    new https.Agent({
+      rejectUnauthorized: false,
+    });
 
   const urlOptions = url.parse(urlString);
   const options = {agent, ...urlOptions};


### PR DESCRIPTION
Adds http/2 support using https://github.com/spdy-http2/node-spdy. Even Node.js core now has `http2` support, the `spdy` module is express-compatible.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
