### PR TITLE
feat(rest): allow assigning express settings

### DIFF
--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -213,6 +213,25 @@ export async function main() {
 For a complete list of CORS options, see
 https://github.com/expressjs/cors#configuration-options.
 
+### Express settings
+
+Override the default express settings and/or assign your own settings:
+
+```ts
+const app = new RestApplication({
+  rest: {
+    expressSettings: {
+      'x-powered-by': false,
+      env: 'production',
+      ...
+    },
+  },
+});
+```
+
+Checkout `express` [documentation](http://expressjs.com/fr/api.html#app.set) for
+more details about the build-in settings.
+
 ### Configure the Base Path
 
 Sometime it's desirable to expose REST endpoints using a base path, such as

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
@@ -3,12 +3,18 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
-import {anOperationSpec} from '@loopback/openapi-spec-builder';
 import {Binding, Context} from '@loopback/context';
 import {Application} from '@loopback/core';
-import {RestServer, Route, RestBindings, RestComponent} from '../../..';
-import {RequestBodyParserOptions} from '../../../types';
+import {anOperationSpec} from '@loopback/openapi-spec-builder';
+import {expect} from '@loopback/testlab';
+import {
+  RequestBodyParserOptions,
+  RestBindings,
+  RestComponent,
+  RestServer,
+  RestServerConfig,
+  Route,
+} from '../../..';
 
 describe('RestServer', () => {
   describe('"bindElement" binding', () => {
@@ -135,6 +141,33 @@ describe('RestServer', () => {
       expect(server.getSync(RestBindings.REQUEST_BODY_PARSER_OPTIONS)).to.equal(
         parserOptions,
       );
+    });
+
+    it('assigns express settings', () => {
+      class TestRestServer extends RestServer {
+        constructor(application: Application, config: RestServerConfig) {
+          super(application, config);
+          this._setupRequestHandlerIfNeeded();
+        }
+
+        get expressApp() {
+          return this._expressApp;
+        }
+      }
+
+      const app = new Application();
+      const server = new TestRestServer(app, {
+        expressSettings: {
+          'x-powered-by': false,
+          env: 'production',
+        },
+      });
+      const expressApp = server.expressApp;
+      expect(expressApp.get('x-powered-by')).to.equal(false);
+      expect(expressApp.get('env')).to.equal('production');
+      // `extended` is the default setting by Express
+      expect(expressApp.get('query parser')).to.equal('extended');
+      expect(expressApp.get('not set')).to.equal(undefined);
     });
   });
 

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -214,7 +214,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   protected _setupRequestHandlerIfNeeded() {
     if (this._expressApp) return;
     this._expressApp = express();
-    this._expressApp.set('query parser', 'extended');
+    this._applyExpressSettings();
     this._requestHandler = this._expressApp;
 
     // Allow CORS support for all endpoints so that users
@@ -243,6 +243,16 @@ export class RestServer extends Context implements Server, HttpServerLike {
         this._onUnhandledError(req, res, err);
       },
     );
+  }
+
+  /**
+   * Apply express settings.
+   */
+  protected _applyExpressSettings() {
+    const settings = this.config.expressSettings || {};
+    for (const key in settings) {
+      this._expressApp.set(key, settings[key]);
+    }
   }
 
   /**
@@ -954,6 +964,8 @@ export interface RestServerOptions {
   apiExplorer?: ApiExplorerOptions;
   requestBodyParser?: RequestBodyParserOptions;
   sequence?: Constructor<SequenceHandler>;
+  // tslint:disable-next-line:no-any
+  expressSettings?: {[name: string]: any};
 }
 
 /**


### PR DESCRIPTION
Add a new rest configuration for `queryParser`

Fixes #2420 

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
