### PR TITLE
chore: update licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: loopback-next
 This project is licensed under the MIT License, full text below.
 

--- a/benchmark/LICENSE
+++ b/benchmark/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/benchmark
 This project is licensed under the MIT License, full text below.
 

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -24,7 +24,7 @@
   "repository": {
     "type": "git"
   },
-  "author": "",
+  "author": "IBM Corp.",
   "license": "MIT",
   "files": [
     "README.md",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,7 @@
   "version": "1.7.3",
   "description": "Documentation for LoopBack 4",
   "homepage": "https://github.com/strongloop/loopback-next/tree/master/docs",
-  "author": {
-    "name": "IBM"
-  },
+  "author": "IBM Corp.",
   "engines": {
     "node": ">=8.9"
   },

--- a/examples/hello-world/LICENSE
+++ b/examples/hello-world/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/example-hello-world
 This project is licensed under the MIT License, full text below.
 

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=8.9"
   },
+  "author": "IBM Corp.",
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build:apidocs": "lb-apidocs",

--- a/examples/log-extension/LICENSE
+++ b/examples/log-extension/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) Author 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/example-log-extension
 This project is licensed under the MIT License, full text below.
 

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=8.9"
   },
+  "author": "IBM Corp.",
   "scripts": {
     "build:apidocs": "lb-apidocs",
     "build": "lb-tsc es2017 --outDir dist",

--- a/examples/rpc-server/LICENSE
+++ b/examples/rpc-server/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/example-rpc-server
 This project is licensed under the MIT License, full text below.
 

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -35,7 +35,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "",
+  "author": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
     "@loopback/context": "^1.5.1",

--- a/examples/soap-calculator/LICENSE
+++ b/examples/soap-calculator/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/example-soap-calculator
 This project is licensed under the MIT License, full text below.
 

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -13,6 +13,7 @@
   "engines": {
     "node": ">=8"
   },
+  "author": "IBM Corp.",
   "scripts": {
     "build:apidocs": "lb-apidocs",
     "build": "lb-tsc es2017 --outDir dist",

--- a/examples/todo-list/LICENSE
+++ b/examples/todo-list/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/example-todo-list
 This project is licensed under the MIT License, full text below.
 

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=8.9"
   },
+  "author": "IBM Corp.",
   "scripts": {
     "build:apidocs": "lb-apidocs",
     "build": "lb-tsc es2017 --outDir dist",

--- a/examples/todo/LICENSE
+++ b/examples/todo/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/example-todo
 This project is licensed under the MIT License, full text below.
 

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=8.9"
   },
+  "author": "IBM Corp.",
   "scripts": {
     "build:apidocs": "lb-apidocs",
     "build": "lb-tsc es2017 --outDir dist",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "node": ">=8.9"
   },
+  "author": "IBM Corp.",
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^7.5.0",

--- a/packages/authentication/LICENSE
+++ b/packages/authentication/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/authentication
 This project is licensed under the MIT License, full text below.
 

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -16,7 +16,7 @@
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-authentication*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/boot/LICENSE
+++ b/packages/boot/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/boot
 This project is licensed under the MIT License, full text below.
 

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -19,7 +19,7 @@
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-boot*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/boot/src/__tests__/fixtures/package.json
+++ b/packages/boot/src/__tests__/fixtures/package.json
@@ -14,6 +14,6 @@
   "repository": {
     "type": "git"
   },
-  "author": "",
-  "license": ""
+  "author": "IBM Corp.",
+  "license": "MIT"
 }

--- a/packages/build/LICENSE
+++ b/packages/build/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/build
 This project is licensed under the MIT License, full text below.
 

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=8.9"
   },
+  "author": "IBM Corp.",
   "main": "index.js",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",

--- a/packages/build/test/integration/fixtures/package.json
+++ b/packages/build/test/integration/fixtures/package.json
@@ -5,6 +5,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
+  "author": "IBM Corp.",
   "license": "MIT"
 }

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/cli
 This project is licensed under the MIT License, full text below.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,9 +3,7 @@
   "version": "1.6.0",
   "description": "Yeoman generator for LoopBack 4",
   "homepage": "https://github.com/strongloop/loopback-next/tree/master/packages/cli",
-  "author": {
-    "name": "IBM"
-  },
+  "author": "IBM Corp.",
   "engines": {
     "node": ">=8.9"
   },

--- a/packages/context/LICENSE
+++ b/packages/context/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/context
 This project is licensed under the MIT License, full text below.
 

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -15,7 +15,7 @@
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-context*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/core
 This project is licensed under the MIT License, full text below.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-core*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/http-caching-proxy/LICENSE
+++ b/packages/http-caching-proxy/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/http-caching-proxy
 This project is licensed under the MIT License, full text below.
 

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -13,7 +13,7 @@
     "test": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "verify": "npm pack && tar xf loopback-caching-proxy*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/http-server/LICENSE
+++ b/packages/http-server/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
-Node module: @loopback/service-proxy
+Node module: @loopback/http-server
 This project is licensed under the MIT License, full text below.
 
 --------

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -13,7 +13,7 @@
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-http-server*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/metadata/LICENSE
+++ b/packages/metadata/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/metadata
 This project is licensed under the MIT License, full text below.
 

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -15,7 +15,7 @@
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-metadata*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/openapi-spec-builder/LICENSE
+++ b/packages/openapi-spec-builder/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/openapi-spec-builder
 This project is licensed under the MIT License, full text below.
 

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -11,7 +11,7 @@
     "clean": "lb-clean loopback-openapi-spec-builder*.tgz dist package api-docs",
     "verify": "npm pack && tar xf loopback-openapi-spec-builder*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "keywords": [

--- a/packages/openapi-v3-types/LICENSE
+++ b/packages/openapi-v3-types/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/openapi-v3-types
 This project is licensed under the MIT License, full text below.
 

--- a/packages/openapi-v3-types/package.json
+++ b/packages/openapi-v3-types/package.json
@@ -23,7 +23,7 @@
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "npm run build && lb-mocha \"dist/__tests__/unit/**/*.js\""
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "keywords": [

--- a/packages/openapi-v3/LICENSE
+++ b/packages/openapi-v3/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/openapi-v3
 This project is licensed under the MIT License, full text below.
 

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -25,7 +25,7 @@
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-openapi-v3*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "keywords": [

--- a/packages/repository-json-schema/LICENSE
+++ b/packages/repository-json-schema/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/repository-json-schema
 This project is licensed under the MIT License, full text below.
 

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -13,7 +13,7 @@
     "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/integration/**/*.js\" \"dist/__tests__/acceptance/**/*.js\"",
     "verify": "npm pack && tar xf loopback-json-schema*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "license": "MIT",
   "keywords": [
     "LoopBack",

--- a/packages/repository/LICENSE
+++ b/packages/repository/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/repository
 This project is licensed under the MIT License, full text below.
 

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -15,7 +15,7 @@
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-repository*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "devDependencies": {

--- a/packages/rest-explorer/LICENSE
+++ b/packages/rest-explorer/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/rest-explorer
 This project is licensed under the MIT License, full text below.
 

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -13,7 +13,7 @@
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-explorer*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/rest/LICENSE
+++ b/packages/rest/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/rest
 This project is licensed under the MIT License, full text below.
 

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -16,7 +16,7 @@
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-rest*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -20,7 +20,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "devDependencies": {

--- a/packages/testlab/LICENSE
+++ b/packages/testlab/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
 Node module: @loopback/testlab
 This project is licensed under the MIT License, full text below.
 

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -13,7 +13,7 @@
     "test": "lb-mocha \"dist/__tests__\"",
     "verify": "npm pack && tar xf loopback-testlab*.tgz && tree package && npm run clean"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/packages/tslint-config/LICENSE
+++ b/packages/tslint-config/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
 Node module: @loopback/tslint-config
 This project is licensed under the MIT License, full text below.
 

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "node": ">=8.9"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {

--- a/sandbox/example/package.json
+++ b/sandbox/example/package.json
@@ -10,7 +10,7 @@
   "engines": {
     "node": ">=8.9"
   },
-  "author": "IBM",
+  "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Connect to https://github.com/strongloop-internal/scrum-apex/issues/406. 

Update the licenses for `loopback-next`, examples, and packages and update authors in `package.json`s to "IBM Corp.".

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
