### PR TITLE
chore: suppress node.js warnings to have clean logs

### DIFF
--- a/packages/build/bin/run-mocha.js
+++ b/packages/build/bin/run-mocha.js
@@ -27,6 +27,9 @@ function run(argv, options) {
     !utils.mochaOptsFileProjectExists();
 
   // Add default options
+  // Keep it backward compatible as dryRun
+  if (typeof options === 'boolean') options = {dryRun: options};
+  options = options || {};
   if (setMochaOpts) {
     const mochaOptsFile = utils.getConfigFile('mocha.opts');
     mochaOpts.unshift('--opts', mochaOptsFile);
@@ -36,6 +39,7 @@ function run(argv, options) {
   if (allowConsoleLogsIx === -1) {
     // Fail any tests that are printing to console.
     mochaOpts.unshift(
+      '--no-warnings', // Disable node.js warnings
       '--require',
       require.resolve('../src/fail-on-console-logs'),
     );

--- a/packages/build/bin/utils.js
+++ b/packages/build/bin/utils.js
@@ -112,6 +112,7 @@ function resolveCLI(cli) {
  * @param {string} cli Path of the cli command
  * @param {string[]} args The arguments
  * @param {object} options Options to control dryRun and spawn
+ * - nodeArgs An array of args for `node`
  * - dryRun Controls if the cli will be executed or not. If set
  * to true, the command itself will be returned without running it
  */
@@ -125,6 +126,12 @@ function runCLI(cli, args, options) {
   if (options.dryRun) {
     return util.format('%s %s', process.execPath, args.join(' '));
   }
+  if (options.nodeArgs) {
+    debug('node args: %s', options.nodeArgs.join(' '));
+    // For example, [--no-warnings]
+    args = options.nodeArgs.concat(args);
+  }
+  debug('Spawn %s %s', process.execPath, args.join(' '));
   var child = spawn(
     process.execPath, // Typically '/usr/local/bin/node'
     args,

--- a/packages/build/src/fail-on-console-logs.js
+++ b/packages/build/src/fail-on-console-logs.js
@@ -18,6 +18,7 @@ console.warn = recordForbiddenCall('warn');
 console.error = recordForbiddenCall('error');
 
 const problems = [];
+const warnings = [];
 
 function recordForbiddenCall(methodName) {
   return function recordForbiddenConsoleUsage(...args) {
@@ -40,7 +41,16 @@ function recordForbiddenCall(methodName) {
   };
 }
 
+process.on('warning', warning => {
+  warnings.push(warning);
+});
+
 process.on('exit', code => {
+  if (!warnings.length) {
+    for (w of warnings) {
+      originalConsole.warn(w);
+    }
+  }
   if (!problems.length) return;
   const log = originalConsole.log;
 


### PR DESCRIPTION
CI fails on Windows. See:

https://ci.appveyor.com/project/strongloop/loopback-next/builds/21019237

This PR adds a flag to suppress Node.js warnings per:
https://medium.com/@jasnell/introducing-process-warnings-in-node-v6-3096700537ee

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
