### PR TITLE
feat(cli): add strict prompt to model generator

### DIFF
--- a/docs/site/Model-generator.md
+++ b/docs/site/Model-generator.md
@@ -41,10 +41,15 @@ The tool will prompt you for:
   been supplied with a valid model class name, the prompt is skipped. It will
   present you with a list of available models from `src/models` including the
   **Entity** and **Model** at the top of the list.
+
   - An **Entity** is a persisted model with an identity (ID).
   - A **Model** is a business domain object.
   - For more information, see
     [here](https://loopback.io/doc/en/lb4/Model.html#overview).
+
+- **Allow additonal properties.** _(allowAdditionalProperties)_ Defaults to
+  **false**. To allow arbitrary properties in addition to well-defined
+  properties, disable strict mode.
 
 The tool will next recursively prompt you for the model's properties until a
 blank one is entered. Properties will be prompted for as follows:

--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -127,8 +127,8 @@ persistence layer respects this constraint and configures underlying
 PersistedModel classes to enforce `strict` mode.
 
 To create a model that allows both well-defined but also arbitrary extra
-properties, you need to disable `strict` mode in model settings and tell
-TypeScript to allow arbitrary additional properties to be set on model
+properties, you need to disable `strict` mode in model settings through the CLI
+and tell TypeScript to allow arbitrary additional properties to be set on model
 instances.
 
 ```ts

--- a/docs/site/todo-list-tutorial-model.md
+++ b/docs/site/todo-list-tutorial-model.md
@@ -32,6 +32,8 @@ for us as follows:
 $ lb4 model
 ? Model class name: TodoList
 ? Please select the model base class Entity
+? Allow additional (free-form) properties? No
+
 Let's add a property to TodoList
 Enter an empty property name when done
 

--- a/docs/site/todo-tutorial-model.md
+++ b/docs/site/todo-tutorial-model.md
@@ -49,6 +49,7 @@ these steps:
 lb4 model
 ? Model class name: todo
 ? Please select the model base class: Entity
+? Allow additional (free-form) properties? No
 
 Let's add a property to Todo
 Enter an empty property name when done

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -154,20 +154,42 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
       },
     ])
       .then(props => {
-        if (typeof props.modelBaseClass === 'object')
+        if (typeof props.modelBaseClass === 'object') {
           props.modelBaseClass = props.modelBaseClass.value;
+        }
 
         Object.assign(this.artifactInfo, props);
         debug(`props after model base class prompt: ${inspect(props)}`);
+        return props;
+      })
+      .catch(err => {
+        debug(`Error during model base class prompt: ${err}`);
+        return this.exit(err);
+      });
+  }
+
+  async promptStrictMode() {
+    if (this.shouldExit()) return false;
+    return this.prompt([
+      {
+        name: 'allowAdditionalProperties',
+        message: 'Allow additional (free-form) properties?',
+        type: 'confirm',
+        default: false,
+        when: !this.artifactInfo.allowAdditionalProperties,
+      },
+    ])
+      .then(setting => {
+        Object.assign(this.artifactInfo, setting);
+
         this.log(
           `Let's add a property to ${chalk.yellow(
             this.artifactInfo.className,
           )}`,
         );
-        return props;
       })
       .catch(err => {
-        debug(`Error during model base class prompt: ${err}`);
+        debug(`Error during model strict mode prompt: ${err}`);
         return this.exit(err);
       });
   }

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -66,6 +66,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
     ];
 
     this.artifactInfo.properties = {};
+    this.artifactInfo.modelSettings = {};
     this.propCounter = 0;
 
     this.artifactInfo.modelDir = path.resolve(
@@ -181,6 +182,10 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
     ])
       .then(setting => {
         Object.assign(this.artifactInfo, setting);
+
+        if (this.artifactInfo.allowAdditionalProperties) {
+          Object.assign(this.artifactInfo.modelSettings, {strict: false});
+        }
 
         this.log(
           `Let's add a property to ${chalk.yellow(

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -5,7 +5,11 @@ import {model, property} from '@loopback/repository';
 import {<%= modelBaseClass %>} from '.';
 <% } -%>
 
+<% if(allowAdditionalProperties) { -%>
+@model({settings: {strict: false}})
+<% } else { -%>
 @model()
+<% } -%>
 export class <%= className %> extends <%= modelBaseClass %> {
 <% Object.entries(properties).forEach(([key, val]) => { -%>
   @property({
@@ -16,8 +20,16 @@ export class <%= className %> extends <%= modelBaseClass %> {
   <%_ }) -%>
   })
   <%= key %><%if (!val.required) {%>?<% } %>: <%= val.tsType %>;
-
 <% }) -%>
+
+<% if(allowAdditionalProperties) { -%>
+  // Define well-known properties here
+
+
+  // Indexer property to allow additional data
+  [prop: string]: any;
+<% } -%>
+
   constructor(data?: Partial<<%= className %>>) {
     super(data);
   }

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -5,8 +5,8 @@ import {model, property} from '@loopback/repository';
 import {<%= modelBaseClass %>} from '.';
 <% } -%>
 
-<% if(allowAdditionalProperties) { -%>
-@model({settings: {strict: false}})
+<% if(Object.keys(modelSettings).length > 0) { -%>
+@model({settings: <%- JSON.stringify(modelSettings) %>})
 <% } else { -%>
 @model()
 <% } -%>
@@ -20,11 +20,10 @@ export class <%= className %> extends <%= modelBaseClass %> {
   <%_ }) -%>
   })
   <%= key %><%if (!val.required) {%>?<% } %>: <%= val.tsType %>;
-<% }) -%>
 
+<% }) -%>
 <% if(allowAdditionalProperties) { -%>
   // Define well-known properties here
-
 
   // Indexer property to allow additional data
   [prop: string]: any;

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -92,6 +92,7 @@ describe('lb4 model integration', () => {
           name: 'test',
           propName: null,
           modelBaseClass: 'Model',
+          allowAdditionalProperties: false,
         });
 
       assert.file(expectedModelFile);
@@ -134,6 +135,35 @@ describe('lb4 model integration', () => {
         expectedModelFile,
         /export class Test extends ProductReview {/,
       );
+    });
+
+    it('scaffolds model with strict setting disabled', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withPrompts({
+          name: 'test',
+          propName: null,
+          modelBaseClass: 'Entity',
+          allowAdditionalProperties: true,
+        });
+
+      assert.file(expectedModelFile);
+      assert.file(expectedIndexFile);
+
+      assert.fileContent(
+        expectedModelFile,
+        /import {Entity, model, property} from '@loopback\/repository';/,
+      );
+      assert.fileContent(
+        expectedModelFile,
+        /@model\({settings: {strict: false}}\)/,
+      );
+      assert.fileContent(
+        expectedModelFile,
+        /export class Test extends Entity {/,
+      );
+      assert.fileContent(expectedModelFile, /\[prop: string\]: any;/);
     });
 
     it('scaffolds correct files with args', async () => {

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -157,7 +157,7 @@ describe('lb4 model integration', () => {
       );
       assert.fileContent(
         expectedModelFile,
-        /@model\({settings: {strict: false}}\)/,
+        /@model\({settings: {"strict":false}}\)/,
       );
       assert.fileContent(
         expectedModelFile,


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-next/issues/1530.

Add a prompt to model generator that asks the user if they want to allow additional properties (disable the `strict` setting). And add `modelSettings` to `this.artifactInfo` in `ModelGenerator` that contains settings such as `strict`.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
