### PR TITLE
Fix/optional array of simple types

### DIFF
--- a/packages/cli/generators/openapi/schema-helper.js
+++ b/packages/cli/generators/openapi/schema-helper.js
@@ -167,11 +167,15 @@ function mapObjectType(schema, options) {
         propDecoration = `@property({name: '${p}', required: true})`;
       }
 
-      if (propertyType.itemType && propertyType.itemType.kind === 'class') {
-        // Use `@property.array` for array types
-        propDecoration = `@property.array(${
-          propertyType.itemType.className
-        }, {name: '${p}'})`;
+      if (propertyType.itemType) {
+        const itemType =
+          propertyType.itemType.kind === 'class'
+            ? propertyType.itemType.className
+            : getJSType(propertyType.itemType.name);
+        if (itemType) {
+          // Use `@property.array` for array types
+          propDecoration = `@property.array(${itemType}, {name: '${p}'})`;
+        }
       }
       const propSpec = {
         name: p,
@@ -256,6 +260,23 @@ function mapPrimitiveType(schema, options) {
   typeSpec.signature = typeSpec.className || typeSpec.declaration + defaultVal;
   typeSpec.name = typeSpec.name || jsType;
   return typeSpec;
+}
+
+const JSTypeMapping = {
+  number: Number,
+  boolean: Boolean,
+  string: String,
+  Date: Date,
+  Buffer: Buffer,
+};
+
+/**
+ * Mapping simple type names to JS Type constructors
+ * @param {string} type Simple type name
+ */
+function getJSType(type) {
+  const ctor = JSTypeMapping[type];
+  return (ctor && ctor.name) || type;
 }
 
 /**

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: '3.0.0'
 info:
   version: 1.0.0
   title: Customer
@@ -117,9 +117,11 @@ components:
           type: string
         last-name:
           $ref: '#/components/schemas/Name'
+        emails:
+          type: array
+          items:
+            type: string
         addresses:
           type: array
           items:
             $ref: '#/components/schemas/Address'
-
-

--- a/packages/cli/test/unit/openapi/schema-model.unit.js
+++ b/packages/cli/test/unit/openapi/schema-model.unit.js
@@ -14,7 +14,7 @@ const {
 const path = require('path');
 
 describe('schema to model', () => {
-  let usptoSpec, usptoSpecAnonymous, petstoreSpec, customerSepc;
+  let usptoSpec, usptoSpecAnonymous, petstoreSpec, customerSpec;
   const uspto = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
   const petstore = path.join(
     __dirname,
@@ -31,7 +31,7 @@ describe('schema to model', () => {
       promoteAnonymousSchemas: true,
     });
     petstoreSpec = await loadSpec(petstore);
-    customerSepc = await loadSpec(customer);
+    customerSpec = await loadSpec(customer);
   });
 
   it('generates models for uspto', () => {
@@ -269,7 +269,7 @@ describe('schema to model', () => {
 
   it('generates models for customer', () => {
     const objectTypeMapping = new Map();
-    const models = generateModelSpecs(customerSepc, {objectTypeMapping});
+    const models = generateModelSpecs(customerSpec, {objectTypeMapping});
     expect(models).to.eql([
       {
         description: 'Name',
@@ -339,6 +339,11 @@ describe('schema to model', () => {
             decoration: "@property({name: 'last-name'})",
           },
           {
+            decoration: "@property.array(String, {name: 'emails'})",
+            name: 'emails',
+            signature: 'emails?: string[];',
+          },
+          {
             name: 'addresses',
             signature: 'addresses?: Address[];',
             decoration: "@property.array(Address, {name: 'addresses'})",
@@ -351,8 +356,8 @@ describe('schema to model', () => {
         import: "import {Customer} from './customer.model';",
         kind: 'class',
         declaration:
-          "{\n  id: number;\n  'first-name'?: string;\n  'last-name'?: " +
-          'Name;\n  addresses?: Address[];\n}',
+          "{\n  id: number;\n  'first-name'?: string;\n  'last-name'?: Name;\n" +
+          '  emails?: string[];\n  addresses?: Address[];\n}',
         signature: 'Customer',
       },
     ]);

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -198,6 +198,25 @@ describe('build-schema', () => {
         expectValidJsonSchema(jsonSchema);
       });
 
+      it('properly converts optional primitive array properties', () => {
+        @model()
+        class TestModel {
+          @property.array('number')
+          numArr?: number[];
+        }
+
+        const jsonSchema = modelToJsonSchema(TestModel);
+        expect(jsonSchema.properties).to.deepEqual({
+          numArr: {
+            type: 'array',
+            items: {
+              type: 'number',
+            },
+          },
+        });
+        expectValidJsonSchema(jsonSchema);
+      });
+
       it('properly converts properties with recursive arrays', () => {
         @model()
         class RecursiveArray {


### PR DESCRIPTION
Reported offline by remko de knikker

> Running into what I think is a BUG in Loopback4, when using a swagger2 and "lb4 openapi" to generate the app on LB4 the Loopback fails on "Cannot start the application. Error: "items" property must be present if "type" is an array" .. looking at the cause it's this line in the original swagger "AddressLine: type: array, items: type: string" which gets translated to LB4 as "AddressLine?: string[];" so that in @loopback/openapi-v3/dist/json-to-schema.js:28:27 the array check fails. When I change the swagger definition to "AddressLine: type: object, properties: AddressLine type:string" I can work around it, but this is causing my required format of AddressLine: [ "1", "2" ] to become AdressLine: [ AddressLine: "1", AddressLine: "2" ] ... making my app non-compliant to the spec. I was planning to file a bug, but wanted to run it by some expert advice first here. 

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
