### PR TITLE
fix(cli): update fixture model in test files

### DIFF
--- a/packages/cli/test/fixtures/repository/models/decoratordefined.model.txt
+++ b/packages/cli/test/fixtures/repository/models/decoratordefined.model.txt
@@ -7,11 +7,11 @@ import {Entity, model} from '@loopback/repository';
         name: {type: 'string', required: true},
       },
     })
-    export class DecoratorDefined extends Entity {
+    export class Decoratordefined extends Entity {
       thePK: number;
       name: string;
 
-      constructor(data?: Partial<DecoratorDefined>) {
+      constructor(data?: Partial<Decoratordefined>) {
         super(data);
       }
     }

--- a/packages/cli/test/fixtures/repository/models/defaultmodel.model.txt
+++ b/packages/cli/test/fixtures/repository/models/defaultmodel.model.txt
@@ -1,7 +1,7 @@
 import {Entity, model, property} from '@loopback/repository';
 
 @model()
-export class DefaultModel extends Entity {
+export class Defaultmodel extends Entity {
   @property({
     type: 'number',
     id: true,
@@ -20,7 +20,7 @@ export class DefaultModel extends Entity {
   })
   balance?: number;
 
-  constructor(data?: Partial<DefaultModel>) {
+  constructor(data?: Partial<Defaultmodel>) {
     super(data);
   }
 }


### PR DESCRIPTION
fix #2413

in the folder /packages/cli/test/fixtures/repository/models there are model files that are used in the CLI tests.
I found two issues with the current models both of them rleated to how class name converted into file name.
so when the CLI tries to load the file from disk it fails model file not found.

## Checklist

- [V ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ V] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
