### PR TITLE
fix: optional auth metadata

### DIFF
--- a/packages/authentication/src/providers/auth-metadata.provider.ts
+++ b/packages/authentication/src/providers/auth-metadata.provider.ts
@@ -15,9 +15,9 @@ import {AuthenticationMetadata, getAuthenticateMetadata} from '../decorators';
 export class AuthMetadataProvider
   implements Provider<AuthenticationMetadata | undefined> {
   constructor(
-    @inject(CoreBindings.CONTROLLER_CLASS)
+    @inject(CoreBindings.CONTROLLER_CLASS, {optional: true})
     private readonly controllerClass: Constructor<{}>,
-    @inject(CoreBindings.CONTROLLER_METHOD_NAME)
+    @inject(CoreBindings.CONTROLLER_METHOD_NAME, {optional: true})
     private readonly methodName: string,
   ) {}
 
@@ -25,6 +25,7 @@ export class AuthMetadataProvider
    * @returns AuthenticationMetadata
    */
   value(): AuthenticationMetadata | undefined {
+    if (!this.controllerClass || !this.methodName) return;
     return getAuthenticateMetadata(this.controllerClass, this.methodName);
   }
 }

--- a/packages/authentication/test/unit/providers/auth-metadata.provider.unit.ts
+++ b/packages/authentication/test/unit/providers/auth-metadata.provider.unit.ts
@@ -65,6 +65,17 @@ describe('AuthMetadataProvider', () => {
         );
         expect(authMetadata).to.be.undefined();
       });
+
+      it('returns undefined when the class or method is missing', async () => {
+        const context: Context = new Context();
+        context
+          .bind(CoreBindings.CONTROLLER_METHOD_META)
+          .toProvider(AuthMetadataProvider);
+        const authMetadata = await context.get(
+          CoreBindings.CONTROLLER_METHOD_META,
+        );
+        expect(authMetadata).to.be.undefined();
+      });
     });
   });
 


### PR DESCRIPTION
### Description

static endpoint like the homepage in the shopping example doesn't have a controller, thus the metadata injected for the auth action should be optional.
Related to https://github.com/strongloop/loopback4-example-shopping/pull/26

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
