### PR TITLE
RFC: helpful error message for deferred bindings [WIP]

### DIFF
--- a/packages/authentication/src/authentication.component.ts
+++ b/packages/authentication/src/authentication.component.ts
@@ -4,11 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {AuthenticationBindings} from './keys';
-import {Component, ProviderMap} from '@loopback/core';
+import {Component, ProviderMap, Binding} from '@loopback/core';
 import {AuthenticateActionProvider, AuthMetadataProvider} from './providers';
 
 export class AuthenticationComponent implements Component {
   providers?: ProviderMap;
+  bindings: Binding[] = [];
 
   // TODO(bajtos) inject configuration
   constructor() {
@@ -16,5 +17,9 @@ export class AuthenticationComponent implements Component {
       [AuthenticationBindings.AUTH_ACTION.key]: AuthenticateActionProvider,
       [AuthenticationBindings.METADATA.key]: AuthMetadataProvider,
     };
+
+    this.bindings.push(
+      Binding.bind(AuthenticationBindings.CURRENT_USER).toDeferred(),
+    );
   }
 }

--- a/packages/authentication/test/unit/providers/authentication.provider.unit.ts
+++ b/packages/authentication/test/unit/providers/authentication.provider.unit.ts
@@ -17,6 +17,7 @@ describe('AuthenticateActionProvider', () => {
       const context = new Context();
       const strategy = new MockStrategy();
       context.bind(AuthenticationBindings.STRATEGY).to(strategy);
+      context.bind(AuthenticationBindings.CURRENT_USER).toDeferred();
       const provider = await instantiateClass(
         AuthenticateActionProvider,
         context,

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -112,6 +112,11 @@ export enum BindingType {
    * A provider class with `value()` function to get the value
    */
   PROVIDER = 'Provider',
+
+  /**
+   * A value that will be bound later.
+   */
+  DEFERRED = 'Deferred',
 }
 
 // tslint:disable-next-line:no-any
@@ -415,6 +420,24 @@ export class Binding<T = BoundValue> {
     this.type = BindingType.CLASS;
     this._getValue = (ctx, session) => instantiateClass(ctor, ctx!, session);
     this.valueConstructor = ctor;
+    return this;
+  }
+
+  /**
+   * Define the binding as deferred: the actual value will be configured
+   * later, typically via `@inject.setter`.
+   */
+  toDeferred(): this {
+    debug('Bind %s as deferred', this.key);
+    this.type = BindingType.DEFERRED;
+    this._getValue = (ctx, session) =>
+      Promise.reject(
+        new Error(
+          `There was no value provided for "${
+            this.key
+          }" yet. Consider using \`@inject.getter()\`.`,
+        ),
+      );
     return this;
   }
 

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -293,9 +293,19 @@ function resolveAsGetter(
 }
 
 function resolveAsSetter(ctx: Context, injection: Injection) {
+  const key = injection.bindingKey;
+  if (!ctx.contains(key)) {
+    // TODO(bajtos) Throw an Error in the next semver-major version
+    console.warn(
+      'To avoid a common source of errors, bindings set via `@inject.setter` ' +
+        'should be defined via bind(key).toDeferred() first. ' +
+        `The binding key: "${key}"`,
+    );
+  }
+
   // No resolution session should be propagated into the setter
   return function setter(value: BoundValue) {
-    ctx.bind(injection.bindingKey).to(value);
+    ctx.bind(key).to(value);
   };
 }
 


### PR DESCRIPTION
When using our authentication package, many users try to inject the current user directly via `@inject()`. Because this injection is resolved before the sequence is executed, and the current-user value is set only inside the sequence, such attempt fails with an error that does not provide any guide on how to fix it.

In this pull request, I am introducing a new kind of bound value: deferred. It is serving as a placeholder for bindings that will be set later via `@inject.setter`. When users try to access such binding too early, we can provide a helpful error message pointing them to `@inject.getter`.

Such improvement is relying on the good will of extension authors to create a deferred binding for a value they will set later using `@inject.setter()`. I think that's too much to ask and we should provide a way to enforce this behavior.

The second part if this pull request is modification of `@inject.setter` to report a warning when the binding key is now know (was not registered as deferred). Originally, I want to `throw new Error`, but that would break backwards compatibility (which I don't want to right now).

**TODO**

 - [ ] tests
 - [ ] optional injection - add a test, decide on the expected behavior
 - [ ] remove warnings triggered by existing code (e.g. tests)
 - [ ] documentation

@strongloop/loopback-next what do you think? If you have encountered  _Error: The key authentication.currentUser was not bound to any value._, would you find it useful if the error message told you to use `@inject.getter()`?

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated