### PR TITLE
docs: fix file name captions

### DIFF
--- a/docs/site/Controllers.md
+++ b/docs/site/Controllers.md
@@ -239,8 +239,9 @@ codes is found
 The example below shows the previous controller revamped with `HttpErrors` along
 with a test to verify that the error is thrown properly.
 
+{% include code-caption.html content="test/integration/controllers/hello.controller.integration.ts" %}
+
 ```ts
-// test/integration/controllers/hello.controller.integration.ts
 import {HelloController} from '../../../src/controllers';
 import {HelloRepository} from '../../../src/repositories';
 import {testdb} from '../../fixtures/datasources/testdb.datasource';
@@ -262,8 +263,9 @@ describe('Hello Controller', () => {
 });
 ```
 
+{% include code-caption.html content="src/controllers/hello.controller.ts" %}
+
 ```ts
-// src/controllers/hello.controller.ts
 import {HelloRepository} from '../repositories';
 import {HelloMessage} from '../models';
 import {get, param, HttpErrors} from '@loopback/rest';

--- a/docs/site/Decorators_authenticate.md
+++ b/docs/site/Decorators_authenticate.md
@@ -16,8 +16,9 @@ requires a strategy name as a parameter.
 Here's an example using 'BasicStrategy': to authenticate user in function
 `whoAmI`:
 
+{% include code-caption.html content="src/controllers/who-am-i.controller.ts" %}
+
 ```ts
-// src/controllers/who-am-i.controller.ts
 import {inject} from '@loopback/context';
 import {
   AuthenticationBindings,

--- a/docs/site/Decorators_inject.md
+++ b/docs/site/Decorators_inject.md
@@ -20,8 +20,9 @@ instance or a request context instance. You can bind values, class definitions,
 and provider functions to those contexts and then resolve the values (or the
 results of functions that return those values!) in other areas of your code.
 
+{% include code-caption.html content="src/application.ts" %}
+
 ```ts
-// src/application.ts
 import {Application} from '@loopback/core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -46,8 +47,9 @@ Now that we've bound the 'config.widget' key to our configuration object, and
 the 'logger.widget' key to the function `logInfo()`, we can inject them in our
 WidgetController:
 
+{% include code-caption.html content="src/controllers/widget.controller.ts" %}
+
 ```ts
-// src/controllers/widget.controller.ts
 import {inject} from '@loopback/context';
 
 export class WidgetController {

--- a/docs/site/Decorators_openapi.md
+++ b/docs/site/Decorators_openapi.md
@@ -240,8 +240,9 @@ _To learn more about decorating models and the corresponding OpenAPI schema, see
 The model decorators allow type information of the model to be visible to the
 spec generator so that `@requestBody` can be used on the parameter:
 
+{% include code-caption.html content="/src/controllers/user.controller.ts" %}
+
 ```ts
-// in file '/src/controllers/user.controller.ts'
 import {User} from '../models/user.model';
 import {put} from '@loopback/rest';
 

--- a/docs/site/Decorators_repository.md
+++ b/docs/site/Decorators_repository.md
@@ -49,7 +49,7 @@ By using a model decorator, you can define a model as your repository's
 metadata, which then allows you to choose between two ways of creating the
 repository instance:
 
-1. Inject your repository and resolve it with the datasource juggler bridge  
+1. Inject your repository and resolve it with the datasource juggler bridge
    that's complete with CRUD operations for accessing the model's data. A use
    case can be found in this section:
    [Repository decorator](#repository-decorator)
@@ -88,8 +88,9 @@ The injection example can be found in
 To create a repository in a controller, you can define your model and datasource
 first, then import them in your controller file:
 
+{% include code-caption.html content="src/controllers/todo.controller.ts" %}
+
 ```ts
-// src/controllers/todo.controller.ts
 import {Todo} from '../models';
 import {db} from '../datasources/db.datasource';
 import {repository, EntityCrudRepository} from '@loopback/repository';

--- a/docs/site/Defining-the-API-using-design-first-approach.shelved.md
+++ b/docs/site/Defining-the-API-using-design-first-approach.shelved.md
@@ -408,9 +408,9 @@ module provides a helper function for checking whether a specification conforms
 to OpenAPI Spec. Just add a new Mocha test that calls this helper function to
 the test suite:
 
-```ts
-// test/acceptance/api-spec.acceptance.ts
+{% include code-caption.html content="test/acceptance/api-spec.acceptance.ts" %}
 
+```ts
 import {validateApiSpec} from '@loopback/testlab';
 import {MyApp} from '../..';
 import {RestServer} from '@loopback/rest';

--- a/docs/site/OpenAPI-generator.md
+++ b/docs/site/OpenAPI-generator.md
@@ -54,26 +54,26 @@ TypeScript type declarations. Object types are mapped to TypeScript classes.
 
 For example,
 
-src/models/message.model.ts:
+{% include code-caption.html content="src/models/message.model.ts" %}
 
 ```ts
 export type Message = string;
 ```
 
-src/models/order-enum.model.ts:
+{% include code-caption.html content="src/models/order-enum.model.ts" %}
 
 ```ts
 export type OrderEnum = 'ascending' | 'descending';
 ```
 
-src/models/comments.model.ts:
+{% include code-caption.html content="src/models/comments.model.ts" %}
 
 ```ts
 import {Comment} from './comment.model';
 export type Comments = Comment[];
 ```
 
-src/models/cart.model.ts:
+{% include code-caption.html content="src/models/cart.model.ts" %}
 
 ```ts
 import {model, property} from '@loopback/repository';
@@ -122,13 +122,13 @@ export class Cart {
 }
 ```
 
-src/models/id-type.model.ts:
+{% include code-caption.html content="src/models/id-type.model.ts" %}
 
 ```ts
 export type IdType = string | number;
 ```
 
-src/models/pet.model.ts:
+{% include code-caption.html content="src/models/pet.model.ts" %}
 
 ```ts
 import {NewPet} from './new-pet.model.ts';

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -94,8 +94,9 @@ When a `DataSource` is instantiated, the configuration properties will be used
 to initialize the connector to connect to the backend system. You can define a
 DataSource using legacy Juggler in your LoopBack 4 app as follows:
 
+{% include code-caption.html content="src/datsources/db.datasource.ts" %}
+
 ```ts
-// src/datsources/db.datasource.ts
 import {juggler} from '@loopback/repository';
 
 // this is just an example, 'test' database doesn't actually exist

--- a/docs/site/Testing-Your-Extensions.md
+++ b/docs/site/Testing-Your-Extensions.md
@@ -73,7 +73,7 @@ and test a function, providing a test double for constructor arguments as
 needed. Following are examples that illustrate how to perform a unit test on a
 controller class:
 
-**`src/controllers/ping.controller.ts`**
+{% include code-caption.html content="src/controllers/ping.controller.ts" %}
 
 ```ts
 export class PingController {
@@ -84,7 +84,7 @@ export class PingController {
 }
 ```
 
-**`test/unit/controllers/ping.controller.unit.ts`**
+{% include code-caption.html content="test/unit/controllers/ping.controller.unit.ts" %}
 
 ```ts
 import {PingController} from '../../..';
@@ -119,7 +119,7 @@ validating whether the metadata was stored or not._
 
 Following is an example for testing a decorator:
 
-**`src/decorators/test.decorator.ts`**
+{% include code-caption.html content="src/decorators/test.decorator.ts" %}
 
 ```ts
 export function test(file: string) {
@@ -145,7 +145,7 @@ export function getTestMetadata(
 }
 ```
 
-**`test/unit/decorators/test.decorator.unit.ts`**
+{% include code-caption.html content="test/unit/decorators/test.decorator.unit.ts" %}
 
 ```ts
 import {test, getTestMetadata} from '../../..';
@@ -180,7 +180,7 @@ requires the Class to have a `value()` function. A unit test for a provider
 should test the `value()` function by instantiating a new `Provider` class,
 using a test double for any constructor arguments.
 
-**`src/providers/random-number.provider.ts`**
+{% include code-caption.html content="src/providers/random-number.provider.ts" %}
 
 ```ts
 import {Provider} from '@loopback/context';
@@ -194,7 +194,7 @@ export class RandomNumberProvider implements Provider<number> {
 }
 ```
 
-**`test/unit/providers/random-number.provider.unit.ts`**
+{% include code-caption.html content="test/unit/providers/random-number.provider.unit.ts" %}
 
 ```ts
 import {RandomNumberProvider} from '../../..';
@@ -230,7 +230,7 @@ Classes to work together, an integration test is needed. A Mixin test checks
 that new or overridden methods exist and work as expected in the new Mixed
 class. Following is an example for an integration test for a Mixin:
 
-**`src/mixins/time.mixin.ts`**
+{% include code-caption.html content="src/mixins/time.mixin.ts" %}
 
 ```ts
 import {Constructor} from '@loopback/context';
@@ -255,7 +255,7 @@ export function TimeMixin<T extends Constructor<any>>(superClass: T) {
 }
 ```
 
-**`test/integration/mixins/time.mixin.integration.ts`**
+{% include code-caption.html content="test/integration/mixins/time.mixin.integration.ts" %}
 
 ```ts
 import {expect} from '@loopback/testlab';

--- a/docs/site/soap-calculator-tutorial-add-datasource.md
+++ b/docs/site/soap-calculator-tutorial-add-datasource.md
@@ -105,7 +105,7 @@ bind the Node.js method _Multiply_.
 Edit the file `src/datasources/calculator.datasource.json` and add the following
 configuration after the `remoteEnabled: true,` property as follows:
 
-##### src/datasources/calculator.datasource.json
+{% include code-caption.html content="src/datasources/calculator.datasource.json" %}
 
 ```ts
 "operations": {

--- a/docs/site/soap-calculator-tutorial-add-service.md
+++ b/docs/site/soap-calculator-tutorial-add-service.md
@@ -39,7 +39,7 @@ lb4 service
 Service Calculator was created in src/services/
 ```
 
-#### src/services/calculator.service.ts
+{% include code-caption.html content="src/services/calculator.service.ts" %}
 
 ```ts
 import {getService} from '@loopback/service-proxy';

--- a/docs/site/todo-list-tutorial-controller.md
+++ b/docs/site/todo-list-tutorial-controller.md
@@ -53,7 +53,7 @@ Controller TodoListTodo was created in src/controllers/
 
 Let's add in an injection for our `TodoListRepository`:
 
-#### src/controllers/todo-list-todo.controller.ts
+{% include code-caption.html content="src/controllers/todo-list-todo.controller.ts" %}
 
 ```ts
 import {repository} from '@loopback/repository';
@@ -74,7 +74,7 @@ factory function that we defined earlier in `TodoListRepository`.
 The `POST` request from `/todo-lists/{id}/todos` should look similar to the
 following request:
 
-#### src/controllers/todo-list-todo.controller.ts
+{% include code-caption.html content="src/controllers/todo-list-todo.controller.ts" %}
 
 ```ts
 import {repository} from '@loopback/repository';
@@ -98,7 +98,7 @@ Using our constraining factory as we did with the `POST` request, we'll define
 the controller methods for the rest of the HTTP verbs for the route. The
 completed controller should look as follows:
 
-#### src/controllers/todo-list.controller.ts
+{% include code-caption.html content="src/controllers/todo-list.controller.ts" %}
 
 ```ts
 import {
@@ -242,7 +242,8 @@ Here are some new requests you can try out:
 - `POST /todo-lists/{id}/todos` using the ID you got back from the previous
   `POST` request and a body for a todo. Notice that response body you get back
   contains property `todoListId` with the ID from before.
-- `GET /todos/{id}/todos` and see if you get the todo you created from before.
+- `GET /todo-lists/{id}/todos` and see if you get the todo you created from
+  before.
 
 And there you have it! You now have the power to define APIs for related models!
 

--- a/docs/site/todo-list-tutorial-model.md
+++ b/docs/site/todo-list-tutorial-model.md
@@ -70,7 +70,7 @@ Model TodoList was created in src/models/
 Now that we have our new model, we need to define its relation with the `Todo`
 model. Add the following import statements and property to the `TodoList` model:
 
-#### src/models/todo-list.model.ts
+{% include code-caption.html content="src/models/todo-list.model.ts" %}
 
 ```ts
 import {hasMany} from '@loopback/repository';
@@ -94,7 +94,7 @@ items.
 To complement `TodoList`'s relationship to `Todo`, we'll add in the `todoListId`
 property on the `Todo` model to define the relation on both ends:
 
-### src/models/todo.model.ts
+{% include code-caption.html content="src/models/todo.model.ts" %}
 
 ```ts
 @model()

--- a/docs/site/todo-list-tutorial-repository.md
+++ b/docs/site/todo-list-tutorial-repository.md
@@ -46,7 +46,7 @@ Once the property type for `todos` has been defined, use
 factory function. Pass in the name of the relationship (`todos`) and the Todo
 repository instance to constrain as the arguments for the function.
 
-#### src/repositories/todo-list.repository.ts
+{% include code-caption.html content="src/repositories/todo-list.repository.ts" %}
 
 ```ts
 import {Getter, inject} from '@loopback/core';

--- a/docs/site/todo-tutorial-datasource.md
+++ b/docs/site/todo-tutorial-datasource.md
@@ -49,7 +49,7 @@ Datasource db was created in src/datasources/
 Create a `data` folder in the applications root and add a new file called
 `db.json` contain and example database.
 
-#### data/db.json
+{% include code-caption.html content="data/db.json" %}
 
 ```json
 {

--- a/docs/site/todo-tutorial-geocoding-service.md
+++ b/docs/site/todo-tutorial-geocoding-service.md
@@ -59,7 +59,7 @@ Edit the newly created datasource configuration to configure Geocoder API
 endpoints. Configuration options provided by REST Connector are described in our
 docs here: [REST connector](/doc/en/lb3/REST-connector.html).
 
-#### /src/datasources/geocoder.datasource.json
+{% include code-caption.html content="/src/datasources/geocoder.datasource.json" %}
 
 ```json
 {
@@ -99,7 +99,7 @@ Create a new directory `src/services` and add the following two new files:
 - `src/services/index.ts` providing a conventient access to all services via a
   single `import` statement.
 
-#### src/services/geocoder.service.ts
+{% include code-caption.html content="src/services/geocoder.service.ts" %}
 
 ```ts
 import {getService, juggler} from '@loopback/service-proxy';
@@ -134,7 +134,7 @@ export class GeocoderServiceProvider implements Provider<GeocoderService> {
 }
 ```
 
-#### src/services/index.ts
+{% include code-caption.html content="src/services/index.ts" %}
 
 ```ts
 export * from './geocoder.service';
@@ -144,7 +144,7 @@ export * from './geocoder.service';
 
 Add two new properties to our Todo model: `remindAtAddress` and `remindAtGeo`.
 
-#### src/models/todo.model.ts
+{% include code-caption.html content="src/models/todo.model.ts" %}
 
 ```ts
 @model()
@@ -171,7 +171,7 @@ coordinates when a new Todo item is created.
 Import `GeocodeService` interface into the `TodoController` and then modify the
 Controller constructor to receive `GeocodeService` as a new dependency.
 
-#### src/controllers/todo.controller.ts
+{% include code-caption.html content="src/controllers/todo.controller.ts" %}
 
 ```ts
 import {inject} from '@loopback/core';
@@ -190,7 +190,7 @@ export class TodoController {
 Modify `createTodo` method to look up the address provided in `remindAtAddress`
 property and convert it to GPS coordinates stored in `remindAtGeo`.
 
-#### src/controllers/todo.controller.ts
+{% include code-caption.html content="src/controllers/todo.controller.ts" %}
 
 ```ts
 export class TodoController {

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -56,7 +56,7 @@ export class TodoListTodoController {
   })
   async find(
     @param.path.number('id') id: number,
-    @param.query.string('filter') filter?: Filter,
+    @param.query.object('filter') filter?: Filter,
   ): Promise<Todo[]> {
     return await this.todoListRepo.todos(id).find(filter);
   }


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-next/issues/1994. 
Changed file name captions to match the `{% include code-caption.html content="..." %}` format. Also, fixed small doc issue in the `TodoList` example and small fix to filter function for `TodoListTodoController`.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
