### PR TITLE
[WIP] fix: set minimum to 1 for filter.limit

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {getFilterSchemaFor} from '../..';
 import {Entity, model, property} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
+import {getFilterSchemaFor} from '../..';
 
 describe('filterSchema', () => {
   @model({
     name: 'my-user-model',
   })
   class MyUserModel extends Entity {
-    @property() id: string;
+    @property({id: true}) id: string;
 
     @property() age: number;
   }
@@ -33,7 +33,7 @@ describe('filterSchema', () => {
           },
         },
         offset: {type: 'integer', minimum: 0},
-        limit: {type: 'integer', minimum: 0},
+        limit: {type: 'integer', minimum: 1, examples: [100]},
         skip: {type: 'integer', minimum: 0},
         order: {type: 'array', items: {type: 'string'}},
       },

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Model, model, getModelRelations} from '@loopback/repository';
+import {getModelRelations, Model, model} from '@loopback/repository';
 import {JSONSchema6 as JsonSchema} from 'json-schema';
 
 @model({settings: {strict: false}})
@@ -34,7 +34,8 @@ export function getFilterJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
 
       limit: {
         type: 'integer',
-        minimum: 0,
+        minimum: 1,
+        examples: [100],
       },
 
       skip: {


### PR DESCRIPTION
API Explorer proposes the following input for `filter` based on the json schema:

```json
{
  "where": {},
  "fields": {
    "id": true,
    "title": true,
    "desc": true,
    "isComplete": true,
    "remindAtAddress": true,
    "remindAtGeo": true
  },
  "offset": 0,
  "limit": 0,
  "skip": 0,
  "order": [
    "string"
  ]
}
``` 

Please note `limit` and `order` contain invalid values.

This PR changes `limit` to be `>=1`. But the explorer does not honor it. We'll continue to investigate how to instruct the explorer to use examples or other constraints from the OpenAPI spec.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
