### PR TITLE
fix: make the tslint-config repo public

### DIFF
--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -19,5 +19,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Description

Turn on the public config for module tslint-config

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
