### PR TITLE
fix: change service generator's ds to uppercase

### DIFF
--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -83,7 +83,7 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     let cmdDatasourceName;
     let datasourcesList;
 
-    // grab the datasourcename from the command line
+    // grab the datasource name from the command line
     cmdDatasourceName = this.options.datasource
       ? utils.toClassName(this.options.datasource) + 'Datasource'
       : '';

--- a/packages/cli/generators/service/templates/service-template.ts.ejs
+++ b/packages/cli/generators/service/templates/service-template.ts.ejs
@@ -12,7 +12,7 @@ export class <%= className %>ServiceProvider implements Provider<<%= className %
   constructor(
     // <%= dataSourceName %> must match the name property in the datasource json file
     @inject('datasources.<%= dataSourceName %>')
-    protected dataSource: <%= dataSourceName %>DataSource = new <%= dataSourceClassName %>(),
+    protected dataSource: <%= dataSourceClassName %> = new <%= dataSourceClassName %>(),
   ) {}
 
   value(): Promise<<%= className %>Service> {

--- a/packages/cli/test/integration/generators/service.integration.js
+++ b/packages/cli/test/integration/generators/service.integration.js
@@ -86,7 +86,7 @@ describe('lb4 service', () => {
       );
       assert.fileContent(
         expectedFile,
-        /dataSource: mydsDataSource = new MydsDataSource\(\),/,
+        /dataSource: MydsDataSource = new MydsDataSource\(\),/,
       );
       assert.fileContent(
         expectedFile,


### PR DESCRIPTION
Co-authored-by: Biniam Admikew <binadmt@hotmail.com>

When using `lb4 service` to generate a service, if the datasource was created starting with a lowercase letter, it would create the service with the datasource name beginning with a lowercase letter. 

For example, when creating a service in the SOAP calculator example using the `Calculator` datasource: `protected dataSource: calculatorDataSource = new CalculatorDataSource()` because in `calculator.datasource.json`: `"name": "calculator"`.

This would cause the error `Cannot find name 'calculatorDataSource'`. So, we changed it to use the datasource's class name, so now it generates: `protected dataSource: CalculatorDataSource = new CalculatorDataSource()` with an uppercase first letter.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
