### PR TITLE
fix(docs): fix example for using --config option

### DIFF
--- a/docs/site/includes/CLI-std-options.md
+++ b/docs/site/includes/CLI-std-options.md
@@ -20,7 +20,7 @@
 For example,
 ```sh
 lb4 app --config config.json
-lb4 app --config {"name":"my-app"}
+lb4 app --config '{"name":"my-app"}'
 cat config.json | lb4 app --config stdin
 lb4 app --config stdin < config.json
 lb4 app --config stdin << EOF


### PR DESCRIPTION
According to [CLI docs](https://loopback.io/doc/en/lb4/Application-generator.html), one of the ways to use `--config` is:
```
lb4 app --config {"name":"my-app"}
```
I've tried it on Mac and it didn't work.  It works for me with quotes added, i.e. 
```
lb4 app --config '{"name":"my-app"}'
```
