### PR TITLE
feat(cli): add `--docker` option to generate docker files

### DIFF
--- a/docs/site/Application-generator.md
+++ b/docs/site/Application-generator.md
@@ -33,6 +33,9 @@ application project.
 
 `--vscode`: Add VSCode config files to LoopBack4 application project
 
+`--docker`: Generate Dockerfile and add npm scripts to build/run the project in
+a docker container.
+
 {% include_relative includes/CLI-std-options.md %}
 
 ### Arguments

--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -12,6 +12,10 @@ module.exports = class AppGenerator extends ProjectGenerator {
   constructor(args, opts) {
     super(args, opts);
     this.buildOptions.push({
+      name: 'docker',
+      description: 'include Dockerfile and .dockerignore',
+    });
+    this.buildOptions.push({
       name: 'repositories',
       description: 'include repository imports and RepositoryMixin',
     });
@@ -27,6 +31,11 @@ module.exports = class AppGenerator extends ProjectGenerator {
     this.option('applicationName', {
       type: String,
       description: 'Application class name',
+    });
+
+    this.option('docker', {
+      type: Boolean,
+      description: 'Include Dockerfile and .dockerignore',
     });
 
     this.option('repositories', {
@@ -112,7 +121,15 @@ module.exports = class AppGenerator extends ProjectGenerator {
   }
 
   scaffold() {
-    return super.scaffold();
+    const result = super.scaffold();
+    if (this.shouldExit()) return result;
+
+    const {docker} = this.projectInfo || {};
+    if (docker) return result;
+
+    this.fs.delete(this.destinationPath('Dockerfile'));
+    this.fs.delete(this.destinationPath('.dockerignore'));
+    return result;
   }
 
   install() {

--- a/packages/cli/generators/app/templates/.dockerignore
+++ b/packages/cli/generators/app/templates/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+/dist
+

--- a/packages/cli/generators/app/templates/Dockerfile
+++ b/packages/cli/generators/app/templates/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:10
+
+# Set to a non-root built-in user `node`
+USER node
+
+# Create app directory (with user `node`)
+RUN mkdir -p /home/node/app
+
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+RUN npm install
+
+# Bundle app source code
+COPY --chown=node . .
+
+RUN npm run build
+
+# Bind to all network interfaces so that it can be mapped to the host OS
+ENV HOST=0.0.0.0 PORT=3000
+
+EXPOSE ${PORT}
+CMD [ "node", "." ]

--- a/packages/cli/generators/app/templates/index.js.ejs
+++ b/packages/cli/generators/app/templates/index.js.ejs
@@ -6,8 +6,8 @@ if (require.main === module) {
   // Run the application
   const config = {
     rest: {
-      port: +process.env.PORT || 3000,
-      host: process.env.HOST || 'localhost',
+      port: +(process.env.PORT || 3000),
+      host: process.env.HOST,
       openApiSpec: {
         // useful when used with OASGraph to locate your application
         setServersFromRequest: true,

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -47,6 +47,10 @@
     "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js",
 <% } -%>
 <% if (project.projectType === 'application') { -%>
+  <% if (project.docker) { -%>
+    "docker:build": "docker build -t <%= project.name -%> .",
+    "docker:run": "docker run -p 3000:3000 -d <%= project.name -%>",
+  <% } -%>
     "migrate": "node ./dist/migrate",
     "prestart": "npm run build",
     "start": "node .",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -46,6 +46,10 @@
     "test:dev": "mocha dist/__tests__/**/*.js",
 <% } -%>
 <% if (project.projectType === 'application') { -%>
+  <% if (project.docker) { -%>
+    "docker:build": "docker build -t <%= project.name -%> .",
+    "docker:run": "docker run -p 3000:3000 -d <%= project.name -%>",
+  <% } -%>
     "migrate": "node ./dist/migrate",
     "start": "npm run build && node .",
 <% } -%>

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -22,12 +22,11 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       },
       {
         name: 'prettier',
-        description:
-          'add new npm scripts to facilitate consistent code formatting',
+        description: 'install prettier to format code conforming to rules',
       },
       {
         name: 'mocha',
-        description: 'install mocha to assist with running tests',
+        description: 'install mocha to run tests',
       },
       {
         name: 'loopbackBuild',
@@ -167,7 +166,6 @@ module.exports = class ProjectGenerator extends BaseGenerator {
 
     return this.prompt(prompts).then(props => {
       Object.assign(this.projectInfo, props);
-      this.destinationRoot(this.projectInfo.outdir);
     });
   }
 
@@ -175,13 +173,15 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     if (this.shouldExit()) return false;
     const choices = [];
     this.buildOptions.forEach(f => {
-      if (!this.options[f.name]) {
+      if (this.options[f.name] == null) {
         choices.push({
           name: `Enable ${f.name}: ${chalk.gray(f.description)}`,
           key: f.name,
           short: `Enable ${f.name}`,
           checked: true,
         });
+      } else {
+        this.projectInfo[f.name] = this.options[f.name];
       }
     });
     const prompts = [
@@ -210,6 +210,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
   scaffold() {
     if (this.shouldExit()) return false;
 
+    this.destinationRoot(this.projectInfo.outdir);
     // First copy common files from ../../project/templates
     this.copyTemplatedFiles(
       this.templatePath('../../project/templates/**/*'),

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -104,9 +104,33 @@ describe('app-generator specific files', () => {
     assert.fileContent('src/migrate.ts', /export async function migrate/);
   });
 
+  it('generates docker files', () => {
+    assert.fileContent('Dockerfile', /FROM node:10/);
+    assert.fileContent('.dockerignore', /node_modules/);
+
+    assert.fileContent('package.json', /"docker:build": "docker build/);
+    assert.fileContent('package.json', /"docker:run": "docker run/);
+  });
+
   it('creates npm script "migrate-db"', async () => {
     const pkg = JSON.parse(await readFile('package.json'));
     expect(pkg.scripts).to.have.property('migrate', 'node ./dist/migrate');
+  });
+});
+
+describe('app-generator with docker disabled', () => {
+  before(() => {
+    return helpers
+      .run(generator)
+      .withOptions({docker: false})
+      .withPrompts(props);
+  });
+  it('does not generate docker files', () => {
+    assert.noFile('Dockerfile');
+    assert.noFile('.dockerignore');
+
+    assert.noFileContent('package.json', /"docker:build": "docker build/);
+    assert.noFileContent('package.json', /"docker:run": "docker run/);
   });
 });
 


### PR DESCRIPTION
This PR adds a `docker` option for `lb4 app` cli to generate:

- Dockerfile
- .dockerignore
- Add `docker:build` and `docker:run` scripts to `package.json`

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
- [ ] Agree to the CLA (Contributor License Agreement) by [clicking and signing](https://cla.strongloop.com/agreements/strongloop/loopback-next)
