### PR TITLE
refactor: remove dependency of package.json keywords

### DIFF
--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -305,14 +305,14 @@ module.exports = class BaseGenerator extends Generator {
 
   /**
    * Checks if current directory is a LoopBack project by checking for
-   * keyword 'loopback' under 'keywords' attribute in package.json.
-   * 'keywords' is an array
+   * "@loopback/core" package in the dependencies section of the
+   * package.json.
    */
   async checkLoopBackProject() {
     debug('Checking for loopback project');
     if (this.shouldExit()) return false;
     const pkg = this.fs.readJSON(this.destinationPath('package.json'));
-    const key = 'loopback';
+
     if (!pkg) {
       const err = new Error(
         'No package.json found in ' +
@@ -323,9 +323,18 @@ module.exports = class BaseGenerator extends Generator {
       this.exit(err);
       return;
     }
-    if (!pkg.keywords || !pkg.keywords.includes(key)) {
+
+    this.packageJson = pkg;
+
+    const projectDeps = pkg.dependencies || {};
+    const projectDevDeps = pkg.devDependencies || {};
+
+    const dependentPackage = '@loopback/core';
+    const projectDepsNames = Object.keys(projectDeps);
+
+    if (!projectDepsNames.includes(dependentPackage)) {
       const err = new Error(
-        'No `loopback` keyword found in ' +
+        'No `@loopback/core` package found in the "dependencies" section of ' +
           this.destinationPath('package.json') +
           '. ' +
           'The command must be run in a LoopBack project.',
@@ -333,10 +342,6 @@ module.exports = class BaseGenerator extends Generator {
       this.exit(err);
       return;
     }
-    this.packageJson = pkg;
-
-    const projectDeps = pkg.dependencies || {};
-    const projectDevDeps = pkg.devDependencies || {};
 
     const cliPkg = require('../package.json');
     const templateDeps = cliPkg.config.templateDependencies;

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -56,15 +56,15 @@ describe('lb4 controller', () => {
     ).to.be.rejectedWith(/No package.json found in/);
   });
 
-  it('does not run without the loopback keyword', () => {
+  it('does not run without "@loopback/core" as a dependency', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: true}),
+          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: true}),
         )
         .withPrompts(basicCLIInput),
-    ).to.be.rejectedWith(/No `loopback` keyword found in/);
+    ).to.be.rejectedWith(/No `@loopback\/core` package found/);
   });
 
   describe('basic controller', () => {

--- a/packages/cli/test/integration/generators/datasource.integration.js
+++ b/packages/cli/test/integration/generators/datasource.integration.js
@@ -86,15 +86,15 @@ describe('lb4 datasource integration', () => {
     ).to.be.rejectedWith(/No package.json found in/);
   });
 
-  it('does not run without the loopback keyword', () => {
+  it('does not run without the "@loopback/core" dependency', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: true}),
+          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: true}),
         )
         .withPrompts(basicCLIInput),
-    ).to.be.rejectedWith(/No `loopback` keyword found in/);
+    ).to.be.rejectedWith(/No `@loopback\/core` package found/);
   });
 
   describe('basic datasource', () => {

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -49,15 +49,15 @@ describe('lb4 model integration', () => {
     ).to.be.rejectedWith(/No package.json found in/);
   });
 
-  it('does not run without the loopback keyword', () => {
+  it('does not run without the "@loopback/core" dependency', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: true}),
+          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: true}),
         )
         .withPrompts(basicCLIInput),
-    ).to.be.rejectedWith(/No `loopback` keyword found in/);
+    ).to.be.rejectedWith(/No `@loopback\/core` package found/);
   });
 
   it('does not run if passed an invalid model from command line', () => {
@@ -65,7 +65,7 @@ describe('lb4 model integration', () => {
       testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeKeyword: false}),
+          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: false}),
         )
         .withArguments('myNewModel --base InvalidModel'),
     ).to.be.rejectedWith(/Model was not found in/);

--- a/packages/cli/test/integration/lib/artifact-generator.js
+++ b/packages/cli/test/integration/lib/artifact-generator.js
@@ -74,22 +74,20 @@ module.exports = function(artiGenerator) {
         undefined,
         /No package.json found/,
       );
+
       testCheckLoopBack(
-        'throws an error if "keywords" key does not exist',
-        {foobar: 'test'},
-        /No `loopback` keyword found/,
-      );
-      testCheckLoopBack(
-        'throws an error if "keywords" key does not map to an array with "loopback" as a member',
-        {keywords: ['foobar', 'test']},
-        /No `loopback` keyword found/,
+        'throws an error if "@loopback/core" is not a dependency',
+        {dependencies: {}},
+        /No `@loopback\/core` package found/,
       );
 
       testCheckLoopBack(
         'throws an error if dependencies have incompatible versions',
         {
-          keywords: ['loopback'],
-          dependencies: {'@loopback/context': '^0.0.0'},
+          dependencies: {
+            '@loopback/context': '^0.0.0',
+            '@loopback/core': '^0.0.0',
+          },
         },
         /Incompatible dependencies/,
       );
@@ -97,7 +95,6 @@ module.exports = function(artiGenerator) {
       testCheckLoopBack(
         'allows */x/X for version range',
         {
-          keywords: ['loopback'],
           devDependencies: {'@types/node': '*'},
           dependencies: {
             '@loopback/context': 'x.x',
@@ -107,8 +104,7 @@ module.exports = function(artiGenerator) {
         // No expected error here
       );
 
-      it('passes if "keywords" maps to "loopback"', async () => {
-        gen.fs.readJSON.returns({keywords: ['test', 'loopback']});
+      it('passes if "@loopback/core" is a dependency', async () => {
         await gen.checkLoopBackProject();
       });
 

--- a/packages/cli/test/test-utils.js
+++ b/packages/cli/test/test-utils.js
@@ -54,7 +54,7 @@ exports.executeGenerator = function(GeneratorOrNamespace, settings) {
  *
  * @param {string} rootDir Root directory in which to create the project
  * @param {Object} options
- * @property {boolean} excludeKeyword Excludes the 'loopback' keyword in package.json
+ * @property {boolean} excludeLoopbackCore Excludes the '@loopback/core' dependency in package.json
  * @property {boolean} excludePackageJSON Excludes package.json
  * @property {boolean} excludeYoRcJSON Excludes .yo-rc.json
  * @property {boolean} excludeControllersDir Excludes the controllers directory
@@ -70,9 +70,16 @@ exports.givenLBProject = function(rootDir, options) {
   options = options || {};
   const sandBoxFiles = options.additionalFiles || [];
 
-  const content = {};
-  if (!options.excludeKeyword) {
-    content.keywords = ['loopback'];
+  const content = {
+    dependencies: {
+      '@loopback/core': '*',
+    },
+  };
+
+  // We infer if a project is loopback by checking whether its dependencies includes @loopback/core or not.
+  // This flag is created for testing invalid loopback projects.
+  if (options.excludeLoopbackCore) {
+    delete content.dependencies['@loopback/core'];
   }
 
   if (!options.excludePackageJSON) {


### PR DESCRIPTION
When the CLI performed an artifact generation, it would validate that the CLI's current working directory was a directory in which a Loopback application is installed. In order to do this, it looked at the package.json's "keywords" section and looked to see if the "loopback" keyword was present in that section. So that we do not have to force users to have the "loopback" keyword in their package.json, we can simply check the package.json dependencies to make sure that the `@loopback/core` package is installed. 

Fixes #2163 

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
