### PR TITLE
docs: use markdown image tags

### DIFF
--- a/docs/site/Preparing-the-API-for-consumption.shelved.md
+++ b/docs/site/Preparing-the-API-for-consumption.shelved.md
@@ -37,11 +37,11 @@ environment to test the API endpoints defined by the raw spec found at
 flavour at <http://localhost:3000/openapi.yaml>
 " %}
 
-{% include image.html file="lb4/10000000.png" alt="" %}
+![10000000.png](./imgs/10000000.png)
 
 The Swagger UI displays all of the endpoints defined in your application.
 
-{% include image.html file="lb4/10000001.png" alt="" %}
+![10000001.png](./imgs/10000001.png)
 
 Clicking on one of the endpoints will show the endpoint's documentation as
 defined in your API spec. Next, click on `Try It Out` to send a request to the
@@ -49,7 +49,7 @@ endpoint. If the endpoint takes parameters, assign the values before the request
 is sent. If the parameter involves a body, a template is given for you to edit
 as specified in your spec. Click `Execute` to send the request:
 
-{% include image.html file="lb4/10000002.png" alt="" %}
+![10000002.png](./imgs/10000002.png)
 
 The response to the request can be seen below the `Execute` button, where the
 response code and the body are displayed. Ideally, each endpoint should be


### PR DESCRIPTION
Use Markdown image tags for LB4 docs.

The `{% include image.html file="lb4/10000000.png" alt="" %}` format is a legacy remnant from the time when LoopBack docs were hosted using Confluence. 

I considered the possibility of replacing all the instances of `{% include image.html }` tag with Markdown tags, but they are way too may in older docs. Replacing them may have unforeseen side-effects, so left them alone.

Good thing is, there were only three instances in the LB4 docs. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
