### PR TITLE
feat(context): add binding.apply(templateFn)

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -1,0 +1,247 @@
+---
+lang: en
+title: 'Binding'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Binding.html
+---
+
+## What is Binding?
+
+`Binding` represents items within a [Context](Context.md) instance. A binding
+connects its value to a unique key as the address to access the entry in a
+context.
+
+### Attributes of a binding
+
+A binding typically has the following attributes:
+
+- key: Each binding has a `key` to uniquely identify itself within the context
+- scope: The scope controls how the binding value is created and cached within
+  the context
+- tags: Tags are names or name/value pairs to describe or annotate a binding
+- value: Each binding must be configured with a type of value provider so that
+  it be resolved to a constant or calculated value
+
+## How to create a binding?
+
+There are a few ways to create a binding:
+
+- Use `Binding` constructor:
+
+  ```ts
+  const binding = new Binding('my-key');
+  ```
+
+- Use `Binding.bind()`
+
+  ```ts
+  const binding = Binding.bind('my-key');
+  ```
+
+- Use `context.bind()`
+
+  ```ts
+  const context = new Context();
+  context.bind('my-key');
+  ```
+
+## How to set up a binding?
+
+The `Binding` class provides a set of fluent APIs to create and configure a
+binding.
+
+### Supply the value or a way to resolve the value
+
+The value can be supplied in one the following forms:
+
+#### A constant
+
+If binding is always resolved to a fixed value, we can bind it to a constant,
+which can be a string, a function, an object, an array, or any other types.
+
+```ts
+binding.to('my-value');
+```
+
+Please note the constant value cannot be a `Promise` to avoid confusions.
+
+#### A factory function
+
+Sometimes the value needs to be dynamically calculated, such as the current time
+or a value fetched from a remote service or database.
+
+```ts
+binding.toDynamicValue(() => 'my-value');
+binding.toDynamicValue(() => new Date());
+binding.toDynamicValue(() => Promise.resolve('my-value'));
+```
+
+#### A class
+
+The binding can represent an instance of a class, for example, a controller. A
+class can be used to instantiate an instance as the resolved value. Dependency
+injection is often leveraged for its members.
+
+```ts
+class MyController {
+  constructor(@inject('my-options') private options: MyOptions) {
+    // ...
+  }
+}
+
+binding.toClass(MyController);
+```
+
+#### A provider
+
+A provider is a class with `value()` method to calculate the value from its
+instance. The main reason to use a provider class is to leverage dependency
+injection for the factory function.
+
+```ts
+class MyValueProvider implements Provider<string> {
+  constructor(@inject('my-options') private options: MyOptions) {
+    // ...
+  }
+
+  value() {
+    return this.options.defaultValue;
+  }
+}
+
+binding.toProvider(MyValueProvider);
+```
+
+### Configure the scope
+
+We allow a binding to be resolved within a context using one of the following
+scopes:
+
+- BindingScope.TRANSIENT (default)
+- BindingScope.CONTEXT
+- BindingScope.SINGLETON
+
+For a complete list of descriptions, please see
+[BindingScope](http://apidocs.loopback.io/@loopback%2fdocs/context.html#BindingScope).
+
+```ts
+binding.inScope(BindingScope.SINGLETON);
+```
+
+The binding scope can be accessed via `binding.scope`.
+
+### Describe tags
+
+Tags can be used to annotate bindings so that they can be grouped or searched.
+For example, we can tag a binding as a `controller` or `repository`. The tags
+are often introduced by an extension point to mark its extensions contributed by
+other components.
+
+There are two types of tags:
+
+- Simple tag - a tag string, such as `'controller'`
+- Value tag - a name/value pair, such as `{name: 'MyController'}`
+
+Internally, we use the tag name as its value for simple tags, for example,
+`{controller: 'controller'}`.
+
+```ts
+binding.tag('controller');
+binding.tag('controller', {name: 'MyController'});
+```
+
+The binding tags can be accessed via `binding.tagMap` or `binding.tagNames`.
+
+### Chain multiple steps
+
+The `Binding` fluent APIs allow us to chain multiple steps as follows:
+
+```ts
+context
+  .bind('my-key')
+  .to('my-value')
+  .tag('my-tag');
+```
+
+### Apply a template function
+
+It's common that we want to configure certain bindings with the same attributes
+such as tags and scope. To allow such setting, use `binding.apply()`:
+
+```ts
+export const serverTemplate = (binding: Binding) =>
+  binding.inScope(BindingScope.SINGLETON).tag('server');
+```
+
+```ts
+const serverBinding = new Binding<RestServer>('servers.RestServer1');
+serverBinding.apply(serverTemplate);
+```
+
+### Encoding value types in binding keys
+
+String keys for bindings do not help enforce the value type. Consider the
+example from the previous section:
+
+```ts
+app.bind('hello').to('world');
+console.log(app.getSync<string>('hello'));
+```
+
+The code obtaining the bound value is explicitly specifying the type of this
+value. Such solution is far from ideal:
+
+1.  Consumers have to know the exact name of the type that's associated with
+    each binding key and also where to import it from.
+2.  Consumers must explicitly provide this type to the compiler when calling
+    ctx.get in order to benefit from compile-type checks.
+3.  It's easy to accidentally provide a wrong type when retrieving the value and
+    get a false sense of security.
+
+The third point is important because the bugs can be subtle and difficult to
+spot.
+
+Consider the following REST binding key:
+
+```ts
+export const HOST = 'rest.host';
+```
+
+The binding key does not provide any indication that `undefined` is a valid
+value for the HOST binding. Without that knowledge, one could write the
+following code and get it accepted by TypeScript compiler, only to learn at
+runtime that HOST may be also undefined and the code needs to find the server's
+host name using a different way.:
+
+```ts
+const resolve = promisify(dns.resolve);
+
+const host = await ctx.get<string>(RestBindings.HOST);
+const records = await resolve(host);
+// etc.
+```
+
+To address this problem, LoopBack provides a templated wrapper class allowing
+binding keys to encode the value type too. The `HOST` binding described above
+can be defined as follows:
+
+```ts
+export const HOST = new BindingKey<string | undefined>('rest.host');
+```
+
+Context methods like `.get()` and `.getSync()` understand this wrapper and use
+the value type from the binding key to describe the type of the value they are
+returning themselves. This allows binding consumers to omit the expected value
+type when calling `.get()` and `.getSync()`.
+
+When we rewrite the failing snippet resolving HOST names to use the new API, the
+TypeScript compiler immediatelly tells us about the problem:
+
+```ts
+const host = await ctx.get(RestBindings.HOST);
+const records = await resolve(host);
+// Compiler complains:
+// - cannot convert string | undefined to string
+//  - cannot convert undefined to string
+```

--- a/docs/site/Concepts.md
+++ b/docs/site/Concepts.md
@@ -23,6 +23,10 @@ LoopBack 4 introduces some new concepts that are important to understand:
   for everything in your app (configurations, state, dependencies, classes and
   so on).
 
+- [**Binding**](Binding.md): An abstraction of items managed by a context. Each
+  binding has a unique key within the context and a value provider to resolve
+  the key to a value.
+
 - [**Dependency Injection**](Dependency-injection.md): The technique used to
   separate the construction of dependencies of a class or function from its
   behavior to keep the code loosely coupled.

--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -135,93 +135,27 @@ class MySequence extends DefaultSequence {
 
 ## Storing and retrieving items from a Context
 
-Items in the Context are indexed via a key and bound to a `ContextValue`. A
-`ContextKey` is simply a string value and is used to look up whatever you store
+Items in the Context are indexed via a key and bound to a `BoundValue`. A
+`BindingKey` is simply a string value and is used to look up whatever you store
 along with the key. For example:
 
 ```ts
 // app level
 const app = new Application();
-app.bind('hello').to('world'); // ContextKey='hello', ContextValue='world'
+app.bind('hello').to('world'); // BindingKey='hello', BoundValue='world'
 console.log(app.getSync<string>('hello')); // => 'world'
 ```
 
-In this case, we bind the 'world' string ContextValue to the 'hello' ContextKey.
-When we fetch the ContextValue via `getSync`, we give it the ContextKey and it
-returns the ContextValue that was initially bound (we can do other fancy things
+In this case, we bind the 'world' string BoundValue to the 'hello' BindingKey.
+When we fetch the BoundValue via `getSync`, we give it the BindingKey and it
+returns the BoundValue that was initially bound (we can do other fancy things
 too -- ie. instantiate your classes, etc)
 
-The process of registering a ContextValue into the Context is known as
-_binding_. Sequence-level bindings work the same way.
+The process of registering a BoundValue into the Context is known as _binding_.
+Please find more details at [Binding](Binding.md).
 
 For a list of the available functions you can use for binding, visit the
 [Context API Docs](http://apidocs.loopback.io/@loopback%2fdocs/context.html).
-
-### Encoding value types in binding keys
-
-Consider the example from the previous section:
-
-```ts
-app.bind('hello').to('world');
-console.log(app.getSync<string>('hello'));
-```
-
-The code obtaining the bound value is explicitly specifying the type of this
-value. Such solution is far from ideal:
-
-1.  Consumers have to know the exact name of the type that's associated with
-    each binding key and also where to import it from.
-2.  Consumers must explicitly provide this type to the compiler when calling
-    ctx.get in order to benefit from compile-type checks.
-3.  It's easy to accidentally provide a wrong type when retrieving the value and
-    get a false sense of security.
-
-The third point is important because the bugs can be subtle and difficult to
-spot.
-
-Consider the following REST binding key:
-
-```ts
-export const HOST = 'rest.host';
-```
-
-The binding key does not provide any indication that `undefined` is a valid
-value for the HOST binding. Without that knowledge, one could write the
-following code and get it accepted by TypeScript compiler, only to learn at
-runtime that HOST may be also undefined and the code needs to find the server's
-host name using a different way.:
-
-```ts
-const resolve = promisify(dns.resolve);
-
-const host = await ctx.get<string>(RestBindings.HOST);
-const records = await resolve(host);
-// etc.
-```
-
-To address this problem, LoopBack provides a templated wrapper class allowing
-binding keys to encode the value type too. The `HOST` binding described above
-can be defined as follows:
-
-```ts
-export const HOST = new BindingKey<string | undefined>('rest.host');
-```
-
-Context methods like `.get()` and `.getSync()` understand this wrapper and use
-the value type from the binding key to describe the type of the value they are
-returning themselves. This allows binding consumers to omit the expected value
-type when calling `.get()` and `.getSync()`.
-
-When we rewrite the failing snippet resolving HOST names to use the new API, the
-TypeScript compiler immediatelly tells us about the problem:
-
-```ts
-const host = await ctx.get(RestBindings.HOST);
-const records = await resolve(host);
-// Compiler complains:
-// - cannot convert string | undefined to string
-//  - cannot convert undefined to string
-```
 
 ## Dependency injection
 

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -116,6 +116,10 @@ children:
     url: Context.html
     output: 'web, pdf'
 
+  - title: 'Binding'
+    url: Binding.html
+    output: 'web, pdf'
+
   - title: 'Dependency injection'
     url: Dependency-injection.html
     output: 'web, pdf'

--- a/packages/context/test/unit/binding.unit.ts
+++ b/packages/context/test/unit/binding.unit.ts
@@ -173,6 +173,29 @@ describe('Binding', () => {
     });
   });
 
+  describe('apply(templateFn)', () => {
+    it('applies a template function', async () => {
+      binding.apply(b => {
+        b.inScope(BindingScope.SINGLETON).tag('myTag');
+      });
+      expect(binding.scope).to.eql(BindingScope.SINGLETON);
+      expect(binding.tagNames).to.eql(['myTag']);
+    });
+
+    it('sets up a placeholder value', async () => {
+      const toBeBound = (b: Binding<unknown>) => {
+        b.toDynamicValue(() => {
+          throw new Error(`Binding ${b.key} is not bound to a value yet`);
+        });
+      };
+      binding.apply(toBeBound);
+      ctx.add(binding);
+      await expect(ctx.get(binding.key)).to.be.rejectedWith(
+        /Binding foo is not bound to a value yet/,
+      );
+    });
+  });
+
   describe('toJSON()', () => {
     it('converts a keyed binding to plain JSON object', () => {
       const json = binding.toJSON();


### PR DESCRIPTION
It allows a binding to be configured using a template function that can consistently set up bindings for certain scope/tags.

For example,
```ts
const serverTemplate = (binding: Binding) =>
  binding.inScope(BindingScope.SINGLETON).tag('server');
const serverBinding = new Binding<RestServer>('servers.RestServer1');
serverBinding.apply(serverTemplate);
```

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
