### PR TITLE
fix(repository): use unique indexes for hasOne FK constraint

### DIFF
--- a/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
@@ -14,28 +14,13 @@ import {BelongsToDefinition, RelationType} from '../relation.types';
  * @param targetResolver A resolver function that returns the target model for
  * a belongsTo relation
  * @param definition Optional metadata for setting up a belongsTo relation
- * @param propertyMeta Optional property metadata to call the proprety decorator
- * with
  * @returns {(target: Object, key:string)}
  */
 export function belongsTo<T extends Entity>(
   targetResolver: EntityResolver<T>,
   definition?: Partial<BelongsToDefinition>,
-  propertyMeta?: Partial<PropertyDefinition>,
 ) {
   return function(decoratedTarget: Entity, decoratedKey: string) {
-    const propMeta: PropertyDefinition = {
-      type: MetadataInspector.getDesignTypeForProperty(
-        decoratedTarget,
-        decoratedKey,
-      ),
-      // TODO(bajtos) Make the foreign key required once our REST API layer
-      // allows controller methods to exclude required properties
-      // required: true,
-    };
-    Object.assign(propMeta, propertyMeta);
-    property(propMeta)(decoratedTarget, decoratedKey);
-
     // @belongsTo() is typically decorating the foreign key property,
     // e.g. customerId. We need to strip the trailing "Id" suffix from the name.
     const relationName = decoratedKey.replace(/Id$/, '');
@@ -57,23 +42,4 @@ export function belongsTo<T extends Entity>(
     );
     relation(meta)(decoratedTarget, decoratedKey);
   };
-}
-
-/**
- * Sugar syntax for belongsTo decorator for hasOne relation. Calls belongsTo
- * with property definition defaults for non-generated id field
- * @param targetResolver A resolver function that returns the target model for
- * a belongsTo relation
- * @param definition Optional metadata for setting up a belongsTo relation
- * @returns {(target: Object, key:string)}
- */
-export function belongsToUniquely<T extends Entity>(
-  targetResolver: EntityResolver<T>,
-  definition?: Partial<BelongsToDefinition>,
-) {
-  const propertyMetaDefaults: Partial<PropertyDefinition> = {
-    id: true,
-    generated: false,
-  };
-  return belongsTo(targetResolver, definition, propertyMetaDefaults);
 }

--- a/packages/repository/src/relations/has-one/has-one-repository.factory.ts
+++ b/packages/repository/src/relations/has-one/has-one-repository.factory.ts
@@ -100,8 +100,9 @@ function resolveHasOneMetadata(
   }
 
   const defaultFkProp = targetModel.definition.properties[defaultFkName];
-  if (!defaultFkProp.id || defaultFkProp.generated) {
-    const reason = `foreign key ${defaultFkName} must be an id property that is not auto generated`;
+  const uniqueFK = defaultFkProp.index && defaultFkProp.index.unique === true;
+  if (!uniqueFK) {
+    const reason = `foreign key ${defaultFkName} must be a unique index property`;
     throw new InvalidRelationError(reason, relationMeta);
   }
 

--- a/packages/repository/test/acceptance/has-one.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-one.relation.acceptance.ts
@@ -44,7 +44,7 @@ describe('hasOne relation', () => {
       street: '123 test avenue',
     });
 
-    const persisted = await addressRepo.findById(address.customerId);
+    const persisted = await addressRepo.findById(address.zipcode);
     expect(persisted.toObject()).to.deepEqual(address.toObject());
   });
 
@@ -52,17 +52,19 @@ describe('hasOne relation', () => {
     const address = await controller.createCustomerAddress(existingCustomerId, {
       street: '123 test avenue',
     });
+    // FIXME(b-admike): memory connector doesn't support unique indexes
+    // need to see if we can make it work there.
     expect(
       controller.createCustomerAddress(existingCustomerId, {
         street: '456 test street',
       }),
-    ).to.be.rejectedWith(/Duplicate entry for Address.customerId/);
+    ).to.be.rejectedWith(/Duplicate entry/);
     expect(address.toObject()).to.containDeep({
       customerId: existingCustomerId,
       street: '123 test avenue',
     });
 
-    const persisted = await addressRepo.findById(address.customerId);
+    const persisted = await addressRepo.findById(address.zipcode);
     expect(persisted.toObject()).to.deepEqual(address.toObject());
   });
 
@@ -106,7 +108,7 @@ describe('hasOne relation', () => {
     const address = await controller.createCustomerAddress(existingCustomerId, {
       street: '123 test avenue',
     });
-    await addressRepo.deleteById(address.customerId);
+    await addressRepo.deleteById(address.zipcode);
 
     await expect(
       controller.findCustomerAddress(existingCustomerId),

--- a/packages/repository/test/fixtures/models/address.model.ts
+++ b/packages/repository/test/fixtures/models/address.model.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property, belongsToUniquely} from '../../..';
+import {Entity, model, property, belongsTo} from '../../..';
 import {Customer} from './customer.model';
 
 @model()
@@ -14,6 +14,7 @@ export class Address extends Entity {
   street: String;
   @property({
     type: 'string',
+    id: true,
   })
   zipcode: String;
   @property({
@@ -25,6 +26,11 @@ export class Address extends Entity {
   })
   province: String;
 
-  @belongsToUniquely(() => Customer)
+  @belongsTo(() => Customer)
+  @property({
+    index: {
+      unique: true,
+    },
+  })
   customerId: number;
 }

--- a/packages/repository/test/fixtures/models/order.model.ts
+++ b/packages/repository/test/fixtures/models/order.model.ts
@@ -27,5 +27,6 @@ export class Order extends Entity {
   isShipped: boolean;
 
   @belongsTo(() => Customer)
+  @property()
   customerId: number;
 }

--- a/packages/repository/test/fixtures/repositories/address.repository.ts
+++ b/packages/repository/test/fixtures/repositories/address.repository.ts
@@ -15,11 +15,11 @@ import {CustomerRepository} from '../repositories';
 
 export class AddressRepository extends DefaultCrudRepository<
   Address,
-  typeof Address.prototype.customerId
+  typeof Address.prototype.zipcode
 > {
   public readonly customer: BelongsToAccessor<
     Customer,
-    typeof Address.prototype.customerId
+    typeof Address.prototype.zipcode
   >;
 
   constructor(

--- a/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/model-and-relation.decorator.unit.ts
@@ -8,7 +8,6 @@ import {expect} from '@loopback/testlab';
 import {RelationMetadata} from '../../..';
 import {
   belongsTo,
-  belongsToUniquely,
   embedsMany,
   embedsOne,
   Entity,
@@ -94,28 +93,17 @@ describe('model decorator', () => {
     @property({type: 'string', id: true, generated: true})
     id: string;
 
-    @belongsTo(
-      () => Customer,
-      {},
-      {
-        id: true,
-        generated: false,
+    @belongsTo(() => Customer)
+    @property({
+      index: {
+        unique: true,
       },
-    )
+    })
     customerId: string;
 
     // Validates that property no longer requires a parameter
     @property()
     isShipped: boolean;
-  }
-
-  @model()
-  class RegistrationDate extends Entity {
-    @belongsToUniquely(() => Customer)
-    customerId: number;
-
-    @property()
-    registeredOn: Date;
   }
 
   @model()
@@ -303,20 +291,7 @@ describe('model decorator', () => {
     expect(relationDef.target()).to.be.exactly(Customer);
   });
 
-  it('passes property metadata from belongsToUniquely', () => {
-    const propMeta =
-      MetadataInspector.getAllPropertyMetadata(
-        MODEL_PROPERTIES_KEY,
-        RegistrationDate.prototype,
-      ) || /* istanbul ignore next */ {};
-
-    expect(propMeta.customerId).to.containEql({
-      id: true,
-      generated: false,
-    });
-  });
-
-  it('passes property metadata from belongsTo', () => {
+  it('allows property decorator to stack with belongsTo', () => {
     const propMeta =
       MetadataInspector.getAllPropertyMetadata(
         MODEL_PROPERTIES_KEY,
@@ -324,8 +299,9 @@ describe('model decorator', () => {
       ) || /* istanbul ignore next */ {};
 
     expect(propMeta.customerId).to.containEql({
-      id: true,
-      generated: false,
+      index: {
+        unique: true,
+      },
     });
   });
 

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -130,35 +130,6 @@ describe('relation decorator', () => {
   });
 
   describe('belongsTo', () => {
-    it('creates juggler property metadata', () => {
-      @model()
-      class AddressBook extends Entity {
-        @property({id: true})
-        id: number;
-      }
-      @model()
-      class Address extends Entity {
-        @belongsTo(() => AddressBook)
-        addressBookId: number;
-      }
-      const jugglerMeta = MetadataInspector.getAllPropertyMetadata(
-        MODEL_PROPERTIES_KEY,
-        Address.prototype,
-      );
-      expect(jugglerMeta).to.eql({
-        addressBookId: {
-          type: Number,
-        },
-      });
-      expect(Address.definition.relations).to.containDeep({
-        addressBook: {
-          keyFrom: 'addressBookId',
-          name: 'addressBook',
-          type: 'belongsTo',
-        },
-      });
-    });
-
     it('assigns it to target key', () => {
       class Address extends Entity {
         addressId: number;

--- a/packages/repository/test/unit/repositories/has-one-repository-factory.unit.ts
+++ b/packages/repository/test/unit/repositories/has-one-repository-factory.unit.ts
@@ -78,7 +78,7 @@ describe('createHasOneRepositoryFactory', () => {
     ).to.throw(/target model Address is missing.*foreign key customerId/);
   });
 
-  it('rejects relations with keyTo that is not an id', () => {
+  it('rejects relations with keyTo that is not an index', () => {
     const relationMeta = givenHasOneDefinition({
       name: 'order',
       target: () => ModelWithoutIndexFK,
@@ -89,15 +89,13 @@ describe('createHasOneRepositoryFactory', () => {
         relationMeta,
         Getter.fromValue(customerRepo),
       ),
-    ).to.throw(
-      /foreign key customerId must be an id property that is not auto generated/,
-    );
+    ).to.throw(/foreign key customerId must be a unique index property/);
   });
 
-  it('rejects relations with keyTo that is a generated id property', () => {
+  it('rejects relations with keyTo that is not a unique index', () => {
     const relationMeta = givenHasOneDefinition({
       name: 'profile',
-      target: () => ModelWithGeneratedFK,
+      target: () => ModelWithoutUniqueIndexFK,
     });
 
     expect(() =>
@@ -105,9 +103,7 @@ describe('createHasOneRepositoryFactory', () => {
         relationMeta,
         Getter.fromValue(customerRepo),
       ),
-    ).to.throw(
-      /foreign key customerId must be an id property that is not auto generated/,
-    );
+    ).to.throw(/foreign key customerId must be a unique index property/);
   });
 
   /*------------- HELPERS ---------------*/
@@ -132,14 +128,11 @@ describe('createHasOneRepositoryFactory', () => {
     province: String;
   }
 
-  // added an id property because the model itself extends from Entity, but the
-  // purpose here is the decorated relational property is not part of the
-  // composite index, thus the name ModelWithoutIndexFK.
   class ModelWithoutIndexFK extends Entity {
-    static definition = new ModelDefinition('ModelWithoutIndexFK')
+    static definition = new ModelDefinition('ModelWithoutUniqueIndex')
       .addProperty('customerId', {
         type: 'string',
-        id: false,
+        index: false,
       })
       .addProperty('description', {
         type: 'string',
@@ -160,12 +153,13 @@ describe('createHasOneRepositoryFactory', () => {
     isShipped: boolean;
   }
 
-  class ModelWithGeneratedFK extends Entity {
-    static definition = new ModelDefinition('ModelWithGeneratedFK')
+  class ModelWithoutUniqueIndexFK extends Entity {
+    static definition = new ModelDefinition('ModelWithoutUniqueIndexFK')
       .addProperty('customerId', {
         type: 'string',
-        id: true,
-        generated: true,
+        index: {
+          unique: false,
+        },
       })
       .addProperty('description', {
         type: 'string',


### PR DESCRIPTION
re-work `hasOne` relation based on https://github.com/strongloop/loopback-next/pull/2005#discussion_r238540913 and consequent comments. See if this approach is plausible. Memory connector doesn't have concept of unique indexes AFAIK, so I'll have to make a fix there to get the uniqueness on create test passing. @bajtos @raymondfeng PTAL.
## Checklist

- [ ] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
