### PR TITLE
feat(repository): allow optional property definition on belongsTo decorator

### DIFF
--- a/packages/repository/src/__tests__/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/relation.decorator.unit.ts
@@ -198,6 +198,51 @@ describe('relation decorator', () => {
         },
       });
     });
+
+    it('accepts additional property metadata', () => {
+      @model()
+      class AddressBook extends Entity {
+        @property({id: true})
+        id: string;
+      }
+
+      @model()
+      class Address extends Entity {
+        id: string;
+        @belongsTo(
+          () => AddressBook,
+          {},
+          {
+            length: 36,
+            postgresql: {
+              dataType: 'uuid',
+            },
+          },
+        )
+        addressBookId: string;
+      }
+
+      const jugglerMeta = MetadataInspector.getAllPropertyMetadata(
+        MODEL_PROPERTIES_KEY,
+        Address.prototype,
+      );
+      expect(jugglerMeta).to.eql({
+        addressBookId: {
+          type: String,
+          length: 36,
+          postgresql: {
+            dataType: 'uuid',
+          },
+        },
+      });
+      expect(Address.definition.relations).to.containDeep({
+        addressBook: {
+          keyFrom: 'addressBookId',
+          name: 'addressBook',
+          type: 'belongsTo',
+        },
+      });
+    });
   });
 });
 

--- a/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
@@ -14,22 +14,30 @@ import {BelongsToDefinition, RelationType} from '../relation.types';
  * @param targetResolver A resolver function that returns the target model for
  * a belongsTo relation
  * @param definition Optional metadata for setting up a belongsTo relation
+ * @param propertyDefinition Optional metadata for setting up the property
  * @returns {(target: Object, key:string)}
  */
 export function belongsTo<T extends Entity>(
   targetResolver: EntityResolver<T>,
   definition?: Partial<BelongsToDefinition>,
+  propertyDefinition?: Partial<PropertyDefinition>,
 ) {
   return function(decoratedTarget: Entity, decoratedKey: string) {
-    const propMeta: PropertyDefinition = {
-      type: MetadataInspector.getDesignTypeForProperty(
-        decoratedTarget,
-        decoratedKey,
-      ),
-      // TODO(bajtos) Make the foreign key required once our REST API layer
-      // allows controller methods to exclude required properties
-      // required: true,
-    };
+    const propMeta: PropertyDefinition = Object.assign(
+      {},
+      // properties provided by the caller
+      propertyDefinition,
+      // properties enforced by the decorator
+      {
+        type: MetadataInspector.getDesignTypeForProperty(
+          decoratedTarget,
+          decoratedKey,
+        ),
+        // TODO(bajtos) Make the foreign key required once our REST API layer
+        // allows controller methods to exclude required properties
+        // required: true,
+      },
+    );
     property(propMeta)(decoratedTarget, decoratedKey);
 
     // @belongsTo() is typically decorating the foreign key property,


### PR DESCRIPTION
allow optional property definition on belongsTo decorator as property decorator can not applied twice

Fixes #2345
Fixes #2256

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
- [x] Agree to the CLA (Contributor License Agreement) by [clicking and signing](https://cla.strongloop.com/agreements/strongloop/loopback-next)
