### PR TITLE
fix(docs): remove .ts from imports

### DIFF
--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -40,7 +40,7 @@ how to define a `hasMany` relation on a source model `Customer`.
 {% include code-caption.html content="/src/models/customer.model.ts" %}
 
 ```ts
-import {Order} from './order.model.ts';
+import {Order} from './order.model';
 import {Entity, property, hasMany} from '@loopback/repository';
 
 export class Customer extends Entity {

--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -50,7 +50,7 @@ defined on a source model `Supplier` in the example below:
 {% include code-caption.html content="/src/models/supplier.model.ts" %}
 
 ```ts
-import {Account} from './account.model.ts';
+import {Account} from './account.model';
 import {Entity, property, hasOne} from '@loopback/repository';
 
 export class Supplier extends Entity {
@@ -79,7 +79,7 @@ On the other side of the relation, we'd need to declare a `belongsTo` relation
 since every `Account` has to belong to exactly one `Supplier`:
 
 ```ts
-import {Supplier} from './supplier.model.ts';
+import {Supplier} from './supplier.model';
 import {Entity, property, belongsTo} from '@loopback/repository';
 
 export class Account extends Entity {


### PR DESCRIPTION
Remove `.ts` from some imports due to: 
<img width="625" alt="screen shot 2019-01-29 at 11 02 25 am" src="https://user-images.githubusercontent.com/42985749/51921574-ac671400-23b5-11e9-949d-71d2f9abf9d9.png">


## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
