### PR TITLE
fix: add model/entity descriptions

### DIFF
--- a/docs/site/Model-generator.md
+++ b/docs/site/Model-generator.md
@@ -41,6 +41,10 @@ The tool will prompt you for:
   been supplied with a valid model class name, the prompt is skipped. It will
   present you with a list of available models from `src/models` including the
   **Entity** and **Model** at the top of the list.
+  - An **Entity** is a persisted model with an identity (ID).
+  - A **Model** is a business domain object.
+  - For more information, see
+    [here](https://loopback.io/doc/en/lb4/Model.html#overview).
 
 The tool will next recursively prompt you for the model's properties until a
 blank one is entered. Properties will be prompted for as follows:

--- a/docs/site/OpenAPI-generator.md
+++ b/docs/site/OpenAPI-generator.md
@@ -234,9 +234,10 @@ export class AccountController {
 
 Try out the following specs or your own with `lb4 openapi`:
 
-- https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml
-- https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/uspto.yaml
-- https://api.apis.guru/v2/specs/api2cart.com/1.0.0/swagger.json
-- https://api.apis.guru/v2/specs/amazonaws.com/codecommit/2015-04-13/swagger.json
+- [Swagger Petstore API](https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml)
+- [USPTO Data Set API](https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/uspto.yaml)
+- [Swagger API2Cart](https://api.apis.guru/v2/specs/api2cart.com/1.0.0/swagger.json)
+- [AWS CodeCommit API](https://api.apis.guru/v2/specs/amazonaws.com/codecommit/2015-04-13/swagger.json)
 
-For more real world OpenAPI specs, see https://api.apis.guru/v2/list.json.
+For more real world OpenAPI specs, see
+[https://api.apis.guru/v2/list.json](https://api.apis.guru/v2/list.json).

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -14,9 +14,13 @@ const path = require('path');
 
 const PROMPT_BASE_MODEL_CLASS = 'Please select the model base class';
 const ERROR_NO_MODELS_FOUND = 'Model was not found in';
-const BASE_MODELS = [
-  'Entity',
-  'Model',
+const BASE_MODELS = ['Entity', 'Model'];
+const CLI_BASE_MODELS = [
+  {
+    name: `Entity ${chalk.gray('(A persisted model with an ID)')}`,
+    value: 'Entity',
+  },
+  {name: `Model ${chalk.gray('(A business domain object)')}`, value: 'Model'},
   {type: 'separator', line: '----- Custom Models -----'},
 ];
 const MODEL_TEMPLATE_PATH = 'model.ts.ejs';
@@ -99,7 +103,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
     if (this.shouldExit()) return;
     const availableModelBaseClasses = [];
 
-    availableModelBaseClasses.push(...BASE_MODELS);
+    availableModelBaseClasses.push(...CLI_BASE_MODELS);
 
     try {
       debug(`model list dir ${this.artifactInfo.modelDir}`);
@@ -150,6 +154,9 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
       },
     ])
       .then(props => {
+        if (typeof props.modelBaseClass === 'object')
+          props.modelBaseClass = props.modelBaseClass.value;
+
         Object.assign(this.artifactInfo, props);
         debug(`props after model base class prompt: ${inspect(props)}`);
         this.log(


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-next/issues/1842.

Added brief descriptions to `Model` and `Entity` in the model generator and in the model generator doc. Also, made the links in the `OpenAPI Generator` page hyperlinked.

How it looks:

<img width="416" alt="screen shot 2018-11-27 at 3 21 59 pm" src="https://user-images.githubusercontent.com/42985749/49109252-3a107100-f258-11e8-8758-3363d45fc286.png">

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
