### PR TITLE
feat(repository): delete & patch operations for HasOne relation

### DIFF
--- a/packages/repository/src/relations/has-one/index.ts
+++ b/packages/repository/src/relations/has-one/index.ts
@@ -4,4 +4,5 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from './has-one.decorator';
+export * from './has-one.repository';
 export * from './has-one-repository.factory';


### PR DESCRIPTION
implemented the missing crud operations delete, patch and put operations
in relation hasOne.

"fix #2233"



## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
