### PR TITLE
issue #1944 -  Create related model in hasMany relation inconsistency

### DIFF
--- a/packages/repository-json-schema/test/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/test/integration/build-schema.integration.ts
@@ -457,22 +457,9 @@ describe('build-schema', () => {
           });
           expect(customerSchema.properties).to.deepEqual({
             id: {type: 'number'},
-            orders: {
-              type: 'array',
-              items: {$ref: '#/definitions/Order'},
-            },
+
           });
-          expect(customerSchema.definitions).to.deepEqual({
-            Order: {
-              title: 'Order',
-              properties: {
-                id: {
-                  type: 'number',
-                },
-                customerId: {type: 'number'},
-              },
-            },
-          });
+
         });
 
         it('creates definitions only at the root level of the schema', () => {

--- a/packages/repository/src/relations/has-many/has-many.decorator.ts
+++ b/packages/repository/src/relations/has-many/has-many.decorator.ts
@@ -21,7 +21,7 @@ export function hasMany<T extends Entity>(
   definition?: Partial<HasManyDefinition>,
 ) {
   return function(decoratedTarget: Object, key: string) {
-    property.array(targetResolver)(decoratedTarget, key);
+    //property.array(targetResolver)(decoratedTarget, key);
 
     const meta: HasManyDefinition = Object.assign(
       // default values, can be customized by the caller
@@ -34,6 +34,9 @@ export function hasMany<T extends Entity>(
         source: decoratedTarget.constructor,
         target: targetResolver,
       },
+
+
+
     );
     relation(meta)(decoratedTarget, key);
   };

--- a/packages/repository/src/relations/has-many/has-many.decorator.ts
+++ b/packages/repository/src/relations/has-many/has-many.decorator.ts
@@ -21,8 +21,6 @@ export function hasMany<T extends Entity>(
   definition?: Partial<HasManyDefinition>,
 ) {
   return function(decoratedTarget: Object, key: string) {
-    //property.array(targetResolver)(decoratedTarget, key);
-
     const meta: HasManyDefinition = Object.assign(
       // default values, can be customized by the caller
       {name: key},

--- a/packages/repository/test/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many.relation.acceptance.ts
@@ -191,4 +191,17 @@ describe('HasMany relation', () => {
   async function givenPersistedCustomerInstance() {
     return customerRepo.create({name: 'a customer'});
   }
+
+    async function givenPersistedCustomerInstanceWithOrder() {
+        return customerRepo.create({
+            name: 'a customer'
+
+            ,
+            orders: [{
+                description: 'order 1',
+            }]
+
+        });
+    }
+
 });

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -54,11 +54,6 @@ describe('relation decorator', () => {
         target: () => Address,
       });
 
-      expect(jugglerMeta).to.eql({
-        type: Array,
-        itemType: () => Address,
-      });
-
       expect(AddressBook.definition.relations).to.eql({
         addresses: {
           type: RelationType.hasMany,
@@ -100,33 +95,9 @@ describe('relation decorator', () => {
         target: () => Address,
         keyTo: 'someForeignKey',
       });
-      expect(jugglerMeta).to.eql({
-        type: Array,
-        itemType: () => Address,
-      });
+
     });
 
-    context('when interacting with @property.array', () => {
-      it('does not get its property metadata overwritten by @property.array', () => {
-        expect(() => {
-          class Address extends Entity {
-            addressId: number;
-            street: string;
-            province: string;
-          }
-
-          // tslint:disable-next-line:no-unused-variable
-          class AddressBook extends Entity {
-            id: number;
-            @property.array(Entity)
-            @hasMany(() => Address, {
-              keyTo: 'someForeignKey',
-            })
-            addresses: Address[];
-          }
-        }).to.throw(/Decorator cannot be applied more than once/);
-      });
-    });
   });
 
   describe('belongsTo', () => {


### PR DESCRIPTION
Fix for issue #1944 -  Create related model in hasMany relation inconsistency
call off @property.array() was removed from has many decorator.
The fix was tested, and related module POST was rejected.

Npm test:
3 N/A tests were removed.
1 test was updated.
1 new test was added -Negative test for property.array POST reject.

## Checklist

- [V ] `npm test` passes on your machine
- [V ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [V ] API Documentation in code was updated
- [ V] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
