### PR TITLE
fix: remove unused juggler import

### DIFF
--- a/packages/cli/generators/repository/templates/src/repositories/repository-crud-default-template.ts.ejs
+++ b/packages/cli/generators/repository/templates/src/repositories/repository-crud-default-template.ts.ejs
@@ -1,4 +1,4 @@
-import {<%= repositoryTypeClass %>, juggler} from '@loopback/repository';
+import {<%= repositoryTypeClass %>} from '@loopback/repository';
 import {<%= modelName %>} from '../models';
 import {<%= dataSourceClassName %>} from '../datasources';
 import {inject} from '@loopback/core';


### PR DESCRIPTION
VSCode complains about the unused `juggler` import in a `repository` generated from the CLI. `juggler` was used before as `juggler.DataSource` which was changed into `dataSourceClassName` (see [commit](https://github.com/strongloop/loopback-next/commit/26915e5762f9bad48010ee3506b671c8ebf43ac6#diff-0dddf087a0acac6ac658913bb40c3128L10) where it was changed).

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
