### PR TITLE
fix(example-todo-list): change rootDir in compilerOptions

### DIFF
--- a/examples/todo-list/tsconfig.build.json
+++ b/examples/todo-list/tsconfig.build.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "@loopback/build/config/tsconfig.common.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
When running `todo-list` example using `npm start`, it throws the following error:
```
module.js:550
    throw err;
    ^

Error: Cannot find module './dist'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
```

It seems like the `rootDir` in the tsconfig.json should be set to `src` instead of `.`.  The other examples, e.g. `todo` example, had been changed and seems like only this example has left out. 

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
- [x] Agree to the CLA (Contributor License Agreement) by [clicking and signing](https://cla.strongloop.com/agreements/strongloop/loopback-next)
