### PR TITLE
feat(rest): introduce requestBodyParser options in RestServerOptions

### DIFF
--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -235,20 +235,36 @@ app.basePath('/api');
 With the `basePath`, all REST APIs and static assets are served on URLs starting
 with the base path.
 
+### Configure the request body parser options
+
+We can now configure request body parser options as follows:
+
+```ts
+const app = new Application({
+  rest: {requestBodyParser: {json: {limit: '1mb'}}},
+});
+```
+
+The value of `rest.requestBodyParser` will be bound to
+RestBindings.REQUEST_BODY_PARSER_OPTIONS. See
+[Customize request body parser options](Parsing-requests.md#customize-parser-options)
+for more details.
+
 ### `rest` options
 
-| Property    | Type                | Purpose                                                                                                   |
-| ----------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| host        | string              | Specify the hostname or ip address on which the RestServer will listen for traffic.                       |
-| port        | number              | Specify the port on which the RestServer listens for traffic.                                             |
-| protocol    | string (http/https) | Specify the protocol on which the RestServer listens for traffic.                                         |
-| basePath    | string              | Specify the base path that RestServer exposes http endpoints.                                             |
-| key         | string              | Specify the SSL private key for https.                                                                    |
-| cert        | string              | Specify the SSL certificate for https.                                                                    |
-| cors        | CorsOptions         | Specify the CORS options.                                                                                 |
-| sequence    | SequenceHandler     | Use a custom SequenceHandler to change the behavior of the RestServer for the request-response lifecycle. |
-| openApiSpec | OpenApiSpecOptions  | Customize how OpenAPI spec is served                                                                      |
-| apiExplorer | ApiExplorerOptions  | Customize how API explorer is served                                                                      |
+| Property          | Type                     | Purpose                                                                                                   |
+| ----------------- | ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| host              | string                   | Specify the hostname or ip address on which the RestServer will listen for traffic.                       |
+| port              | number                   | Specify the port on which the RestServer listens for traffic.                                             |
+| protocol          | string (http/https)      | Specify the protocol on which the RestServer listens for traffic.                                         |
+| basePath          | string                   | Specify the base path that RestServer exposes http endpoints.                                             |
+| key               | string                   | Specify the SSL private key for https.                                                                    |
+| cert              | string                   | Specify the SSL certificate for https.                                                                    |
+| cors              | CorsOptions              | Specify the CORS options.                                                                                 |
+| sequence          | SequenceHandler          | Use a custom SequenceHandler to change the behavior of the RestServer for the request-response lifecycle. |
+| openApiSpec       | OpenApiSpecOptions       | Customize how OpenAPI spec is served                                                                      |
+| apiExplorer       | ApiExplorerOptions       | Customize how API explorer is served                                                                      |
+| requestBodyParser | RequestBodyParserOptions | Customize how request body is parsed                                                                      |
 
 ## Add servers to application instance
 

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
@@ -8,6 +8,7 @@ import {anOperationSpec} from '@loopback/openapi-spec-builder';
 import {Binding, Context} from '@loopback/context';
 import {Application} from '@loopback/core';
 import {RestServer, Route, RestBindings, RestComponent} from '../../..';
+import {RequestBodyParserOptions} from '../../../types';
 
 describe('RestServer', () => {
   describe('"bindElement" binding', () => {
@@ -121,6 +122,18 @@ describe('RestServer', () => {
         }
       }).to.throw(
         /Base path cannot be set as the request handler has been created/,
+      );
+    });
+
+    it('honors requestBodyParser options in config', async () => {
+      const parserOptions: RequestBodyParserOptions = {json: {limit: '1mb'}};
+      const app = new Application({
+        rest: {requestBodyParser: parserOptions},
+      });
+      app.component(RestComponent);
+      const server = await app.getServer(RestServer);
+      expect(server.getSync(RestBindings.REQUEST_BODY_PARSER_OPTIONS)).to.equal(
+        parserOptions,
       );
     });
   });

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -52,6 +52,7 @@ import {
   Request,
   Response,
   Send,
+  RequestBodyParserOptions,
 } from './types';
 
 const debug = debugFactory('loopback:rest:server');
@@ -189,6 +190,12 @@ export class RestServer extends Context implements Server, HttpServerLike {
     this.bind(RestBindings.HOST).to(config.host);
     this.bind(RestBindings.PROTOCOL).to(config.protocol || 'http');
     this.bind(RestBindings.HTTPS_OPTIONS).to(config as ServerOptions);
+
+    if (config.requestBodyParser) {
+      this.bind(RestBindings.REQUEST_BODY_PARSER_OPTIONS).to(
+        config.requestBodyParser,
+      );
+    }
 
     if (config.sequence) {
       this.sequence(config.sequence);
@@ -936,6 +943,7 @@ export interface RestServerOptions {
   cors?: cors.CorsOptions;
   openApiSpec?: OpenApiSpecOptions;
   apiExplorer?: ApiExplorerOptions;
+  requestBodyParser?: RequestBodyParserOptions;
   sequence?: Constructor<SequenceHandler>;
 }
 


### PR DESCRIPTION
Inspired by #2415.

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
- [ ] Agree to the CLA (Contributor License Agreement) by [clicking and signing](https://cla.strongloop.com/agreements/strongloop/loopback-next)
