### PR TITLE
chore: fix tslint violations

### DIFF
--- a/packages/repository/test/acceptance/has-one.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-one.relation.acceptance.ts
@@ -55,7 +55,7 @@ describe('hasOne relation', () => {
     const address = await controller.createCustomerAddress(existingCustomerId, {
       street: '123 test avenue',
     });
-    expect(
+    await expect(
       controller.createCustomerAddress(existingCustomerId, {
         street: '456 test street',
       }),

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -465,7 +465,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
     if (config.disabled) {
       debug('Redirect to swagger-ui was disabled by configuration.');
-      return next();
+      next();
+      return;
     }
 
     debug('Redirecting to swagger-ui from %j.', request.originalUrl);


### PR DESCRIPTION
The rule "no-unused-variable" is messing up with TypeScript compiler state and as a result, other rules don't detect certain violations.

In this commit, I am fixing few violations I discovered when I have temporarily disabled no-unused-variable rule.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated
