### PR TITLE
[RFC - WIP] Context watcher for bindings that can come and go

### DIFF
--- a/packages/context/src/context-watcher.ts
+++ b/packages/context/src/context-watcher.ts
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Context, BindingFilter} from './context';
+import {Binding} from './binding';
+import {ResolutionSession} from './resolution-session';
+import {resolveList, ValueOrPromise} from './value-promise';
+import {Getter} from './inject';
+import * as debugFactory from 'debug';
+const debug = debugFactory('loopback:context:watcher');
+
+/**
+ * Watching a given context chain to maintain a live list of matching bindings
+ * and their resolved values within the context hierarchy.
+ *
+ * This class is the key utility to implement dynamic extensions for extension
+ * points. For example, the RestServer can react to `controller` bindings even
+ * they are added/removed/updated after the application starts.
+ *
+ */
+export class ContextWatcher<T = unknown> {
+  private _cachedBindings: Readonly<Binding<T>>[] | undefined;
+  private _cachedValues: ValueOrPromise<T[]> | undefined;
+
+  constructor(
+    protected readonly ctx: Context,
+    public readonly filter: BindingFilter,
+  ) {}
+
+  watch() {
+    debug('Start watching context %s', this.ctx.name);
+    this.ctx.subscribe(this);
+  }
+
+  unwatch() {
+    debug('Stop watching context %s', this.ctx.name);
+    this.ctx.unsubscribe(this);
+  }
+
+  /**
+   * Get the list of matched bindings. If they are not cached, it tries to find
+   * them from the context.
+   */
+  get bindings(): Readonly<Binding<T>>[] {
+    debug('Reading bindings');
+    if (this._cachedBindings == null) {
+      this._cachedBindings = this.findBindings();
+    }
+    return this._cachedBindings;
+  }
+
+  /**
+   * Find matching bindings and refresh the cache
+   */
+  protected findBindings() {
+    debug('Finding matching bindings');
+    this._cachedBindings = this.ctx.find(this.filter);
+    return this._cachedBindings;
+  }
+
+  /**
+   * Listen on `bind` or `unbind` and invalidate the cache
+   */
+  listen(event: 'bind' | 'unbind', binding: Readonly<Binding<unknown>>) {
+    this.reset();
+  }
+
+  /**
+   * Reset the watcher by invalidating its cache
+   */
+  reset() {
+    debug('Invalidating cache');
+    this._cachedBindings = undefined;
+    this._cachedValues = undefined;
+  }
+
+  /**
+   * Resolve values for the matching bindings
+   * @param session
+   */
+  resolve(session?: ResolutionSession) {
+    debug('Resolving values');
+    this._cachedValues = resolveList(this.bindings, b => {
+      return b.getValue(this.ctx, ResolutionSession.fork(session));
+    });
+    return this._cachedValues;
+  }
+
+  /**
+   * Get the list of resolved values. If they are not cached, it tries tp find
+   * and resolve them.
+   */
+  values(): Promise<T[]> {
+    debug('Reading values');
+    // [REVIEW] We need to get values in the next tick so that it can pick up
+    // binding changes as `Context` publishes such events in `process.nextTick`
+    return new Promise<T[]>(resolve => {
+      process.nextTick(async () => {
+        if (this._cachedValues == null) {
+          this._cachedValues = this.resolve();
+        }
+        resolve(await this._cachedValues);
+      });
+    });
+  }
+
+  /**
+   * As a `Getter` function
+   */
+  asGetter(): Getter<T[]> {
+    return () => this.values();
+  }
+}

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -21,11 +21,13 @@ export {
 
 export {Binding, BindingScope, BindingType, TagMap} from './binding';
 
-export {Context} from './context';
+export {Context, BindingFilter} from './context';
 export {BindingKey, BindingAddress} from './binding-key';
 export {ResolutionSession} from './resolution-session';
 export {inject, Setter, Getter, Injection, InjectionMetadata} from './inject';
 export {Provider} from './provider';
+
+export {ContextWatcher} from './context-watcher';
 
 export {instantiateClass, invokeMethod} from './resolver';
 // internals for testing

--- a/packages/context/test/acceptance/context-watcher.acceptance.ts
+++ b/packages/context/test/acceptance/context-watcher.acceptance.ts
@@ -1,0 +1,116 @@
+import {expect} from '@loopback/testlab';
+import {Context, ContextWatcher, Getter, inject} from '../..';
+
+describe('ContextWatcher - watches matching bindings', () => {
+  let ctx: Context;
+  let contextWatcher: ContextWatcher;
+  beforeEach(givenContextWatcher);
+
+  it('watches matching bindings', async () => {
+    // We have ctx: 1, parent: 2
+    expect(await getControllers()).to.eql(['1', '2']);
+    ctx.unbind('controllers.1');
+    // Now we have parent: 2
+    expect(await getControllers()).to.eql(['2']);
+    ctx.parent!.unbind('controllers.2');
+    // All controllers are gone from the context chain
+    expect(await getControllers()).to.eql([]);
+    // Add a new controller - ctx: 3
+    givenController(ctx, '3');
+    expect(await getControllers()).to.eql(['3']);
+  });
+
+  function givenContextWatcher() {
+    ctx = givenContext();
+    contextWatcher = ctx.watch(Context.bindingTagFilter('controller'));
+    givenController(ctx, '1');
+    givenController(ctx.parent!, '2');
+  }
+
+  function givenController(_ctx: Context, _name: string) {
+    class MyController {
+      name = _name;
+    }
+    _ctx
+      .bind(`controllers.${_name}`)
+      .toClass(MyController)
+      .tag('controller');
+  }
+
+  async function getControllers() {
+    // tslint:disable-next-line:no-any
+    return (await contextWatcher.values()).map((v: any) => v.name);
+  }
+});
+
+describe('@inject.filter - injects a live collection of matching bindings', async () => {
+  let ctx: Context;
+  beforeEach(givenPrimeNumbers);
+
+  class MyControllerWithGetter {
+    @inject.filter(Context.bindingTagFilter('prime'), {watch: true})
+    getter: Getter<string[]>;
+  }
+
+  class MyControllerWithValues {
+    constructor(
+      @inject.filter(Context.bindingTagFilter('prime'))
+      public values: string[],
+    ) {}
+  }
+
+  class MyControllerWithTracker {
+    @inject.filter(Context.bindingTagFilter('prime'))
+    watcher: ContextWatcher<string[]>;
+  }
+
+  it('injects as getter', async () => {
+    ctx.bind('my-controller').toClass(MyControllerWithGetter);
+    const inst = await ctx.get<MyControllerWithGetter>('my-controller');
+    const getter = inst.getter;
+    expect(await getter()).to.eql([3, 5]);
+    // Add a new binding that matches the filter
+    givenPrime(ctx, 7);
+    // The getter picks up the new binding
+    expect(await getter()).to.eql([3, 7, 5]);
+  });
+
+  it('injects as values', async () => {
+    ctx.bind('my-controller').toClass(MyControllerWithValues);
+    const inst = await ctx.get<MyControllerWithValues>('my-controller');
+    expect(inst.values).to.eql([3, 5]);
+  });
+
+  it('injects as a watcher', async () => {
+    ctx.bind('my-controller').toClass(MyControllerWithTracker);
+    const inst = await ctx.get<MyControllerWithTracker>('my-controller');
+    const watcher = inst.watcher;
+    expect(await watcher.values()).to.eql([3, 5]);
+    // Add a new binding that matches the filter
+    // Add a new binding that matches the filter
+    givenPrime(ctx, 7);
+    // The watcher picks up the new binding
+    expect(await watcher.values()).to.eql([3, 7, 5]);
+    ctx.unbind('prime.7');
+    expect(await watcher.values()).to.eql([3, 5]);
+  });
+
+  function givenPrimeNumbers() {
+    ctx = givenContext();
+    givenPrime(ctx, 3);
+    givenPrime(ctx.parent!, 5);
+  }
+
+  function givenPrime(_ctx: Context, p: number) {
+    _ctx
+      .bind(`prime.${p}`)
+      .to(p)
+      .tag('prime');
+  }
+});
+
+function givenContext() {
+  const parent = new Context('app');
+  const ctx = new Context(parent, 'server');
+  return ctx;
+}

--- a/packages/context/test/unit/context-watcher.unit.ts
+++ b/packages/context/test/unit/context-watcher.unit.ts
@@ -1,0 +1,179 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  Binding,
+  BindingScope,
+  Context,
+  ContextWatcher,
+  Getter,
+  inject,
+} from '../..';
+
+describe('ContextWatcher', () => {
+  let ctx: Context;
+  let bindings: Binding<unknown>[];
+  let contextWatcher: ContextWatcher;
+
+  beforeEach(givenContextWatcher);
+
+  it('tracks bindings', () => {
+    expect(contextWatcher.bindings).to.eql(bindings);
+  });
+
+  it('resolves bindings', async () => {
+    expect(await contextWatcher.resolve()).to.eql(['BAR', 'FOO']);
+    expect(await contextWatcher.values()).to.eql(['BAR', 'FOO']);
+  });
+
+  it('resolves bindings as a getter', async () => {
+    expect(await contextWatcher.asGetter()()).to.eql(['BAR', 'FOO']);
+  });
+
+  it('reloads bindings after reset', async () => {
+    contextWatcher.reset();
+    const abcBinding = ctx
+      .bind('abc')
+      .to('ABC')
+      .tag('abc');
+    const xyzBinding = ctx
+      .bind('xyz')
+      .to('XYZ')
+      .tag('foo');
+    expect(contextWatcher.bindings).to.containEql(xyzBinding);
+    // `abc` does not have the matching tag
+    expect(contextWatcher.bindings).to.not.containEql(abcBinding);
+    expect(await contextWatcher.values()).to.eql(['BAR', 'XYZ', 'FOO']);
+  });
+
+  it('reloads bindings if context bindings are added', async () => {
+    const abcBinding = ctx
+      .bind('abc')
+      .to('ABC')
+      .tag('abc');
+    const xyzBinding = ctx
+      .bind('xyz')
+      .to('XYZ')
+      .tag('foo');
+    expect(contextWatcher.bindings).to.containEql(xyzBinding);
+    // `abc` does not have the matching tag
+    expect(contextWatcher.bindings).to.not.containEql(abcBinding);
+    expect(await contextWatcher.values()).to.eql(['BAR', 'XYZ', 'FOO']);
+  });
+
+  it('reloads bindings if context bindings are removed', async () => {
+    ctx.unbind('bar');
+    expect(await contextWatcher.values()).to.eql(['FOO']);
+  });
+
+  it('reloads bindings if context bindings are rebound', async () => {
+    ctx.bind('bar').to('BAR'); // No more tagged with `foo`
+    expect(await contextWatcher.values()).to.eql(['FOO']);
+  });
+
+  it('reloads bindings if parent context bindings are added', async () => {
+    const xyzBinding = ctx
+      .parent!.bind('xyz')
+      .to('XYZ')
+      .tag('foo');
+    expect(contextWatcher.bindings).to.containEql(xyzBinding);
+    expect(await contextWatcher.values()).to.eql(['BAR', 'FOO', 'XYZ']);
+  });
+
+  it('reloads bindings if parent context bindings are removed', async () => {
+    ctx.parent!.unbind('foo');
+    expect(await contextWatcher.values()).to.eql(['BAR']);
+  });
+
+  it('stops watching', async () => {
+    expect(await contextWatcher.values()).to.eql(['BAR', 'FOO']);
+    contextWatcher.unwatch();
+    ctx.parent!.unbind('foo');
+    expect(await contextWatcher.values()).to.eql(['BAR', 'FOO']);
+  });
+
+  function givenContextWatcher() {
+    bindings = [];
+    ctx = givenContext(bindings);
+    contextWatcher = ctx.watch(Context.bindingTagFilter('foo'));
+  }
+});
+
+describe('@inject.filter', async () => {
+  let ctx: Context;
+  beforeEach(() => (ctx = givenContext()));
+
+  class MyControllerWithGetter {
+    @inject.filter(Context.bindingTagFilter('foo'), {watch: true})
+    getter: Getter<string[]>;
+  }
+
+  class MyControllerWithValues {
+    constructor(
+      @inject.filter(Context.bindingTagFilter('foo'))
+      public values: string[],
+    ) {}
+  }
+
+  class MyControllerWithTracker {
+    @inject.filter(Context.bindingTagFilter('foo'))
+    tracker: ContextWatcher<string[]>;
+  }
+
+  it('injects as getter', async () => {
+    ctx.bind('my-controller').toClass(MyControllerWithGetter);
+    const inst = await ctx.get<MyControllerWithGetter>('my-controller');
+    const getter = inst.getter;
+    expect(getter).to.be.a.Function();
+    expect(await getter()).to.eql(['BAR', 'FOO']);
+    // Add a new binding that matches the filter
+    ctx
+      .bind('xyz')
+      .to('XYZ')
+      .tag('foo');
+    // The getter picks up the new binding
+    expect(await getter()).to.eql(['BAR', 'XYZ', 'FOO']);
+  });
+
+  it('injects as values', async () => {
+    ctx.bind('my-controller').toClass(MyControllerWithValues);
+    const inst = await ctx.get<MyControllerWithValues>('my-controller');
+    expect(inst.values).to.eql(['BAR', 'FOO']);
+  });
+
+  it('injects as a tracker', async () => {
+    ctx.bind('my-controller').toClass(MyControllerWithTracker);
+    const inst = await ctx.get<MyControllerWithTracker>('my-controller');
+    expect(inst.tracker).to.be.instanceOf(ContextWatcher);
+    expect(await inst.tracker.values()).to.eql(['BAR', 'FOO']);
+    // Add a new binding that matches the filter
+    ctx
+      .bind('xyz')
+      .to('XYZ')
+      .tag('foo');
+    // The tracker picks up the new binding
+    expect(await inst.tracker.values()).to.eql(['BAR', 'XYZ', 'FOO']);
+  });
+});
+
+function givenContext(bindings: Binding[] = []) {
+  const parent = new Context('app');
+  const ctx = new Context(parent, 'server');
+  bindings.push(
+    ctx
+      .bind('bar')
+      .toDynamicValue(() => Promise.resolve('BAR'))
+      .tag('foo', 'bar')
+      .inScope(BindingScope.SINGLETON),
+  );
+  bindings.push(
+    parent
+      .bind('foo')
+      .to('FOO')
+      .tag('foo', 'bar'),
+  );
+  return ctx;
+}


### PR DESCRIPTION
This PR serves as a PoC to enable reactive context bindings to support the following use cases:

- An extension point wants to see an up-to-date list of extensions, which can be bound/unbound from the context. For example, controllers can be added the application after it starts. See https://github.com/strongloop/loopback-next/issues/433

1. Add `ContextWatcher` to use a filter function to watch the context
2. The `ContextWatcher` maintains a cache of matched bindings/values. The list can be updated after initialization upon events from the context.
3. Subscribe `ContextWatcher` to the context chain to receive notifications.
4. Introduce `@inject.filter` with the option to receive a live of list of matching binding values. Reimplement `@inject.tag` to leverage it.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
