### PR TITLE
fix(rest): remove trailing slash for routing match

### DIFF
--- a/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
@@ -6,19 +6,19 @@
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {get, getControllerSpec, param} from '@loopback/openapi-v3';
 import {
-  ShotRequestOptions,
   expect,
+  ShotRequestOptions,
   stubExpressContext,
 } from '@loopback/testlab';
+import * as HttpErrors from 'http-errors';
 import {
   ControllerRoute,
-  Request,
-  RoutingTable,
-  RestRouter,
   RegExpRouter,
+  Request,
+  RestRouter,
+  RoutingTable,
   TrieRouter,
 } from '../../..';
-import * as HttpErrors from 'http-errors';
 
 describe('RoutingTable', () => {
   it('joins basePath and path', () => {
@@ -220,16 +220,22 @@ function runTestsWithRouter(router: RestRouter) {
       async getOrderById(@param.path.number('id') id: number): Promise<object> {
         return {id};
       }
-      @get('/orders')
-      async findOrders(): Promise<object[]> {
-        return [];
-      }
       // A path that overlaps with `/orders/{id}`. Please note a different var
       // name is used - `{orderId}`
       @get('/orders/{orderId}/shipments')
       async getShipmentsForOrder(
         @param.path.number('orderId') id: number,
       ): Promise<object> {
+        return [];
+      }
+      // With trailing `/`
+      @get('/orders/')
+      async findOrders(): Promise<object[]> {
+        return [];
+      }
+      // Without trailing `/`
+      @get('/pendingOrders')
+      async findPendingOrders(): Promise<object[]> {
         return [];
       }
     }
@@ -250,6 +256,9 @@ function runTestsWithRouter(router: RestRouter) {
     findAndCheckRoute('/orders/1', '/orders/{id}');
     findAndCheckRoute('/orders/1/shipments', '/orders/{orderId}/shipments');
     findAndCheckRoute('/orders', '/orders');
+    findAndCheckRoute('/orders/', '/orders');
+    findAndCheckRoute('/pendingOrders', '/pendingOrders');
+    findAndCheckRoute('/pendingOrders/', '/pendingOrders');
   });
 
   it('throws if router is not found', () => {

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -31,7 +31,7 @@ import {
 import {HttpProtocol} from '@loopback/http-server';
 import * as https from 'https';
 import {ErrorWriterOptions} from 'strong-error-handler';
-import {RestRouter} from './router';
+import {RestRouter, RestRouterOptions} from './router';
 import {RequestBodyParser, BodyParser} from './body-parsers';
 
 /**
@@ -79,6 +79,10 @@ export namespace RestBindings {
    * Internal binding key for rest router
    */
   export const ROUTER = BindingKey.create<RestRouter>('rest.router');
+
+  export const ROUTER_OPTIONS = BindingKey.create<RestRouterOptions>(
+    'rest.router.options',
+  );
 
   /**
    * Binding key for setting and injecting Reject action's error handling

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -42,6 +42,7 @@ import {
   RouteEntry,
   RoutingTable,
   StaticAssetsRoute,
+  RestRouterOptions,
 } from './router';
 import {DefaultSequence, SequenceFunction, SequenceHandler} from './sequence';
 import {
@@ -194,6 +195,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
       this.sequence(config.sequence);
     }
 
+    if (config.router) {
+      this.bind(RestBindings.ROUTER_OPTIONS).to(config.router);
+    }
+
     this.basePath(config.basePath);
 
     this.bind(RestBindings.BASE_PATH).toDynamicValue(() => this._basePath);
@@ -204,6 +209,9 @@ export class RestServer extends Context implements Server, HttpServerLike {
     if (this._expressApp) return;
     this._expressApp = express();
     this._expressApp.set('query parser', 'extended');
+    if (this.config.router && typeof this.config.router.strict === 'boolean') {
+      this._expressApp.set('strict routing', this.config.router.strict);
+    }
     this._requestHandler = this._expressApp;
 
     // Allow CORS support for all endpoints so that users
@@ -937,6 +945,7 @@ export interface RestServerOptions {
   openApiSpec?: OpenApiSpecOptions;
   apiExplorer?: ApiExplorerOptions;
   sequence?: Constructor<SequenceHandler>;
+  router?: RestRouterOptions;
 }
 
 /**

--- a/packages/rest/src/router/regexp-router.ts
+++ b/packages/rest/src/router/regexp-router.ts
@@ -3,13 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {RouteEntry, createResolvedRoute, ResolvedRoute} from './route-entry';
-import {Request, PathParameterValues} from '../types';
+import {inject} from '@loopback/context';
 import {inspect} from 'util';
-import {compareRoute} from './route-sort';
-import pathToRegExp = require('path-to-regexp');
-import {BaseRouter} from './router-base';
+import {RestBindings} from '../keys';
+import {PathParameterValues, Request} from '../types';
 import {toExpressPath} from './openapi-path';
+import {RestRouterOptions} from './rest-router';
+import {createResolvedRoute, ResolvedRoute, RouteEntry} from './route-entry';
+import {compareRoute} from './route-sort';
+import {BaseRouter} from './router-base';
+import pathToRegExp = require('path-to-regexp');
 
 const debug = require('debug')('loopback:rest:router:regexp');
 
@@ -36,25 +39,38 @@ export class RegExpRouter extends BaseRouter {
     }
   }
 
+  constructor(
+    @inject(RestBindings.ROUTER_OPTIONS, {optional: true})
+    options?: RestRouterOptions,
+  ) {
+    super(options);
+  }
+
   protected addRouteWithPathVars(route: RouteEntry) {
     const path = toExpressPath(route.path);
     const keys: pathToRegExp.Key[] = [];
-    const regexp = pathToRegExp(path, keys, {strict: false, end: true});
+    const regexp = pathToRegExp(path, keys, {
+      strict: this.options.strict,
+      end: true,
+    });
     const entry: RegExpRouteEntry = Object.assign(route, {keys, regexp});
     this.routes.push(entry);
     this._sorted = false;
   }
 
-  protected findRouteWithPathVars(request: Request): ResolvedRoute | undefined {
+  protected findRouteWithPathVars(
+    verb: string,
+    path: string,
+  ): ResolvedRoute | undefined {
     this._sort();
     for (const r of this.routes) {
       debug('trying endpoint %s', inspect(r, {depth: 5}));
-      if (r.verb !== request.method.toLowerCase()) {
+      if (r.verb !== verb.toLowerCase()) {
         debug(' -> verb mismatch');
         continue;
       }
 
-      const match = r.regexp.exec(request.path);
+      const match = r.regexp.exec(path);
       if (!match) {
         debug(' -> path mismatch');
         continue;

--- a/packages/rest/src/router/rest-router.ts
+++ b/packages/rest/src/router/rest-router.ts
@@ -29,3 +29,12 @@ export interface RestRouter {
    */
   list(): RouteEntry[];
 }
+
+export type RestRouterOptions = {
+  /**
+   * When true it allows an optional trailing slash to match. (default: false)
+   *
+   * See `strict routing` at http://expressjs.com/en/4x/api.html#app
+   */
+  strict?: boolean;
+};

--- a/packages/rest/src/router/trie-router.ts
+++ b/packages/rest/src/router/trie-router.ts
@@ -3,11 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {RouteEntry, createResolvedRoute} from './route-entry';
-import {Trie} from './trie';
-import {Request} from '../types';
+import {inject} from '@loopback/context';
 import {inspect} from 'util';
+import {RestBindings} from '../keys';
+import {Request} from '../types';
+import {RestRouterOptions} from './rest-router';
+import {createResolvedRoute, RouteEntry} from './route-entry';
 import {BaseRouter} from './router-base';
+import {Trie} from './trie';
 
 const debug = require('debug')('loopback:rest:router:trie');
 
@@ -17,16 +20,23 @@ const debug = require('debug')('loopback:rest:router:trie');
 export class TrieRouter extends BaseRouter {
   private trie = new Trie<RouteEntry>();
 
+  constructor(
+    @inject(RestBindings.ROUTER_OPTIONS, {optional: true})
+    options?: RestRouterOptions,
+  ) {
+    super(options);
+  }
+
   protected addRouteWithPathVars(route: RouteEntry) {
     // Add the route to the trie
     const key = this.getKeyForRoute(route);
     this.trie.create(key, route);
   }
 
-  protected findRouteWithPathVars(request: Request) {
-    const path = this.getKeyForRequest(request);
+  protected findRouteWithPathVars(verb: string, path: string) {
+    const key = this.getKey(verb, path);
 
-    const found = this.trie.match(path);
+    const found = this.trie.match(key);
     debug('Route matched: %j', found);
 
     if (found) {


### PR DESCRIPTION
Handle trailing slash for urls.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
