### PR TITLE
docs: make DEVELOPING.md to be part of docs

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -1,3 +1,12 @@
+---
+lang: en
+title: 'Contributing code in LoopBack 4'
+keywords: LoopBack 4.0, contributing, community
+sidebar: contrib_sidebar
+permalink: /doc/en/contrib/code-contrib-lb4.html
+toc: false
+---
+
 # Developing LoopBack
 
 This document describes how to develop modules living in loopback-next monorepo.


### PR DESCRIPTION
There are a few similar tasks on "Contributing to LoopBack", e.g. https://github.com/strongloop/loopback-next/issues/1673.

This PR is to make `DEVELOPING.md` show up in the contribute side bar. 
https://loopback.io/doc/en/contrib/code-contrib.html

![screen shot 2018-11-22 at 2 43 13 pm](https://user-images.githubusercontent.com/25489897/48920171-5893f800-ee65-11e8-8a31-03e98404995f.png)

![screen shot 2018-11-22 at 2 43 19 pm](https://user-images.githubusercontent.com/25489897/48926073-7a5aa280-ee98-11e8-84a6-5e0791b8fa16.png)

It has been ran locally.  (Thanks @b-admike and @nabdelgadir!)