### PR TITLE
fix(cli): change enable setting check

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -199,7 +199,8 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       const features = choices.map(c => {
         return {
           key: c.key,
-          value: settings.indexOf(c.short) !== -1,
+          value:
+            settings.indexOf(c.name) !== -1 || settings.indexOf(c.short) !== -1,
         };
       });
       features.forEach(f => (this.projectInfo[f.key] = f.value));


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-next/issues/2251.

When checking for which settings to enable, the `settings` variable: https://github.com/strongloop/loopback-next/blob/master/packages/cli/lib/project-generator.js#L198 is either equal to `props.settings` which includes the long version of the names 
```
[ 'Enable tslint: \u001b[90madd a linter with pre-configured lint rules\u001b[39m',
  'Enable prettier: \u001b[90madd new npm scripts to facilitate consistent code formatting\u001b[39m',
  'Enable mocha: \u001b[90minstall mocha to assist with running tests\u001b[39m',
  'Enable loopbackBuild: \u001b[90muse @loopback/build helpers (e.g. lb-tslint)\u001b[39m',
  'Enable vscode: \u001b[90madd VSCode config files\u001b[39m',
  'Enable repositories: \u001b[90minclude repository imports and RepositoryMixin\u001b[39m',
  'Enable services: \u001b[90minclude service-proxy imports and ServiceMixin\u001b[39m' ]
```
or `choices.map(c => c.short);` which includes the short versions:
```
[ 'Enable tslint',
  'Enable prettier',
  'Enable mocha',
  'Enable loopbackBuild',
  'Enable vscode' ]
```

In my last PR https://github.com/strongloop/loopback-next/pull/2186, I didn't check when it was `props.settings`, which would determine whether to enable a setting depending on whether it could find the long version of the name. This PR is to fix that.


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
