### PR TITLE
fix(rest): only return matched trie nodes with values

### DIFF
--- a/packages/rest/src/router/trie.ts
+++ b/packages/rest/src/router/trie.ts
@@ -161,7 +161,7 @@ function search<T>(
   // There might be multiple matches, such as `/users/{id}` and `/users/{userId}`
   for (const child of children) {
     const result = search(keys, index + 1, params, child.node);
-    if (result) {
+    if (result && isNodeWithValue(result.node)) {
       Object.assign(params, child.params);
       return result;
     }


### PR DESCRIPTION
Fixes #2188 

This is a spin-off from #2355.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
