### PR TITLE
fix(cli): allow base class exist for model config option

### DIFF
--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -71,6 +71,15 @@ describe('lb4 model integration', () => {
     ).to.be.rejectedWith(/Model was not found in/);
   });
 
+  it('run if passed a valid base model from command line', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .withArguments('test --base Model');
+
+    assert.file(expectedModelFile);
+  });
+
   describe('model generator', () => {
     it('scaffolds correct files with input', async () => {
       await testUtils
@@ -177,6 +186,30 @@ describe('lb4 model integration', () => {
 
       basicModelFileChecks();
     });
+  });
+});
+
+describe('model generator using --config option', () => {
+  it('create models with valid json', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .withArguments(['--config', '{"name":"test", "base":"Entity"}', '--yes']);
+
+    basicModelFileChecks();
+  });
+
+  it('does not run if pass invalid json', () => {
+    return expect(
+      testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withArguments([
+          '--config',
+          '{"name":"test", "base":"InvalidBaseModel"}',
+          '--yes',
+        ]),
+    ).to.be.rejectedWith(/Model was not found in/);
   });
 });
 


### PR DESCRIPTION
When using `lb4 model --config` option, if the json file I passed in contains `base` attribute/class, it gives an error saying `Model was not found`.   In a previous version of `@loopback/cli`, it was working with the following json as stated in https://github.com/strongloop/loopback-next/issues/1517#issuecomment-433522659:
```
{
    "name": "Customer",
    "base": "Entity",
    "properties": {
        "id": {
            "type": "number",
            "id": true,
            "required": false
        },
        "name": {
            "type": "string",
            "length": 200,
            "id": false,
            "required": true
        }
    }
}
```

It is caused by the check being incorrect in this line:  https://github.com/strongloop/loopback-next/blob/master/packages/cli/generators/model/index.js#L131

cc @b-admike 

Fixes https://github.com/strongloop/loopback-next/issues/2257