### PR TITLE
fix(docs): create a new page for How-tos sidebar section

### DIFF
--- a/docs/site/How-tos.md
+++ b/docs/site/How-tos.md
@@ -1,0 +1,22 @@
+---
+lang: en
+title: 'HOWTOs'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/How-tos.html
+---
+
+We provide the following "how to" guides:
+
+- [Exposing GraphQL APIs](exposing-graphql-apis.md): a tutorial showing how to
+  expose GraphQL APIs in an existing LoopBack application.
+
+- [Deploying to IBM Cloud](Deploying-to-IBM-Cloud.md): a basic guide for
+  deploying LoopBack 4 applications to IBM Cloud using Cloudfoundry.
+
+- [Serving static files](Serving-static-files.md): a guide for setting up static
+  assets (e.g. HTML5 front-end).
+
+- [Database migrations](Database-migrations.md): a tutorial showing how to
+  automatically update the database schema to match the models defined by the
+  application.

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -191,8 +191,8 @@ children:
     url: Error-handling.html
     output: 'web, pdf'
 
-- title: 'How tos'
-  url: Concepts.html
+- title: 'How-tos'
+  url: How-tos.html
   output: 'web, pdf'
   children:
     - title: 'Exposing GraphQL APIs'


### PR DESCRIPTION
Rename "How tos" to "How-tos", I find "How tos" as difficult to read.

Add a new page `docs/site/How-tos.md` and use it to back "How-tos"
section. Before this change, both "How-tos" and "Key concepts" were
sharing the same section page, which was confusing.


## BEFORE

<img width="1197" alt="screen shot 2018-11-26 at 12 32 55" src="https://user-images.githubusercontent.com/1140553/49011695-6bfdd680-f177-11e8-8235-dda8eab5813d.png">

## AFTER

<img width="1194" alt="screen shot 2018-11-26 at 12 33 28" src="https://user-images.githubusercontent.com/1140553/49011726-7fa93d00-f177-11e8-914c-562ab55f6dcb.png">

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated
