### PR TITLE
feat(rest): allow basePath for rest servers

### DIFF
--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -211,12 +211,38 @@ export async function main() {
 For a complete list of CORS options, see
 https://github.com/expressjs/cors#configuration-options.
 
+### Configure the Base Path
+
+Sometime it's desirable to expose REST endpoints using a base path, such as
+`/api`. The base path can be set as part of the RestServer configuration.
+
+```ts
+const app = new RestApplication({
+  rest: {
+    basePath: '/api',
+  },
+});
+```
+
+The `RestApplication` and `RestServer` both provide a `basePath()` API:
+
+```ts
+const app: RestApplication;
+// ...
+app.basePath('/api');
+```
+
+With the `basePath`, all REST APIs and static assets are served on URLs starting
+with the base path.
+
 ### `rest` options
 
 | Property    | Type                | Purpose                                                                                                   |
 | ----------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| port        | number              | Specify the port on which the RestServer will listen for traffic.                                         |
-| protocol    | string (http/https) | Specify the protocol on which the RestServer will listen for traffic.                                     |
+| host        | string              | Specify the hostname or ip address on which the RestServer will listen for traffic.                       |
+| port        | number              | Specify the port on which the RestServer listens for traffic.                                             |
+| protocol    | string (http/https) | Specify the protocol on which the RestServer listens for traffic.                                         |
+| basePath    | string              | Specify the base path that RestServer exposes http endpoints.                                             |
 | key         | string              | Specify the SSL private key for https.                                                                    |
 | cert        | string              | Specify the SSL certificate for https.                                                                    |
 | cors        | CorsOptions         | Specify the CORS options.                                                                                 |

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -64,6 +64,12 @@ export namespace RestBindings {
   export const HTTPS_OPTIONS = BindingKey.create<https.ServerOptions>(
     'rest.httpsOptions',
   );
+
+  /**
+   * Internal binding key for basePath
+   */
+  export const BASE_PATH = BindingKey.create<string>('rest.basePath');
+
   /**
    * Internal binding key for http-handler
    */

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -108,6 +108,14 @@ export class RestApplication extends Application implements HttpServerLike {
   }
 
   /**
+   * Configure the `basePath` for the rest server
+   * @param path Base path
+   */
+  basePath(path: string = '') {
+    this.restServer.basePath(path);
+  }
+
+  /**
    * Register a new Controller-based route.
    *
    * ```ts

--- a/packages/rest/test/integration/rest.application.integration.ts
+++ b/packages/rest/test/integration/rest.application.integration.ts
@@ -3,11 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {createRestAppClient, Client, expect} from '@loopback/testlab';
-import {RestApplication} from '../..';
-import * as path from 'path';
+import {anOperationSpec} from '@loopback/openapi-spec-builder';
+import {Client, createRestAppClient, expect} from '@loopback/testlab';
 import * as fs from 'fs';
-import {RestServer, RestServerConfig} from '../../src';
+import * as path from 'path';
+import {RestApplication, RestServer, RestServerConfig} from '../..';
 
 const ASSETS = path.resolve(__dirname, '../../../fixtures/assets');
 
@@ -90,6 +90,27 @@ describe('RestApplication (integration)', () => {
       .get('/greet')
       .expect(200)
       .expect('Hello');
+  });
+
+  it('honors basePath for static assets', async () => {
+    givenApplication();
+    restApp.basePath('/html');
+    restApp.static('/', ASSETS);
+    await restApp.start();
+    client = createRestAppClient(restApp);
+    await client.get('/html/index.html').expect(200);
+  });
+
+  it('honors basePath for routes', async () => {
+    givenApplication();
+    restApp.basePath('/api');
+    restApp.route('get', '/status', anOperationSpec().build(), () => ({
+      running: true,
+    }));
+
+    await restApp.start();
+    client = createRestAppClient(restApp);
+    await client.get('/api/status').expect(200, {running: true});
   });
 
   it('returns RestServer instance', async () => {

--- a/packages/rest/test/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/test/unit/rest.server/rest.server.unit.ts
@@ -86,6 +86,43 @@ describe('RestServer', () => {
       expect(server.getSync(RestBindings.PORT)).to.equal(4000);
       expect(server.getSync(RestBindings.HOST)).to.equal('my-host');
     });
+
+    it('honors basePath in config', async () => {
+      const app = new Application({
+        rest: {port: 0, basePath: '/api'},
+      });
+      app.component(RestComponent);
+      const server = await app.getServer(RestServer);
+      expect(server.getSync(RestBindings.BASE_PATH)).to.equal('/api');
+    });
+
+    it('honors basePath via api', async () => {
+      const app = new Application({
+        rest: {port: 0},
+      });
+      app.component(RestComponent);
+      const server = await app.getServer(RestServer);
+      server.basePath('/api');
+      expect(server.getSync(RestBindings.BASE_PATH)).to.equal('/api');
+    });
+
+    it('rejects basePath if request handler is created', async () => {
+      const app = new Application({
+        rest: {port: 0},
+      });
+      app.component(RestComponent);
+      const server = await app.getServer(RestServer);
+      expect(() => {
+        // Force the `getter` function to be triggered by referencing
+        // `server.requestHandler` so that the servers has `requestHandler`
+        // populated to prevent `basePath` to be set.
+        if (server.requestHandler) {
+          server.basePath('/api');
+        }
+      }).to.throw(
+        /Base path cannot be set as the request handler has been created/,
+      );
+    });
   });
 
   async function givenRequestContext() {


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/918

Some deviation from #918:

- The `basePath` is only available as part of `RestServerConfig` because we set up express routes within the constructor.
- The `basePath` only applies to registered routes (including static assets)
- `servers` in openapi spec are adjusted accordingly
 
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
