### PR TITLE
feat(context): add support for binding configuration and injection

### DIFF
--- a/packages/context/src/__tests__/acceptance/binding-config.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/binding-config.acceptance.ts
@@ -1,0 +1,199 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {config, configBindingKeyFor, Context, ContextView, Getter} from '../..';
+
+describe('Context bindings - injecting configuration for bound artifacts', () => {
+  let ctx: Context;
+
+  beforeEach(givenContext);
+
+  it('binds configuration independent of binding', async () => {
+    // Bind configuration
+    ctx.configure('servers.rest.server1').to({port: 3000});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+
+    expect(server1.configObj).to.eql({port: 3000});
+  });
+
+  it('configures an artifact with a dynamic source', async () => {
+    // Bind configuration
+    ctx
+      .configure('servers.rest.server1')
+      .toDynamicValue(() => Promise.resolve({port: 3000}));
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+    expect(server1.configObj).to.eql({port: 3000});
+  });
+
+  it('configures an artifact with alias', async () => {
+    // Configure rest server 1 to reference `rest` property of the application
+    // configuration
+    ctx
+      .configure('servers.rest.server1')
+      .toAlias(configBindingKeyFor('application', 'rest'));
+
+    // Configure the application
+    ctx.configure('application').to({rest: {port: 3000}});
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServer);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServer>('servers.rest.server1');
+    expect(server1.configObj).to.eql({port: 3000});
+  });
+
+  it('allows configPath for injection', async () => {
+    class RestServerWithPort {
+      constructor(@config('port') public port: number) {}
+    }
+
+    // Bind configuration
+    ctx
+      .configure('servers.rest.server1')
+      .toDynamicValue(() => Promise.resolve({port: 3000}));
+
+    // Bind RestServer
+    ctx.bind('servers.rest.server1').toClass(RestServerWithPort);
+
+    // Resolve an instance of RestServer
+    // Expect server1.config to be `{port: 3000}
+    const server1 = await ctx.get<RestServerWithPort>('servers.rest.server1');
+    expect(server1.port).to.eql(3000);
+  });
+
+  const LOGGER_KEY = 'loggers.Logger';
+  it('injects a getter function to access config', async () => {
+    class Logger {
+      constructor(
+        @config.getter()
+        public configGetter: Getter<LoggerConfig | undefined>,
+      ) {}
+    }
+
+    // Bind logger configuration
+    ctx.configure(LOGGER_KEY).to({level: 'INFO'});
+
+    // Bind Logger
+    ctx.bind(LOGGER_KEY).toClass(Logger);
+
+    const logger = await ctx.get<Logger>(LOGGER_KEY);
+    let configObj = await logger.configGetter();
+    expect(configObj).to.eql({level: 'INFO'});
+
+    // Update logger configuration
+    const configBinding = ctx.configure(LOGGER_KEY).to({level: 'DEBUG'});
+
+    configObj = await logger.configGetter();
+    expect(configObj).to.eql({level: 'DEBUG'});
+
+    // Now remove the logger configuration
+    ctx.unbind(configBinding.key);
+
+    // configGetter returns undefined as config is optional by default
+    configObj = await logger.configGetter();
+    expect(configObj).to.be.undefined();
+  });
+
+  it('injects a view to access config', async () => {
+    class Logger {
+      constructor(
+        @config.view()
+        public configView: ContextView<LoggerConfig>,
+      ) {}
+    }
+
+    // Bind logger configuration
+    ctx.configure(LOGGER_KEY).to({level: 'INFO'});
+
+    // Bind Logger
+    ctx.bind(LOGGER_KEY).toClass(Logger);
+
+    const logger = await ctx.get<Logger>(LOGGER_KEY);
+    let configObj = await logger.configView.singleValue();
+    expect(configObj).to.eql({level: 'INFO'});
+
+    // Update logger configuration
+    ctx.configure(LOGGER_KEY).to({level: 'DEBUG'});
+
+    configObj = await logger.configView.singleValue();
+    expect(configObj).to.eql({level: 'DEBUG'});
+  });
+
+  it('injects a view to access config with path', async () => {
+    class Logger {
+      constructor(
+        @config.view('level')
+        public configView: ContextView<string>,
+      ) {}
+    }
+
+    // Bind logger configuration
+    ctx.configure(LOGGER_KEY).to({level: 'INFO'});
+
+    // Bind Logger
+    ctx.bind(LOGGER_KEY).toClass(Logger);
+
+    const logger = await ctx.get<Logger>(LOGGER_KEY);
+    let level = await logger.configView.singleValue();
+    expect(level).to.eql('INFO');
+
+    // Update logger configuration
+    ctx.configure(LOGGER_KEY).to({level: 'DEBUG'});
+
+    level = await logger.configView.singleValue();
+    expect(level).to.eql('DEBUG');
+  });
+
+  it('rejects injection of config view if the target type is not ContextView', async () => {
+    class Logger {
+      constructor(
+        @config.view()
+        public configView: object,
+      ) {}
+    }
+
+    // Bind logger configuration
+    ctx.configure(LOGGER_KEY).to({level: 'INFO'});
+
+    // Bind Logger
+    ctx.bind(LOGGER_KEY).toClass(Logger);
+
+    await expect(ctx.get<Logger>(LOGGER_KEY)).to.be.rejectedWith(
+      'The type of Logger.constructor[0] (Object) is not ContextView',
+    );
+  });
+
+  function givenContext() {
+    ctx = new Context();
+  }
+
+  interface RestServerConfig {
+    host?: string;
+    port?: number;
+  }
+
+  class RestServer {
+    constructor(@config() public configObj: RestServerConfig) {}
+  }
+
+  interface LoggerConfig {
+    level: 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
+  }
+});

--- a/packages/context/src/__tests__/acceptance/binding-config.feature.md
+++ b/packages/context/src/__tests__/acceptance/binding-config.feature.md
@@ -1,0 +1,84 @@
+# Feature: Context bindings - injecting configuration for bound artifacts
+
+- In order to receive configuration for a given binding
+- As a developer
+- I want to set up configuration for a binding key
+- So that configuration can be injected by the IoC framework
+
+# Scenario: configure an artifact before it's bound
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+  `config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@config()`
+- When I bind a configuration object `{port: 3000}` to
+  `servers.rest.server1:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+  constructor(@config() public config: RestServerConfig) {}
+}
+
+const ctx = new Context();
+
+// Bind configuration
+ctx.configure('servers.rest.server1').to({port: 3000});
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Scenario: configure an artifact with a dynamic source
+
+- Given a `Context`
+- Given a class RestServer with a constructor accepting a single argument
+  `config: RestServerConfig`
+- Given `RestServer` ctor argument is decorated with `@config()`
+- When I bind a configuration factory of `{port: 3000}` to
+  `servers.rest.server1:$config`
+- And bind the rest server to `servers.rest.server1`
+- And resolve the binding for `servers.rest.server1`
+- Then I get a new instance of `RestServer`
+- And the instance was created with `config` set to `{port: 3000}`
+
+```ts
+class RestServer {
+  constructor(@config() public config: RestServerConfig) {}
+}
+
+const ctx = new Context();
+
+// Bind configuration
+ctx
+  .configure('servers.rest.server1')
+  .toDynamicValue(() => Promise.resolve({port: 3000}));
+
+// Bind RestServer
+ctx.bind('servers.rest.server1').toClass(RestServer);
+
+// Resolve an instance of RestServer
+// Expect server1.config to be `{port: 3000}
+const server1 = await ctx.get('servers.rest.server1');
+```
+
+# Notes
+
+This document only captures the expected behavior at context binding level. It
+establishes conventions to configure and resolve binding.
+
+Sources of configuration can be one or more files, databases, distributed
+registries, or services. How such sources are discovered and loaded is out of
+scope.
+
+See the following modules as candidates for configuration management facilities:
+
+- https://github.com/lorenwest/node-config
+- https://github.com/mozilla/node-convict

--- a/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
@@ -9,11 +9,13 @@ import {
   BindingCreationPolicy,
   BindingKey,
   BindingScope,
+  config,
   Constructor,
   Context,
   Getter,
   inject,
   Injection,
+  instantiateClass,
   invokeMethod,
   Provider,
   ResolutionSession,
@@ -456,14 +458,14 @@ describe('Context bindings - Injecting dependencies of classes', () => {
 
   it('injects a nested property', async () => {
     class TestComponent {
-      constructor(@inject('config#test') public config: string) {}
+      constructor(@inject('config#test') public configForTest: string) {}
     }
 
     ctx.bind('config').to({test: 'test-config'});
     ctx.bind('component').toClass(TestComponent);
 
     const resolved = await ctx.get<TestComponent>('component');
-    expect(resolved.config).to.equal('test-config');
+    expect(resolved.configForTest).to.equal('test-config');
   });
 
   describe('@inject.binding', () => {
@@ -691,6 +693,168 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       .toDynamicValue(() => Promise.reject(new Error('Bad')))
       .tag('store:location');
     await expect(ctx.get(STORE_KEY)).to.be.rejectedWith('Bad');
+  });
+
+  it('injects a config property', () => {
+    class Store {
+      constructor(
+        @config('x') public optionX: number,
+        @config('y') public optionY: string,
+      ) {}
+    }
+
+    ctx.configure('store').to({x: 1, y: 'a'});
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.optionX).to.eql(1);
+    expect(store.optionY).to.eql('a');
+  });
+
+  it('injects a config property with promise value', async () => {
+    class Store {
+      constructor(@config('x') public optionX: number) {}
+    }
+
+    ctx.configure('store').toDynamicValue(() => Promise.resolve({x: 1}));
+    ctx.bind('store').toClass(Store);
+    const store = await ctx.get<Store>('store');
+    expect(store.optionX).to.eql(1);
+  });
+
+  it('injects a config property with a binding provider', async () => {
+    class MyConfigProvider implements Provider<{}> {
+      constructor(@inject('prefix') private prefix: string) {}
+      value() {
+        return {
+          myOption: this.prefix + 'my-option',
+        };
+      }
+    }
+
+    class Store {
+      constructor(@config('myOption') public myOption: string) {}
+    }
+
+    ctx.bind('config').toProvider(MyConfigProvider);
+    ctx.configure('store').toProvider(MyConfigProvider);
+    ctx.bind('prefix').to('hello-');
+    ctx.bind('store').toClass(Store);
+
+    const store = await ctx.get<Store>('store');
+    expect(store.myOption).to.eql('hello-my-option');
+  });
+
+  it('injects a config property with a rejected promise', async () => {
+    class Store {
+      constructor(@config('x') public optionX: number) {}
+    }
+
+    ctx
+      .configure('store')
+      .toDynamicValue(() => Promise.reject(Error('invalid')));
+
+    ctx.bind('store').toClass(Store);
+
+    await expect(ctx.get('store')).to.be.rejectedWith('invalid');
+  });
+
+  it('injects a config property with nested property', () => {
+    class Store {
+      constructor(@config('x.y') public optionXY: string) {}
+    }
+
+    ctx.configure('store').to({x: {y: 'y'}});
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.optionXY).to.eql('y');
+  });
+
+  it('injects config if the configPath is not present', () => {
+    class Store {
+      constructor(@config() public configObj: object) {}
+    }
+
+    ctx.configure('store').to({x: 1, y: 'a'});
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.configObj).to.eql({x: 1, y: 'a'});
+  });
+
+  it("injects config if the configPath is ''", () => {
+    class Store {
+      constructor(@config('') public configObj: object) {}
+    }
+
+    ctx.configure('store').to({x: 1, y: 'a'});
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.configObj).to.eql({x: 1, y: 'a'});
+  });
+
+  it('injects config with configPath', () => {
+    class Store {
+      constructor(@config('x') public optionX: number) {}
+    }
+
+    ctx.configure('store').to({x: 1, y: 'a'});
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.optionX).to.eql(1);
+  });
+
+  it('injects undefined option if configPath not found', () => {
+    class Store {
+      constructor(@config('not-exist') public option: string | undefined) {}
+    }
+
+    ctx.configure('store').to({x: 1, y: 'a'});
+    ctx.bind('store').toClass(Store);
+    const store: Store = ctx.getSync('store');
+    expect(store.option).to.be.undefined();
+  });
+
+  it('injects a config property for different bindings with the same class', async () => {
+    class Store {
+      constructor(
+        @config('x') public optionX: number,
+        @config('y') public optionY: string,
+      ) {}
+    }
+
+    ctx.configure('store1').to({x: 1, y: 'a'});
+    ctx.configure('store2').to({x: 2, y: 'b'});
+
+    ctx.bind('store1').toClass(Store);
+    ctx.bind('store2').toClass(Store);
+
+    const store1 = await ctx.get<Store>('store1');
+    expect(store1.optionX).to.eql(1);
+    expect(store1.optionY).to.eql('a');
+
+    const store2 = await ctx.get<Store>('store2');
+    expect(store2.optionX).to.eql(2);
+    expect(store2.optionY).to.eql('b');
+  });
+
+  it('injects undefined config if no binding is present', async () => {
+    class Store {
+      constructor(@config('x') public settings: object | undefined) {}
+    }
+
+    const store = await instantiateClass(Store, ctx);
+    expect(store.settings).to.be.undefined();
+  });
+
+  it('injects config from config binding', () => {
+    class MyStore {
+      constructor(@config('x') public optionX: number) {}
+    }
+
+    ctx.configure('stores.MyStore').to({x: 1, y: 'a'});
+    ctx.bind('stores.MyStore').toClass(MyStore);
+
+    const store: MyStore = ctx.getSync('stores.MyStore');
+    expect(store.optionX).to.eql(1);
   });
 
   function createContext() {

--- a/packages/context/src/__tests__/unit/context-config.unit.ts
+++ b/packages/context/src/__tests__/unit/context-config.unit.ts
@@ -1,0 +1,142 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  BindingAddress,
+  BindingKey,
+  ConfigurationResolver,
+  Context,
+  ContextTags,
+  DefaultConfigurationResolver,
+  ResolutionOptions,
+  ValueOrPromise,
+} from '../..';
+
+describe('Context binding configuration', () => {
+  /**
+   * Create a subclass of context so that we can access parents and registry
+   * for assertions
+   */
+  class TestContext extends Context {
+    public configResolver: ConfigurationResolver;
+  }
+
+  let ctx: TestContext;
+  beforeEach(createContext);
+
+  describe('configure()', () => {
+    it('configures options for a binding before it is bound', () => {
+      const bindingForConfig = ctx.configure('foo').to({x: 1});
+      expect(bindingForConfig.key).to.equal(
+        BindingKey.buildKeyForConfig('foo'),
+      );
+      expect(bindingForConfig.tagMap).to.eql({
+        [ContextTags.CONFIGURATION_FOR]: 'foo',
+      });
+    });
+
+    it('configures options for a binding after it is bound', () => {
+      ctx.bind('foo').to('bar');
+      const bindingForConfig = ctx.configure('foo').to({x: 1});
+      expect(bindingForConfig.key).to.equal(
+        BindingKey.buildKeyForConfig('foo'),
+      );
+      expect(bindingForConfig.tagMap).to.eql({
+        [ContextTags.CONFIGURATION_FOR]: 'foo',
+      });
+    });
+  });
+
+  describe('getConfig()', () => {
+    it('gets config for a binding', async () => {
+      ctx.configure('foo').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getConfig('foo')).to.eql({x: 1});
+    });
+
+    it('gets config for a binding with configPath', async () => {
+      ctx
+        .configure('foo')
+        .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
+      ctx.configure('foo.a').toDynamicValue(() => Promise.resolve({x: 1}));
+      expect(await ctx.getConfig<number>('foo.a', 'x')).to.eql(1);
+      expect(await ctx.getConfig<number>('foo.a', 'y')).to.be.undefined();
+    });
+
+    it('defaults optional to true for config resolution', async () => {
+      // `servers.rest` does not exist yet
+      let server1port = await ctx.getConfig<number>('servers.rest', 'port');
+      expect(server1port).to.be.undefined();
+
+      // Now add `servers.rest`
+      ctx.configure('servers.rest').to({port: 3000});
+      server1port = await ctx.getConfig<number>('servers.rest', 'port');
+      expect(server1port).to.eql(3000);
+    });
+
+    it('throws error if a required config cannot be resolved', async () => {
+      await expect(
+        ctx.getConfig('servers.rest', 'host', {
+          optional: false,
+        }),
+      ).to.be.rejectedWith(/The key 'servers\.rest\:\$config' is not bound/);
+    });
+  });
+
+  describe('getConfigSync()', () => {
+    it('gets config for a binding', () => {
+      ctx.configure('foo').to({x: 1});
+      expect(ctx.getConfigSync('foo')).to.eql({x: 1});
+    });
+
+    it('gets config for a binding with configPath', () => {
+      ctx.configure('foo').to({x: 1});
+      expect(ctx.getConfigSync('foo', 'x')).to.eql(1);
+      expect(ctx.getConfigSync('foo', 'y')).to.be.undefined();
+    });
+
+    it('throws a helpful error when the config is async', () => {
+      ctx.configure('foo').toDynamicValue(() => Promise.resolve('bar'));
+      expect(() => ctx.getConfigSync('foo')).to.throw(
+        /Cannot get config for foo synchronously: the value is a promise/,
+      );
+    });
+  });
+
+  describe('configResolver', () => {
+    class MyConfigResolver implements ConfigurationResolver {
+      getConfigAsValueOrPromise<ConfigValueType>(
+        key: BindingAddress<unknown>,
+        configPath?: string,
+        resolutionOptions?: ResolutionOptions,
+      ): ValueOrPromise<ConfigValueType | undefined> {
+        return (`Dummy config for ${key}` as unknown) as ConfigValueType;
+      }
+    }
+    it('gets default resolver', () => {
+      ctx.getConfigSync('xyz');
+      expect(ctx.configResolver).to.be.instanceOf(DefaultConfigurationResolver);
+    });
+
+    it('allows custom resolver', () => {
+      ctx.configResolver = new MyConfigResolver();
+      const config = ctx.getConfigSync('xyz');
+      expect(config).to.equal('Dummy config for xyz');
+    });
+
+    it('allows custom resolver bound to the context', () => {
+      ctx
+        .bind(`${BindingKey.CONFIG_NAMESPACE}.resolver`)
+        .toClass(MyConfigResolver);
+      const config = ctx.getConfigSync('xyz');
+      expect(config).to.equal('Dummy config for xyz');
+      expect(ctx.configResolver).to.be.instanceOf(MyConfigResolver);
+    });
+  });
+
+  function createContext() {
+    ctx = new TestContext();
+  }
+});

--- a/packages/context/src/__tests__/unit/context-view.unit.ts
+++ b/packages/context/src/__tests__/unit/context-view.unit.ts
@@ -45,6 +45,17 @@ describe('ContextView', () => {
     expect(await taggedAsFoo.asGetter()()).to.eql(['BAR', 'FOO']);
   });
 
+  it('reports error on singleValue() if multiple values exist', async () => {
+    return expect(taggedAsFoo.singleValue()).to.be.rejectedWith(
+      /The ContextView has more than one value\. Use values\(\) to access them\./,
+    );
+  });
+
+  it('supports singleValue() if only one value exist', async () => {
+    server.unbind('bar');
+    expect(await taggedAsFoo.singleValue()).to.eql('FOO');
+  });
+
   it('reloads bindings after refresh', async () => {
     taggedAsFoo.refresh();
     const abcBinding = server

--- a/packages/context/src/__tests__/unit/context.unit.ts
+++ b/packages/context/src/__tests__/unit/context.unit.ts
@@ -538,6 +538,21 @@ describe('Context', () => {
     });
   });
 
+  describe('getOwnerContext', () => {
+    it('returns owner context', () => {
+      ctx.bind('foo').to('bar');
+      expect(ctx.getOwnerContext('foo')).to.equal(ctx);
+    });
+
+    it('returns owner context with parent', () => {
+      ctx.bind('foo').to('bar');
+      const childCtx = new Context(ctx, 'child');
+      childCtx.bind('xyz').to('abc');
+      expect(childCtx.getOwnerContext('foo')).to.equal(ctx);
+      expect(childCtx.getOwnerContext('xyz')).to.equal(childCtx);
+    });
+  });
+
   describe('get', () => {
     it('returns a promise when the binding is async', async () => {
       ctx.bind('foo').toDynamicValue(() => Promise.resolve('bar'));

--- a/packages/context/src/binding-config.ts
+++ b/packages/context/src/binding-config.ts
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {BindingAddress, BindingKey} from './binding-key';
+import {Context} from './context';
+import {ResolutionOptions} from './resolution-session';
+import {ValueOrPromise} from './value-promise';
+
+/**
+ * Resolver for configuration of bindings. It's responsible for finding
+ * corresponding configuration for a given binding key.
+ *
+ * By default, `undefined` is expected if no configuration is provided. The
+ * behavior can be overridden by setting `optional` to `false` in resolution
+ * options.
+ */
+export interface ConfigurationResolver {
+  /**
+   * Resolve config for the binding key
+   *
+   * @param key - Binding key
+   * @param configPath - Property path for the option. For example, `x.y`
+   * requests for `<config>.x.y`. If not set, the `config` object will be
+   * returned.
+   * @param resolutionOptions - Options for the resolution.
+   * - optional: if not set or set to `true`, `undefined` will be returned if
+   * no corresponding value is found. Otherwise, an error will be thrown.
+   */
+  getConfigAsValueOrPromise<ConfigValueType>(
+    key: BindingAddress<unknown>,
+    configPath?: string,
+    resolutionOptions?: ResolutionOptions,
+  ): ValueOrPromise<ConfigValueType | undefined>;
+}
+
+/**
+ * Resolver for configurations of bindings
+ */
+export class DefaultConfigurationResolver implements ConfigurationResolver {
+  constructor(public readonly context: Context) {}
+
+  getConfigAsValueOrPromise<ConfigValueType>(
+    key: BindingAddress<unknown>,
+    configPath?: string,
+    resolutionOptions?: ResolutionOptions,
+  ): ValueOrPromise<ConfigValueType | undefined> {
+    configPath = configPath || '';
+    const configKey = configBindingKeyFor(key, configPath);
+
+    const options: ResolutionOptions = Object.assign(
+      {optional: true},
+      resolutionOptions,
+    );
+    return this.context.getValueOrPromise<ConfigValueType>(configKey, options);
+  }
+}
+
+/**
+ * Create binding key for configuration of the binding
+ * @param key - Binding key for the target binding
+ * @param configPath - Property path for the configuration
+ */
+export function configBindingKeyFor<ConfigValueType = unknown>(
+  key: BindingAddress,
+  configPath?: string,
+) {
+  return BindingKey.create<ConfigValueType>(
+    BindingKey.buildKeyForConfig<ConfigValueType>(key).toString(),
+    configPath,
+  );
+}

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -103,4 +103,21 @@ export class BindingKey<ValueType> {
       keyWithPath.substr(index + 1),
     );
   }
+
+  /**
+   * Name space for configuration binding keys
+   */
+  static CONFIG_NAMESPACE = '$config';
+
+  /**
+   * Build a binding key for the configuration of the given binding.
+   * The format is `<key>:$config`
+   *
+   * @param key - Key of the target binding to be configured
+   */
+  static buildKeyForConfig<T>(key: BindingAddress = ''): BindingAddress<T> {
+    const suffix = BindingKey.CONFIG_NAMESPACE;
+    const bindingKey = key ? `${key}:${suffix}` : suffix;
+    return bindingKey;
+  }
 }

--- a/packages/context/src/context-view.ts
+++ b/packages/context/src/context-view.ts
@@ -157,6 +157,18 @@ export class ContextView<T = unknown> extends EventEmitter
   asGetter(session?: ResolutionSession): Getter<T[]> {
     return () => this.values(session);
   }
+
+  /**
+   * Get the single value
+   */
+  async singleValue(session?: ResolutionSession): Promise<T | undefined> {
+    const values = await this.values(session);
+    if (values.length === 0) return undefined;
+    if (values.length === 1) return values[0];
+    throw new Error(
+      'The ContextView has more than one value. Use values() to access them.',
+    );
+  }
 }
 
 /**

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from '@loopback/metadata';
 export * from './binding';
+export * from './binding-config';
 export * from './binding-decorator';
 export * from './binding-filter';
 export * from './binding-inspector';
@@ -16,6 +17,7 @@ export * from './context-view';
 export * from './inject';
 export * from './interception-proxy';
 export * from './interceptor';
+export * from './inject-config';
 export * from './keys';
 export * from './provider';
 export * from './resolution-session';

--- a/packages/context/src/inject-config.ts
+++ b/packages/context/src/inject-config.ts
@@ -1,0 +1,198 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {BindingFilter} from './binding-filter';
+import {BindingKey} from './binding-key';
+import {Context} from './context';
+import {ContextView} from './context-view';
+import {assertTargetType, inject, Injection, InjectionMetadata} from './inject';
+import {ResolutionSession} from './resolution-session';
+import {getDeepProperty, ValueOrPromise} from './value-promise';
+
+/**
+ * Inject a property from `config` of the current binding. If no corresponding
+ * config value is present, `undefined` will be injected as the configuration
+ * binding is resolved with `optional: true` by default.
+ *
+ * @example
+ * ```ts
+ * class Store {
+ *   constructor(
+ *     @config('x') public optionX: number,
+ *     @config('y') public optionY: string,
+ *   ) { }
+ * }
+ *
+ * ctx.configure('store1', { x: 1, y: 'a' });
+ * ctx.configure('store2', { x: 2, y: 'b' });
+ *
+ * ctx.bind('store1').toClass(Store);
+ * ctx.bind('store2').toClass(Store);
+ *
+ * const store1 = ctx.getSync('store1');
+ * expect(store1.optionX).to.eql(1);
+ * expect(store1.optionY).to.eql('a');
+ *
+ * const store2 = ctx.getSync('store2');
+ * expect(store2.optionX).to.eql(2);
+ * expect(store2.optionY).to.eql('b');
+ * ```
+ *
+ * @param configPath - Optional property path of the config. If is `''` or not
+ * present, the `config` object will be returned.
+ * @param metadata - Optional metadata to help the injection
+ */
+export function config(configPath?: string, metadata?: InjectionMetadata) {
+  configPath = configPath || '';
+  metadata = Object.assign(
+    {configPath, decorator: '@config', optional: true},
+    metadata,
+  );
+  return inject('', metadata, resolveFromConfig);
+}
+
+export namespace config {
+  /**
+   * `@inject.getter` decorator to inject a config getter function
+   * @param configPath - Optional property path of the config object
+   * @param metadata - Injection metadata
+   */
+  export const getter = function injectConfigGetter(
+    configPath?: string,
+    metadata?: InjectionMetadata,
+  ) {
+    configPath = configPath || '';
+    metadata = Object.assign(
+      {configPath, decorator: '@config.getter', optional: true},
+      metadata,
+    );
+    return inject('', metadata, resolveAsGetterFromConfig);
+  };
+
+  /**
+   * `@inject.view` decorator to inject a config context view to allow dynamic
+   * changes in configuration
+   * @param configPath - Optional property path of the config object
+   * @param metadata - Injection metadata
+   */
+  export const view = function injectConfigView(
+    configPath?: string,
+    metadata?: InjectionMetadata,
+  ) {
+    configPath = configPath || '';
+    metadata = Object.assign(
+      {configPath, decorator: '@config.view', optional: true},
+      metadata,
+    );
+    return inject('', metadata, resolveAsViewFromConfig);
+  };
+}
+
+/**
+ * Get the key for the current binding on which dependency injection is
+ * performed
+ * @param session - Resolution session
+ */
+function getCurrentBindingKey(session: ResolutionSession) {
+  // The current binding is not set if `instantiateClass` is invoked directly
+  return session.currentBinding && session.currentBinding.key;
+}
+
+/**
+ * Resolver for `@config`
+ * @param ctx - Context object
+ * @param injection - Injection metadata
+ * @param session - Resolution session
+ */
+function resolveFromConfig(
+  ctx: Context,
+  injection: Injection,
+  session: ResolutionSession,
+): ValueOrPromise<unknown> {
+  const bindingKey = getCurrentBindingKey(session);
+  // Return `undefined` if no current binding is present
+  if (!bindingKey) return undefined;
+  const meta = injection.metadata;
+  return ctx.getConfigAsValueOrPromise(bindingKey, meta.configPath, {
+    session,
+    optional: meta.optional,
+  });
+}
+
+/**
+ * Resolver from `@config.getter`
+ * @param ctx - Context object
+ * @param injection - Injection metadata
+ * @param session - Resolution session
+ */
+function resolveAsGetterFromConfig(
+  ctx: Context,
+  injection: Injection,
+  session: ResolutionSession,
+) {
+  assertTargetType(injection, Function, 'Getter function');
+  const bindingKey = getCurrentBindingKey(session);
+  // We need to clone the session for the getter as it will be resolved later
+  const forkedSession = ResolutionSession.fork(session);
+  const meta = injection.metadata;
+  return async function getter() {
+    // Return `undefined` if no current binding is present
+    if (!bindingKey) return undefined;
+    return ctx.getConfigAsValueOrPromise(bindingKey, meta.configPath, {
+      session: forkedSession,
+      optional: meta.optional,
+    });
+  };
+}
+
+/**
+ * Resolver for `@config.view`
+ * @param ctx - Context object
+ * @param injection - Injection metadata
+ * @param session - Resolution session
+ */
+function resolveAsViewFromConfig(
+  ctx: Context,
+  injection: Injection,
+  session: ResolutionSession,
+) {
+  assertTargetType(injection, ContextView);
+  const bindingKey = getCurrentBindingKey(session);
+  // Return `undefined` if no current binding is present
+  if (!bindingKey) return undefined;
+  const view = new ConfigView(
+    ctx,
+    binding =>
+      binding.key === BindingKey.buildKeyForConfig(bindingKey).toString(),
+    injection.metadata.configPath,
+  );
+  view.open();
+  return view;
+}
+
+/**
+ * A subclass of `ContextView` to handle dynamic configuration as its
+ * `values()` honors the `configPath`.
+ */
+class ConfigView extends ContextView {
+  constructor(
+    ctx: Context,
+    filter: BindingFilter,
+    private configPath?: string,
+  ) {
+    super(ctx, filter);
+  }
+
+  /**
+   * Get values for the configuration with a property path
+   * @param session - Resolution session
+   */
+  async values(session?: ResolutionSession) {
+    const configValues = await super.values(session);
+    const configPath = this.configPath;
+    if (!configPath) return configValues;
+    return configValues.map(v => getDeepProperty(v, configPath));
+  }
+}

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -506,7 +506,7 @@ export function describeInjectedArguments(
  * JavaScript type
  * @param injection - Injection information
  */
-function inspectTargetType(injection: Readonly<Injection>) {
+export function inspectTargetType(injection: Readonly<Injection>) {
   let type = MetadataInspector.getDesignTypeForProperty(
     injection.target,
     injection.member!,

--- a/packages/context/src/keys.ts
+++ b/packages/context/src/keys.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {ConfigurationResolver} from './binding-config';
 import {BindingKey} from './binding-key';
 
 /**
@@ -30,6 +31,11 @@ export namespace ContextTags {
   export const KEY = 'key';
 
   /**
+   * Binding tag to associate a configuration binding with the target binding key
+   */
+  export const CONFIGURATION_FOR = 'configurationFor';
+
+  /**
    * Binding tag for global interceptors
    */
   export const GLOBAL_INTERCEPTOR = 'globalInterceptor';
@@ -43,6 +49,13 @@ export namespace ContextTags {
  * Namespace for context bindings
  */
 export namespace ContextBindings {
+  /**
+   * Binding key for ConfigurationResolver
+   */
+  export const CONFIGURATION_RESOLVER = BindingKey.create<
+    ConfigurationResolver
+  >(`${BindingKey.CONFIG_NAMESPACE}.resolver`);
+
   /**
    * Binding key for ordered groups of global interceptors
    */


### PR DESCRIPTION
Reactivation of #983 based on requirements illustrated by #2249.

1. Add context.configure() to configure bindings
2. Add context.getConfig/getConfigSync() to look up configuration for a binding
3. Add `@config`, `@config.getter`, and `@config.view` to receive injection of configuration


## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
