### PR TITLE
chore: add required config for greenkeeper integration

### DIFF
--- a/bin/update-greenkeeper-json.js
+++ b/bin/update-greenkeeper-json.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * This is an internal script to update `greenkeeper.json` with lerna packages.
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const Project = require('@lerna/project');
+
+async function updateGreenKeeperJson() {
+  const project = new Project(process.cwd());
+  const packages = await project.getPackages();
+  const rootPath = project.rootPath;
+  const packageJsonPaths = packages.map(p =>
+    path.relative(rootPath, p.manifestLocation),
+  );
+  const greenKeeperJson = {
+    groups: {
+      default: {
+        packages: ['package.json'],
+      },
+    },
+  };
+
+  for (const p of packageJsonPaths) {
+    greenKeeperJson.groups.default.packages.push(p);
+  }
+
+  if (process.argv[2] === '-f') {
+    const greenKeeperJsonFile = path.join(rootPath, 'greenkeeper.json');
+    writeJsonFile(greenKeeperJsonFile, greenKeeperJson);
+  } else {
+    console.log(JSON.stringify(greenKeeperJson, null, 2));
+  }
+}
+
+if (require.main === module) updateGreenKeeperJson();
+
+function writeJsonFile(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  console.log('%s has been updated.', filePath);
+}

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,0 +1,37 @@
+{
+  "groups": {
+    "default": {
+      "packages": [
+        "package.json",
+        "benchmark/package.json",
+        "docs/package.json",
+        "examples/hello-world/package.json",
+        "examples/log-extension/package.json",
+        "examples/rpc-server/package.json",
+        "examples/soap-calculator/package.json",
+        "examples/todo-list/package.json",
+        "examples/todo/package.json",
+        "packages/authentication/package.json",
+        "packages/boot/package.json",
+        "packages/build/package.json",
+        "packages/cli/package.json",
+        "packages/context/package.json",
+        "packages/core/package.json",
+        "packages/http-caching-proxy/package.json",
+        "packages/http-server/package.json",
+        "packages/metadata/package.json",
+        "packages/openapi-spec-builder/package.json",
+        "packages/openapi-v3-types/package.json",
+        "packages/openapi-v3/package.json",
+        "packages/repository-json-schema/package.json",
+        "packages/repository/package.json",
+        "packages/rest-explorer/package.json",
+        "packages/rest/package.json",
+        "packages/service-proxy/package.json",
+        "packages/testlab/package.json",
+        "packages/tslint-config/package.json",
+        "sandbox/example/package.json"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "prerelease": "npm run build:full && npm run mocha && npm run lint",
     "release": "lerna version && lerna publish from-git --yes",
     "update-template-deps": "node bin/update-template-deps -f",
+    "update-greenkeeper-json": "node bin/update-greenkeeper-json -f",
     "sync-dev-deps": "node bin/sync-dev-deps",
-    "version": "npm run update-template-deps && npm run apidocs",
+    "version": "npm run update-template-deps && npm run update-greenkeeper-json && npm run apidocs",
     "outdated": "npm outdated --depth 0 && lerna exec --no-bail \"npm outdated --depth 0\"",
     "apidocs": "node bin/run-lerna run build:apidocs",
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
@@ -62,6 +63,25 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
+  "greenkeeper": {
+    "commitMessages": {
+      "initialBadge": "docs: add Greenkeeper badge",
+      "initialDependencies": "chore: update dependencies",
+      "initialBranches": "chore: whitelist greenkeeper branches",
+      "dependencyUpdate": "chore: update ${dependency} to version ${version}",
+      "devDependencyUpdate": "chore: update ${dependency} to version ${version}",
+      "dependencyPin": "chore: pin ${dependency} to ${oldVersion}",
+      "devDependencyPin": "chore: pin ${dependency} to ${oldVersion}"
+    },
+    "prTitles": {
+      "initialPR": "[greenkeeper] update dependencies to enable Greenkeeper",
+      "initialPrBadge": "[greenkeeper] add badge to enable Greenkeeper",
+      "initialPrBadgeOnly": "[greenkeeper] add Greenkeeper badge",
+      "initialSubgroupPR": "[greenkeeper] update dependencies for ${group}",
+      "basicPR": "[greenkeeper] update ${dependency} to the latest",
+      "groupPR": "[greenkeeper] update ${dependency} in group ${group} to the latest"
     }
   }
 }


### PR DESCRIPTION
Customize Greenkeeper config per https://greenkeeper.io/docs.html#monorepo

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
