### PR TITLE
feat(cli): use a custom repository base class

### DIFF
--- a/packages/cli/generators/repository/templates/src/repositories/repository-crud-default-template.ts.ejs
+++ b/packages/cli/generators/repository/templates/src/repositories/repository-crud-default-template.ts.ejs
@@ -1,9 +1,14 @@
+<%if (isRepositoryBaseBuiltin) {  -%>
 import {<%= repositoryTypeClass %>} from '@loopback/repository';
+<% } -%>
 import {<%= modelName %>} from '../models';
 import {<%= dataSourceClassName %>} from '../datasources';
 import {inject} from '@loopback/core';
+<%if ( !isRepositoryBaseBuiltin ) { -%>
+import {<%=repositoryBaseClass %>} from './<%=repositoryBaseFile %>';
+<% } -%>
 
-export class <%= className %>Repository extends <%= repositoryTypeClass %><
+export class <%= className %>Repository extends <%= repositoryBaseClass %><
   <%= modelName %>,
   typeof <%= modelName %>.prototype.<%= idProperty %>
 > {

--- a/packages/cli/generators/repository/templates/src/repositories/repository-kv-template.ts.ejs
+++ b/packages/cli/generators/repository/templates/src/repositories/repository-kv-template.ts.ejs
@@ -1,11 +1,16 @@
-import {<%= repositoryTypeClass %>} from '@loopback/repository';
+<%if (isRepositoryBaseBuiltin) {  -%>
+import {<%= repositoryTypeClass %>, juggler} from '@loopback/repository';
+<% } -%>
 import {<%= modelName %>} from '../models';
 import {<%= dataSourceClassName %>} from '../datasources';
 import {inject} from '@loopback/core';
+<%if ( !isRepositoryBaseBuiltin ) { -%>
+import {<%=repositoryBaseClass %>} from './<%=repositoryBaseFile %>';
+<% } -%>
 
-export class <%= className %>Repository extends <%= repositoryTypeClass %><
+export class <%= className %>Repository extends <%= repositoryBaseClass %><
   <%= modelName %>
- > {
+> {
   constructor(
     @inject('datasources.<%= dataSourceName %>') dataSource: <%= dataSourceClassName %>,
   ) {

--- a/packages/cli/test/fixtures/repository/index.js
+++ b/packages/cli/test/fixtures/repository/index.js
@@ -1,5 +1,6 @@
 const DATASOURCE_APP_PATH = 'src/datasources';
 const MODEL_APP_PATH = 'src/models';
+const REPOSITORY_APP_PATH = 'src/repositories';
 const CONFIG_PATH = '.';
 const DUMMY_CONTENT = '--DUMMY VALUE--';
 const fs = require('fs');
@@ -106,5 +107,15 @@ exports.SANDBOX_FILES = [
     content: fs.readFileSync(require.resolve('./models/invalid-id.model.txt'), {
       encoding: 'utf-8',
     }),
+  },
+  {
+    path: REPOSITORY_APP_PATH,
+    file: 'defaultmodel.repository.base.ts',
+    content: fs.readFileSync(
+      require.resolve('./repositories/defaultmodel.repository.base.ts'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
   },
 ];

--- a/packages/cli/test/fixtures/repository/repositories/defaultmodel.repository.base.ts
+++ b/packages/cli/test/fixtures/repository/repositories/defaultmodel.repository.base.ts
@@ -1,0 +1,13 @@
+import {DefaultCrudRepository} from '@loopback/repository';
+import {Defaultmodel} from '../models';
+import {DbmemDataSource} from '../datasources';
+import {inject} from '@loopback/core';
+
+export class DefaultmodelRepository extends DefaultCrudRepository<
+  Defaultmodel,
+  typeof Defaultmodel.prototype.id
+> {
+  constructor(@inject('datasources.dbmem') dataSource: DbmemDataSource) {
+    super(Defaultmodel, dataSource);
+  }
+}

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -384,6 +384,41 @@ describe('lb4 repository', function() {
         /export \* from '.\/decoratordefined.repository';/,
       );
     });
+    it('generates a crud repository from custom base class', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments(
+          '--datasource dbmem --model decoratordefined --repositoryBaseClass DefaultmodelRepository',
+        );
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        REPOSITORY_APP_PATH,
+        'decoratordefined.repository.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /import {DefaultmodelRepository} from '.\/defaultmodel.repository.base';/,
+      );
+      assert.fileContent(
+        expectedFile,
+        /export class DecoratordefinedRepository extends DefaultmodelRepository\</,
+      );
+      assert.fileContent(
+        expectedFile,
+        /typeof Decoratordefined.prototype.thePK/,
+      );
+      assert.file(INDEX_FILE);
+      assert.fileContent(
+        INDEX_FILE,
+        /export \* from '.\/decoratordefined.repository';/,
+      );
+    });
   });
 
   describe('valid generation of kv repositories', () => {
@@ -395,7 +430,9 @@ describe('lb4 repository', function() {
             additionalFiles: SANDBOX_FILES,
           }),
         )
-        .withArguments('--datasource dbkv --model Defaultmodel');
+        .withArguments(
+          '--datasource dbkv --model Defaultmodel --repositoryBaseClass DefaultKeyValueRepository',
+        );
       const expectedFile = path.join(
         SANDBOX_PATH,
         REPOSITORY_APP_PATH,
@@ -425,7 +462,9 @@ describe('lb4 repository', function() {
           }),
         )
         .withPrompts(basicPrompt)
-        .withArguments('--model decoratordefined');
+        .withArguments(
+          '--model decoratordefined --repositoryBaseClass DefaultKeyValueRepository',
+        );
       const expectedFile = path.join(
         SANDBOX_PATH,
         REPOSITORY_APP_PATH,


### PR DESCRIPTION
Allow the user to specify a custom Repository class to inherit from.
CLI supports custom repository name
* via an interactive prompt
* via CLI options
* via JSON config

Two tests modified to use the new parameter to pass
Modified tests:
* generates a kv repository from default model
* generates a kv repository from decorator defined model

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #2149 
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
