### PR TITLE
refactor: rename tsconfig.build files in examples

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -510,3 +510,25 @@ configuration, it's important to verify that all usage scenarios keep working.
 5.  Test integration with supported IDEs:
 
     - [VS Code](./VSCODE.md#how-to-verify-tslint-setup)
+
+### tsconfig files
+
+In the [`loopback-next`](https://github.com/strongloop/loopback-next) monorepo,
+`TypeScript` is set up in two places:
+
+1. When using VS Code, the `TypeScript` engine views `loopback-next` as a single
+   big project.
+
+   This enables the "refactor - rename" command to change all places using the
+   renamed symbol, and also makes "go to definition" command jump to `.ts` files
+   containing the original source code. Otherwise "refactor - rename" works
+   within the same package only and "go to definition" jumps to `.d.ts` files.
+
+2. When building the monorepo, we need to build the packages individually, so
+   that one `dist` directory is created for each package.
+
+This is why we have two sets of `tsconfig` files:
+
+- At monorepo root, there is `tsconfig.json` used by VS Code.
+- Inside each package, there is `tsconfig.build.json` used by `npm run build`
+  command.

--- a/packages/cli/generators/example/index.js
+++ b/packages/cli/generators/example/index.js
@@ -10,6 +10,7 @@ const chalk = require('chalk');
 const downloadAndExtractExample = require('./downloader');
 const path = require('path');
 const utils = require('../../lib/utils');
+const fs = require('fs-extra');
 
 const EXAMPLES = {
   todo: 'Tutorial example on how to build an application with LoopBack 4.',
@@ -94,6 +95,10 @@ module.exports = class extends BaseGenerator {
     const cwd = process.cwd();
     const absOutDir = await downloadAndExtractExample(this.exampleName, cwd);
     this.outDir = path.relative(cwd, absOutDir);
+    fs.rename(
+      `${this.outDir}/tsconfig.build.json`,
+      `${this.outDir}/tsconfig.json`,
+    );
   }
 
   install() {


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-next/issues/2175.

Renamed the `tsconfig.build.ts` files in the examples to `tsconfig.ts` because, when using the examples from the `lb4 example` command, they weren't extending [`tsconfig.common.json`](https://github.com/strongloop/loopback-next/blob/master/packages/build/config/tsconfig.common.json) until after the rename. They also now match the [`rpc-server`](https://github.com/strongloop/loopback-next/blob/master/examples/rpc-server/tsconfig.json) example. 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
