### PR TITLE
feat(repository): created hasManyThrough following convention pattern

### DIFF
--- a/packages/repository/src/relations/has-many-through/has-many-through-repository.factory.ts
+++ b/packages/repository/src/relations/has-many-through/has-many-through-repository.factory.ts
@@ -1,0 +1,111 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as debugFactory from 'debug';
+import {camelCase} from 'lodash';
+import {DataObject} from '../../common-types';
+import {InvalidRelationError} from '../../errors';
+import {Entity} from '../../model';
+import {EntityCrudRepository} from '../../repositories/repository';
+import {isTypeResolver} from '../../type-resolver';
+import {Getter, HasManyThroughDefinition} from '../relation.types';
+import {
+  DefaultHasManyThroughRepository,
+  HasManyThroughRepository,
+} from './has-many-through.repository';
+
+const debug = debugFactory(
+  'loopback:repository:has-many-through-repository-factory',
+);
+
+export type HasManyThroughRepositoryFactory<
+  Target extends Entity,
+  ForeignKeyType
+> = (fkValue: ForeignKeyType) => HasManyThroughRepository<Target>;
+
+/**
+ * Enforces a constraint on a repository based on a relationship contract
+ * between models. For example, if a Customer model is related to an Order model
+ * via a HasManyThrough relation, then, the relational repository returned by the
+ * factory function would be constrained by a Customer model instance's id(s).
+ *
+ * @param relationMetadata The relation metadata used to describe the
+ * relationship and determine how to apply the constraint.
+ * @param targetRepositoryGetter The repository which represents the target model of a
+ * relation attached to a datasource.
+ * @returns The factory function which accepts a foreign key value to constrain
+ * the given target repository
+ */
+export function createHasManyThroughRepositoryFactory<
+  Target extends Entity,
+  TargetID,
+  ForeignKeyType
+>(
+  relationMetadata: HasManyThroughDefinition,
+  targetRepositoryGetter: Getter<EntityCrudRepository<Target, TargetID>>,
+): HasManyThroughRepositoryFactory<Target, ForeignKeyType> {
+  const meta = resolveHasManyThroughMetadata(relationMetadata);
+  debug('Resolved HasManyThrough relation metadata: %o', meta);
+  return function(fkValue: ForeignKeyType) {
+    // tslint:disable-next-line:no-any
+    const constraint: any = {[meta.keyTo]: fkValue};
+    return new DefaultHasManyThroughRepository<
+      Target,
+      TargetID,
+      EntityCrudRepository<Target, TargetID>
+    >(targetRepositoryGetter, constraint as DataObject<Target>);
+  };
+}
+
+type HasManyThroughResolvedDefinition = HasManyThroughDefinition & {
+  keyTo: string;
+};
+
+/**
+ * Resolves given hasManyThrough metadata if target is specified to be a resolver.
+ * Mainly used to infer what the `keyTo` property should be from the target's
+ * belongsTo metadata
+ * @param relationMeta hasManyThrough metadata to resolve
+ */
+function resolveHasManyThroughMetadata(
+  relationMeta: HasManyThroughDefinition,
+): HasManyThroughResolvedDefinition {
+  if (!isTypeResolver(relationMeta.target)) {
+    const reason = 'target must be a type resolver';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  if (relationMeta.keyTo) {
+    // The explict cast is needed because of a limitation of type inference
+    return relationMeta as HasManyThroughResolvedDefinition;
+  }
+
+  const sourceModel = relationMeta.source;
+  if (!sourceModel || !sourceModel.modelName) {
+    const reason = 'source model must be defined';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const targetModel = relationMeta.target();
+  debug(
+    'Resolved model %s from given metadata: %o',
+    targetModel.modelName,
+    targetModel,
+  );
+  const defaultFkName = camelCase(sourceModel.modelName + '_id');
+  const hasDefaultFkProperty =
+    targetModel.definition &&
+    targetModel.definition.properties &&
+    targetModel.definition.properties[defaultFkName];
+
+  if (!hasDefaultFkProperty) {
+    const reason = `target model ${
+      targetModel.name
+    } is missing definition of foreign key ${defaultFkName}`;
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  return Object.assign(relationMeta, {keyTo: defaultFkName});
+}

--- a/packages/repository/src/relations/has-many-through/has-many-through.decorator.ts
+++ b/packages/repository/src/relations/has-many-through/has-many-through.decorator.ts
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity, EntityResolver} from '../../model';
+import {relation} from '../relation.decorator';
+import {HasManyThroughDefinition, RelationType} from '../relation.types';
+
+/**
+ * Decorator for hasManyThrough
+ * Calls property.array decorator underneath the hood and infers foreign key
+ * name from target model name unless explicitly specified
+ * @param targetResolver Target model for hasManyThrough relation
+ * @param definition Optional metadata for setting up hasManyThrough relation
+ * @returns {(target:any, key:string)}
+ */
+export function hasManyThrough<T extends Entity>(
+  targetResolver: EntityResolver<T>,
+  definition?: Partial<HasManyThroughDefinition>,
+) {
+  return function(decoratedTarget: Object, key: string) {
+    const meta: HasManyThroughDefinition = Object.assign(
+      // default values, can be customized by the caller
+      {name: key},
+      // properties provided by the caller
+      definition,
+      // properties enforced by the decorator
+      {
+        type: RelationType.hasManyThrough,
+        source: decoratedTarget.constructor,
+        target: targetResolver,
+      },
+    );
+    relation(meta)(decoratedTarget, key);
+  };
+}

--- a/packages/repository/src/relations/has-many-through/has-many-through.decorator.ts
+++ b/packages/repository/src/relations/has-many-through/has-many-through.decorator.ts
@@ -17,6 +17,7 @@ import {HasManyThroughDefinition, RelationType} from '../relation.types';
  */
 export function hasManyThrough<T extends Entity>(
   targetResolver: EntityResolver<T>,
+  throughResolver: EntityResolver<T>,
   definition?: Partial<HasManyThroughDefinition>,
 ) {
   return function(decoratedTarget: Object, key: string) {
@@ -30,6 +31,7 @@ export function hasManyThrough<T extends Entity>(
         type: RelationType.hasManyThrough,
         source: decoratedTarget.constructor,
         target: targetResolver,
+        through: throughResolver,
       },
     );
     relation(meta)(decoratedTarget, key);

--- a/packages/repository/src/relations/has-many-through/has-many-through.repository.ts
+++ b/packages/repository/src/relations/has-many-through/has-many-through.repository.ts
@@ -1,0 +1,117 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Getter} from '@loopback/context';
+import {Count, DataObject, Options} from '../../common-types';
+import {Entity} from '../../model';
+import {Filter, Where} from '../../query';
+import {
+  constrainDataObject,
+  constrainFilter,
+  constrainWhere,
+} from '../../repositories/constraint-utils';
+import {EntityCrudRepository} from '../../repositories/repository';
+
+/**
+ * CRUD operations for a target repository of a HasManyThrough relation
+ */
+export interface HasManyThroughRepository<Target extends Entity> {
+  /**
+   * Create a target model instance
+   * @param targetModelData The target model data
+   * @param options Options for the operation
+   * @returns A promise which resolves to the newly created target model instance
+   */
+  create(
+    targetModelData: DataObject<Target>,
+    options?: Options,
+  ): Promise<Target>;
+  /**
+   * Find target model instance(s)
+   * @param filter A filter object for where, order, limit, etc.
+   * @param options Options for the operation
+   * @returns A promise which resolves with the found target instance(s)
+   */
+  find(filter?: Filter<Target>, options?: Options): Promise<Target[]>;
+  /**
+   * Delete multiple target model instances
+   * @param where Instances within the where scope are deleted
+   * @param options
+   * @returns A promise which resolves the deleted target model instances
+   */
+  delete(where?: Where<Target>, options?: Options): Promise<Count>;
+  /**
+   * Patch multiple target model instances
+   * @param dataObject The fields and their new values to patch
+   * @param where Instances within the where scope are patched
+   * @param options
+   * @returns A promise which resolves the patched target model instances
+   */
+  patch(
+    dataObject: DataObject<Target>,
+    where?: Where<Target>,
+    options?: Options,
+  ): Promise<Count>;
+}
+
+export class DefaultHasManyThroughRepository<
+  TargetEntity extends Entity,
+  TargetID,
+  TargetRepository extends EntityCrudRepository<TargetEntity, TargetID>
+> implements HasManyThroughRepository<TargetEntity> {
+  /**
+   * Constructor of DefaultHasManyThroughEntityCrudRepository
+   * @param getTargetRepository the getter of the related target model repository instance
+   * @param constraint the key value pair representing foreign key name to constrain
+   * the target repository instance
+   */
+  constructor(
+    public getTargetRepository: Getter<TargetRepository>,
+    public constraint: DataObject<TargetEntity>,
+  ) {}
+
+  async create(
+    targetModelData: DataObject<TargetEntity>,
+    options?: Options,
+  ): Promise<TargetEntity> {
+    const targetRepository = await this.getTargetRepository();
+    return targetRepository.create(
+      constrainDataObject(targetModelData, this.constraint),
+      options,
+    );
+  }
+
+  async find(
+    filter?: Filter<TargetEntity>,
+    options?: Options,
+  ): Promise<TargetEntity[]> {
+    const targetRepository = await this.getTargetRepository();
+    return targetRepository.find(
+      constrainFilter(filter, this.constraint),
+      options,
+    );
+  }
+
+  async delete(where?: Where<TargetEntity>, options?: Options): Promise<Count> {
+    const targetRepository = await this.getTargetRepository();
+    return targetRepository.deleteAll(
+      constrainWhere(where, this.constraint as Where<TargetEntity>),
+      options,
+    );
+  }
+
+  async patch(
+    dataObject: DataObject<TargetEntity>,
+    where?: Where<TargetEntity>,
+    options?: Options,
+  ): Promise<Count> {
+    const targetRepository = await this.getTargetRepository();
+    return targetRepository.updateAll(
+      constrainDataObject(dataObject, this.constraint),
+      constrainWhere(where, this.constraint as Where<TargetEntity>),
+      options,
+    );
+  }
+}

--- a/packages/repository/src/relations/has-many-through/has-many-through.repository.ts
+++ b/packages/repository/src/relations/has-many-through/has-many-through.repository.ts
@@ -69,7 +69,7 @@ export class DefaultHasManyThroughRepository<
    */
   constructor(
     public getTargetRepository: Getter<TargetRepository>,
-    public constraint: DataObject<TargetEntity>,
+    public getConstraint: () => Promise<DataObject<TargetEntity>>,
   ) {}
 
   async create(
@@ -78,7 +78,7 @@ export class DefaultHasManyThroughRepository<
   ): Promise<TargetEntity> {
     const targetRepository = await this.getTargetRepository();
     return targetRepository.create(
-      constrainDataObject(targetModelData, this.constraint),
+      constrainDataObject(targetModelData, await this.getConstraint()),
       options,
     );
   }
@@ -89,7 +89,7 @@ export class DefaultHasManyThroughRepository<
   ): Promise<TargetEntity[]> {
     const targetRepository = await this.getTargetRepository();
     return targetRepository.find(
-      constrainFilter(filter, this.constraint),
+      constrainFilter(filter, await this.getConstraint()),
       options,
     );
   }
@@ -97,7 +97,9 @@ export class DefaultHasManyThroughRepository<
   async delete(where?: Where<TargetEntity>, options?: Options): Promise<Count> {
     const targetRepository = await this.getTargetRepository();
     return targetRepository.deleteAll(
-      constrainWhere(where, this.constraint as Where<TargetEntity>),
+      constrainWhere(where, (await this.getConstraint()) as Where<
+        TargetEntity
+      >),
       options,
     );
   }
@@ -109,8 +111,10 @@ export class DefaultHasManyThroughRepository<
   ): Promise<Count> {
     const targetRepository = await this.getTargetRepository();
     return targetRepository.updateAll(
-      constrainDataObject(dataObject, this.constraint),
-      constrainWhere(where, this.constraint as Where<TargetEntity>),
+      constrainDataObject(dataObject, await this.getConstraint()),
+      constrainWhere(where, (await this.getConstraint()) as Where<
+        TargetEntity
+      >),
       options,
     );
   }

--- a/packages/repository/src/relations/has-many-through/index.ts
+++ b/packages/repository/src/relations/has-many-through/index.ts
@@ -1,0 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './has-many-through-repository.factory';
+export * from './has-many-through.decorator';
+export * from './has-many-through.repository';

--- a/packages/repository/src/relations/index.ts
+++ b/packages/repository/src/relations/index.ts
@@ -3,8 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './relation.types';
-export * from './relation.decorator';
 export * from './belongs-to';
 export * from './has-many';
+export * from './has-many-through';
 export * from './has-one';
+export * from './relation.decorator';
+export * from './relation.types';

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -8,12 +8,13 @@ import {TypeResolver} from '../type-resolver';
 
 export enum RelationType {
   belongsTo = 'belongsTo',
-  hasOne = 'hasOne',
-  hasMany = 'hasMany',
-  embedsOne = 'embedsOne',
   embedsMany = 'embedsMany',
-  referencesOne = 'referencesOne',
+  embedsOne = 'embedsOne',
+  hasMany = 'hasMany',
+  hasManyThrough = 'hasManyThrough',
+  hasOne = 'hasOne',
   referencesMany = 'referencesMany',
+  referencesOne = 'referencesOne',
 }
 
 export interface RelationDefinitionBase {
@@ -56,6 +57,19 @@ export interface HasManyDefinition extends RelationDefinitionBase {
   keyTo?: string;
 }
 
+export interface HasManyThroughDefinition extends RelationDefinitionBase {
+  type: RelationType.hasManyThrough;
+
+  /**
+   * The foreign key used by the target model.
+   *
+   * E.g. when a Customer has many Order instances, then keyTo is "customerId".
+   * Note that "customerId" is the default FK assumed by the framework, users
+   * can provide a custom FK name by setting "keyTo".
+   */
+  keyTo?: string;
+}
+
 export interface BelongsToDefinition extends RelationDefinitionBase {
   type: RelationType.belongsTo;
 
@@ -87,8 +101,9 @@ export interface HasOneDefinition extends RelationDefinitionBase {
  * A union type describing all possible Relation metadata objects.
  */
 export type RelationMetadata =
-  | HasManyDefinition
   | BelongsToDefinition
+  | HasManyDefinition
+  | HasManyThroughDefinition
   | HasOneDefinition
   // TODO(bajtos) add other relation types and remove RelationDefinitionBase once
   // all relation types are covered.

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -61,6 +61,13 @@ export interface HasManyThroughDefinition extends RelationDefinitionBase {
   type: RelationType.hasManyThrough;
 
   /**
+   * The through model of this relation.
+   *
+   * E.g. when a Customer has many Order instances and a Seller has many Order instances, then Order is through.
+   */
+  through: TypeResolver<Entity, typeof Entity>;
+
+  /**
    * The foreign key used by the target model.
    *
    * E.g. when a Customer has many Order instances, then keyTo is "customerId".
@@ -68,6 +75,8 @@ export interface HasManyThroughDefinition extends RelationDefinitionBase {
    * can provide a custom FK name by setting "keyTo".
    */
   keyTo?: string;
+
+  targetFkName?: string;
 }
 
 export interface BelongsToDefinition extends RelationDefinitionBase {

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -258,15 +258,19 @@ export class DefaultCrudRepository<T extends Entity, ID>
    * @param targetRepo Target repository instance
    */
   protected _createHasManyThroughRepositoryFactoryFor<
+    Through extends Entity,
+    ThroughID,
     Target extends Entity,
     TargetID,
     ForeignKeyType
   >(
     relationName: string,
+    throughRepoGetter: Getter<EntityCrudRepository<Through, ThroughID>>,
     targetRepoGetter: Getter<EntityCrudRepository<Target, TargetID>>,
   ): HasManyThroughRepositoryFactory<Target, ForeignKeyType> {
     return this.createHasManyThroughRepositoryFactoryFor(
       relationName,
+      throughRepoGetter,
       targetRepoGetter,
     );
   }
@@ -298,19 +302,24 @@ export class DefaultCrudRepository<T extends Entity, ID>
    * @param targetRepo Target repository instance
    */
   protected createHasManyThroughRepositoryFactoryFor<
+    Through extends Entity,
+    ThroughID,
     Target extends Entity,
     TargetID,
     ForeignKeyType
   >(
     relationName: string,
+    throughRepoGetter: Getter<EntityCrudRepository<Through, ThroughID>>,
     targetRepoGetter: Getter<EntityCrudRepository<Target, TargetID>>,
   ): HasManyThroughRepositoryFactory<Target, ForeignKeyType> {
     const meta = this.entityClass.definition.relations[relationName];
     return createHasManyThroughRepositoryFactory<
+      Through,
+      ThroughID,
       Target,
       TargetID,
       ForeignKeyType
-    >(meta as HasManyThroughDefinition, targetRepoGetter);
+    >(meta as HasManyThroughDefinition, throughRepoGetter, targetRepoGetter);
   }
 
   protected _createHasOneRepositoryFactoryFor<


### PR DESCRIPTION
I created some boilerplate for the hasThroughMany relation using the hasMany relation. Currently, this contains the identical functionality as the hasMany relation.

See also #2264

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
