### PR TITLE
docs: add note to create table in todo example

### DIFF
--- a/docs/site/todo-tutorial-controller.md
+++ b/docs/site/todo-tutorial-controller.md
@@ -50,10 +50,8 @@ that a new controller instance is created for each request. As a result, we want
 to inject our `TodoRepository` since the creation of these instances is more
 complex and expensive than making new controller instances.
 
-> **NOTE**: You can customize the lifecycle of _all_ bindings in LoopBack 4!
-> Controllers can easily be made to use singleton lifecycles to minimize startup
-> costs. For more information, see the
-> [Dependency injection](Dependency-injection.md) section of our docs.
+{% include note.html content="You can customize the lifecycle of _all_ bindings in LoopBack 4! Controllers can easily be made to use singleton lifecycles to minimize startup costs. For more information, see the [Dependency injection](Dependency-injection.md) section of our docs.
+" %}
 
 In this example, there are two new decorators to provide LoopBack with metadata
 about the route, verb and the format of the incoming request body:

--- a/docs/site/todo-tutorial-datasource.md
+++ b/docs/site/todo-tutorial-datasource.md
@@ -67,6 +67,11 @@ Create a `data` folder in the applications root and add a new file called
 }
 ```
 
+{% include note.html content="If you are using a relational database as the
+datasource, don't forget to create the corresponding table or follow the
+[Database migration instruction](https://loopback.io/doc/en/lb4/Database-migrations.html) to get it created programmatically.
+" %}
+
 Once you're ready, we'll move onto adding a
 [repository](todo-tutorial-repository.md) for the datasource.
 

--- a/docs/site/todo-tutorial-model.md
+++ b/docs/site/todo-tutorial-model.md
@@ -24,10 +24,8 @@ Models are used for data exchange on the wire or between different systems.
 For more information about Models and how they are used in LoopBack, see
 [Models](https://loopback.io/doc/en/lb4/Model.html).
 
-> **NOTE:** LoopBack 3 treated models as the "center" of operations; in LoopBack
-> 4, that is no longer the case. While LoopBack 4 provides many of the helper
-> methods and decorators that allow you to utilize models in a similar way, you
-> are no longer _required_ to do so!
+{% include note.html content="LoopBack 3 treated models as the 'center' of operations; in LoopBack 4, that is no longer the case. While LoopBack 4 provides many of the helper methods and decorators that allow you to utilize models in a similar way, you are no longer _required_ to do so!
+" %}
 
 ### Building your Todo model
 


### PR DESCRIPTION
When running the `todo` or `todo-list` example, if I choose to use a relational database as datasource instead of the in-memory database, I will need to create the table.  As a new user, it might not be trivial. 

In this PR, I've added a note to remind users to have the table created or follow the [database migration docs](https://loopback.io/doc/en/lb4/Database-migrations.html).