### PR TITLE
Extract tslint config into a standalone package

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2"
   },
   "keywords": [

--- a/examples/hello-world/tslint.build.json
+++ b/examples/hello-world/tslint.build.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["@loopback/tslint-config/tslint.build.json"]
 }

--- a/examples/hello-world/tslint.json
+++ b/examples/hello-world/tslint.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["@loopback/tslint-config/tslint.common.json"]
 }

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/debug": "0.0.30",
     "@types/node": "^10.11.2"
   },

--- a/examples/log-extension/tslint.build.json
+++ b/examples/log-extension/tslint.build.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["@loopback/tslint-config/tslint.build.json"]
 }

--- a/examples/log-extension/tslint.json
+++ b/examples/log-extension/tslint.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["@loopback/tslint-config/tslint.common.json"]
 }

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/express": "^4.11.1",
     "@types/node": "^10.11.2",
     "@types/p-event": "^1.3.0"

--- a/examples/rpc-server/tslint.build.json
+++ b/examples/rpc-server/tslint.build.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["@loopback/tslint-config/tslint.build.json"]
 }

--- a/examples/rpc-server/tslint.json
+++ b/examples/rpc-server/tslint.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["@loopback/tslint-config/tslint.common.json"]
 }

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/mocha": "^5.0.0",
     "@types/node": "^10.11.2",
     "mocha": "^5.1.1",

--- a/examples/soap-calculator/tslint.build.json
+++ b/examples/soap-calculator/tslint.build.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["@loopback/tslint-config/tslint.build.json"]
 }

--- a/examples/soap-calculator/tslint.json
+++ b/examples/soap-calculator/tslint.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["@loopback/tslint-config/tslint.common.json"]
 }

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -50,6 +50,7 @@
     "@loopback/build": "^1.0.2",
     "@loopback/http-caching-proxy": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/lodash": "^4.14.109",
     "@types/node": "^10.11.2",
     "lodash": "^4.17.10"

--- a/examples/todo-list/tslint.build.json
+++ b/examples/todo-list/tslint.build.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["@loopback/tslint-config/tslint.build.json"]
 }

--- a/examples/todo-list/tslint.json
+++ b/examples/todo-list/tslint.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["@loopback/tslint-config/tslint.common.json"]
 }

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -50,6 +50,7 @@
     "@loopback/build": "^1.0.2",
     "@loopback/http-caching-proxy": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/lodash": "^4.14.109",
     "@types/node": "^10.11.2",
     "lodash": "^4.17.10"

--- a/examples/todo/tslint.build.json
+++ b/examples/todo/tslint.build.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["@loopback/tslint-config/tslint.build.json"]
 }

--- a/examples/todo/tslint.json
+++ b/examples/todo/tslint.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["@loopback/tslint-config/tslint.common.json"]
 }

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -32,6 +32,7 @@
     "@loopback/build": "^1.0.2",
     "@loopback/openapi-spec-builder": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2",
     "@types/passport": "^0.4.4",
     "@types/passport-http": "^0.3.6",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -37,6 +37,7 @@
     "@loopback/openapi-v3": "^1.1.4",
     "@loopback/rest": "^1.5.0",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2"
   },
   "files": [

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -105,32 +105,33 @@ Now you run the scripts, such as:
   `lb-tslint` also depends on `tsconfig.build.json` or `tsconfig.json` to
   reference the project.
 
+  **NOTE:** Our recommended configuration of tslint rules is maintained inside
+  the package `@loopback/tslint-config`. We strongly recommend users to create
+  their own tslint configuration files inheriting from `@loopback/tslint-config`
+  instead of relying on the defaults provided by `@loopback/build`.
+
   To customize the configuration:
 
   - Create `tslint.build.json` in your project's root directory, for example:
+
     ```json
     {
       "$schema": "http://json.schemastore.org/tslint",
-      "extends": [
-        "./node_modules/@loopback/build/config/tslint.common.json"
-      ],
+      "extends": ["@loopback/eslint-config/tslint.build.json"],
       // This configuration files enabled rules which require type checking
       // and therefore cannot be run by Visual Studio Code TSLint extension
       // See https://github.com/Microsoft/vscode-tslint/issues/70
       "rules": {
         // These rules find errors related to TypeScript features.
+        // These rules catch common errors in JS programming or otherwise
+        // confusing constructs that are prone to producing bugs.
+
+        "await-promise": true,
+        "no-floating-promises": true,
+        "no-void-expression": [true, "ignore-arrow-function-shorthand"]
+      }
+    }
     ```
-
-```json
-    // These rules catch common errors in JS programming or otherwise
-    // confusing constructs that are prone to producing bugs.
-
-    "await-promise": true,
-    "no-floating-promises": true,
-    "no-void-expression": [true, "ignore-arrow-function-shorthand"]
-  }
-}
-```
 
 - Set options explicitly for the script
 

--- a/packages/build/config/tslint.build.json
+++ b/packages/build/config/tslint.build.json
@@ -1,23 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
   "extends": [
-    "./tslint.common.json"
-  ],
-  // This configuration files enabled rules which require type checking
-  // and therefore cannot be run by Visual Studio Code TSLint extension
-  // See https://github.com/Microsoft/vscode-tslint/issues/70
-  "rules": {
-    // These rules find errors related to TypeScript features.
-
-    // These rules catch common errors in JS programming or otherwise
-    // confusing constructs that are prone to producing bugs.
-
-    // User-land promises like Bluebird implement "PromiseLike" (not "Promise")
-    // interface only. The string "PromiseLike" bellow is needed to
-    // tell tslint that it's ok to `await` such promises.
-    "await-promise": [true, "PromiseLike", "RequestPromise"],
-    "no-floating-promises": [true, "PromiseLike", "RequestPromise"],
-    "no-unused-variable": true,
-    "no-void-expression": [true, "ignore-arrow-function-shorthand"]
-  }
+    "@loopback/tslint-config/tslint.build.json"
+  ]
 }

--- a/packages/build/config/tslint.common.json
+++ b/packages/build/config/tslint.common.json
@@ -1,26 +1,6 @@
 {
-  // See https://palantir.github.io/tslint/rules/
-  "rules": {
-    // These rules find errors related to TypeScript features.
-    "adjacent-overload-signatures": true,
-    "prefer-for-of": true,
-    "unified-signatures": true,
-    "no-any": true,
-
-    // These rules catch common errors in JS programming or otherwise
-    // confusing constructs that are prone to producing bugs.
-
-    "label-position": true,
-    "no-arg": true,
-    "no-construct": true,
-    "no-duplicate-variable": true,
-
-    "no-invalid-this": true,
-    "no-misused-new": true,
-    "no-shadowed-variable": true,
-    "no-string-throw": true,
-    "no-unused-expression": true,
-    "no-var-keyword": true,
-    "triple-equals": [true, "allow-null-check", "allow-undefined-check"]
-  }
+  "$schema": "http://json.schemastore.org/tslint",
+  "extends": [
+    "@loopback/tslint-config/tslint.common.json"
+  ]
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -42,5 +42,8 @@
   "scripts": {
     "test": "npm run mocha",
     "mocha": "node bin/run-mocha --timeout 30000 \"test/integration/*.js\""
+  },
+  "devDependencies": {
+    "@loopback/tslint-config": "^1.0.0-1"
   }
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -13,6 +13,7 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/mocha": "^5.0.0",
     "@types/node": "^10.11.2",
     "cross-spawn": "^6.0.5",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -92,6 +92,7 @@
   "devDependencies": {
     "@loopback/build": "<%= project.dependencies['@loopback/build'] -%>",
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
+    "@loopback/tslint-config": "<%= project.dependencies['@loopback/tslint-config'] -%>",
     "@types/node": "<%= project.dependencies['@types/node'] -%>"
   }
 }

--- a/packages/cli/generators/project/templates/tslint.build.json.ejs
+++ b/packages/cli/generators/project/templates/tslint.build.json.ejs
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./node_modules/@loopback/build/config/tslint.build.json"]
+  "extends": ["@loopback/tslint-config/tslint.build.json"]
 }

--- a/packages/cli/generators/project/templates/tslint.json.ejs
+++ b/packages/cli/generators/project/templates/tslint.json.ejs
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
 <% if (project.loopbackBuild) { -%>
-  "extends": ["./node_modules/@loopback/build/config/tslint.common.json"]
+  "extends": ["@loopback/tslint-config/tslint.common.json"]
 <% } else { -%>
   // See https://palantir.github.io/tslint/rules/
   "rules": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -113,7 +113,8 @@
       "@loopback/http-server": "^1.1.1",
       "@loopback/example-todo-list": "^1.3.0",
       "@loopback/dist-util": "^0.4.0",
-      "@loopback/rest-explorer": "^1.1.3"
+      "@loopback/rest-explorer": "^1.1.3",
+      "@loopback/tslint-config": "^1.0.0-1"
     }
   },
   "copyright.owner": "IBM Corp.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/ejs": "^2.6.0",
     "@types/node": "^10.11.2",
     "glob": "^7.1.2",

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -249,7 +249,7 @@ module.exports = function(projGenerator, props, projectType) {
         assert.jsonFileContent('package.json', props);
         assert.fileContent([
           ['package.json', '@loopback/build'],
-          ['tslint.json', '@loopback/build'],
+          ['tslint.json', '@loopback/tslint-config'],
           ['tsconfig.json', '@loopback/build'],
         ]);
         assert.noFileContent([

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/bluebird": "^3.5.20",
     "@types/debug": "^0.0.30",
     "@types/node": "^10.11.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2"
   },
   "files": [

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/debug": "^0.0.30",
     "@types/node": "^10.11.2",
     "@types/p-event": "^1.3.0",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -23,6 +23,7 @@
     "@loopback/build": "^1.0.2",
     "@loopback/core": "^1.1.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2",
     "@types/p-event": "^1.3.0",
     "@types/request-promise-native": "^1.0.15",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/debug": "^0.0.30",
     "@types/lodash": "^4.14.106",
     "@types/node": "^10.11.2"

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2"
   },
   "files": [

--- a/packages/openapi-v3-types/package.json
+++ b/packages/openapi-v3-types/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2"
   },
   "scripts": {

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -10,6 +10,7 @@
     "@loopback/openapi-spec-builder": "^1.0.2",
     "@loopback/repository": "^1.1.0",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/debug": "0.0.30",
     "@types/lodash": "^4.14.106",
     "@types/node": "^10.11.2"

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2",
     "ajv": "^6.5.0"
   },

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/lodash": "^4.14.108",
     "@types/node": "^10.11.2"
   },

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/ejs": "^2.6.0",
     "@types/node": "^10.1.1"
   },

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -53,6 +53,7 @@
     "@loopback/openapi-spec-builder": "^1.0.2",
     "@loopback/repository": "^1.1.0",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/debug": "0.0.30",
     "@types/js-yaml": "^3.11.1",
     "@types/lodash": "^4.14.106",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@loopback/build": "^1.0.2",
     "@loopback/testlab": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2"
   },
   "dependencies": {

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^1.0.2",
+    "@loopback/tslint-config": "^1.0.0-1",
     "@types/node": "^10.11.2"
   },
   "files": [

--- a/packages/tslint-config/.npmrc
+++ b/packages/tslint-config/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/tslint-config/LICENSE
+++ b/packages/tslint-config/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Node module: @loopback/tslint-config
+This project is licensed under the MIT License, full text below.
+
+--------
+
+MIT license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/tslint-config/README.md
+++ b/packages/tslint-config/README.md
@@ -1,0 +1,43 @@
+# @loopback/tslint-config
+
+Shared TSLint config to enforce a consistent code style for LoopBack development
+
+## Installation
+
+```shell
+$ npm install --save @loopback/tslint-config
+```
+
+## Basic Use
+
+An example `tslint.json` file:
+
+```json5
+{
+  $schema: 'http://json.schemastore.org/tslint',
+  extends: ['@loopback/tslint-config/tslint.common.json'],
+}
+```
+
+An example `tslint.buid.json` file:
+
+```json5
+{
+  $schema: 'http://json.schemastore.org/tslint',
+  extends: ['@loopback/tslint-config/tslint.build.json'],
+}
+```
+
+## Contributions
+
+- [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md)
+- [Join the team](https://github.com/strongloop/loopback-next/issues/110)
+
+## Contributors
+
+See
+[all contributors](https://github.com/strongloop/loopback-next/graphs/contributors).
+
+## License
+
+MIT

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@loopback/tslint-config",
+  "version": "1.0.0-1",
+  "description": "",
+  "engines": {
+    "node": ">=8.9"
+  },
+  "author": "IBM",
+  "copyright.owner": "IBM Corp.",
+  "license": "MIT",
+  "peerDependencies": {
+    "tslint": ">=5.11.0"
+  },
+  "files": [
+    "README.md",
+    "tslint.common.json",
+    "tslint.build.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-next.git"
+  }
+}

--- a/packages/tslint-config/tslint.build.json
+++ b/packages/tslint-config/tslint.build.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json.schemastore.org/tslint",
+  "extends": [
+    "./tslint.common.json"
+  ],
+  // This configuration files enabled rules which require type checking
+  // and therefore cannot be run by Visual Studio Code TSLint extension
+  // See https://github.com/Microsoft/vscode-tslint/issues/70
+  "rules": {
+    // These rules find errors related to TypeScript features.
+
+    // These rules catch common errors in JS programming or otherwise
+    // confusing constructs that are prone to producing bugs.
+
+    // User-land promises like Bluebird implement "PromiseLike" (not "Promise")
+    // interface only. The string "PromiseLike" bellow is needed to
+    // tell tslint that it's ok to `await` such promises.
+    "await-promise": [true, "PromiseLike", "RequestPromise"],
+    "no-floating-promises": [true, "PromiseLike", "RequestPromise"],
+    "no-unused-variable": true,
+    "no-void-expression": [true, "ignore-arrow-function-shorthand"]
+  }
+}

--- a/packages/tslint-config/tslint.common.json
+++ b/packages/tslint-config/tslint.common.json
@@ -1,0 +1,26 @@
+{
+  // See https://palantir.github.io/tslint/rules/
+  "rules": {
+    // These rules find errors related to TypeScript features.
+    "adjacent-overload-signatures": true,
+    "prefer-for-of": true,
+    "unified-signatures": true,
+    "no-any": true,
+
+    // These rules catch common errors in JS programming or otherwise
+    // confusing constructs that are prone to producing bugs.
+
+    "label-position": true,
+    "no-arg": true,
+    "no-construct": true,
+    "no-duplicate-variable": true,
+
+    "no-invalid-this": true,
+    "no-misused-new": true,
+    "no-shadowed-variable": true,
+    "no-string-throw": true,
+    "no-unused-expression": true,
+    "no-var-keyword": true,
+    "triple-equals": [true, "allow-null-check", "allow-undefined-check"]
+  }
+}

--- a/sandbox/example/package.json
+++ b/sandbox/example/package.json
@@ -16,5 +16,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git"
+  },
+  "devDependencies": {
+    "@loopback/tslint-config": "^1.0.0-1"
   }
 }

--- a/tslint.build.json
+++ b/tslint.build.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./packages/build/config/tslint.build.json"],
+  "extends": ["./packages/tslint-config/tslint.build.json"],
   "linterOptions": {
     "exclude": [
       "./packages/cli/generators/*/templates/**/*",

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tslint",
-  "extends": ["./packages/build/config/tslint.common.json"],
+  "extends": ["./packages/tslint-config/tslint.common.json"],
   "linterOptions": {
     "exclude": [
       "./packages/cli/generators/*/templates/**/*",


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/pull/2156

By keeping the tslint config in an independently versioned package `@loopback/tslint-config`, we can properly communicate breaking changes without having to worry about long-term support for multiple versions of `@loobpack/build`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated