### PR TITLE
 docs: change type of customerId property from string to number

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -50,7 +50,7 @@ export class Order extends Entity {
   id: number;
 
   @belongsTo(() => Customer)
-  customerId: string;
+  customerId: number;
 
   @property({type: 'number'})
   quantity: number;
@@ -73,7 +73,7 @@ above example is as follows:
 class Order extends Entity {
   // constructor, properties, etc.
   @belongsTo(() => Customer, {keyTo: 'pk'})
-  customerId: string;
+  customerId: number;
 }
 ```
 


### PR DESCRIPTION
I think the type of customerId should be number, not string. Is it a typo mistake or it must be string?

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
