### PR TITLE
fix(cli): force test host to be HOST env var or ipv4 interface

### DIFF
--- a/packages/cli/generators/app/templates/src/__tests__/acceptance/test-helper.ts.ejs
+++ b/packages/cli/generators/app/templates/src/__tests__/acceptance/test-helper.ts.ejs
@@ -6,8 +6,17 @@ import {
 } from '@loopback/testlab';
 
 export async function setupApplication(): Promise<AppWithClient> {
+  const config = givenHttpServerConfig();
+
+  // Set host to `HOST` env var or ipv4 loopback interface
+  // By default, docker container has ipv6 disabled.
+  config.host = config.host || process.env.HOST || '127.0.0.1';
+
+  // Set port to `PORT` env var or `0`
+  config.port = config.port || +(process.env.PORT || 0);
+
   const app = new <%= project.applicationName %>({
-    rest: givenHttpServerConfig(),
+    rest: config,
   });
 
   await app.boot();

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -80,6 +80,14 @@ describe('app-generator specific files', () => {
       'src/__tests__/acceptance/test-helper.ts',
       /export async function setupApplication/,
     );
+    assert.fileContent(
+      'src/__tests__/acceptance/test-helper.ts',
+      "process.env.HOST || '127.0.0.1'",
+    );
+    assert.fileContent(
+      'src/__tests__/acceptance/test-helper.ts',
+      '+(process.env.PORT || 0)',
+    );
   });
 
   it('generates database migration script', () => {


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/1995

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
- [ ] Agree to the CLA (Contributor License Agreement) by [clicking and signing](https://cla.strongloop.com/agreements/strongloop/loopback-next)
