### PR TITLE
chore(build): upgrade prettier to 1.16.1

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -22,7 +22,7 @@
     "glob": "^7.1.2",
     "mocha": "^5.1.1",
     "nyc": "^13.0.1",
-    "prettier": "^1.15.1",
+    "prettier": "^1.16.1",
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.5",
     "strong-docs": "^4.0.0",

--- a/packages/context/src/binding-decorator.ts
+++ b/packages/context/src/binding-decorator.ts
@@ -89,7 +89,7 @@ export namespace bind {
    */
   export function provider(
     ...specs: BindingSpec[]
-  ): ((target: Constructor<Provider<unknown>>) => void) {
+  ): (target: Constructor<Provider<unknown>>) => void {
     return (target: Constructor<Provider<unknown>>) => {
       if (!isProviderClass(target)) {
         throw new Error(`Target ${target} is not a Provider`);


### PR DESCRIPTION
Upgrade prettier to 1.16.1 and reformat code to avoid CI failure.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
