### PR TITLE
fix(example-soap-calculator): switch to a new soap calculator webservice

### DIFF
--- a/docs/site/soap-calculator-tutorial-add-controller.md
+++ b/docs/site/soap-calculator-tutorial-add-controller.md
@@ -70,10 +70,10 @@ and the interfaces we modeled in the previous step as follows:
 import {
   CalculatorService,
   CalculatorParameters,
-  AddResult,
-  MultiplyResult,
-  DivideResult,
-  SubtractResult,
+  AddResponse,
+  MultiplyResponse,
+  DivideResponse,
+  SubtractResponse,
 } from '../services/calculator.service';
 ```
 
@@ -106,7 +106,7 @@ service are available from here due to the dependency injection available
 through out **LB4**.
 
 ```ts
- async divide(intA: number,intB: number): Promise<DivideResult> {
+ async divide(intA: number,intB: number): Promise<DivideResponse> {
     //Preconditions
     if (intB === 0) {
       throw new HttpErrors.PreconditionFailed('Cannot divide by zero');
@@ -122,8 +122,8 @@ Now, if we add the **@GET** decorator we are making it available to the **REST**
 _server_ as follows.
 
 ```ts
-  @get('/divide/{arg1}/{arg2}')
-   async divide(intA: number,intB: number): Promise<DivideResult> {
+  @get('/divide/{intA}/{intB}')
+   async divide(intA: number,intB: number): Promise<DivideResponse> {
 ```
 
 Finally we can use the **@param** decorator on the two properties to help us
@@ -134,11 +134,11 @@ service expects this data type and this is done automatically for us.
 The final code looks like as follows:
 
 ```ts
-@get('/divide/{arg1}/{arg2}')
+@get('/divide/{intA}/{intB}')
   async divide(
-    @param.path.integer('arg1') intA: number,
+    @param.path.integer('intB') intA: number,
     @param.path.integer('arg2') intB: number,
-  ): Promise<DivideResult> {
+  ): Promise<DivideResponse> {
     //Preconditions
     if (intB === 0) {
       throw new HttpErrors.PreconditionFailed('Cannot divide by zero');
@@ -156,32 +156,32 @@ Add the following end point methods inside the CalculatorController class above
 the divide end point method.
 
 ```ts
- @get('/multiply/{arg1}/{arg2}')
+ @get('/multiply/{intA}/{intB}')
   async multiply(
-    @param.path.integer('arg1') intA: number,
+    @param.path.integer('intB') intA: number,
     @param.path.integer('arg2') intB: number,
-  ): Promise<MultiplyResult> {
+  ): Promise<MultiplyResponse> {
     return await this.calculatorService.Multiply(<CalculatorParameters>{
       intA,
       intB,
     });
   }
-  @get('/add/{arg1}/{arg2}')
+  @get('/add/{intA}/{intB}')
   async add(
-    @param.path.integer('arg1') intA: number,
+    @param.path.integer('intB') intA: number,
     @param.path.integer('arg2') intB: number,
-  ): Promise<AddResult> {
+  ): Promise<AddResponse> {
     return await this.calculatorService.Add(<CalculatorParameters>{
       intA,
       intB,
     });
   }
 
-  @get('/subtract/{arg1}/{arg2}')
+  @get('/subtract/{intA}/{intB}')
   async subtract(
-    @param.path.integer('arg1') intA: number,
+    @param.path.integer('intB') intA: number,
     @param.path.integer('arg2') intB: number,
-  ): Promise<SubtractResult> {
+  ): Promise<SubtractResponse> {
     return await this.calculatorService.Subtract(<CalculatorParameters>{
       intA,
       intB,

--- a/docs/site/soap-calculator-tutorial-add-datasource.md
+++ b/docs/site/soap-calculator-tutorial-add-datasource.md
@@ -40,13 +40,14 @@ by StrongLoop) connector from the list as shown below:
 #### Specify the SOAP web service endpoint
 
 Now we must tell **CLI** about the full URL path for our web service. In this
-case, let's type `http://lb4ws.eycgrupo.com/calculator/` for the URL and
-`http://lb4ws.eycgrupo.com/calculator/?wsdl` for the WSDL path.
+case, let's type `https://calculator-webservice.mybluemix.net/calculator` for
+the URL and `https://calculator-webservice.mybluemix.net/calculator?wsdl` for
+the WSDL path.
 
 ```sh
 ? Select the connector for calculator: SOAP webservices (supported by StrongLoop)
-? URL to the SOAP web service endpoint: http://lb4ws.eycgrupo.com/calculator/
-? HTTP URL or local file system path to the WSDL file: http://lb4ws.eycgrupo.com/calculator/?wsdl
+? URL to the SOAP web service endpoint: https://calculator-webservice.mybluemix.net/calculator
+? HTTP URL or local file system path to the WSDL file: https://calculator-webservice.mybluemix.net/calculator?wsdl
 ```
 
 #### Enabling expose REST API operations
@@ -79,10 +80,10 @@ The **SOAP** web service is exposing 4 operations, all of them share the same
 SOAP port, which in this case is **CalculatorSoap** and the service
 **Calculator**. The operations are:
 
-- Multiply
-- Add
-- Subtract
-- Divide
+- multiply
+- add
+- subtract
+- divide
 
 We need to configure in the Datasource JSON file, the corresponding Node.js
 methods for these remote SOAP operations. For simplicity, we will name the
@@ -94,10 +95,10 @@ bind the Node.js method _Multiply_.
 
 ```ts
 "operations": {
-     "Multiply": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
-      "operation": "Multiply"
+     "multiply": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
+      "operation": "multiply"
    }
  }
 ```
@@ -109,24 +110,24 @@ configuration after the `remoteEnabled: true,` property as follows:
 
 ```ts
 "operations": {
-     "Multiply": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+     "multiply": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Multiply"
     },
-    "Add": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+    "add": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Add"
     },
-    "Subtract": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+    "subtract": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Subtract"
     },
-    "Divide": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+    "divide": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Divide"
     }
   }

--- a/docs/site/soap-calculator-tutorial-add-service.md
+++ b/docs/site/soap-calculator-tutorial-add-service.md
@@ -73,24 +73,24 @@ expecting the same pair of arguments intA and intB. Now, it is time to define
 this scenario using interfaces as follows:
 
 ```ts
-export interface MultiplyResult {
+export interface MultiplyResponse {
   result: {
-    MultiplyResult: number;
+    value: number;
   };
 }
-export interface AddResult {
+export interface AddResponse {
   result: {
-    AddResult: number;
+    value: number;
   };
 }
-export interface SubtractResult {
+export interface SubtractResponse {
   result: {
-    SubtractResult: number;
+    value: number;
   };
 }
-export interface DivideResult {
+export interface DivideResponse {
   result: {
-    DivideResult: number;
+    value: number;
   };
 }
 export interface CalculatorParameters {
@@ -106,10 +106,10 @@ follows:
 
 ```ts
 export interface CalculatorService {
-  Multiply(args: CalculatorParameters): Promise<MultiplyResult>;
-  Add(args: CalculatorParameters): Promise<AddResult>;
-  Divide(args: CalculatorParameters): Promise<DivideResult>;
-  Subtract(args: CalculatorParameters): Promise<SubtractResult>;
+  multiply(args: CalculatorParameters): Promise<MultiplyResponse>;
+  add(args: CalculatorParameters): Promise<AddResponse>;
+  divide(args: CalculatorParameters): Promise<DivideResponse>;
+  subtract(args: CalculatorParameters): Promise<SubtractResponse>;
 }
 ```
 

--- a/docs/site/soap-calculator-tutorial-run-and-test.md
+++ b/docs/site/soap-calculator-tutorial-run-and-test.md
@@ -40,10 +40,10 @@ JSON format and the envelope property in XML format.
 The XML response is useful if you want to process the response in this format.
 However, if you are programming only in JSON format, focus only on the result
 property. Your client application will have access to result value using the
-normal convention `result.AddResult` and get the `100`.
+normal convention `result.value` and get the `100`.
 
 ```sh
-{"result":{"AddResult":100},"envelope":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://wsdl.example.org/\"><SOAP-ENV:Body><ns1:AddResponse><AddResult>100</AddResult></ns1:AddResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+{"result":{"value":100},"envelope":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://wsdl.example.org/\"><SOAP-ENV:Body><ns1:AddResponse><AddResult>100</AddResult></ns1:AddResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
 ```
 
 ### Changing the listening URL and PORT number

--- a/docs/site/soap-calculator-tutorial-web-service-overview.md
+++ b/docs/site/soap-calculator-tutorial-web-service-overview.md
@@ -9,14 +9,14 @@ permalink: /doc/en/lb4/soap-calculator-tutorial-web-service-overview.html
 ### Overview
 
 The calculator is a web service using the **SOAP** protocol and reside in this
-[server](http://lb4ws.eycgrupo.com/calculator/?wsdl), exclusively used by this
-**LB4** tutorial, it is exposing four end points that resembles the operation of
-a basic calculator as follows:
+[server](https://calculator-webservice.mybluemix.net/calculator?wsdl),
+exclusively used by this **LB4** tutorial, it is exposing four end points that
+resembles the operation of a basic calculator as follows:
 
-1. **Add**
-2. **Subtract**
-3. **Divide**
-4. **Multiply**
+1. **add**
+2. **subtract**
+3. **divide**
+4. **multiply**
 
 ### SOAP Calculator Payloads
 
@@ -44,15 +44,15 @@ sample for the Add method.
 #### SOAP WS Response
 
 The SOAP Web Service will respond to **LB4** with the following xml result,
-based on the corresponding succesfully invoked method, in this case the sample
+based on the corresponding successfully invoked method, in this case the sample
 is just for the Add method.
 
 ```xml
 <SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://wsdl.example.org/\">
    <SOAP-ENV:Body>
-      <ns1:AddResponse>
-         <AddResult>55</AddResult>
-      </ns1:AddResponse>
+      <ns1:addResponse>
+         <value>55</value>
+      </ns1:addResponse>
    </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
 ```
@@ -84,7 +84,7 @@ convert it to JSON format before sending it back to the client application.
 
 ```ts
 result: {
-  AddResult: 55;
+  value: 55;
 }
 ```
 

--- a/examples/soap-calculator/src/__tests__/acceptance/application.acceptance.ts
+++ b/examples/soap-calculator/src/__tests__/acceptance/application.acceptance.ts
@@ -58,25 +58,25 @@ describe('Application', function() {
 
   it('divides two numbers', async () => {
     const response = await client.get('/divide/50/2').expect(200);
-    const answer = {result: {DivideResult: 25}};
+    const answer = {result: {value: 25}};
     expect(response.body).to.containDeep(answer);
   });
 
   it('adds two numbers', async () => {
     const response = await client.get('/add/25/25').expect(200);
-    const answer = {result: {AddResult: 50}};
+    const answer = {result: {value: 50}};
     expect(response.body).to.containDeep(answer);
   });
 
   it('multiplies two numbers', async () => {
     const response = await client.get('/multiply/25/3').expect(200);
-    const answer = {result: {MultiplyResult: 75}};
+    const answer = {result: {value: 75}};
     expect(response.body).to.containDeep(answer);
   });
 
   it('subtracts two numbers', async () => {
     const response = await client.get('/subtract/100/25').expect(200);
-    const answer = {result: {SubtractResult: 75}};
+    const answer = {result: {value: 75}};
     expect(response.body).to.containDeep(answer);
   });
 

--- a/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
+++ b/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
@@ -13,35 +13,35 @@ describe('CalculatorService', () => {
   before(givenACalculatorService);
 
   it('adds two numbers', async () => {
-    const response = await calculatorService.Add(<CalculatorParameters>{
+    const response = await calculatorService.add(<CalculatorParameters>{
       intA: 50,
       intB: 2,
     });
-    expect(response.result.AddResult).to.deepEqual(52);
+    expect(response.result.value).to.deepEqual(52);
   });
 
   it('subtracts two numbers', async () => {
-    const response = await calculatorService.Subtract(<CalculatorParameters>{
+    const response = await calculatorService.subtract(<CalculatorParameters>{
       intA: 40,
       intB: 20,
     });
-    expect(response.result.SubtractResult).to.deepEqual(20);
+    expect(response.result.value).to.deepEqual(20);
   });
 
   it('multiplies two numbers', async () => {
-    const response = await calculatorService.Multiply(<CalculatorParameters>{
+    const response = await calculatorService.multiply(<CalculatorParameters>{
       intA: 50,
       intB: 2,
     });
-    expect(response.result.MultiplyResult).to.deepEqual(100);
+    expect(response.result.value).to.deepEqual(100);
   });
 
   it('divides two numbers', async () => {
-    const response = await calculatorService.Divide(<CalculatorParameters>{
+    const response = await calculatorService.divide(<CalculatorParameters>{
       intA: 100,
       intB: 4,
     });
-    expect(response.result.DivideResult).to.deepEqual(25);
+    expect(response.result.value).to.deepEqual(25);
   });
 
   async function givenACalculatorService() {

--- a/examples/soap-calculator/src/controllers/calculator.controller.ts
+++ b/examples/soap-calculator/src/controllers/calculator.controller.ts
@@ -4,10 +4,10 @@ import {get, param, HttpErrors} from '@loopback/rest';
 import {
   CalculatorService,
   CalculatorParameters,
-  AddResult,
-  MultiplyResult,
-  DivideResult,
-  SubtractResult,
+  AddResponse,
+  MultiplyResponse,
+  DivideResponse,
+  SubtractResponse,
 } from '../services/calculator.service';
 
 export class CalculatorController {
@@ -16,48 +16,48 @@ export class CalculatorController {
     protected calculatorService: CalculatorService,
   ) {}
 
-  @get('/multiply/{arg1}/{arg2}')
+  @get('/multiply/{intA}/{intB}')
   async multiply(
-    @param.path.integer('arg1') intA: number,
-    @param.path.integer('arg2') intB: number,
-  ): Promise<MultiplyResult> {
-    return await this.calculatorService.Multiply(<CalculatorParameters>{
+    @param.path.integer('intA') intA: number,
+    @param.path.integer('intB') intB: number,
+  ): Promise<MultiplyResponse> {
+    return await this.calculatorService.multiply(<CalculatorParameters>{
       intA,
       intB,
     });
   }
-  @get('/add/{arg1}/{arg2}')
+  @get('/add/{intA}/{intB}')
   async add(
-    @param.path.integer('arg1') intA: number,
-    @param.path.integer('arg2') intB: number,
-  ): Promise<AddResult> {
-    return await this.calculatorService.Add(<CalculatorParameters>{
+    @param.path.integer('intA') intA: number,
+    @param.path.integer('intB') intB: number,
+  ): Promise<AddResponse> {
+    return await this.calculatorService.add(<CalculatorParameters>{
       intA,
       intB,
     });
   }
 
-  @get('/subtract/{arg1}/{arg2}')
+  @get('/subtract/{intA}/{intB}')
   async subtract(
-    @param.path.integer('arg1') intA: number,
-    @param.path.integer('arg2') intB: number,
-  ): Promise<SubtractResult> {
-    return await this.calculatorService.Subtract(<CalculatorParameters>{
+    @param.path.integer('intA') intA: number,
+    @param.path.integer('intB') intB: number,
+  ): Promise<SubtractResponse> {
+    return await this.calculatorService.subtract(<CalculatorParameters>{
       intA,
       intB,
     });
   }
 
-  @get('/divide/{arg1}/{arg2}')
+  @get('/divide/{intA}/{intB}')
   async divide(
-    @param.path.integer('arg1') intA: number,
-    @param.path.integer('arg2') intB: number,
-  ): Promise<DivideResult> {
+    @param.path.integer('intA') intA: number,
+    @param.path.integer('intB') intB: number,
+  ): Promise<DivideResponse> {
     //Preconditions
     if (intB === 0) {
       throw new HttpErrors.PreconditionFailed('Cannot divide by zero');
     }
-    return await this.calculatorService.Divide(<CalculatorParameters>{
+    return await this.calculatorService.divide(<CalculatorParameters>{
       intA,
       intB,
     });

--- a/examples/soap-calculator/src/datasources/calculator.datasource.json
+++ b/examples/soap-calculator/src/datasources/calculator.datasource.json
@@ -1,28 +1,28 @@
 {
   "name": "calculator",
   "connector": "soap",
-  "url": "http://lb4ws.eycgrupo.com/calculator/",
-  "wsdl": "http://lb4ws.eycgrupo.com/calculator/?wsdl",
+  "url": "https://calculator-webservice.mybluemix.net/calculator",
+  "wsdl": "https://calculator-webservice.mybluemix.net/calculator?wsdl",
   "remotingEnabled": true,
   "operations": {
-     "Multiply": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+     "multiply": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Multiply"
     },
-    "Add": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+    "add": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Add"
     },
-    "Subtract": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+    "subtract": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Subtract"
     },
-    "Divide": {
-      "service": "Calculator",
-      "port": "CalculatorSoap",
+    "divide": {
+      "service": "CalculatorService",
+      "port": "CalculatorPort",
       "operation": "Divide"
     }
   }

--- a/examples/soap-calculator/src/services/calculator.service.ts
+++ b/examples/soap-calculator/src/services/calculator.service.ts
@@ -2,36 +2,37 @@ import {getService, juggler} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
 import {CalculatorDataSource} from '../datasources/calculator.datasource';
 
-export interface MultiplyResult {
+export interface MultiplyResponse {
   result: {
-    MultiplyResult: number;
+    value: number;
   };
 }
-export interface AddResult {
+export interface AddResponse {
   result: {
-    AddResult: number;
+    value: number;
   };
 }
-export interface SubtractResult {
+export interface SubtractResponse {
   result: {
-    SubtractResult: number;
+    value: number;
   };
 }
-export interface DivideResult {
+export interface DivideResponse {
   result: {
-    DivideResult: number;
+    value: number;
   };
 }
+
 export interface CalculatorParameters {
   intA: number;
   intB: number;
 }
 
 export interface CalculatorService {
-  Multiply(args: CalculatorParameters): Promise<MultiplyResult>;
-  Add(args: CalculatorParameters): Promise<AddResult>;
-  Divide(args: CalculatorParameters): Promise<DivideResult>;
-  Subtract(args: CalculatorParameters): Promise<SubtractResult>;
+  multiply(args: CalculatorParameters): Promise<MultiplyResponse>;
+  add(args: CalculatorParameters): Promise<AddResponse>;
+  divide(args: CalculatorParameters): Promise<DivideResponse>;
+  subtract(args: CalculatorParameters): Promise<SubtractResponse>;
 }
 
 export class CalculatorServiceProvider implements Provider<CalculatorService> {


### PR DESCRIPTION
Fixes #2444. 

The hosted server is a deployment of https://github.com/raymondfeng/calculator-webservice on my account@IBM Cloud using CF.

See https://calculator-webservice.mybluemix.net/calculator

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
- [ ] Agree to the CLA (Contributor License Agreement) by [clicking and signing](https://cla.strongloop.com/agreements/strongloop/loopback-next)
