### PR TITLE
fix(docs): update link in todo-tutorial-geocoding-service

### DIFF
--- a/docs/site/todo-tutorial-geocoding-service.md
+++ b/docs/site/todo-tutorial-geocoding-service.md
@@ -14,7 +14,7 @@ To call other APIs and web services from LoopBack applications, we recommend to
 use Service Proxies as a design pattern for encapsulating low-level
 implementation details of communication with 3rd-party services and providing
 JavaScript/TypeScript API that's easy to consume e.g. from Controllers. See
-[Calling other APIs and web services](./Calling-other-APIs-and-web-services.md)
+[Calling other APIs and web services](./Calling-other-APIs-and-Web-Services.md)
 for more details.
 
 In LoopBack, each service proxy is backed by a


### PR DESCRIPTION
This pull request supersedes https://github.com/strongloop/loopback-next/pull/1891, which seems to be abandoned.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated