### PR TITLE
test(cli): increate test timeout to prevent CI build failures

### DIFF
--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -61,7 +61,10 @@ describe('app-generator (SLOW)', function() {
     });
   });
 
-  after(() => {
+  after(function() {
+    // Increase the timeout to accommodate slow CI build machines
+    this.timeout(30 * 1000);
+
     process.chdir(rootDir);
     build.clean(['node', 'run-clean', sandbox]);
     process.chdir(cwd);


### PR DESCRIPTION
See e.g. https://travis-ci.org/strongloop/loopback-next/builds/478157375