### PR TITLE
docs: add specific relation decorators

### DIFF
--- a/docs/site/Decorators_repository.md
+++ b/docs/site/Decorators_repository.md
@@ -106,7 +106,7 @@ If the model or datasource is already bound to the app, you can create the
 repository by providing their names instead of the classes. For example:
 
 ```ts
-// with `datasource` and `Todo` already defined.
+// with `db` and `Todo` already defined.
 app.bind('datasources.db').to(db);
 app.bind('models.Todo').to(Todo);
 
@@ -119,9 +119,6 @@ export class TodoController {
 
 ### Relation Decorators
 
-_This feature has not yet been released in alpha form. Documentation will be
-added here as this feature progresses._
-
 The relation decorator defines the nature of a relationship between two models.
 
 #### Relation Decorator
@@ -133,19 +130,137 @@ Register a general relation.
 _This feature has not yet been released in alpha form. Documentation will be
 added here as this feature progresses._
 
-#### Specific Relation Decorator
+#### BelongsTo Decorator
 
 Syntax:
+`@belongsTo(targetResolver: EntityResolver<T>, definition?: Partial<BelongsToDefinition>)`
 
-- `@belongsTo`
-- `@hasOne`
-- `@hasMany`
+Many-to-one or one-to-one connection between models e.g. a `Todo` model belongs
+to a `TodoList` model. See [BelongsTo relation](BelongsTo-relation.md) for more
+details.
+
+{% include code-caption.html content="todo.model.ts" %}
+
+```ts
+import {belongsTo} from '@loopback/repository';
+import {TodoList} from './todo-list.model';
+
+export class Todo extends Entity {
+  // properties
+
+  @belongsTo(() => TodoList)
+  todoListId: number;
+
+  // etc
+}
+```
+
+#### HasOne Decorator
+
+Syntax:
+`@hasOne(targetResolver: EntityResolver<T>, definition?: Partial<HasOneDefinition>)`
+
+One-to-one connection between models e.g. a `TodoList` model has one
+`TodoListImage` model. See [HasOne relation](hasOne-relation.md) for more
+details.
+
+{% include code-caption.html content="todo-list.model.ts" %}
+
+```ts
+import {hasOne} from '@loopback/repository';
+import {TodoListImage} from './todo-list-image.model';
+
+export class TodoList extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+  })
+  id?: number;
+
+  // other properties
+
+  @hasOne(() => TodoListImage)
+  image: TodoListImage;
+
+  // etc
+}
+```
+
+{% include code-caption.html content="todo-list-image.model.ts" %}
+
+```ts
+import {belongsTo} from '@loopback/repository';
+import {TodoList} from './todo-list.model';
+
+export class TodoListImage extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+  })
+  id: number;
+
+  // other properties
+
+  @belongsTo(() => TodoList)
+  todoListId?: number;
+
+  // etc
+}
+```
+
+#### HasMany Decorator
+
+Syntax:
+`@hasMany(targetResolver: EntityResolver<T>, definition?: Partial<HasManyDefinition>)`
+
+One-to-many connection between models e.g. a `TodoList` model has many of the
+`Todo` model. See [HasMany relation](HasMany-relation.md) for more details.
+
+{% include code-caption.html content="todo-list.model.ts" %}
+
+```ts
+import {hasMany} from '@loopback/repository';
+import {Todo} from './todo.model';
+
+export class TodoList extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+  })
+  id?: number;
+
+  // other properties
+
+  @hasMany(() => Todo)
+  todos: Todo[];
+
+  // etc
+}
+```
+
+{% include code-caption.html content="todo.model.ts" %}
+
+```ts
+import {belongsTo} from '@loopback/repository';
+import {TodoList} from './todo-list.model';
+
+export class Todo extends Entity {
+  // other properties
+
+  @belongsTo(() => TodoList)
+  todoListId?: number;
+
+  // etc
+}
+```
+
+#### Other Decorators
+
+The following decorators are not implemented yet. To see their progress, please
+go to the
+[Relations epic](https://github.com/strongloop/loopback-next/issues/1450).
+
 - `@embedsOne`
 - `@embedsMany`
 - `@referencesOne`
 - `@referencesMany`
-
-Register a specific relation.
-
-_This feature has not yet been released in alpha form. Documentation will be
-added here as this feature progresses._


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-next/issues/1910.

Add syntax and examples to `belongsTo`, `hasOne`, and `hasMany` decorator docs.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
