### PR TITLE
feat(context): add `@bind` to decorate classes with binding attributes

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -179,6 +179,56 @@ const serverBinding = new Binding<RestServer>('servers.RestServer1');
 serverBinding.apply(serverTemplate);
 ```
 
+### Configure binding attributes for a class
+
+Classes can be discovered and bound to the application context during `boot`. In
+addition to conventions, it's often desirable to allow certain binding
+attributes, such as scope and tags, to be specified as metadata for the class.
+When the class is bound, these attributes are honored to create a binding. You
+can use `@bind` decorator to configure how to bind a class.
+
+```ts
+import {bind, BindingScope} from '@loopback/context';
+
+// @bind() accepts scope and tags
+@bind({
+  scope: BindingScope.SINGLETON,
+  tags: ['service'],
+})
+export class MyService {}
+
+// @binding.provider is a shortcut for a provider class
+@bind.provider({
+  tags: {
+    key: 'my-date-provider',
+  },
+})
+export class MyDateProvider implements Provider<Date> {
+  value() {
+    return new Date();
+  }
+}
+
+@bind({
+  tags: ['controller', {name: 'my-controller'}],
+})
+export class MyController {}
+
+// @bind() can take one or more binding template functions
+@bind(binding => binding.tag('controller', {name: 'your-controller'})
+export class YourController {}
+```
+
+Then a binding can be created by inspecting the class,
+
+```ts
+import {createBindingFromClass} from '@loopback/context';
+
+const ctx = new Context();
+const binding = createBindingFromClass(MyService);
+ctx.add(binding);
+```
+
 ### Encoding value types in binding keys
 
 String keys for bindings do not help enforce the value type. Consider the

--- a/packages/context/docs.json
+++ b/packages/context/docs.json
@@ -7,6 +7,7 @@
     "src/index.ts",
     "src/inject.ts",
     "src/value-promise.ts",
+    "src/bind-decorator.ts",
     "src/provider.ts",
     "src/resolution-session.ts",
     "src/resolver.ts"

--- a/packages/context/src/binding-decorator.ts
+++ b/packages/context/src/binding-decorator.ts
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {ClassDecoratorFactory} from '@loopback/metadata';
+import {
+  asBindingTemplate,
+  asProvider,
+  BindingMetadata,
+  BindingSpec,
+  BINDING_METADATA_KEY,
+  isProviderClass,
+  asClassOrProvider,
+  removeNameAndKeyTags,
+} from './binding-inspector';
+import {Provider} from './provider';
+import {Constructor} from './value-promise';
+
+/**
+ * Decorator factory for `@bind`
+ */
+class BindDecoratorFactory extends ClassDecoratorFactory<BindingMetadata> {
+  mergeWithInherited(inherited: BindingMetadata, target: Function) {
+    if (inherited) {
+      return {
+        templates: [
+          ...inherited.templates,
+          removeNameAndKeyTags,
+          ...this.spec.templates,
+        ],
+        target: this.spec.target,
+      };
+    } else {
+      this.withTarget(this.spec, target);
+      return this.spec;
+    }
+  }
+
+  withTarget(spec: BindingMetadata, target: Function) {
+    spec.target = target as Constructor<unknown>;
+    return spec;
+  }
+}
+
+/**
+ * Decorate a class with binding configuration
+ *
+ * @example
+ * ```ts
+ * @bind((binding) => {binding.inScope(BindingScope.SINGLETON).tag('controller')}
+ * )
+ * export class MyController {
+ * }
+ * ```
+ *
+ * @param specs A list of binding scope/tags or template functions to
+ * configure the binding
+ */
+export function bind(...specs: BindingSpec[]): ClassDecorator {
+  const templateFunctions = specs.map(t => {
+    if (typeof t === 'function') {
+      return t;
+    } else {
+      return asBindingTemplate(t);
+    }
+  });
+
+  return (target: Function) => {
+    const cls = target as Constructor<unknown>;
+    const spec: BindingMetadata = {
+      templates: [asClassOrProvider(cls), ...templateFunctions],
+      target: cls,
+    };
+
+    const decorator = BindDecoratorFactory.createDecorator(
+      BINDING_METADATA_KEY,
+      spec,
+    );
+    decorator(target);
+  };
+}
+
+export namespace bind {
+  /**
+   * `@bind.provider` to denote a provider class
+   *
+   * A list of binding scope/tags or template functions to configure the binding
+   */
+  export function provider(
+    ...specs: BindingSpec[]
+  ): ((target: Constructor<Provider<unknown>>) => void) {
+    return (target: Constructor<Provider<unknown>>) => {
+      if (!isProviderClass(target)) {
+        throw new Error(`Target ${target} is not a Provider`);
+      }
+      bind(
+        // Set up the default for providers
+        asProvider(target),
+        // Call other template functions
+        ...specs,
+      )(target);
+    };
+  }
+}

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -1,0 +1,287 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {MetadataAccessor, MetadataInspector} from '@loopback/metadata';
+import {Binding, BindingScope, BindingTag, BindingTemplate} from './binding';
+import {BindingAddress} from './binding-key';
+import {ContextTags} from './keys';
+import {Provider} from './provider';
+import {Constructor} from './value-promise';
+
+/**
+ * Binding metadata from `@bind`
+ */
+export type BindingMetadata = {
+  /**
+   * An array of template functions to configure a binding
+   */
+  templates: BindingTemplate[];
+  /**
+   * The target class where binding metadata is decorated
+   */
+  target: Constructor<unknown>;
+};
+
+/**
+ * Metadata key for binding metadata
+ */
+export const BINDING_METADATA_KEY = MetadataAccessor.create<
+  BindingMetadata,
+  ClassDecorator
+>('binding.metadata');
+
+/**
+ * An object to configure binding scope and tags
+ */
+export type BindingScopeAndTags = {
+  scope?: BindingScope;
+  tags?: BindingTag | BindingTag[];
+};
+
+/**
+ * Specification of parameters for `@bind()`
+ */
+export type BindingSpec = BindingTemplate | BindingScopeAndTags;
+
+/**
+ * Check if a class implements `Provider` interface
+ * @param cls A class
+ */
+export function isProviderClass(
+  cls: Constructor<unknown>,
+): cls is Constructor<Provider<unknown>> {
+  return cls && typeof cls.prototype.value === 'function';
+}
+
+/**
+ * A factory function to create a template function to bind the target class
+ * as a `Provider`.
+ * @param target Target provider class
+ */
+export function asProvider(
+  target: Constructor<Provider<unknown>>,
+): BindingTemplate {
+  return binding =>
+    binding.toProvider(target).tag(ContextTags.PROVIDER, {
+      [ContextTags.TYPE]: ContextTags.PROVIDER,
+    });
+}
+
+/**
+ * A factory function to create a template function to bind the target class
+ * as a class or `Provider`.
+ * @param target Target class, which can be an implementation of `Provider`
+ */
+export function asClassOrProvider(
+  target: Constructor<unknown>,
+): BindingTemplate {
+  // Add a template to bind to a class or provider
+  return binding => {
+    if (isProviderClass(target)) {
+      asProvider(target)(binding);
+    } else {
+      binding.toClass(target);
+    }
+  };
+}
+
+/**
+ * Convert binding scope and tags as a template function
+ * @param scopeAndTags Binding scope and tags
+ */
+export function asBindingTemplate(
+  scopeAndTags: BindingScopeAndTags,
+): BindingTemplate {
+  return binding => {
+    if (scopeAndTags.scope) {
+      binding.inScope(scopeAndTags.scope);
+    }
+    if (scopeAndTags.tags) {
+      if (Array.isArray(scopeAndTags.tags)) {
+        binding.tag(...scopeAndTags.tags);
+      } else {
+        binding.tag(scopeAndTags.tags);
+      }
+    }
+  };
+}
+
+/**
+ * Get binding metadata for a class
+ * @param target The target class
+ */
+export function getBindingMetadata(
+  target: Function,
+): BindingMetadata | undefined {
+  return MetadataInspector.getClassMetadata<BindingMetadata>(
+    BINDING_METADATA_KEY,
+    target,
+  );
+}
+
+/**
+ * A binding template function to delete `name` and `key` tags
+ */
+export function removeNameAndKeyTags(binding: Binding<unknown>) {
+  if (binding.tagMap) {
+    delete binding.tagMap.name;
+    delete binding.tagMap.key;
+  }
+}
+
+/**
+ * Get the binding template for a class with binding metadata
+ *
+ * @param cls A class with optional `@bind`
+ */
+export function bindingTemplateFor(cls: Constructor<unknown>): BindingTemplate {
+  const spec = getBindingMetadata(cls);
+  const templateFunctions = (spec && spec.templates) || [
+    asClassOrProvider(cls),
+  ];
+  return binding => {
+    for (const t of templateFunctions) {
+      binding.apply(t);
+    }
+    if (spec && spec.target !== cls) {
+      // Remove name/key tags inherited from base classes
+      binding.apply(removeNameAndKeyTags);
+    }
+  };
+}
+
+/**
+ * Mapping artifact types to binding key namespaces (prefixes). For example:
+ * ```ts
+ * {
+ *   repository: 'repositories'
+ * }
+ * ```
+ */
+export type TypeNamespaceMapping = {[name: string]: string};
+
+export const DEFAULT_TYPE_NAMESPACES: TypeNamespaceMapping = {
+  class: 'classes',
+  provider: 'providers',
+};
+
+/**
+ * Options to customize the binding created from a class
+ */
+export type BindingFromClassOptions = {
+  /**
+   * Binding key
+   */
+  key?: BindingAddress<unknown>;
+  /**
+   * Artifact type, such as `server`, `controller`, `repository` or `service`
+   */
+  type?: string;
+  /**
+   * Artifact name, such as `my-rest-server` and `my-controller`
+   */
+  name?: string;
+  /**
+   * Namespace for the binding key, such as `servers` and `controllers`
+   */
+  namespace?: string;
+  /**
+   * Mapping artifact type to binding key namespaces
+   */
+  typeNamespaceMapping?: TypeNamespaceMapping;
+};
+
+/**
+ * Create a binding from a class with decorated metadata
+ * @param cls A class
+ * @param options Options to customize the binding key
+ */
+export function createBindingFromClass(
+  cls: Constructor<unknown>,
+  options: BindingFromClassOptions = {},
+): Binding {
+  const templateFn = bindingTemplateFor(cls);
+  let key = options.key;
+  if (!key) {
+    key = buildBindingKey(cls, options);
+  }
+  const binding = Binding.bind(key).apply(templateFn);
+  if (options.name) {
+    binding.tag({name: options.name});
+  }
+  if (options.type) {
+    binding.tag({type: options.type}, options.type);
+  }
+  return binding;
+}
+
+/**
+ * Find/infer binding key namespace for a type
+ * @param type Artifact type, such as `controller`, `datasource`, or `server`
+ * @param typeNamespaces An object mapping type names to namespaces
+ */
+function getNamespace(type: string, typeNamespaces = DEFAULT_TYPE_NAMESPACES) {
+  if (type in typeNamespaces) {
+    return typeNamespaces[type];
+  } else {
+    // Return the plural form
+    return `${type}s`;
+  }
+}
+
+/**
+ * Build the binding key for a class with optional binding metadata.
+ * The binding key is resolved in the following steps:
+ *
+ * 1. Check `options.key`, if it exists, return it
+ * 2. Check if the binding metadata has `key` tag, if yes, return its tag value
+ * 3. Identify `namespace` and `name` to form the binding key as
+ * `<namespace>.<name>`.
+ *   - namespace
+ *     - `options.namespace`
+ *     - Map `options.type` or `type` tag value to a namespace, for example,
+ *       'controller` to 'controller'.
+ *   - name
+ *     - `options.name`
+ *     - `name` tag value
+ *     - the class name
+ *
+ * @param cls A class to be bound
+ * @param options Options to customize how to build the key
+ */
+function buildBindingKey(
+  cls: Constructor<unknown>,
+  options: BindingFromClassOptions = {},
+) {
+  const templateFn = bindingTemplateFor(cls);
+  // Create a temporary binding
+  const bindingTemplate = new Binding('template').apply(templateFn);
+  // Is there a `key` tag?
+  let key: string = options.key || bindingTemplate.tagMap[ContextTags.KEY];
+  if (key) return key;
+
+  let namespace = options.namespace;
+  if (!namespace) {
+    const namespaces = Object.assign(
+      {},
+      DEFAULT_TYPE_NAMESPACES,
+      options.typeNamespaceMapping,
+    );
+    // Derive the key from type + name
+    let type = options.type || bindingTemplate.tagMap[ContextTags.TYPE];
+    if (!type) {
+      type =
+        bindingTemplate.tagNames.find(t => namespaces[t] != null) ||
+        ContextTags.CLASS;
+    }
+    namespace = getNamespace(type, namespaces);
+  }
+
+  const name =
+    options.name || bindingTemplate.tagMap[ContextTags.NAME] || cls.name;
+  key = `${namespace}.${name}`;
+
+  return key;
+}

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -119,6 +119,16 @@ export enum BindingType {
 export type TagMap = MapObject<any>;
 
 /**
+ * Binding tag can be a simple name or name/value pairs
+ */
+export type BindingTag = TagMap | string;
+
+/**
+ * A function as the template to configure bindings
+ */
+export type BindingTemplate<T = unknown> = (binding: Binding<T>) => void;
+
+/**
  * Binding represents an entry in the `Context`. Each binding has a key and a
  * corresponding value getter.
  */
@@ -269,7 +279,7 @@ export class Binding<T = BoundValue> {
    *
    * ```
    */
-  tag(...tags: (string | TagMap)[]): this {
+  tag(...tags: BindingTag[]): this {
     for (const t of tags) {
       if (typeof t === 'string') {
         this.tagMap[t] = t;
@@ -438,7 +448,7 @@ export class Binding<T = BoundValue> {
    * ```
    * @param templateFn A function to configure the binding
    */
-  apply(templateFn: (binding: Binding<T>) => void): this {
+  apply(templateFn: BindingTemplate<T>): this {
     templateFn(this);
     return this;
   }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -3,15 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, TagMap} from './binding';
-import {BindingKey, BindingAddress} from './binding-key';
-import {isPromiseLike, getDeepProperty, BoundValue} from './value-promise';
-import {ResolutionOptions, ResolutionSession} from './resolution-session';
-
-import {v1 as uuidv1} from 'uuid';
-
 import * as debugModule from 'debug';
+import {v1 as uuidv1} from 'uuid';
 import {ValueOrPromise} from '.';
+import {Binding, BindingTag} from './binding';
+import {BindingAddress, BindingKey} from './binding-key';
+import {ResolutionOptions, ResolutionSession} from './resolution-session';
+import {BoundValue, getDeepProperty, isPromiseLike} from './value-promise';
+
 const debug = debugModule('loopback:context');
 
 /**
@@ -207,7 +206,7 @@ export class Context {
    * `{name: 'my-controller'}`
    */
   findByTag<ValueType = BoundValue>(
-    tagFilter: string | RegExp | TagMap,
+    tagFilter: BindingTag | RegExp,
   ): Readonly<Binding<ValueType>>[] {
     if (typeof tagFilter === 'string' || tagFilter instanceof RegExp) {
       const regexp =

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -4,29 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from '@loopback/metadata';
-
-export {
-  isPromiseLike,
-  BoundValue,
-  Constructor,
-  ValueOrPromise,
-  MapObject,
-  resolveList,
-  resolveMap,
-  resolveUntil,
-  transformValueOrPromise,
-  tryWithFinally,
-  getDeepProperty,
-} from './value-promise';
-
-export {Binding, BindingScope, BindingType, TagMap} from './binding';
-
-export {Context} from './context';
-export {BindingKey, BindingAddress} from './binding-key';
-export {ResolutionSession} from './resolution-session';
-export {inject, Setter, Getter, Injection, InjectionMetadata} from './inject';
-export {Provider} from './provider';
-
-export {instantiateClass, invokeMethod} from './resolver';
-// internals for testing
-export {describeInjectedArguments, describeInjectedProperties} from './inject';
+export * from './binding';
+export * from './binding-decorator';
+export * from './binding-inspector';
+export * from './binding-key';
+export * from './context';
+export * from './inject';
+export * from './keys';
+export * from './provider';
+export * from './resolution-session';
+export * from './resolver';
+export * from './value-promise';

--- a/packages/context/src/keys.ts
+++ b/packages/context/src/keys.ts
@@ -1,0 +1,22 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export namespace ContextTags {
+  export const CLASS = 'class';
+  export const PROVIDER = 'provider';
+
+  /**
+   * Type of the artifact
+   */
+  export const TYPE = 'type';
+  /**
+   * Name of the artifact
+   */
+  export const NAME = 'name';
+  /**
+   * Binding key for the artifact
+   */
+  export const KEY = 'key';
+}

--- a/packages/context/test/acceptance/bind-decorator.acceptance.ts
+++ b/packages/context/test/acceptance/bind-decorator.acceptance.ts
@@ -1,0 +1,70 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Context, bind, BindingScope, Provider} from '../..';
+import {createBindingFromClass} from '../../src';
+
+describe('@bind - customize classes with binding attributes', () => {
+  @bind({
+    scope: BindingScope.SINGLETON,
+    tags: ['service'],
+  })
+  class MyService {}
+
+  @bind.provider({
+    tags: {
+      key: 'my-date-provider',
+    },
+  })
+  class MyDateProvider implements Provider<Date> {
+    value() {
+      return new Date();
+    }
+  }
+
+  @bind({
+    tags: ['controller', {name: 'my-controller', type: 'controller'}],
+  })
+  class MyController {}
+
+  const discoveredClasses = [MyService, MyDateProvider, MyController];
+
+  it('allows discovery of classes to be bound', () => {
+    const ctx = new Context();
+    discoveredClasses.forEach(c => {
+      const binding = createBindingFromClass(c);
+      if (binding.tagMap.controller) {
+        ctx.add(binding);
+      }
+    });
+    expect(ctx.findByTag('controller').map(b => b.key)).eql([
+      'controllers.my-controller',
+    ]);
+    expect(ctx.find().map(b => b.key)).eql(['controllers.my-controller']);
+  });
+
+  it('allows binding attributes to be customized', () => {
+    const ctx = new Context();
+    discoveredClasses.forEach(c => {
+      const binding = createBindingFromClass(c, {
+        typeNamespaceMapping: {
+          controller: 'controllers',
+          service: 'service-proxies',
+        },
+      });
+      ctx.add(binding);
+    });
+    expect(ctx.findByTag('provider').map(b => b.key)).eql(['my-date-provider']);
+    expect(ctx.getBinding('service-proxies.MyService').scope).to.eql(
+      BindingScope.SINGLETON,
+    );
+    expect(ctx.find().map(b => b.key)).eql([
+      'service-proxies.MyService',
+      'my-date-provider',
+      'controllers.my-controller',
+    ]);
+  });
+});

--- a/packages/context/test/acceptance/binding-decorator.feature.md
+++ b/packages/context/test/acceptance/binding-decorator.feature.md
@@ -1,0 +1,52 @@
+# Feature: @bind for classes representing various artifacts
+
+- In order to automatically bind classes for various artifacts to a context
+- As a developer
+- I want to decorate my classes to provide more metadata
+- So that the bootstrapper can bind them to a context according to the metadata
+
+## Scenario: Add metadata to a class to facilitate automatic binding
+
+When the bootstrapper discovers a file under `controllers` folder, it tries to
+bind the exported constructs to the context automatically.
+
+For example:
+
+controllers/log-controller.ts
+
+```ts
+export class LogController {}
+
+export const LOG_LEVEL = 'info';
+export class LogProvider implements Provider<Logger> {
+  value() {
+    return msg => console.log(msg);
+  }
+}
+```
+
+There are three exported entries from `log-controller.ts` and the bootstrapper
+does not have enough information to bind them to the context correctly. For
+example, it's impossible for the bootstrapper to infer that `LogProvider` is a
+provider so that the class can be bound using
+`ctx.bind('providers.LogProvider').toProvider(LogProvider)`.
+
+Developers can help the bootstrapper by decorating these classes with `@bind`.
+
+```ts
+@bind({tags: ['log']})
+export class LogController {}
+
+export const LOG_LEVEL = 'info';
+
+@bind.provider(tags: ['log']})
+export class LogProvider implements Provider<Logger> {
+  value() {
+    return msg => console.log(msg);
+  }
+}
+```
+
+Please note that we don't intend to use `@bind` to help the bootstrapper
+discover such artifacts. The purpose of `@bind` is to allow developers to
+provide more metadata on how the class should be bound.

--- a/packages/context/test/unit/binding-decorator.test.ts
+++ b/packages/context/test/unit/binding-decorator.test.ts
@@ -1,0 +1,166 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  bind,
+  BindingScope,
+  BindingScopeAndTags,
+  Constructor,
+  Binding,
+  bindingTemplateFor,
+  BindingTemplate,
+  Provider,
+} from '../..';
+
+describe('@bind', () => {
+  const expectedScopeAndTags = {
+    tags: {rest: 'rest'},
+    scope: BindingScope.SINGLETON,
+  };
+
+  it('decorates a class', () => {
+    const spec = {
+      tags: ['rest'],
+      scope: BindingScope.SINGLETON,
+    };
+
+    @bind(spec)
+    class MyController {}
+
+    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
+  });
+
+  it('allows inheritance for certain tags and scope', () => {
+    const spec = {
+      tags: ['rest'],
+      scope: BindingScope.SINGLETON,
+    };
+
+    @bind(spec)
+    class MyController {}
+
+    class MySubController extends MyController {}
+
+    expect(inspectScopeAndTags(MySubController)).to.eql(expectedScopeAndTags);
+  });
+
+  it('ignores `name` and `key` from base class', () => {
+    const spec = {
+      tags: [
+        'rest',
+        {
+          name: 'my-controller',
+          key: 'controllers.my-controller',
+        },
+      ],
+      scope: BindingScope.SINGLETON,
+    };
+
+    @bind(spec)
+    class MyController {}
+
+    @bind()
+    class MySubController extends MyController {}
+
+    const result = inspectScopeAndTags(MySubController);
+    expect(result).to.containEql(expectedScopeAndTags);
+    expect(result.tags).to.not.containEql({
+      name: 'my-controller',
+    });
+    expect(result.tags).to.not.containEql({
+      key: 'controllers.my-controller',
+    });
+  });
+
+  it('accepts template functions', () => {
+    const spec: BindingTemplate = binding => {
+      binding.tag('rest').inScope(BindingScope.SINGLETON);
+    };
+
+    @bind(spec)
+    class MyController {}
+
+    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
+  });
+
+  it('accepts multiple scope/tags', () => {
+    @bind({tags: 'rest'}, {scope: BindingScope.SINGLETON})
+    class MyController {}
+
+    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
+  });
+
+  it('accepts multiple template functions', () => {
+    @bind(
+      binding => binding.tag('rest'),
+      binding => binding.inScope(BindingScope.SINGLETON),
+    )
+    class MyController {}
+
+    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
+  });
+
+  it('accepts both template functions and tag/scopes', () => {
+    const spec: BindingTemplate = binding => {
+      binding.tag('rest').inScope(BindingScope.SINGLETON);
+    };
+
+    @bind(spec, {tags: [{name: 'my-controller'}]})
+    class MyController {}
+
+    expect(inspectScopeAndTags(MyController)).to.eql({
+      tags: {rest: 'rest', name: 'my-controller'},
+      scope: BindingScope.SINGLETON,
+    });
+  });
+
+  it('decorates a provider classes', () => {
+    const spec = {
+      tags: ['rest'],
+      scope: BindingScope.CONTEXT,
+    };
+
+    @bind.provider(spec)
+    class MyProvider implements Provider<string> {
+      value() {
+        return 'my-value';
+      }
+    }
+
+    expect(inspectScopeAndTags(MyProvider)).to.eql({
+      tags: {rest: 'rest', type: 'provider', provider: 'provider'},
+      scope: BindingScope.CONTEXT,
+    });
+  });
+
+  it('recognizes provider classes', () => {
+    const spec = {
+      tags: ['rest', {type: 'provider'}],
+      scope: BindingScope.CONTEXT,
+    };
+
+    @bind(spec)
+    class MyProvider implements Provider<string> {
+      value() {
+        return 'my-value';
+      }
+    }
+
+    expect(inspectScopeAndTags(MyProvider)).to.eql({
+      tags: {rest: 'rest', type: 'provider', provider: 'provider'},
+      scope: BindingScope.CONTEXT,
+    });
+  });
+
+  function inspectScopeAndTags(cls: Constructor<unknown>): BindingScopeAndTags {
+    const templateFn = bindingTemplateFor(cls);
+    const bindingTemplate = new Binding('template').apply(templateFn);
+    return {
+      scope: bindingTemplate.scope,
+      tags: bindingTemplate.tagMap,
+    };
+  }
+});

--- a/packages/context/test/unit/binding-inspector.test.ts
+++ b/packages/context/test/unit/binding-inspector.test.ts
@@ -1,0 +1,197 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  bind,
+  BindingScope,
+  BindingScopeAndTags,
+  Constructor,
+  Context,
+  createBindingFromClass,
+  Provider,
+} from '../..';
+import {BindingFromClassOptions} from '../../src';
+
+describe('createBindingFromClass()', () => {
+  it('inspects classes', () => {
+    const spec: BindingScopeAndTags = {
+      tags: {type: 'controller', name: 'my-controller', rest: 'rest'},
+      scope: BindingScope.SINGLETON,
+    };
+
+    @bind(spec)
+    class MyController {}
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyController, ctx);
+
+    expect(binding.scope).to.eql(spec.scope);
+    expect(binding.tagMap).to.containEql({
+      name: 'my-controller',
+      type: 'controller',
+      rest: 'rest',
+    });
+    expect(ctx.getSync(binding.key)).to.be.instanceof(MyController);
+  });
+
+  it('inspects classes without @bind', () => {
+    class MyController {}
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyController, ctx);
+
+    expect(binding.key).to.eql('classes.MyController');
+    expect(ctx.getSync(binding.key)).to.be.instanceof(MyController);
+  });
+
+  it('supports options to customize class bindings with @bind', () => {
+    const spec: BindingScopeAndTags = {
+      tags: {name: 'my-controller', rest: 'rest'},
+      scope: BindingScope.SINGLETON,
+    };
+
+    @bind(spec)
+    class MyController {}
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyController, ctx, {
+      key: 'controllers.controller1',
+    });
+
+    expect(binding.key).to.eql('controllers.controller1');
+    expect(binding.tagMap).to.containEql({
+      name: 'my-controller',
+      rest: 'rest',
+    });
+  });
+
+  it('supports options to customize class bindings without @bind', () => {
+    class MyController {}
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyController, ctx, {
+      type: 'controller',
+      namespace: 'controllers',
+      name: 'my-controller',
+    });
+
+    expect(binding.key).to.eql('controllers.my-controller');
+    expect(binding.tagMap).to.containEql({
+      controller: 'controller',
+      name: 'my-controller',
+      type: 'controller',
+    });
+    expect(ctx.getSync(binding.key)).to.be.instanceof(MyController);
+  });
+
+  it('inspects provider classes', () => {
+    const spec = {
+      tags: ['rest'],
+      scope: BindingScope.CONTEXT,
+    };
+
+    @bind.provider(spec)
+    class MyProvider implements Provider<string> {
+      value() {
+        return 'my-value';
+      }
+    }
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyProvider, ctx);
+
+    expect(binding.key).to.eql('providers.MyProvider');
+    expect(binding.scope).to.eql(spec.scope);
+    expect(binding.tagMap).to.containDeep({
+      type: 'provider',
+      provider: 'provider',
+      rest: 'rest',
+    });
+    expect(ctx.getSync(binding.key)).to.eql('my-value');
+  });
+
+  it('recognizes provider classes', () => {
+    const spec = {
+      tags: ['rest', {type: 'provider'}],
+      scope: BindingScope.CONTEXT,
+    };
+
+    @bind(spec)
+    class MyProvider implements Provider<string> {
+      value() {
+        return 'my-value';
+      }
+    }
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyProvider, ctx);
+
+    expect(binding.key).to.eql('providers.MyProvider');
+    expect(binding.scope).to.eql(spec.scope);
+    expect(binding.tagMap).to.containDeep({
+      type: 'provider',
+      provider: 'provider',
+      rest: 'rest',
+    });
+    expect(ctx.getSync(binding.key)).to.eql('my-value');
+  });
+
+  it('recognizes provider classes without @bind', () => {
+    class MyProvider implements Provider<string> {
+      value() {
+        return 'my-value';
+      }
+    }
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyProvider, ctx);
+    expect(binding.key).to.eql('providers.MyProvider');
+    expect(ctx.getSync(binding.key)).to.eql('my-value');
+  });
+
+  it('honors the binding key', () => {
+    const spec: BindingScopeAndTags = {
+      tags: {
+        type: 'controller',
+        key: 'controllers.my',
+        name: 'my-controller',
+      },
+    };
+
+    @bind(spec)
+    class MyController {}
+
+    const binding = givenBindingFromClass(MyController);
+
+    expect(binding.key).to.eql('controllers.my');
+
+    expect(binding.tagMap).to.eql({
+      name: 'my-controller',
+      type: 'controller',
+      key: 'controllers.my',
+    });
+  });
+
+  it('defaults type to class', () => {
+    const spec: BindingScopeAndTags = {};
+
+    @bind(spec)
+    class MyClass {}
+
+    const binding = givenBindingFromClass(MyClass);
+    expect(binding.key).to.eql('classes.MyClass');
+  });
+
+  function givenBindingFromClass(
+    cls: Constructor<unknown>,
+    ctx: Context = new Context(),
+    options: BindingFromClassOptions = {},
+  ) {
+    const binding = createBindingFromClass(cls, options);
+    ctx.add(binding);
+    return binding;
+  }
+});


### PR DESCRIPTION
This PR is a reactivation of https://github.com/strongloop/loopback-next/pull/992.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
