### PR TITLE
feat(rest): add strict option for routers

### DIFF
--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -256,6 +256,23 @@ app.basePath('/api');
 With the `basePath`, all REST APIs and static assets are served on URLs starting
 with the base path.
 
+### Configure the router
+
+The router can be configured to enforce `strict` mode as follows:
+
+1. `strict` is true:
+
+- request `/orders` matches route `/orders` but not `/orders/`
+- request `/orders/` matches route `/orders/` but not `/orders`
+
+2. `strict` is false (default)
+
+- request `/orders` matches route `/orders` first and falls back to `/orders/`
+- request `/orders/` matches route `/orders/` first and falls back to `/orders`
+
+See `strict routing` at http://expressjs.com/en/4x/api.html#app for more
+information.
+
 ### Configure the request body parser options
 
 We can now configure request body parser options as follows:
@@ -286,6 +303,7 @@ for more details.
 | openApiSpec       | OpenApiSpecOptions       | Customize how OpenAPI spec is served                                                                      |
 | apiExplorer       | ApiExplorerOptions       | Customize how API explorer is served                                                                      |
 | requestBodyParser | RequestBodyParserOptions | Customize how request body is parsed                                                                      |
+| router            | RouterOptions            | Customize how trailing slashes are used for routing                                                       |
 
 ## Add servers to application instance
 

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
@@ -143,7 +143,7 @@ describe('RestServer', () => {
       );
     });
 
-    it('assigns express settings', () => {
+    describe('express settings', () => {
       class TestRestServer extends RestServer {
         constructor(application: Application, config: RestServerConfig) {
           super(application, config);
@@ -155,19 +155,32 @@ describe('RestServer', () => {
         }
       }
 
-      const app = new Application();
-      const server = new TestRestServer(app, {
-        expressSettings: {
-          'x-powered-by': false,
-          env: 'production',
-        },
+      it('honors expressSettings', () => {
+        const app = new Application();
+        const server = new TestRestServer(app, {
+          expressSettings: {
+            'x-powered-by': false,
+            env: 'production',
+          },
+        });
+        const expressApp = server.expressApp;
+        expect(expressApp.get('x-powered-by')).to.equal(false);
+        expect(expressApp.get('env')).to.equal('production');
+        // `extended` is the default setting by Express
+        expect(expressApp.get('query parser')).to.equal('extended');
+        expect(expressApp.get('not set')).to.equal(undefined);
       });
-      const expressApp = server.expressApp;
-      expect(expressApp.get('x-powered-by')).to.equal(false);
-      expect(expressApp.get('env')).to.equal('production');
-      // `extended` is the default setting by Express
-      expect(expressApp.get('query parser')).to.equal('extended');
-      expect(expressApp.get('not set')).to.equal(undefined);
+
+      it('honors strict', () => {
+        const app = new Application();
+        const server = new TestRestServer(app, {
+          router: {
+            strict: true,
+          },
+        });
+        const expressApp = server.expressApp;
+        expect(expressApp.get('strict routing')).to.equal(true);
+      });
     });
   });
 

--- a/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
@@ -6,19 +6,19 @@
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {get, getControllerSpec, param} from '@loopback/openapi-v3';
 import {
-  ShotRequestOptions,
   expect,
+  ShotRequestOptions,
   stubExpressContext,
 } from '@loopback/testlab';
+import * as HttpErrors from 'http-errors';
 import {
   ControllerRoute,
-  Request,
-  RoutingTable,
-  RestRouter,
   RegExpRouter,
+  Request,
+  RestRouter,
+  RoutingTable,
   TrieRouter,
 } from '../../..';
-import * as HttpErrors from 'http-errors';
 
 describe('RoutingTable', () => {
   it('joins basePath and path', () => {
@@ -220,16 +220,22 @@ function runTestsWithRouter(router: RestRouter) {
       async getOrderById(@param.path.number('id') id: number): Promise<object> {
         return {id};
       }
-      @get('/orders')
-      async findOrders(): Promise<object[]> {
-        return [];
-      }
       // A path that overlaps with `/orders/{id}`. Please note a different var
       // name is used - `{orderId}`
       @get('/orders/{orderId}/shipments')
       async getShipmentsForOrder(
         @param.path.number('orderId') id: number,
       ): Promise<object> {
+        return [];
+      }
+      // With trailing `/`
+      @get('/orders/')
+      async findOrders(): Promise<object[]> {
+        return [];
+      }
+      // Without trailing `/`
+      @get('/pendingOrders')
+      async findPendingOrders(): Promise<object[]> {
         return [];
       }
     }
@@ -250,6 +256,9 @@ function runTestsWithRouter(router: RestRouter) {
     findAndCheckRoute('/orders/1', '/orders/{id}');
     findAndCheckRoute('/orders/1/shipments', '/orders/{orderId}/shipments');
     findAndCheckRoute('/orders', '/orders');
+    findAndCheckRoute('/orders/', '/orders');
+    findAndCheckRoute('/pendingOrders', '/pendingOrders');
+    findAndCheckRoute('/pendingOrders/', '/pendingOrders');
   });
 
   it('throws if router is not found', () => {

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -31,7 +31,7 @@ import {
 import {HttpProtocol} from '@loopback/http-server';
 import * as https from 'https';
 import {ErrorWriterOptions} from 'strong-error-handler';
-import {RestRouter} from './router';
+import {RestRouter, RestRouterOptions} from './router';
 import {RequestBodyParser, BodyParser} from './body-parsers';
 
 /**
@@ -79,6 +79,10 @@ export namespace RestBindings {
    * Internal binding key for rest router
    */
   export const ROUTER = BindingKey.create<RestRouter>('rest.router');
+
+  export const ROUTER_OPTIONS = BindingKey.create<RestRouterOptions>(
+    'rest.router.options',
+  );
 
   /**
    * Binding key for setting and injecting Reject action's error handling

--- a/packages/rest/src/router/rest-router.ts
+++ b/packages/rest/src/router/rest-router.ts
@@ -29,3 +29,20 @@ export interface RestRouter {
    */
   list(): RouteEntry[];
 }
+
+export type RestRouterOptions = {
+  /**
+   * When `true` it uses trailing slash to match. (default: `false`)
+   *
+   * 1. `strict` is true:
+   * - request `/orders` matches route `/orders` but not `/orders/`
+   * - request `/orders/` matches route `/orders/` but not `/orders`
+   *
+   * 2. `strict` is false (default)
+   * - request `/orders` matches route `/orders` first and falls back to `/orders/`
+   * - request `/orders/` matches route `/orders/` first and falls back to `/orders`
+   *
+   * See `strict routing` at http://expressjs.com/en/4x/api.html#app
+   */
+  strict?: boolean;
+};

--- a/packages/rest/src/router/trie-router.ts
+++ b/packages/rest/src/router/trie-router.ts
@@ -3,11 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {RouteEntry, createResolvedRoute} from './route-entry';
-import {Trie} from './trie';
-import {Request} from '../types';
+import {inject} from '@loopback/context';
 import {inspect} from 'util';
+import {RestBindings} from '../keys';
+import {RestRouterOptions} from './rest-router';
+import {createResolvedRoute, RouteEntry} from './route-entry';
 import {BaseRouter} from './router-base';
+import {Trie} from './trie';
 
 const debug = require('debug')('loopback:rest:router:trie');
 
@@ -17,16 +19,23 @@ const debug = require('debug')('loopback:rest:router:trie');
 export class TrieRouter extends BaseRouter {
   private trie = new Trie<RouteEntry>();
 
+  constructor(
+    @inject(RestBindings.ROUTER_OPTIONS, {optional: true})
+    options?: RestRouterOptions,
+  ) {
+    super(options);
+  }
+
   protected addRouteWithPathVars(route: RouteEntry) {
     // Add the route to the trie
     const key = this.getKeyForRoute(route);
     this.trie.create(key, route);
   }
 
-  protected findRouteWithPathVars(request: Request) {
-    const path = this.getKeyForRequest(request);
+  protected findRouteWithPathVars(verb: string, path: string) {
+    const key = this.getKey(verb, path);
 
-    const found = this.trie.match(path);
+    const found = this.trie.match(key);
     debug('Route matched: %j', found);
 
     if (found) {


### PR DESCRIPTION
This PR replaces https://github.com/strongloop/loopback-next/pull/2355.

It introduces `strict` option for REST routers to deal with trailing slashes.

1. `strict` is true:
- request `/orders` matches route `/orders` but not `/orders/`
- request `/orders/` matches route `/orders/` but not `/orders`

2. `strict` is false (default)
- request `/orders` matches route `/orders` first and falls back to `/orders`
- request `/orders/` matches route `/orders/` first and falls back to `/orders`

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
