### PR TITLE
chore(docs): clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ To create your first LoopBack 4 application, see
 - [API documentation](http://apidocs.loopback.io/#LoopBack4)
 - [FAQ](http://loopback.io/doc/en/lb4/FAQ.html)
 - [LoopBack 3 vs LoopBack 4](http://loopback.io/doc/en/lb4/LoopBack-3.x.html)
-- [Tutorials and examples](http://loopback.io/doc/en/lb4/Examples-and-tutorials.html)
+- [Tutorials](http://loopback.io/doc/en/lb4/Tutorials.html)
+- [Examples](http://loopback.io/doc/en/lb4/Examples.html)
 
 ## Contributing
 

--- a/docs/site/Application-generator.md
+++ b/docs/site/Application-generator.md
@@ -87,6 +87,7 @@ the following files and directories:
 |   ├── repositories/
 |   ├── application.ts
 |   ├── index.ts
+|   ├── migrate.ts
 |   └── sequence.ts
 └── package.json
 ```

--- a/docs/site/Download-examples.md
+++ b/docs/site/Download-examples.md
@@ -24,7 +24,7 @@ lb4 example [options] [<example-name>]
 `example-name` - Optional name of the example to clone. If provided, the tool
 will skip the example-name prompt and run in a non-interactive mode.
 
-See [Examples and tutorials](Examples-and-tutorials.md) for the list of
+See [Examples](Examples.md) and [Tutorials](Tutorials.md) for the list of
 available examples.
 
 ### Interactive Prompts

--- a/docs/site/FAQ.md
+++ b/docs/site/FAQ.md
@@ -19,7 +19,7 @@ See [Crafting LoopBack 4](Crafting-LoopBack-4.md) for more details.
 
 ### Where are the tutorials?
 
-See [Examples and tutorials](Examples-and-tutorials.md).
+See [Examples](Examples.md) and [Tutorials](Tutorials.md).
 
 ### What features are planned?
 

--- a/docs/site/soap-calculator-tutorial-scaffolding.md
+++ b/docs/site/soap-calculator-tutorial-scaffolding.md
@@ -63,10 +63,12 @@ npm start
 ```
 
 You will see the app running on port 3000 by default, you can point your browser
-to http://localhost:3000/ping and see a greeting message from **LB4**.
+to <http://localhost:3000/ping> and see a greeting message from **LB4**.
 
-**NOTE:** Press Ctrl-C to stop running the application and continue to the next
+{% include note.html content="
+Press Ctrl-C to stop running the application and continue to the next
 step.
+" %}
 
 ### Navigation
 

--- a/docs/site/submitting_a_pr.md
+++ b/docs/site/submitting_a_pr.md
@@ -113,7 +113,7 @@ v4.
 
 #### 1. Fork the loopback-next repository
 
-In your browser, navigate to <https://github.com/strongloop/loopback-next> .
+In your browser, navigate to <https://github.com/strongloop/loopback-next>.
 
 Create your own fork of the repository by pressing the `Fork` link on the
 right-hand side.
@@ -121,7 +121,7 @@ right-hand side.
 ![submit_pr_fork_main_repo.png](./imgs/submit_pr_fork_main_repo.png)
 
 When the forking process is complete, the repository will show up as
-`{ your user id }/loopback-next`. In my case, it is `emonddr/loopback-next` .
+`{ your user id }/loopback-next`. In my case, it is `emonddr/loopback-next`.
 
 ![submit_pr_my_forked_repo.png](./imgs/submit_pr_my_forked_repo.png)
 
@@ -137,7 +137,7 @@ Click on the `Clone or download` button
 
 ![submit_pr_create_feature_branch_1.png](./imgs/submit_pr_create_feature_branch_1.png)
 
-This brings up tiny dialog with different choices : Clone with SSH, Use HTTPS,
+This brings up tiny dialog with different choices: Clone with SSH, Use HTTPS,
 Open in Desktop, or Download Zip.
 
 In my case, I will leave it as `Clone with SSH`, and click on the
@@ -147,7 +147,7 @@ to paste this value in a terminal window soon).
 ![submit_pr_create_feature_branch_2.png](./imgs/submit_pr_create_feature_branch_2.png)
 
 Open a terminal window, and navigate to the directory where you want to clone
-the repository. In my case, this is `/Users/dremond/git` .
+the repository. In my case, this is `/Users/dremond/git`.
 
 To create the `feature` branch, run:
 
@@ -299,7 +299,7 @@ In my case, the fork of the repository is behind by several commits.
 
 ![submit_pr_rebase_1.png](./imgs/submit_pr_rebase_1.png)
 
-It is necessary to perform a `rebase` .
+It is necessary to perform a `rebase`.
 
 To `rebase` your forked repository's `master` branch off of the original
 repository, run:
@@ -408,7 +408,7 @@ into one.
 Ensure that you currently have your feature branch checked out, and that your
 local feature branch is in sync with your remote feature branch.
 
-Run :
+Run:
 
 ```
 git status
@@ -422,7 +422,7 @@ feature branch.
 Now let's rebase the feature branch off of the master branch in an interactive
 mode that allows us to `squash` the commits.
 
-Run :
+Run:
 
 ```
 git rebase -i master
@@ -456,7 +456,7 @@ message.
 
 If I had a large number of commits and didn't want all commit messages to be
 appended together, I would have specified: `pick, fixup, fixup` instead of
-`pick, squash, squash` . The command `fixup` is like `squash`, except that it
+`pick, squash, squash`. The command `fixup` is like `squash`, except that it
 discards a commit's log message.
 
 In my case, I only like the message of the first commit, so I will delete the
@@ -468,7 +468,7 @@ Save the changes, and the interactive `rebase` command finally completes.
 
 Push the changes from the local feature branch to the remote feature branch.
 
-Run :
+Run:
 
 ```
 git push --force-with-lease

--- a/docs/site/todo-tutorial-putting-it-together.md
+++ b/docs/site/todo-tutorial-putting-it-together.md
@@ -35,7 +35,8 @@ Let's try out our application! First, you'll want to start the app.
 
 ```sh
 $ npm start
-Server is running at http://[::1]:3000
+
+Server is running at http://127.0.0.1:3000
 ```
 
 Next, you can use the [API Explorer](http://localhost:3000/explorer) to browse
@@ -50,10 +51,10 @@ Here are some requests you can try:
   `{ "desc": "need milk for cereal" }`
 
 {% include note.html content="
-For the meantime, use
+In the meantime, use
 `{ \"title\": \"get the milk\", \"desc\": \"need milk for cereal\" }` as the
 body for `PATCH/todos/{id}`, as LoopBack 4 doesn't support partial updates yet.
-For more info, see
+For more information, see
 [GitHub issue 1722](https://github.com/strongloop/loopback-next/issues/1722).
 " %}
 
@@ -79,8 +80,8 @@ left off here to guide you through adding in an additional feature:
 ### More examples and tutorials
 
 Eager to continue learning about LoopBack 4? Check out our
-[examples and tutorials](Examples-and-tutorials.md) section to find examples for
-creating your own custom components, sequences and more!
+[Examples](Examples.md) and [Tutorials](Tutorials.md) sections to find examples
+for creating your own custom components, sequences and more!
 
 ### Navigation
 

--- a/docs/site/todo-tutorial-scaffolding.md
+++ b/docs/site/todo-tutorial-scaffolding.md
@@ -35,7 +35,7 @@ $ lb4 app
 ```
 
 For this tutorial, when prompted with the options for enabling certain project
-features (loopback's build, tslint, mocha, etc.), leave them all enabled.
+features (LoopBack's build, tslint, mocha, etc.), leave them all enabled.
 
 ### Structure
 
@@ -43,15 +43,17 @@ After your application is generated, you will have a folder structure similar to
 the following:
 
 ```text
+public/
+  index.html
 src/
   __tests__/
     README.md
-    mocha.opts
     acceptance/
-      home-page.controller.acceptance.ts
+      home-page.acceptance.ts
       ping.controller.acceptance.ts
+      test-helper.ts
   controllers/
-    home-page.controller.ts
+    index.ts
     README.md
     ping.controller.ts
   datasources/
@@ -62,7 +64,10 @@ src/
     README.md
   application.ts
   index.ts
+  migrate.ts
   sequence.ts
+test/
+  mocha.opts
 node_modules/
   ***
 LICENSE


### PR DESCRIPTION
Quick docs clean up (including updating `Examples-and-tutorials` link to reflect change).

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
