### PR TITLE
feat(cli): allow annonymous schemas in openapi to be mapped to models

### DIFF
--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -38,6 +38,14 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
       default: false,
       type: Boolean,
     });
+
+    this.option('promote-anonymous-schemas', {
+      description: 'Promote anonymous schemas as models',
+      required: false,
+      default: false,
+      type: Boolean,
+    });
+
     return super._setupGenerator();
   }
 
@@ -70,6 +78,7 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
       const result = await loadAndBuildSpec(this.url, {
         log: this.log,
         validate: this.options.validate,
+        promoteAnonymousSchemas: this.options['promote-anonymous-schemas'],
       });
       debugJson('OpenAPI spec', result.apiSpec);
       Object.assign(this, result);

--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -4,11 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
-const fs = require('fs');
-const util = require('util');
 
 const debug = require('../../lib/debug')('openapi-generator');
-const {mapSchemaType} = require('./schema-helper');
+const {mapSchemaType, registerSchema} = require('./schema-helper');
 const {
   isExtension,
   titleCase,
@@ -17,7 +15,6 @@ const {
   camelCase,
   escapeIdentifier,
   escapePropertyOrMethodName,
-  toJsonStr,
 } = require('./utils');
 
 const HTTP_VERBS = [
@@ -143,6 +140,49 @@ function getMethodName(opSpec) {
   );
 }
 
+function registerAnonymousSchema(names, schema, typeRegistry) {
+  if (!typeRegistry.promoteAnonymousSchemas) {
+    // Skip anonymous schemas
+    return;
+  }
+
+  // Skip referenced schemas
+  if (schema['x-$ref']) return;
+
+  // Only map object/array types
+  if (
+    schema.properties ||
+    schema.type === 'object' ||
+    schema.type === 'array'
+  ) {
+    if (typeRegistry.anonymousSchemaNames == null) {
+      typeRegistry.anonymousSchemaNames = new Set();
+    }
+    // Infer the schema name
+    let schemaName;
+    if (Array.isArray(names)) {
+      schemaName = names.join('-');
+    } else if (typeof names === 'string') {
+      schemaName = names;
+    }
+
+    if (!schemaName && schema.title) {
+      schemaName = schema.title;
+    }
+
+    schemaName = camelCase(schemaName);
+
+    // Make sure the schema name is unique
+    let index = 1;
+    while (typeRegistry.anonymousSchemaNames.has(schemaName)) {
+      schemaName = schemaName + index++;
+    }
+    typeRegistry.anonymousSchemaNames.add(schemaName);
+
+    registerSchema(schemaName, schema, typeRegistry);
+  }
+}
+
 /**
  * Build method spec for an operation
  * @param {object} OpenAPI operation
@@ -162,6 +202,7 @@ function buildMethodSpec(controllerSpec, op, options) {
       } else {
         paramNames[name] = 1;
       }
+      registerAnonymousSchema([methodName, name], p.schema, options);
       const pType = mapSchemaType(p.schema, options);
       addImportsForType(pType);
       comments.push(`@param ${name} ${p.description || ''}`);
@@ -182,14 +223,22 @@ function buildMethodSpec(controllerSpec, op, options) {
      */
     let bodyType = {signature: 'any'};
     const content = op.spec.requestBody.content;
-    const jsonType = content && content['application/json'];
-    if (jsonType && jsonType.schema) {
-      bodyType = mapSchemaType(jsonType.schema, options);
-      addImportsForType(bodyType);
-    }
-    let bodyName = 'body';
+    const contentType =
+      content &&
+      (content['application/json'] || content[Object.keys(content)[0]]);
+
+    let bodyName = 'requestBody';
     if (bodyName in paramNames) {
       bodyName = `${bodyName}${paramNames[bodyName]++}`;
+    }
+    if (contentType && contentType.schema) {
+      registerAnonymousSchema(
+        [methodName, bodyName],
+        contentType.schema,
+        options,
+      );
+      bodyType = mapSchemaType(contentType.schema, options);
+      addImportsForType(bodyType);
     }
     const bodyParam = bodyName; // + (op.spec.requestBody.required ? '' : '?');
     // Add body as the 1st param
@@ -219,9 +268,16 @@ function buildMethodSpec(controllerSpec, op, options) {
       if (isExtension(code)) continue;
       if (code !== '200' && code !== '201') continue;
       const content = responses[code].content;
-      const jsonType = content && content['application/json'];
-      if (jsonType && jsonType.schema) {
-        returnType = mapSchemaType(jsonType.schema, options);
+      const contentType =
+        content &&
+        (content['application/json'] || content[Object.keys(content)[0]]);
+      if (contentType && contentType.schema) {
+        registerAnonymousSchema(
+          [methodName, 'responseBody'],
+          contentType.schema,
+          options,
+        );
+        returnType = mapSchemaType(contentType.schema, options);
         addImportsForType(returnType);
         comments.push(`@returns ${responses[code].description || ''}`);
         break;

--- a/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
@@ -1,3 +1,4 @@
+/* tslint:disable:no-any */
 <%_
 const _properties = locals.properties || [];
 if (_properties.length) {

--- a/packages/cli/generators/openapi/templates/src/models/type-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/type-template.ts.ejs
@@ -1,3 +1,4 @@
+/* tslint:disable:no-any */
 <%_
 imports.forEach(i => {
 -%>

--- a/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
@@ -1,0 +1,82 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const generator = path.join(__dirname, '../../../generators/openapi');
+const specPath = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
+
+const testlab = require('@loopback/testlab');
+const TestSandbox = testlab.TestSandbox;
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+const testUtils = require('../../test-utils');
+
+const props = {
+  url: specPath,
+};
+
+describe('openapi-generator specific files', () => {
+  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const searchController = path.resolve(
+    SANDBOX_PATH,
+    'src/controllers/search.controller.ts',
+  );
+  const metadataController = path.resolve(
+    SANDBOX_PATH,
+    'src/controllers/metadata.controller.ts',
+  );
+  const performSearchRequestBodyModel = path.resolve(
+    SANDBOX_PATH,
+    'src/models/perform-search-request-body.model.ts',
+  );
+  const performSearchResponseBodyModel = path.resolve(
+    SANDBOX_PATH,
+    'src/models/perform-search-response-body.model.ts',
+  );
+
+  after('reset sandbox', async () => {
+    await sandbox.reset();
+  });
+
+  it('generates all the proper files', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .withArguments('--promote-anonymous-schemas')
+      .withPrompts(props);
+    assert.file(metadataController);
+
+    assert.fileContent(
+      searchController,
+      `async performSearch(@requestBody() requestBody: PerformSearchRequestBody, ` +
+        `@param({name: 'version', in: 'path'}) version: string, ` +
+        `@param({name: 'dataset', in: 'path'}) dataset: string): ` +
+        `Promise<PerformSearchResponseBody> {`,
+    );
+
+    assert.fileContent(
+      performSearchRequestBodyModel,
+      'export class PerformSearchRequestBody {',
+    );
+
+    assert.fileContent(
+      performSearchResponseBodyModel,
+      'export type PerformSearchResponseBody = {',
+    );
+
+    assert.fileContent(
+      performSearchResponseBodyModel,
+      '[additionalProperty: string]: {',
+    );
+
+    assert.fileContent(index, `export * from './search.controller';`);
+    assert.fileContent(index, `export * from './metadata.controller';`);
+  });
+});

--- a/packages/cli/test/unit/openapi/controller-spec.unit.js
+++ b/packages/cli/test/unit/openapi/controller-spec.unit.js
@@ -44,13 +44,13 @@ describe('openapi to controllers/models', () => {
             comments: [
               'Creates a new customer',
               '\n',
-              '@param body Customer to add',
+              '@param requestBody Customer to add',
               '@param accessToken Access token',
               '@returns customer response',
             ],
             decoration: "@operation('post', '/customers')",
             signature:
-              'async createCustomer(@requestBody() body: Customer, ' +
+              'async createCustomer(@requestBody() requestBody: Customer, ' +
               "@param({name: 'access-token', in: 'query'}) accessToken: " +
               'string): Promise<Customer>',
           },

--- a/packages/cli/test/unit/openapi/schema-model.unit.js
+++ b/packages/cli/test/unit/openapi/schema-model.unit.js
@@ -4,14 +4,17 @@
 // License text available at https://opensource.org/licenses/MIT
 
 const expect = require('@loopback/testlab').expect;
-const {loadSpec} = require('../../../generators/openapi/spec-loader');
+const {
+  loadSpec,
+  loadAndBuildSpec,
+} = require('../../../generators/openapi/spec-loader');
 const {
   generateModelSpecs,
 } = require('../../../generators/openapi/schema-helper');
 const path = require('path');
 
 describe('schema to model', () => {
-  let usptoSpec, petstoreSpec, customerSepc;
+  let usptoSpec, usptoSpecAnonymous, petstoreSpec, customerSepc;
   const uspto = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
   const petstore = path.join(
     __dirname,
@@ -24,6 +27,9 @@ describe('schema to model', () => {
 
   before(async () => {
     usptoSpec = await loadSpec(uspto);
+    usptoSpecAnonymous = await loadAndBuildSpec(uspto, {
+      promoteAnonymousSchemas: true,
+    });
     petstoreSpec = await loadSpec(petstore);
     customerSepc = await loadSpec(customer);
   });
@@ -59,6 +65,103 @@ describe('schema to model', () => {
           '  apiVersionNumber?: string;\n  apiUrl?: string;\n' +
           '  apiDocumentationUrl?: string;\n}[];\n}',
         signature: 'DataSetList',
+      },
+    ]);
+  });
+
+  it('generates models for uspto with promoted anonymous schemas', () => {
+    const models = usptoSpecAnonymous.modelSpecs;
+    expect(models).to.eql([
+      {
+        description: 'dataSetList',
+        name: 'dataSetList',
+        className: 'DataSetList',
+        fileName: 'data-set-list.model.ts',
+        properties: [
+          {
+            name: 'total',
+            signature: 'total?: number;',
+            decoration: "@property({name: 'total'})",
+          },
+          {
+            name: 'apis',
+            signature:
+              'apis?: {\n  apiKey?: string;\n  apiVersionNumber?: string;\n  ' +
+              'apiUrl?: string;\n  apiDocumentationUrl?: string;\n}[];',
+            decoration: "@property({name: 'apis'})",
+          },
+        ],
+        imports: [],
+        import: "import {DataSetList} from './data-set-list.model';",
+        kind: 'class',
+        declaration:
+          '{\n  total?: number;\n  apis?: {\n  apiKey?: string;\n  ' +
+          'apiVersionNumber?: string;\n  apiUrl?: string;\n  ' +
+          'apiDocumentationUrl?: string;\n}[];\n}',
+        signature: 'DataSetList',
+      },
+      {
+        description: 'performSearchRequestBody',
+        name: 'performSearchRequestBody',
+        className: 'PerformSearchRequestBody',
+        fileName: 'perform-search-request-body.model.ts',
+        properties: [
+          {
+            name: 'criteria',
+            signature: "criteria: string = '*:*';",
+            decoration: "@property({name: 'criteria'})",
+            description:
+              'Uses Lucene Query Syntax in the format of propertyName:value, ' +
+              'propertyName:[num1 TO num2] and date range format: ' +
+              'propertyName:[yyyyMMdd TO yyyyMMdd]. In the response please ' +
+              "see the 'docs' element which has the list of record objects. " +
+              'Each record structure would consist of all the fields and ' +
+              'their corresponding values.',
+          },
+          {
+            name: 'start',
+            signature: 'start?: number = 0;',
+            decoration: "@property({name: 'start'})",
+            description: 'Starting record number. Default value is 0.',
+          },
+          {
+            name: 'rows',
+            signature: 'rows?: number = 100;',
+            decoration: "@property({name: 'rows'})",
+            description:
+              'Specify number of rows to be returned. If you run the search ' +
+              "with default values, in the response you will see 'numFound' " +
+              'attribute which will tell the number of records available in ' +
+              'the dataset.',
+          },
+        ],
+        imports: [],
+        import:
+          "import {PerformSearchRequestBody} from './perform-search-request-body.model';",
+        kind: 'class',
+        declaration:
+          "{\n  criteria: string = '*:*';\n  start?: number = 0;\n  " +
+          'rows?: number = 100;\n}',
+        signature: 'PerformSearchRequestBody',
+      },
+      {
+        description: 'performSearchResponseBody',
+        name: '{\n  [additionalProperty: string]: {\n  \n};\n}[]',
+        className: 'PerformSearchResponseBody',
+        fileName: 'perform-search-response-body.model.ts',
+        properties: [],
+        imports: [],
+        import:
+          'import {PerformSearchResponseBody} from ' +
+          "'./perform-search-response-body.model';",
+        declaration: '{\n  [additionalProperty: string]: {\n  \n};\n}[]',
+        signature: 'PerformSearchResponseBody',
+        itemType: {
+          imports: [],
+          declaration: '{\n  [additionalProperty: string]: {\n  \n};\n}',
+          properties: [],
+          signature: '{\n  [additionalProperty: string]: {\n  \n};\n}',
+        },
       },
     ]);
   });


### PR DESCRIPTION
This PR adds `--promote-anonymous-schemas` option to map anonymous schemas in OpenAPI specs to LoopBack 4 models. Without the flag, we generate such schemas as TypeScript type literals.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
