### PR TITLE
fix: remove multiple application start calls

### DIFF
--- a/examples/rpc-server/src/index.ts
+++ b/examples/rpc-server/src/index.ts
@@ -13,7 +13,3 @@ export async function main(options: ApplicationConfig = {}) {
   console.log(`Server is running on port ${app.options.port}`);
   return app;
 }
-
-main().catch(err => {
-  console.error('Unhandled exception!');
-});


### PR DESCRIPTION
`main` function is calling two times which trying to re-binding of port on `app.start()` call.

Fixes #2191

## Checklist

- [ ] `npm test` passes on your machine
- [x] Affected example projects in `examples/*` were updated
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
