### PR TITLE
feat(context): introduce context events and observers for bind/unbind

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@loopback/metadata": "^1.0.6",
     "debug": "^4.0.1",
+    "p-event": "^2.3.1",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/packages/context/src/__tests__/unit/context-observer.unit.ts
+++ b/packages/context/src/__tests__/unit/context-observer.unit.ts
@@ -1,0 +1,365 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {promisify} from 'util';
+import {
+  Binding,
+  Context,
+  ContextEventType,
+  ContextObserver,
+  filterByTag,
+} from '../..';
+
+const pEvent = require('p-event');
+const setImmediateAsync = promisify(setImmediate);
+
+/**
+ * Create a subclass of context so that we can access parents and registry
+ * for assertions
+ */
+class TestContext extends Context {
+  get parentEventListeners() {
+    return this._parentEventListeners;
+  }
+  /**
+   * Wait until the context event queue is empty or an error is thrown
+   */
+  waitUntilObserversNotified(): Promise<void> {
+    return this.waitUntilPendingNotificationsDone(100);
+  }
+}
+
+describe('Context', () => {
+  let ctx: TestContext;
+  beforeEach('given a context', createContext);
+
+  describe('observer subscription', () => {
+    let nonMatchingObserver: ContextObserver;
+
+    beforeEach(givenNonMatchingObserver);
+
+    it('subscribes observers', () => {
+      ctx.subscribe(nonMatchingObserver);
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.true();
+    });
+
+    it('unsubscribes observers', () => {
+      ctx.subscribe(nonMatchingObserver);
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.true();
+      ctx.unsubscribe(nonMatchingObserver);
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.false();
+    });
+
+    it('allows subscription.unsubscribe()', () => {
+      const subscription = ctx.subscribe(nonMatchingObserver);
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.true();
+      subscription.unsubscribe();
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.false();
+      expect(subscription.closed).to.be.true();
+    });
+
+    it('registers observers on context with parent', () => {
+      const childCtx = new TestContext(ctx, 'child');
+      expect(childCtx.parentEventListeners).to.be.undefined();
+      childCtx.subscribe(nonMatchingObserver);
+      expect(childCtx.parentEventListeners!.has('bind')).to.be.true();
+      expect(childCtx.parentEventListeners!.has('unbind')).to.be.true();
+      expect(childCtx.isSubscribed(nonMatchingObserver)).to.true();
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.false();
+    });
+
+    it('un-registers observers on context chain', () => {
+      const childCtx = new Context(ctx, 'child');
+      childCtx.subscribe(nonMatchingObserver);
+      expect(childCtx.isSubscribed(nonMatchingObserver)).to.true();
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.false();
+      childCtx.unsubscribe(nonMatchingObserver);
+      expect(childCtx.isSubscribed(nonMatchingObserver)).to.false();
+      expect(ctx.isSubscribed(nonMatchingObserver)).to.false();
+    });
+
+    it('un-registers observers on context chain during close', () => {
+      const childCtx = new TestContext(ctx, 'child');
+      childCtx.subscribe(nonMatchingObserver);
+      const parentEventListeners = new Map(childCtx.parentEventListeners!);
+      childCtx.close();
+      for (const [event, listener] of parentEventListeners) {
+        expect(ctx.listeners(event)).to.not.containEql(listener);
+      }
+      expect(childCtx.parentEventListeners).to.be.undefined();
+      expect(childCtx.isSubscribed(nonMatchingObserver)).to.false();
+    });
+
+    function givenNonMatchingObserver() {
+      nonMatchingObserver = {
+        filter: binding => false,
+        observe: () => {},
+      };
+    }
+  });
+
+  describe('event notification', () => {
+    const events: string[] = [];
+    let nonMatchingObserverCalled = false;
+
+    beforeEach(givenObservers);
+
+    it('emits one bind event to matching observers', async () => {
+      ctx.bind('foo').to('foo-value');
+      await ctx.waitUntilObserversNotified();
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+      ]);
+      expect(nonMatchingObserverCalled).to.be.false();
+    });
+
+    it('emits multiple bind events to matching observers', async () => {
+      ctx.bind('foo').to('foo-value');
+      ctx.bind('xyz').to('xyz-value');
+      await ctx.waitUntilObserversNotified();
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+        'SYNC:xyz:xyz-value:bind',
+        'ASYNC:xyz:xyz-value:bind',
+      ]);
+    });
+
+    it('emits unbind event to matching observers', async () => {
+      ctx.bind('foo').to('foo-value');
+      await ctx.waitUntilObserversNotified();
+      ctx.unbind('foo');
+      await ctx.waitUntilObserversNotified();
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+        'SYNC:foo:foo-value:unbind',
+        'ASYNC:foo:foo-value:unbind',
+      ]);
+      expect(nonMatchingObserverCalled).to.be.false();
+    });
+
+    it('emits bind/unbind events for rebind to matching observers', async () => {
+      ctx.bind('foo').to('foo-value');
+      await ctx.waitUntilObserversNotified();
+      ctx.bind('foo').to('new-foo-value');
+      await ctx.waitUntilObserversNotified();
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+        'SYNC:foo:foo-value:unbind',
+        'ASYNC:foo:foo-value:unbind',
+        'SYNC:foo:new-foo-value:bind',
+        'ASYNC:foo:new-foo-value:bind',
+      ]);
+      expect(nonMatchingObserverCalled).to.be.false();
+    });
+
+    it('does not trigger observers if affected binding is the same', async () => {
+      const binding = ctx.bind('foo').to('foo-value');
+      await ctx.waitUntilObserversNotified();
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+      ]);
+      ctx.add(binding);
+      await ctx.waitUntilObserversNotified();
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+      ]);
+    });
+
+    it('reports error if an observer fails', () => {
+      ctx.bind('bar').to('bar-value');
+      return expect(ctx.waitUntilObserversNotified()).to.be.rejectedWith(
+        'something wrong',
+      );
+    });
+
+    it('does not trigger observers registered after an event', async () => {
+      ctx.bind('foo').to('foo-value');
+      process.nextTick(() => {
+        // Register a new observer after 1st event
+        ctx.subscribe((event, binding, context) => {
+          const val = binding.getValue(context);
+          events.push(`LATE:${binding.key}:${val}:${event}`);
+        });
+      });
+
+      await ctx.waitUntilObserversNotified();
+      // The late observer is not triggered
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+      ]);
+      // Emit another event
+      ctx.bind('xyz').to('xyz-value');
+      await ctx.waitUntilObserversNotified();
+      // Now the late observer is triggered
+      expect(events).to.eql([
+        'SYNC:foo:foo-value:bind',
+        'ASYNC:foo:foo-value:bind',
+        'SYNC:xyz:xyz-value:bind',
+        'ASYNC:xyz:xyz-value:bind',
+        'LATE:xyz:xyz-value:bind',
+      ]);
+    });
+
+    function givenObservers() {
+      nonMatchingObserverCalled = false;
+      events.splice(0, events.length);
+      // An observer does not match the criteria
+      const nonMatchingObserver: ContextObserver = {
+        filter: binding => false,
+        observe: () => {
+          nonMatchingObserverCalled = true;
+        },
+      };
+      // A sync observer matches the criteria
+      const matchingObserver: ContextObserver = {
+        observe: (event, binding, context) => {
+          // Make sure the binding is configured with value
+          // when the observer is notified
+          const val = binding.getValue(context);
+          events.push(`SYNC:${binding.key}:${val}:${event}`);
+        },
+      };
+      // An async observer matches the criteria
+      const matchingAsyncObserver: ContextObserver = {
+        filter: binding => true,
+        observe: async (event, binding, context) => {
+          await setImmediateAsync();
+          const val = binding.getValue(context);
+          events.push(`ASYNC:${binding.key}:${val}:${event}`);
+        },
+      };
+      // An async observer matches the criteria that throws an error
+      const matchingAsyncObserverWithError: ContextObserver = {
+        filter: binding => binding.key === 'bar',
+        observe: async () => {
+          await setImmediateAsync();
+          throw new Error('something wrong');
+        },
+      };
+      ctx.subscribe(nonMatchingObserver);
+      ctx.subscribe(matchingObserver);
+      ctx.subscribe(matchingAsyncObserver);
+      ctx.subscribe(matchingAsyncObserverWithError);
+    }
+  });
+
+  describe('event notification for context chain', () => {
+    let app: Context;
+    let server: Context;
+
+    let contextObserver: MyObserverForControllers;
+    beforeEach(givenControllerObserver);
+
+    it('receives notifications of matching binding events', async () => {
+      const controllers = await getControllers();
+      // We have server: 1, app: 2
+      // NOTE: The controllers are not guaranteed to be ['1', '2'] as the events
+      // are emitted by two context objects and they are processed asynchronously
+      expect(controllers).to.containEql('1@server');
+      expect(controllers).to.containEql('2@app');
+      server.unbind('controllers.1');
+      // Now we have app: 2
+      expect(await getControllers()).to.eql(['2@app']);
+      app.unbind('controllers.2');
+      // All controllers are gone from the context chain
+      expect(await getControllers()).to.eql([]);
+      // Add a new controller - server: 3
+      givenController(server, '3');
+      expect(await getControllers()).to.eql(['3@server']);
+    });
+
+    it('does not emit matching binding events from parent if shadowed', async () => {
+      // We have server: 1, app: 2
+      givenController(app, '1');
+      // All controllers are gone from the context chain
+      expect(await getControllers()).to.not.containEql('1@app');
+    });
+
+    it('reports error on current context if an observer fails', async () => {
+      const err = new Error('something wrong');
+      server.subscribe((event, binding) => {
+        if (binding.key === 'bar') {
+          return Promise.reject(err);
+        }
+      });
+      server.bind('bar').to('bar-value');
+      // Please note the following code registers an `error` listener on `server`
+      const obj = await pEvent(server, 'error');
+      expect(obj).to.equal(err);
+    });
+
+    it('reports error on the first context with error listeners on the chain', async () => {
+      const err = new Error('something wrong');
+      server.subscribe((event, binding) => {
+        if (binding.key === 'bar') {
+          return Promise.reject(err);
+        }
+      });
+      server.bind('bar').to('bar-value');
+      // No error listener is registered on `server`
+      const obj = await pEvent(app, 'error');
+      expect(obj).to.equal(err);
+    });
+
+    class MyObserverForControllers implements ContextObserver {
+      controllers: Set<string> = new Set();
+      filter = filterByTag('controller');
+      observe(
+        event: ContextEventType,
+        binding: Readonly<Binding<unknown>>,
+        context: Context,
+      ) {
+        const name = `${binding.tagMap.name}@${context.name}`;
+        if (event === 'bind') {
+          this.controllers.add(name);
+        } else if (event === 'unbind') {
+          this.controllers.delete(name);
+        }
+      }
+    }
+
+    function givenControllerObserver() {
+      givenServerWithinAnApp();
+      contextObserver = new MyObserverForControllers();
+      server.subscribe(contextObserver);
+      givenController(server, '1');
+      givenController(app, '2');
+    }
+
+    function givenController(context: Context, controllerName: string) {
+      class MyController {
+        name = controllerName;
+      }
+      context
+        .bind(`controllers.${controllerName}`)
+        .toClass(MyController)
+        .tag('controller', {name: controllerName});
+    }
+
+    async function getControllers() {
+      return new Promise<string[]>(resolve => {
+        // Wrap it inside `setImmediate` to make the events are triggered
+        setImmediate(() => resolve(Array.from(contextObserver.controllers)));
+      });
+    }
+
+    function givenServerWithinAnApp() {
+      app = new Context('app');
+      server = new Context(app, 'server');
+    }
+  });
+
+  function createContext() {
+    ctx = new TestContext();
+  }
+});

--- a/packages/context/src/__tests__/unit/context.unit.ts
+++ b/packages/context/src/__tests__/unit/context.unit.ts
@@ -5,12 +5,12 @@
 
 import {expect} from '@loopback/testlab';
 import {
-  Context,
   Binding,
+  BindingKey,
   BindingScope,
   BindingType,
+  Context,
   isPromiseLike,
-  BindingKey,
 } from '../..';
 
 /**
@@ -61,7 +61,7 @@ describe('Context constructor', () => {
 });
 
 describe('Context', () => {
-  let ctx: Context;
+  let ctx: TestContext;
   beforeEach('given a context', createContext);
 
   describe('bind', () => {
@@ -640,6 +640,22 @@ describe('Context', () => {
     });
   });
 
+  describe('close()', () => {
+    it('clears all bindings', () => {
+      ctx.bind('foo').to('foo-value');
+      expect(ctx.bindingMap.size).to.eql(1);
+      ctx.close();
+      expect(ctx.bindingMap.size).to.eql(0);
+    });
+
+    it('dereferences parent', () => {
+      const childCtx = new TestContext(ctx);
+      expect(childCtx.parent).to.equal(ctx);
+      childCtx.close();
+      expect(childCtx.parent).to.be.undefined();
+    });
+  });
+
   describe('toJSON()', () => {
     it('converts to plain JSON object', () => {
       ctx
@@ -682,6 +698,6 @@ describe('Context', () => {
   });
 
   function createContext() {
-    ctx = new Context();
+    ctx = new TestContext();
   }
 });

--- a/packages/context/src/context-observer.ts
+++ b/packages/context/src/context-observer.ts
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Binding} from './binding';
+import {BindingFilter} from './binding-filter';
+import {ValueOrPromise} from './value-promise';
+import {Context} from './context';
+
+/**
+ * Context event types. We support `bind` and `unbind` for now but
+ * keep it open for new types
+ */
+export type ContextEventType = 'bind' | 'unbind' | string;
+
+/**
+ * Listen on `bind`, `unbind`, or other events
+ * @param eventType Context event type
+ * @param binding The binding as event source
+ * @param context Context object for the binding event
+ */
+export type ContextObserverFn = (
+  eventType: ContextEventType,
+  binding: Readonly<Binding<unknown>>,
+  context: Context,
+) => ValueOrPromise<void>;
+
+/**
+ * Observers of context bind/unbind events
+ */
+export interface ContextObserver {
+  /**
+   * An optional filter function to match bindings. If not present, the listener
+   * will be notified of all binding events.
+   */
+  filter?: BindingFilter;
+
+  /**
+   * Listen on `bind`, `unbind`, or other events
+   * @param eventType Context event type
+   * @param binding The binding as event source
+   */
+  observe: ContextObserverFn;
+}
+
+/**
+ * Context event observer type - An instance of `ContextObserver` or a function
+ */
+export type ContextEventObserver = ContextObserver | ContextObserverFn;
+
+/**
+ * Subscription of context events. It's modeled after
+ * https://github.com/tc39/proposal-observable.
+ */
+export interface Subscription {
+  /**
+   * unsubscribe
+   */
+  unsubscribe(): void;
+  /**
+   * Is the subscription closed?
+   */
+  closed: boolean;
+}
+
+/**
+ * Event data for observer notifications
+ */
+export type Notification = {
+  /**
+   * Context event type - bind/unbind
+   */
+  eventType: ContextEventType;
+  /**
+   * Binding added/removed
+   */
+  binding: Readonly<Binding<unknown>>;
+  /**
+   * Owner context for the binding
+   */
+  context: Context;
+  /**
+   * A snapshot of observers when the original event is emitted
+   */
+  observers: Set<ContextEventObserver>;
+};

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -10,6 +10,7 @@ export * from './binding-inspector';
 export * from './binding-key';
 export * from './binding-filter';
 export * from './context';
+export * from './context-observer';
 export * from './inject';
 export * from './keys';
 export * from './provider';

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -40,6 +40,7 @@
     "http-errors": "^1.6.3",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.11",
+    "on-finished": "^2.3.0",
     "openapi-schema-to-json-schema": "^2.1.0",
     "openapi3-ts": "^1.0.0",
     "path-to-regexp": "^3.0.0",
@@ -59,6 +60,7 @@
     "@types/lodash": "^4.14.106",
     "@types/multer": "^1.3.7",
     "@types/node": "^10.11.2",
+    "@types/on-finished": "^2.3.1",
     "@types/qs": "^6.5.1",
     "multer": "^1.4.1"
   },

--- a/packages/rest/src/request-context.ts
+++ b/packages/rest/src/request-context.ts
@@ -4,8 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from '@loopback/context';
-import {HandlerContext, Request, Response} from './types';
+import * as onFinished from 'on-finished';
 import {RestBindings} from './keys';
+import {HandlerContext, Request, Response} from './types';
 
 /**
  * A per-request Context combining an IoC container with handler context
@@ -20,6 +21,9 @@ export class RequestContext extends Context implements HandlerContext {
   ) {
     super(parent, name);
     this._setupBindings(request, response);
+    onFinished(this.response, () => {
+      this.close();
+    });
   }
 
   private _setupBindings(request: Request, response: Response) {


### PR DESCRIPTION
Spin-off from #2122 

- Add support for context to emit bind and unbind events
- Allow observers to register with the context chain and respond to come and go of bindings of interest

Followed-up PRs:

#2122 (depends on #2291)

- Introduce ContextView to dynamically resolve values of matching bindings
- Introduce @inject.view to support dependency injection of multiple bound values
- Extend @inject and @inject.getter to support multiple bound values

#2249
- Add an example package to illustrate how to implement extension point/extension pattern using LoopBack 4’s IoC and DI container

#2259
- Propose new APIs for Context to configure bindings
- Add @inject.config to simplify injection of configuration

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
