### PR TITLE
fix(repository): add near operator for where filters

### DIFF
--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -39,7 +39,8 @@ export type Operators =
   | 'nlike' // NOT LIKE
   | 'ilike' // ILIKE'
   | 'nilike' // NOT ILIKE
-  | 'regexp'; // REGEXP'
+  | 'regexp' // REGEXP'
+  | 'near'; // NEAR
 
 /**
  * Matching predicate comparison
@@ -60,6 +61,7 @@ export type PredicateComparison<PT> = {
   ilike?: PT;
   nilike?: PT;
   regexp?: string | RegExp;
+  near?: object;
   // [extendedOperation: string]: any;
 };
 


### PR DESCRIPTION
Fixes #1419. Currently, I'm not able to reproduce the error message seen in the issue itself. https://loopback.io/doc/en/lb2/Where-filter.html#near shows that the `near` operator includes additional properties like `maxDistance` and `unit`, but I see them being specified concurrently or at the same level as `near` and not nested inside, so I've left them out of its type definition.
## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
