### PR TITLE
docs(docs): has-one-relation typo corrected

### DIFF
--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -172,7 +172,7 @@ repository, the following are required:
   `HasOneRepositoryFactory<targetModel, typeof sourceModel.prototype.id>` on the
   source repository class.
 
-- Call the `createHasOneRepositoryFactoryFor` function in the constructor of the
+- Call the `_createHasOneRepositoryFactoryFor` function in the constructor of the
   source repository class with the relation name (decorated relation property on
   the source model) and target repository instance and assign it the property
   mentioned above.
@@ -207,7 +207,7 @@ export class SupplierRepository extends DefaultCrudRepository<
     getAccountRepository: Getter<AccountRepository>,
   ) {
     super(Customer, db);
-    this.account = this.createHasOneRepositoryFactoryFor(
+    this.account = this._createHasOneRepositoryFactoryFor(
       'account',
       getAccountRepository,
     );


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Doc has a typo in function name `createHasOneRepositoryFactoryFor` -> `_createHasOneRepositoryFactoryFor`

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
