### PR TITLE
chore: ignore @types/node upgrade by greenkeeper

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -33,5 +33,6 @@
         "sandbox/example/package.json"
       ]
     }
-  }
+  },
+  "ignore": ["@types/node"]
 }


### PR DESCRIPTION

Add `@types/node` to `ignore` list so that Greenkeeper skips PRs such as #2377. 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
