### PR TITLE
fix(build): fix path lookup in build helpers

### DIFF
--- a/packages/build/bin/utils.js
+++ b/packages/build/bin/utils.js
@@ -99,9 +99,9 @@ function getConfigFile(name, defaultName) {
  * @param {string} cli
  */
 function resolveCLI(cli) {
-  const path = './node_modules/' + cli;
+  const modulePath = './node_modules/' + cli;
   try {
-    return require.resolve(path.join(getPackageDir(), path));
+    return require.resolve(path.join(getPackageDir(), modulePath));
   } catch (e) {
     return require.resolve(cli);
   }


### PR DESCRIPTION
Fix the algorithm looking up CLI paths to correctly detect CLIs present in the target package.

The old version was overloading the same variable `path` with two different values (a string path, a built-in `path` module), throwing an error as a result and thus always falling back to the version bundled inside `@loopback/build`.

I discovered the problem while working on #2156.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated