### PR TITLE
feat(http-server): make http2 server creation extensible

### DIFF
--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -26,7 +26,9 @@
     "@types/node": "^10.11.2",
     "@types/p-event": "^1.3.0",
     "@types/request-promise-native": "^1.0.15",
-    "request-promise-native": "^1.0.5"
+    "@types/spdy": "^3.4.4",
+    "request-promise-native": "^1.0.5",
+    "spdy": "^4.0.0"
   },
   "files": [
     "README.md",

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -3,64 +3,17 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {IncomingMessage, ServerResponse} from 'http';
 import * as http from 'http';
 import * as https from 'https';
 import {AddressInfo} from 'net';
-
 import * as pEvent from 'p-event';
-
-export type RequestListener = (
-  req: IncomingMessage,
-  res: ServerResponse,
-) => void;
-
-/**
- * Basic HTTP server listener options
- *
- * @export
- * @interface ListenerOptions
- */
-export interface ListenerOptions {
-  host?: string;
-  port?: number;
-}
-
-/**
- * HTTP server options
- *
- * @export
- * @interface HttpOptions
- */
-export interface HttpOptions extends ListenerOptions {
-  protocol?: 'http';
-}
-
-/**
- * HTTPS server options
- *
- * @export
- * @interface HttpsOptions
- */
-export interface HttpsOptions extends ListenerOptions, https.ServerOptions {
-  protocol: 'https';
-}
-
-/**
- * Possible server options
- *
- * @export
- * @type HttpServerOptions
- */
-export type HttpServerOptions = HttpOptions | HttpsOptions;
-
-/**
- * Supported protocols
- *
- * @export
- * @type HttpProtocol
- */
-export type HttpProtocol = 'http' | 'https'; // Will be extended to `http2` in the future
+import {
+  HttpProtocol,
+  HttpServer,
+  HttpServerOptions,
+  RequestListener,
+  ProtocolServerFactory,
+} from './types';
 
 /**
  * HTTP / HTTPS server used by LoopBack's RestServer
@@ -68,15 +21,18 @@ export type HttpProtocol = 'http' | 'https'; // Will be extended to `http2` in t
  * @export
  * @class HttpServer
  */
-export class HttpServer {
+export class DefaultHttpServer implements HttpServer {
   private _port: number;
   private _host?: string;
   private _listening: boolean = false;
-  private _protocol: HttpProtocol;
+  protected _protocol: string;
+  private _urlScheme: string;
   private _address: AddressInfo;
-  private requestListener: RequestListener;
-  readonly server: http.Server | https.Server;
-  private serverOptions?: HttpServerOptions;
+  protected readonly requestListener: RequestListener;
+  protected _server: http.Server | https.Server;
+  protected readonly serverOptions: HttpServerOptions;
+
+  protected protocolServerFactories: ProtocolServerFactory[];
 
   /**
    * @param requestListener
@@ -84,48 +40,67 @@ export class HttpServer {
    */
   constructor(
     requestListener: RequestListener,
-    serverOptions?: HttpServerOptions,
+    serverOptions: HttpServerOptions = {},
+    protocolServerFactories?: ProtocolServerFactory[],
   ) {
     this.requestListener = requestListener;
+    serverOptions = serverOptions || {};
     this.serverOptions = serverOptions;
-    this._port = serverOptions ? serverOptions.port || 0 : 0;
-    this._host = serverOptions ? serverOptions.host : undefined;
-    this._protocol = serverOptions ? serverOptions.protocol || 'http' : 'http';
-    if (this._protocol === 'https') {
-      this.server = https.createServer(
-        this.serverOptions as https.ServerOptions,
-        this.requestListener,
-      );
-    } else {
-      this.server = http.createServer(this.requestListener);
+    this._port = serverOptions.port || 0;
+    this._host = serverOptions.host || undefined;
+    this._protocol = serverOptions.protocol || 'http';
+    this.protocolServerFactories = protocolServerFactories || [
+      new HttpProtocolServerFactory(),
+    ];
+    const server = this.createServer();
+    this._server = server.server;
+    this._urlScheme = server.urlScheme;
+  }
+
+  /**
+   * Create a server for the given protocol
+   */
+  protected createServer() {
+    for (const factory of this.protocolServerFactories) {
+      if (factory.supports(this._protocol, this.serverOptions)) {
+        const server = factory.createServer(
+          this._protocol,
+          this.requestListener,
+          this.serverOptions,
+        );
+        if (server) {
+          return server;
+        }
+      }
     }
+    throw new Error(`The ${this._protocol} protocol is not supported`);
   }
 
   /**
    * Starts the HTTP / HTTPS server
    */
   public async start() {
-    this.server.listen(this._port, this._host);
-    await pEvent(this.server, 'listening');
+    this._server.listen(this._port, this._host);
+    await pEvent(this._server, 'listening');
     this._listening = true;
-    this._address = this.server.address() as AddressInfo;
+    this._address = this._server.address() as AddressInfo;
   }
 
   /**
    * Stops the HTTP / HTTPS server
    */
   public async stop() {
-    if (!this.server) return;
-    this.server.close();
-    await pEvent(this.server, 'close');
+    if (!this._server) return;
+    this._server.close();
+    await pEvent(this._server, 'close');
     this._listening = false;
   }
 
   /**
    * Protocol of the HTTP / HTTPS server
    */
-  public get protocol(): HttpProtocol {
-    return this._protocol;
+  public get protocol(): string {
+    return this._urlScheme || this._protocol;
   }
 
   /**
@@ -147,13 +122,13 @@ export class HttpServer {
    */
   public get url(): string {
     let host = this.host;
-    if (this._address.family === 'IPv6') {
+    if (this._address && this._address.family === 'IPv6') {
       if (host === '::') host = '::1';
       host = `[${host}]`;
     } else if (host === '0.0.0.0') {
       host = '127.0.0.1';
     }
-    return `${this._protocol}://${host}:${this.port}`;
+    return `${this.protocol}://${host}:${this.port}`;
   }
 
   /**
@@ -163,10 +138,45 @@ export class HttpServer {
     return this._listening;
   }
 
+  public get server(): http.Server | https.Server {
+    return this._server;
+  }
+
   /**
    * Address of the HTTP / HTTPS server
    */
   public get address(): AddressInfo | undefined {
     return this._listening ? this._address : undefined;
+  }
+}
+
+export class HttpProtocolServerFactory implements ProtocolServerFactory {
+  /**
+   * Supports http and https
+   * @param protocol
+   */
+  supports(protocol: string) {
+    return protocol === 'http' || protocol === 'https';
+  }
+
+  /**
+   * Create a server for the given protocol
+   */
+  createServer(
+    protocol: string,
+    requestListener: RequestListener,
+    serverOptions: HttpServerOptions,
+  ) {
+    if (protocol === 'https') {
+      const server = https.createServer(
+        serverOptions as https.ServerOptions,
+        requestListener,
+      );
+      return {server, urlScheme: protocol};
+    } else if (protocol === 'http') {
+      const server = http.createServer(requestListener);
+      return {server, urlScheme: protocol};
+    }
+    throw new Error(`The ${protocol} protocol is not supported`);
   }
 }

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -1,1 +1,7 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/http-server
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './types';
 export * from './http-server';

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -1,0 +1,110 @@
+import {AddressInfo} from 'net';
+import * as http from 'http';
+import * as https from 'https';
+import {IncomingMessage, ServerResponse} from 'http';
+
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/http-server
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export type RequestListener = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => void;
+
+/**
+ * Basic HTTP server listener options
+ *
+ * @export
+ * @interface ListenerOptions
+ */
+export interface ListenerOptions {
+  host?: string;
+  port?: number;
+}
+
+/**
+ * HTTP server options
+ *
+ * @export
+ * @interface HttpOptions
+ */
+export interface HttpOptions extends ListenerOptions {
+  protocol?: 'http';
+}
+
+/**
+ * HTTPS server options
+ *
+ * @export
+ * @interface HttpsOptions
+ */
+export interface HttpsOptions extends ListenerOptions, https.ServerOptions {
+  protocol: 'https';
+}
+
+/**
+ * HTTP/2 server options
+ *
+ * @export
+ * @interface Http2Options
+ */
+export interface Http2Options extends ListenerOptions {
+  protocol: 'http2';
+  // Other options for a module like https://github.com/spdy-http2/node-spdy
+  [name: string]: unknown;
+}
+
+/**
+ * Possible server options
+ *
+ * @export
+ * @type HttpServerOptions
+ */
+export type HttpServerOptions = HttpOptions | HttpsOptions | Http2Options;
+
+/**
+ * Supported protocols
+ *
+ * @export
+ * @type HttpProtocol
+ */
+export type HttpProtocol = 'http' | 'https' | 'http2';
+
+/**
+ * HTTP / HTTPS server used by LoopBack's RestServer
+ *
+ * @export
+ * @class HttpServer
+ */
+export interface HttpServer {
+  readonly server: http.Server | https.Server;
+  readonly protocol: string;
+  readonly port: number;
+  readonly host: string | undefined;
+  readonly url: string;
+  readonly listening: boolean;
+  readonly address: AddressInfo | undefined;
+
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export interface ProtocolServer {
+  server: http.Server | https.Server;
+  /**
+   * Scheme for the URL
+   */
+  urlScheme: string;
+}
+
+export interface ProtocolServerFactory {
+  supports(protocol: string, serverOptions: HttpServerOptions): boolean;
+
+  createServer(
+    protocol: string,
+    requestListener: RequestListener,
+    serverOptions: HttpServerOptions,
+  ): ProtocolServer;
+}

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -3,16 +3,19 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {CoreBindings} from '@loopback/core';
 import {BindingKey, Context} from '@loopback/context';
-
+import {CoreBindings} from '@loopback/core';
+import {HttpProtocol, HttpServer} from '@loopback/http-server';
+import * as https from 'https';
 /**
  * See https://github.com/Microsoft/TypeScript/issues/26985
  */
 // import {OpenApiSpec} from '@loopback/openapi-v3-types';
 import {OpenAPIObject as OpenApiSpec} from 'openapi3-ts';
-
+import {ErrorWriterOptions} from 'strong-error-handler';
+import {BodyParser, RequestBodyParser} from './body-parsers';
 import {HttpHandler} from './http-handler';
+import {RestRouter} from './router';
 import {SequenceHandler} from './sequence';
 import {
   BindElement,
@@ -20,19 +23,13 @@ import {
   GetFromContext,
   InvokeMethod,
   LogError,
-  Request,
-  Response,
   ParseParams,
   Reject,
-  Send,
+  Request,
   RequestBodyParserOptions,
+  Response,
+  Send,
 } from './types';
-
-import {HttpProtocol} from '@loopback/http-server';
-import * as https from 'https';
-import {ErrorWriterOptions} from 'strong-error-handler';
-import {RestRouter} from './router';
-import {RequestBodyParser, BodyParser} from './body-parsers';
 
 /**
  * RestServer-specific bindings
@@ -85,6 +82,11 @@ export namespace RestBindings {
   export const ERROR_WRITER_OPTIONS = BindingKey.create<ErrorWriterOptions>(
     'rest.errorWriterOptions',
   );
+
+  /**
+   * Binding key for http server factory
+   */
+  export const HTTP_SERVER = BindingKey.create<HttpServer>('rest.httpServer');
 
   /**
    * Binding key for request body parser options

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -12,7 +12,11 @@ import {
   BindingAddress,
 } from '@loopback/context';
 import {Application, CoreBindings, Server} from '@loopback/core';
-import {HttpServer, HttpServerOptions} from '@loopback/http-server';
+import {
+  HttpServer,
+  HttpServerOptions,
+  DefaultHttpServer,
+} from '@loopback/http-server';
 import {getControllerSpec} from '@loopback/openapi-v3';
 import {
   OpenApiSpec,
@@ -761,7 +765,12 @@ export class RestServer extends Context implements Server, HttpServerLike {
     if (protocol === 'https') Object.assign(serverOptions, httpsOptions);
     Object.assign(serverOptions, {port, host, protocol});
 
-    this._httpServer = new HttpServer(this.requestHandler, serverOptions);
+    const httpServer: HttpServer =
+      (await this.get(RestBindings.HTTP_SERVER, {
+        optional: true,
+      })) || new DefaultHttpServer(this.requestHandler, serverOptions);
+
+    this._httpServer = httpServer;
 
     await this._httpServer.start();
 

--- a/packages/testlab/src/request.ts
+++ b/packages/testlab/src/request.ts
@@ -22,10 +22,15 @@ export function httpGetAsync(urlString: string): Promise<IncomingMessage> {
  * Async wrapper for making HTTPS GET requests
  * @param urlString
  */
-export function httpsGetAsync(urlString: string): Promise<IncomingMessage> {
-  const agent = new https.Agent({
-    rejectUnauthorized: false,
-  });
+export function httpsGetAsync(
+  urlString: string,
+  agent?: https.Agent,
+): Promise<IncomingMessage> {
+  agent =
+    agent ||
+    new https.Agent({
+      rejectUnauthorized: false,
+    });
 
   const urlOptions = url.parse(urlString);
   const options = {agent, ...urlOptions};


### PR DESCRIPTION
Supercedes https://github.com/strongloop/loopback-next/pull/2065

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
