### PR TITLE
feat: scaffold DB migration script for new app projects

### DIFF
--- a/docs/site/Database-migrations.md
+++ b/docs/site/Database-migrations.md
@@ -31,9 +31,9 @@ breakdown of behaviors for automigrate! " %}
 
 LoopBack applications are typically using `RepositoryMixin` to enhance the core
 `Application` class with additional repository-related APIs. One of such methods
-is `migrateSchema`, which iterates over all registered repositories and asks
-them to migrate their schema. Repositories that do not support schema migrations
-are silently skipped.
+is `migrateSchema`, which iterates over all registered datasources and asks them
+to migrate schema of models they are backing. Datasources that do not support
+schema migrations are silently skipped.
 
 In the future, we would like to provide finer-grained control of database schema
 updates, learn more in the GitHub issue
@@ -65,33 +65,35 @@ export async function main(options: ApplicationConfig = {}) {
 ### Auto-update the database explicitly
 
 It's usually better to have more control about the database migration and
-trigger the updates explicitly. To do so, you can implement a custom script as
-shown below.
+trigger the updates explicitly. To do so, projects scaffolded using `lb4 app`
+come with a custom CLI script `src/migrate.ts` to run schema migration. Check
+out e.g.
+[Todo example app](https://github.com/strongloop/loopback-next/blob/master/examples/todo/src/migrate.ts)
+to see the full source code of the script.
 
-{% include code-caption.html content="src/migrate.ts" %}
+Besides the migration CLI, new projects come with a handy npm script to run the
+migration too.
 
-```ts
-import {TodoListApplication} from './application';
+The migration process consists of two steps now:
 
-export async function migrate(args: string[]) {
-  const dropExistingTables = args.includes('--rebuild');
-  console.log('Migrating schemas (%s)', rebuild ? 'rebuild' : 'update');
+1. Build the project:
 
-  const app = new TodoListApplication();
-  await app.boot();
-  await app.migrateSchema({dropExistingTables});
-}
+   ```sh
+   $ npm run build
+   ```
 
-migrate(process.argv).catch(err => {
-  console.error('Cannot migrate database schema', err);
-  process.exit(1);
-});
-```
+2. Migrate database schemas (alter existing tables):
 
-After you have compiled your application via `npm run build`, you can update
-your database by running `node dist/src/migrate` and rebuild it from scratch by
-running `node dist/src/migrate --rebuild`. It is also possible to save this
-commands as `npm` scripts in your `package.json` file.
+   ```sh
+   $ npm run migrate
+   ```
+
+   Alternatively, you can also tell the migration script to drop any existing
+   schemas:
+
+   ```sh
+   $ npm run migrate -- --rebuild
+   ```
 
 ### Implement additional migration steps
 

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -22,6 +22,7 @@
     "test": "lb-mocha \"dist/test/*/**/*.js\"",
     "test:dev": "lb-mocha --allow-console-logs dist/test/**/*.js && npm run posttest",
     "verify": "npm pack && tar xf loopback-todo-list*.tgz && tree package && npm run clean",
+    "migrate": "node ./dist/src/migrate",
     "prestart": "npm run build",
     "start": "node ."
   },

--- a/examples/todo-list/src/migrate.ts
+++ b/examples/todo-list/src/migrate.ts
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {TodoListApplication} from './application';
+
+export async function migrate(args: string[]) {
+  const existingSchema = args.includes('--rebuild') ? 'drop' : 'alter';
+  console.log('Migrating schemas (%s existing schema)', existingSchema);
+
+  const app = new TodoListApplication();
+  await app.boot();
+  await app.migrateSchema({existingSchema});
+
+  // Connectors usually keep a pool of opened connections,
+  // this keeps the process running even after all work is done.
+  // We need to exit explicitly.
+  process.exit(0);
+}
+
+migrate(process.argv).catch(err => {
+  console.error('Cannot migrate database schema', err);
+  process.exit(1);
+});

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -22,6 +22,7 @@
     "test": "lb-mocha \"dist/test/*/**/*.js\"",
     "test:dev": "lb-mocha --allow-console-logs dist/test/**/*.js && npm run posttest",
     "verify": "npm pack && tar xf loopback-todo*.tgz && tree package && npm run clean",
+    "migrate": "node ./dist/src/migrate",
     "prestart": "npm run build",
     "start": "node ."
   },

--- a/packages/cli/generators/app/templates/src/migrate.ts.ejs
+++ b/packages/cli/generators/app/templates/src/migrate.ts.ejs
@@ -1,0 +1,20 @@
+import {<%= project.applicationName %>} from './application';
+
+export async function migrate(args: string[]) {
+  const existingSchema = args.includes('--rebuild') ? 'drop' : 'alter';
+  console.log('Migrating schemas (%s existing schema)', existingSchema);
+
+  const app = new <%= project.applicationName %>();
+  await app.boot();
+  await app.migrateSchema({existingSchema});
+
+  // Connectors usually keep a pool of opened connections,
+  // this keeps the process running even after all work is done.
+  // We need to exit explicitly.
+  process.exit(0);
+}
+
+migrate(process.argv).catch(err => {
+  console.error('Cannot migrate database schema', err);
+  process.exit(1);
+});

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -47,6 +47,7 @@
     "test:dev": "lb-mocha --allow-console-logs dist/test/**/*.js",
 <% } -%>
 <% if (project.projectType === 'application') { -%>
+    "migrate": "node ./dist/src/migrate",
     "prestart": "npm run build",
     "start": "node .",
 <% } -%>

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -46,6 +46,7 @@
     "test:dev": "mocha dist/test/**/*.js",
 <% } -%>
 <% if (project.projectType === 'application') { -%>
+    "migrate": "node ./dist/src/migrate",
     "start": "npm run build && node .",
 <% } -%>
     "prepare": "npm run build"


### PR DESCRIPTION
As a follow-up for https://github.com/strongloop/loopback-next/pull/2059:

- Add a template of `migrate.ts` to `lb4 app` generator. All new app project will be created with `src/migrate.ts` now.

- Further extend `lb4 app` generator to include the following npm/package script:

    ```
    "migrate": "node ./dist/src/migrate"
    ```

- Apply these changes to `examples/todo` and `examples/todo-list`

- Update `Database migrations` documentation page accordingly.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated