### PR TITLE
feat(rest): add redirect route

### DIFF
--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -735,6 +735,39 @@ paths:
       );
       expect(response.body.servers).to.containEql({url: '/api'});
     });
+
+    it('can redirect routes when it does not exist', async () => {
+      server.controller(DummyController);
+      server.redirect('/page/html', '/html');
+      const response = await createClientForHandler(server.requestHandler)
+        .get('/api/page/html')
+        .expect(303);
+      await createClientForHandler(server.requestHandler)
+        .get(response.header.location)
+        .expect(200, 'Hi');
+    });
+
+    it('can redirect routes', async () => {
+      server.controller(DummyController);
+      server.redirect('/hello', '/endpoint');
+      const response = await createClientForHandler(server.requestHandler)
+        .get('/api/hello')
+        .expect(303);
+      await createClientForHandler(server.requestHandler)
+        .get(response.header.location)
+        .expect(200, 'hello');
+    });
+
+    it('can server redirect routes with custom status', async () => {
+      server.controller(DummyController);
+      server.redirect('/hello', '/endpoint', 304);
+      const response = await createClientForHandler(server.requestHandler)
+        .get('/api/hello')
+        .expect(304);
+      await createClientForHandler(server.requestHandler)
+        .get(response.header.location)
+        .expect(200, 'hello');
+    });
   });
 
   async function givenAServer(
@@ -762,6 +795,12 @@ paths:
     })
     ping(): string {
       return 'Hi';
+    }
+    @get('/endpoint', {
+      responses: {},
+    })
+    hello(): string {
+      return 'hello';
     }
   }
 

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.redirect.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.redirect.unit.ts
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Application} from '@loopback/core';
+import {RestServer, RestComponent} from '../../..';
+
+describe('RestServer.redirect()', () => {
+  it('binds the redirect route', async () => {
+    const app = new Application();
+    app.component(RestComponent);
+    const server = await app.getServer(RestServer);
+    server.redirect('/test', '/test/');
+    let boundRoutes = server.find('routes.*').map(b => b.key);
+    expect(boundRoutes).to.containEql('routes.get %2Ftest');
+  });
+});

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -238,8 +238,8 @@ export class RestApplication extends Application implements HttpServerLike {
    * @param source URL path of the redirect endpoint
    * @param target URL path of the endpoint
    */
-  redirect(source: string, target: string): Binding {
-    return this.restServer.redirect(source, target);
+  redirect(source: string, target: string, statusCode?: number): Binding {
+    return this.restServer.redirect(source, target, statusCode);
   }
 
   /**

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -229,6 +229,20 @@ export class RestApplication extends Application implements HttpServerLike {
   }
 
   /**
+   * Redirect route by invoking a handler function.
+   *
+   * ```ts
+   * app.redirect('/explorer', '/explorer/');
+   * ```
+   *
+   * @param source URL path of the redirect endpoint
+   * @param target URL path of the endpoint
+   */
+  redirect(source: string, target: string): Binding {
+    return this.restServer.redirect(source, target);
+  }
+
+  /**
    * Set the OpenAPI specification that defines the REST API schema for this
    * application. All routes, parameter definitions and return types will be
    * defined in this way.

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -640,8 +640,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param source URL path of the redirect endpoint
    * @param target URL path of the endpoint
    */
-  redirect(source: string, target: string): Binding {
-    return this.route(new RedirectRoute(source, this._basePath + target));
+  redirect(source: string, target: string, statusCode?: number): Binding {
+    return this.route(
+      new RedirectRoute(source, this._basePath + target, statusCode),
+    );
   }
 
   // The route for static assets

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -42,6 +42,7 @@ import {
   RouteEntry,
   RoutingTable,
   StaticAssetsRoute,
+  RedirectRoute,
 } from './router';
 import {DefaultSequence, SequenceFunction, SequenceHandler} from './sequence';
 import {
@@ -627,6 +628,20 @@ export class RestServer extends Context implements Server, HttpServerLike {
         methodName,
       ),
     );
+  }
+
+  /**
+   * Redirect route by invoking a handler function.
+   *
+   * ```ts
+   * server.redirect('/explorer', '/explorer/');
+   * ```
+   *
+   * @param source URL path of the redirect endpoint
+   * @param target URL path of the endpoint
+   */
+  redirect(source: string, target: string): Binding {
+    return this.route(new RedirectRoute(source, this._basePath + target));
   }
 
   // The route for static assets

--- a/packages/rest/src/router/index.ts
+++ b/packages/rest/src/router/index.ts
@@ -9,6 +9,8 @@ export * from './base-route';
 export * from './controller-route';
 export * from './handler-route';
 export * from './static-assets-route';
+export * from './redirect-route';
+export * from './swagger-route';
 
 // routers
 export * from './rest-router';

--- a/packages/rest/src/router/index.ts
+++ b/packages/rest/src/router/index.ts
@@ -10,7 +10,6 @@ export * from './controller-route';
 export * from './handler-route';
 export * from './static-assets-route';
 export * from './redirect-route';
-export * from './swagger-route';
 
 // routers
 export * from './rest-router';

--- a/packages/rest/src/router/redirect-route.ts
+++ b/packages/rest/src/router/redirect-route.ts
@@ -37,6 +37,6 @@ export class RedirectRoute implements RouteEntry, ResolvedRoute {
   }
 
   describe(): string {
-    return `RedirectRoute.${this.sourcePath}.${this.targetPath}`;
+    return `RedirectRoute from "${this.sourcePath}" to "${this.targetPath}"`;
   }
 }

--- a/packages/rest/src/router/redirect-route.ts
+++ b/packages/rest/src/router/redirect-route.ts
@@ -1,0 +1,42 @@
+import {RouteEntry, ResolvedRoute} from '.';
+import {RequestContext} from '../request-context';
+import {OperationObject, SchemasObject} from '@loopback/openapi-v3-types';
+import {OperationArgs, OperationRetval, PathParameterValues} from '../types';
+
+export class RedirectRoute implements RouteEntry, ResolvedRoute {
+  // ResolvedRoute API
+  readonly pathParams: PathParameterValues = [];
+  readonly schemas: SchemasObject = {};
+
+  // RouteEntry implementation
+  readonly verb: string = 'get';
+  readonly path: string = this.sourcePath;
+  readonly spec: OperationObject = {
+    description: 'LoopBack Redirect route',
+    'x-visibility': 'undocumented',
+    responses: {},
+  };
+
+  constructor(
+    public readonly sourcePath: string,
+    public targetPath: string,
+    public statusCode: number = 303,
+  ) {
+    this.sourcePath = sourcePath;
+  }
+
+  async invokeHandler(
+    {response}: RequestContext,
+    args: OperationArgs,
+  ): Promise<OperationRetval> {
+    response.redirect(this.statusCode, this.targetPath);
+  }
+
+  updateBindings(requestContext: RequestContext) {
+    // no-op
+  }
+
+  describe(): string {
+    return `RedirectRoute.${this.sourcePath}.${this.targetPath}`;
+  }
+}


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Fixes #2022 



Implement RedirectRoute to redirect request route , beside SwaggerRoute that extend from RedirectRoute to redirect swagger ui including some refactoring of rest server to support the new swagger route instead of express middleware   
The implementation, including 12 (unit/integration/acceptance) tests.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
