### PR TITLE
fix(rest): allow `.` to be used in openapi path template

### DIFF
--- a/packages/rest/src/router/openapi-path.ts
+++ b/packages/rest/src/router/openapi-path.ts
@@ -34,7 +34,7 @@ export function validateApiPath(path: string = '/') {
     );
   }
 
-  const regexpPath = path.replace(POSSIBLE_VARNAME_PATTERN, ':$1');
+  const regexpPath = toExpressPath(path);
   tokens = pathToRegExp.parse(regexpPath);
   for (const token of tokens) {
     if (typeof token === 'string') continue;
@@ -62,5 +62,7 @@ export function getPathVariables(path: string) {
  * @param path OpenAPI path with optional variables as `{var}`
  */
 export function toExpressPath(path: string) {
-  return path.replace(POSSIBLE_VARNAME_PATTERN, ':$1');
+  // Convert `.` to `\\.` so that path-to-regexp will treat it as the plain
+  // `.` character
+  return path.replace(POSSIBLE_VARNAME_PATTERN, ':$1').replace('.', '\\.');
 }

--- a/packages/rest/src/router/trie.ts
+++ b/packages/rest/src/router/trie.ts
@@ -4,6 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {PathParameterValues} from '../types';
+import {toExpressPath} from './openapi-path';
+import pathToRegexp = require('path-to-regexp');
 
 /**
  * A Node in the trie
@@ -215,17 +217,13 @@ function createNode<T>(
   }
 
   // Check if the key has variables such as `{var}`
-  const pattern = /\{([^\{]*)\}/g;
-  const names: string[] = [];
-  let match;
-  while ((match = pattern.exec(key))) {
-    names.push(match[1]);
-  }
+  const path = toExpressPath(key);
+  const params: pathToRegexp.Key[] = [];
+  const re = pathToRegexp(path, params);
 
-  if (names.length) {
-    child.names = names;
-    const re = '^' + key.replace(/\{([^\}]+)\}/g, '(.+)') + '$';
-    child.regexp = new RegExp(re);
+  if (params.length) {
+    child.names = params.map(p => `${p.name}`);
+    child.regexp = re;
   }
 
   // Add the node to the parent

--- a/packages/rest/test/unit/router/openapi-path.unit.ts
+++ b/packages/rest/test/unit/router/openapi-path.unit.ts
@@ -22,6 +22,16 @@ describe('validateApiPath', () => {
     expect(path).to.eql('/{foo}/{bar}');
   });
 
+  it('allows /{foo}.{bar}', () => {
+    const path = validateApiPath('/{foo}.{bar}');
+    expect(path).to.eql('/{foo}.{bar}');
+  });
+
+  it('allows /{foo}@{bar}', () => {
+    const path = validateApiPath('/{foo}@{bar}');
+    expect(path).to.eql('/{foo}@{bar}');
+  });
+
   it('allows /{_foo}/{bar}', () => {
     const path = validateApiPath('/{_foo}/{bar}');
     expect(path).to.eql('/{_foo}/{bar}');

--- a/packages/rest/test/unit/router/routing-table.unit.ts
+++ b/packages/rest/test/unit/router/routing-table.unit.ts
@@ -188,6 +188,32 @@ function runTestsWithRouter(router: RestRouter) {
     expect(route.pathParams).to.containEql({arg1: '3', arg2: '2'});
   });
 
+  it('finds "GET /getProfile/{userId}.{format}" endpoint', () => {
+    const spec = anOpenApiSpec()
+      .withOperationReturningString(
+        'get',
+        '/getProfile/{userId}.{format}',
+        'getProfile',
+      )
+      .build();
+
+    spec.basePath = '/my';
+
+    class TestController {}
+
+    const table = givenRoutingTable();
+    table.registerController(spec, TestController);
+
+    let request = givenRequest({
+      method: 'get',
+      url: '/my/getProfile/1.json',
+    });
+
+    let route = table.find(request);
+    expect(route.path).to.eql('/my/getProfile/{userId}.{format}');
+    expect(route.pathParams).to.containEql({userId: '1', format: 'json'});
+  });
+
   it('throws if router is not found', () => {
     const table = givenRoutingTable();
 

--- a/packages/rest/test/unit/router/trie.unit.ts
+++ b/packages/rest/test/unit/router/trie.unit.ts
@@ -53,7 +53,7 @@ describe('Trie', () => {
                   key: '{id}',
                   value: getOrderById,
                   names: ['id'],
-                  regexp: /^(.+)$/,
+                  regexp: /^([^\/]+?)(?:\/)?$/i,
                   children: {},
                 },
               },
@@ -89,7 +89,7 @@ describe('Trie', () => {
         key: '{id}',
         value: {verb: 'get', path: '/orders/{id}'},
         names: ['id'],
-        regexp: /^(.+)$/,
+        regexp: /^([^\/]+?)(?:\/)?$/i,
       },
     ]);
   });
@@ -104,7 +104,7 @@ describe('Trie', () => {
         key: '{id}',
         value: {verb: 'get', path: '/orders/{id}'},
         names: ['id'],
-        regexp: /^(.+)$/,
+        regexp: /^([^\/]+?)(?:\/)?$/i,
         children: {},
       },
     ]);


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/1866

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
