### PR TITLE
fix(repository): remove property.array() call from hasMany decorator

### DIFF
--- a/packages/repository-json-schema/test/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/test/integration/build-schema.integration.ts
@@ -42,6 +42,7 @@ describe('build-schema', () => {
         class NoPropertyMeta {
           prop: string;
         }
+
         @model()
         class OnePropertyDecorated {
           @property()
@@ -64,6 +65,7 @@ describe('build-schema', () => {
 
       it('does not convert models that have not been decorated with @model()', () => {
         class Empty {}
+
         class NoModelMeta {
           @property()
           foo: string;
@@ -106,6 +108,7 @@ describe('build-schema', () => {
         const topMeta = {
           description: 'Test description',
         };
+
         @model(topMeta)
         class TestModel {
           @property()
@@ -457,12 +460,14 @@ describe('build-schema', () => {
           });
           expect(customerSchema.properties).to.deepEqual({
             id: {type: 'number'},
+          });
+          expect(customerSchema.properties).to.not.containDeep({
             orders: {
               type: 'array',
               items: {$ref: '#/definitions/Order'},
             },
           });
-          expect(customerSchema.definitions).to.deepEqual({
+          expect(customerSchema.definitions).to.not.containEql({
             Order: {
               title: 'Order',
               properties: {
@@ -548,6 +553,7 @@ describe('build-schema', () => {
         @property()
         foo: number;
       }
+
       const cachedSchema: JsonSchema = {
         properties: {
           cachedProperty: {
@@ -560,11 +566,9 @@ describe('build-schema', () => {
         cachedSchema,
         TestModel,
       );
-
       const jsonSchema = getJsonSchema(TestModel);
       expect(jsonSchema).to.eql(cachedSchema);
     });
-
     it('creates JSON schema if one does not already exist', () => {
       @model()
       class NewModel {

--- a/packages/repository/src/relations/has-many/has-many.decorator.ts
+++ b/packages/repository/src/relations/has-many/has-many.decorator.ts
@@ -3,7 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {property} from '../../decorators/model.decorator';
 import {Entity, EntityResolver} from '../../model';
 import {relation} from '../relation.decorator';
 import {HasManyDefinition, RelationType} from '../relation.types';
@@ -21,8 +20,6 @@ export function hasMany<T extends Entity>(
   definition?: Partial<HasManyDefinition>,
 ) {
   return function(decoratedTarget: Object, key: string) {
-    property.array(targetResolver)(decoratedTarget, key);
-
     const meta: HasManyDefinition = Object.assign(
       // default values, can be customized by the caller
       {name: key},

--- a/packages/repository/test/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository/test/acceptance/has-many.relation.acceptance.ts
@@ -139,6 +139,19 @@ describe('HasMany relation', () => {
     expect(_.pick(orders[0], ['customerId', 'description'])).to.eql(newOrder);
   });
 
+  it('does not create an array of the related model', async () => {
+    await expect(
+      customerRepo.create({
+        name: 'a customer',
+        orders: [
+          {
+            description: 'order 1',
+          },
+        ],
+      }),
+    ).to.be.rejectedWith(/`orders` is not defined/);
+  });
+
   // This should be enforced by the database to avoid race conditions
   it.skip('reject create request when the customer does not exist');
 
@@ -170,6 +183,7 @@ describe('HasMany relation', () => {
 
   function givenApplicationWithMemoryDB() {
     class TestApp extends RepositoryMixin(Application) {}
+
     app = new TestApp();
     app.dataSource(new juggler.DataSource({name: 'db', connector: 'memory'}));
   }

--- a/packages/repository/test/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/test/unit/decorator/relation.decorator.unit.ts
@@ -53,12 +53,10 @@ describe('relation decorator', () => {
         source: AddressBook,
         target: () => Address,
       });
-
-      expect(jugglerMeta).to.eql({
+      expect(jugglerMeta).to.not.containEql({
         type: Array,
         itemType: () => Address,
       });
-
       expect(AddressBook.definition.relations).to.eql({
         addresses: {
           type: RelationType.hasMany,
@@ -100,31 +98,9 @@ describe('relation decorator', () => {
         target: () => Address,
         keyTo: 'someForeignKey',
       });
-      expect(jugglerMeta).to.eql({
+      expect(jugglerMeta).to.not.containEql({
         type: Array,
         itemType: () => Address,
-      });
-    });
-
-    context('when interacting with @property.array', () => {
-      it('does not get its property metadata overwritten by @property.array', () => {
-        expect(() => {
-          class Address extends Entity {
-            addressId: number;
-            street: string;
-            province: string;
-          }
-
-          // tslint:disable-next-line:no-unused
-          class AddressBook extends Entity {
-            id: number;
-            @property.array(Entity)
-            @hasMany(() => Address, {
-              keyTo: 'someForeignKey',
-            })
-            addresses: Address[];
-          }
-        }).to.throw(/Decorator cannot be applied more than once/);
       });
     });
   });


### PR DESCRIPTION
…y relation inconsistency

Fix for issue #1944 - Create related model in hasMany relation inconsistency

fix #1944

<!--
Hi @b-admike , thanks for your help.
I opened a new pull request related to PR #2167, in a new branch included all the fixes (fix the commit message etc .. ).

Fix for issue #1944 - Create a related model in hasMany relation inconsistency
call off @property.array() was removed from has many decorator.
The fix was tested, and related module POST was rejected.
Npm test:
3 N/A tests were removed.
1 test was updated.
1 new test was added -Negative test for property.array POST reject.


Fixes #1944 
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
