### PR TITLE
feat: allow rest-server to be mounted on a path to express

### DIFF
--- a/packages/rest/src/__tests__/integration/express.integration.ts
+++ b/packages/rest/src/__tests__/integration/express.integration.ts
@@ -1,0 +1,89 @@
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Application} from '@loopback/core';
+import {get} from '@loopback/openapi-v3';
+import {
+  Client,
+  createClientForHandler,
+  expect,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
+import * as express from 'express';
+import {RestComponent} from '../../rest.component';
+import {
+  HttpRequestListener,
+  RestServer,
+  RestServerConfig,
+} from '../../rest.server';
+
+describe('HttpHandler mounted as an express router', () => {
+  let client: Client;
+  beforeEach(givenLoopBackApp);
+  beforeEach(givenExpressApp);
+  beforeEach(givenClient);
+
+  context('with a simple HelloWorld controller', () => {
+    beforeEach(function setupHelloController() {
+      class HelloController {
+        @get('/hello')
+        public async greet(): Promise<string> {
+          return 'Hello world!';
+        }
+      }
+
+      givenControllerClass(HelloController);
+    });
+
+    it('handles simple "GET /hello" requests', () => {
+      return client
+        .get('/api/hello')
+        .expect(200)
+        .expect('content-type', 'text/plain')
+        .expect('Hello world!');
+    });
+
+    it('handles openapi.json', async () => {
+      const res = await client
+        .get('/api/openapi.json')
+        .set('Accept', 'application/json')
+        .expect(200);
+      expect(res.body.servers[0]).to.eql({url: '/api'});
+    });
+  });
+
+  let expressApp: express.Application;
+  let server: RestServer;
+  let handler: HttpRequestListener;
+
+  function givenControllerClass(
+    // tslint:disable-next-line:no-any
+    ctor: new (...args: any[]) => Object,
+  ) {
+    server.controller(ctor);
+  }
+
+  async function givenLoopBackApp(
+    options: {rest: RestServerConfig} = {rest: {port: 0}},
+  ) {
+    options.rest = givenHttpServerConfig(options.rest);
+    const app = new Application(options);
+    app.component(RestComponent);
+    server = await app.getServer(RestServer);
+    handler = server.requestHandler;
+  }
+
+  /**
+   * Create an express app that mounts the LoopBack routes to `/api`
+   */
+  function givenExpressApp() {
+    expressApp = express();
+    expressApp.use('/api', handler);
+  }
+
+  function givenClient() {
+    client = createClientForHandler(expressApp);
+  }
+});


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/pull/2306#discussion_r252321716

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
