### PR TITLE
fix(docs): broken link in Crafting in LB

### DIFF
--- a/docs/site/Crafting-LoopBack-4.md
+++ b/docs/site/Crafting-LoopBack-4.md
@@ -473,7 +473,7 @@ There are several key pillars to make extensibility a reality for LoopBack 4.
 - [Context](Context.md), the IoC container to manage services
 - [Dependency injection](Dependency-injection.md) to facilitate composition
 - [Decorators](Decorators.md) to supply metadata using annotations
-- [Component](Component.md) as the packaging model to bundle extensions
+- [Component](Using-components.md) as the packaging model to bundle extensions
 
 Please check out [Extending LoopBack 4](Extending-LoopBack-4.md).
 


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/2020

This PR is a quick fix in the `Crafting in LoopBack` page for the broken link. 
As suggested by @bajtos, we'll create a dedicated Component page as a longer term fix. 
 See https://github.com/strongloop/loopback-next/issues/2020#issuecomment-461822363.
 