### PR TITLE
fix(context): tidy up binding scopes for LB4 constructs to fix issue 2495

### DIFF
--- a/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
@@ -82,6 +82,19 @@ describe('TodoListApplication', () => {
         .and.not.containEql(notMyTodo.toJSON());
     });
 
+    // https://github.com/strongloop/loopback-next/issues/2495
+    it('finds todos for a todoList more than once', async () => {
+      await client
+        .get(`/todo-lists/${persistedTodoList.id}/todos`)
+        .send()
+        .expect(200);
+
+      await client
+        .get(`/todo-lists/${persistedTodoList.id}/todos`)
+        .send()
+        .expect(200);
+    });
+
     it('updates todos for a todoList', async () => {
       const patchedIsCompleteTodo = {isComplete: true};
       const response = await client

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -69,10 +69,7 @@ export class Bootstrapper {
     // Bind booters passed in as a part of BootOptions
     // We use _bindBooter so this Class can be used without the Mixin
     if (execOptions && execOptions.booters) {
-      execOptions.booters.forEach(booter =>
-        // tslint:disable-next-line:no-any
-        _bindBooter(this.app, booter),
-      );
+      execOptions.booters.forEach(booter => _bindBooter(this.app, booter));
     }
 
     // Determine the phases to be run. If a user set a phases filter, those
@@ -94,7 +91,7 @@ export class Bootstrapper {
       binding.key.slice(prefix_length),
     );
 
-    // Determing the booters to be run. If a user set a booters filter (class
+    // Determining the booters to be run. If a user set a booters filter (class
     // names of booters that should be run), that is the value, otherwise it
     // is all the registered booters by default.
     const names = execOptions

--- a/packages/context/src/__tests__/unit/context.unit.ts
+++ b/packages/context/src/__tests__/unit/context.unit.ts
@@ -648,7 +648,7 @@ describe('Context', () => {
       expect(ctx.bindingMap.size).to.eql(0);
     });
 
-    it('dereferences parent', () => {
+    it('set parent to undefined', () => {
       const childCtx = new TestContext(ctx);
       expect(childCtx.parent).to.equal(ctx);
       childCtx.close();

--- a/packages/context/src/__tests__/unit/resolver.unit.ts
+++ b/packages/context/src/__tests__/unit/resolver.unit.ts
@@ -649,7 +649,7 @@ describe('method injection', () => {
 
     expect(() => {
       invokeMethod(TestClass.prototype, 'test', ctx);
-    }).to.throw(/The key .+ was not bound to any value/);
+    }).to.throw(/The key .+ is not bound to any value/);
   });
 
   it('resolves arguments for a static method', () => {

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -545,7 +545,7 @@ export class Context extends EventEmitter {
   }
 
   /**
-   * Get the value bound to the given key, throw an error when no value was
+   * Get the value bound to the given key, throw an error when no value is
    * bound for the given key.
    *
    * @example
@@ -576,7 +576,7 @@ export class Context extends EventEmitter {
    *
    * ```ts
    * // get "rest" property from the value bound to "config"
-   * // use "undefined" when not config was provided
+   * // use `undefined` when no config is provided
    * const config = await ctx.get<RestComponentConfig>('config#rest', {
    *   optional: true
    * });
@@ -587,7 +587,7 @@ export class Context extends EventEmitter {
    * @param optionsOrSession Options or session for resolution. An instance of
    * `ResolutionSession` is accepted for backward compatibility.
    * @returns A promise of the bound value, or a promise of undefined when
-   * the optional binding was not found.
+   * the optional binding is not found.
    */
   get<ValueType>(
     keyWithPath: BindingAddress<ValueType>,
@@ -644,7 +644,7 @@ export class Context extends EventEmitter {
    *
    * ```ts
    * // get "rest" property from the value bound to "config"
-   * // use "undefined" when no config was provided
+   * // use "undefined" when no config is provided
    * const config = await ctx.getSync<RestComponentConfig>('config#rest', {
    *   optional: true
    * });
@@ -654,7 +654,7 @@ export class Context extends EventEmitter {
    *   (deeply) nested property to retrieve.
    * * @param optionsOrSession Options or session for resolution. An instance of
    * `ResolutionSession` is accepted for backward compatibility.
-   * @returns The bound value, or undefined when an optional binding was not found.
+   * @returns The bound value, or undefined when an optional binding is not found.
    */
   getSync<ValueType>(
     keyWithPath: BindingAddress<ValueType>,
@@ -722,7 +722,9 @@ export class Context extends EventEmitter {
     }
 
     if (options && options.optional) return undefined;
-    throw new Error(`The key ${key} was not bound to any value.`);
+    throw new Error(
+      `The key '${key}' is not bound to any value in context ${this.name}`,
+    );
   }
 
   /**
@@ -749,7 +751,7 @@ export class Context extends EventEmitter {
    *   (deeply) nested property to retrieve.
    * @param optionsOrSession Options for resolution or a session
    * @returns The bound value or a promise of the bound value, depending
-   *   on how the binding was configured.
+   *   on how the binding is configured.
    * @internal
    */
   getValueOrPromise<ValueType>(

--- a/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
+++ b/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
@@ -199,6 +199,8 @@ describe('RepositoryMixin', () => {
   function expectNoteRepoToBeBound(myApp: Application) {
     const boundRepositories = myApp.find('repositories.*').map(b => b.key);
     expect(boundRepositories).to.containEql('repositories.NoteRepo');
+    const binding = myApp.getBinding('repositories.NoteRepo');
+    expect(binding.scope).to.equal(BindingScope.TRANSIENT);
     const repoInstance = myApp.getSync('repositories.NoteRepo');
     expect(repoInstance).to.be.instanceOf(NoteRepo);
   }

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -71,7 +71,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
         name,
         namespace: 'repositories',
         type: 'repository',
-      }).inScope(BindingScope.SINGLETON);
+      });
       this.add(binding);
       return binding;
     }

--- a/packages/rest/src/__tests__/acceptance/request-parsing/request-parsing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/request-parsing/request-parsing.acceptance.ts
@@ -64,7 +64,7 @@ describe('request parsing', () => {
   });
 
   it('allows built-in body parsers to be removed', async () => {
-    app.unbind(RestBindings.REQUEST_BODY_PARSER_JSON);
+    app.restServer.unbind(RestBindings.REQUEST_BODY_PARSER_JSON);
     await postRequest('/show-body', 415);
   });
 

--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -3,37 +3,32 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Context, inject, BindingScope} from '@loopback/context';
+import {Application, CoreBindings} from '@loopback/core';
+import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
+import {api, get, param, post, requestBody} from '@loopback/openapi-v3';
 import {
-  Request,
-  Response,
-  RestBindings,
-  RestServer,
-  RestComponent,
-  RestApplication,
-  SequenceActions,
-  HttpServerLike,
+  OperationObject,
+  ParameterObject,
+  ResponseObject,
+} from '@loopback/openapi-v3-types';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
+import {
   ControllerClass,
   ControllerInstance,
   createControllerFactoryForClass,
   createControllerFactoryForInstance,
+  HttpServerLike,
+  RegExpRouter,
+  Request,
+  Response,
+  RestApplication,
+  RestBindings,
+  RestComponent,
+  RestServer,
+  SequenceActions,
 } from '../../..';
-
-import {api, get, post, param, requestBody} from '@loopback/openapi-v3';
-
-import {Application, CoreBindings} from '@loopback/core';
-
-import {
-  ParameterObject,
-  OperationObject,
-  ResponseObject,
-} from '@loopback/openapi-v3-types';
-
-import {expect, Client, createClientForHandler} from '@loopback/testlab';
-import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
-import {inject, Context, BindingScope} from '@loopback/context';
-
 import {createUnexpectedHttpErrorLogger} from '../../helpers';
-import {RegExpRouter} from '../../..';
 
 /* # Feature: Routing
  * - In order to build REST APIs
@@ -361,7 +356,7 @@ describe('Routing', () => {
       });
   });
 
-  it('binds the current controller', async () => {
+  it('binds the current controller as singleton', async () => {
     const app = givenAnApplication();
     const server = await givenAServer(app);
     const spec = anOpenApiSpec()
@@ -378,7 +373,7 @@ describe('Routing', () => {
         };
       }
     }
-    givenControllerInApp(app, GetCurrentController);
+    givenControllerInApp(app, GetCurrentController, BindingScope.SINGLETON);
 
     return whenIMakeRequestTo(server)
       .get('/name')
@@ -761,8 +756,9 @@ describe('Routing', () => {
   function givenControllerInApp(
     app: Application,
     controller: ControllerClass<ControllerInstance>,
+    scope = BindingScope.TRANSIENT,
   ) {
-    app.controller(controller).inScope(BindingScope.CONTEXT);
+    app.controller(controller).inScope(scope);
   }
 
   function whenIMakeRequestTo(serverOrApp: HttpServerLike): Client {

--- a/packages/rest/src/__tests__/unit/rest.component/rest.component.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.component/rest.component.unit.ts
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Application, CoreBindings} from '@loopback/core';
+import {expect} from '@loopback/testlab';
+import {RestComponent, RestBindings, RestServer} from '../../..';
+
+describe('RestComponent', () => {
+  let app: Application;
+
+  before(givenApplicationWithRestComponent);
+
+  it('adds bindings of RestServer', async () => {
+    expect(app.contains(`${CoreBindings.SERVERS}.RestServer`)).to.be.true();
+    expect(await app.getServer(RestServer)).to.be.instanceOf(RestServer);
+  });
+
+  it('adds body parser bindings to RestServer', async () => {
+    expect(app.contains(RestBindings.REQUEST_BODY_PARSER)).to.be.false();
+    const server = await app.getServer(RestServer);
+    expect(server.contains(RestBindings.REQUEST_BODY_PARSER)).to.be.true();
+  });
+
+  function givenApplicationWithRestComponent() {
+    app = new Application();
+    app.component(RestComponent);
+  }
+});

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -3,18 +3,18 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, Constructor, BindingAddress} from '@loopback/context';
+import {Binding, BindingAddress, Constructor} from '@loopback/context';
 import {Application, ApplicationConfig, Server} from '@loopback/core';
 import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3-types';
 import {PathParams} from 'express-serve-static-core';
 import {ServeStaticOptions} from 'serve-static';
 import {format} from 'util';
+import {BodyParser} from './body-parsers';
 import {RestBindings} from './keys';
 import {RestComponent} from './rest.component';
 import {HttpRequestListener, HttpServerLike, RestServer} from './rest.server';
 import {ControllerClass, ControllerFactory, RouteEntry} from './router';
 import {SequenceFunction, SequenceHandler} from './sequence';
-import {BodyParser} from './body-parsers';
 
 export const ERR_NO_MULTI_SERVER = format(
   'RestApplication does not support multiple servers!',
@@ -87,7 +87,6 @@ export class RestApplication extends Application implements HttpServerLike {
    * See https://expressjs.com/en/4x/api.html#express.static
    * @param path The path(s) to serve the asset.
    * See examples at https://expressjs.com/en/4x/api.html#path-examples
-   * To avoid performance penalty, `/` is not allowed for now.
    * @param rootDir The root directory from which to serve static assets
    * @param options Options for serve-static
    */

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  BindingScope,
   Constructor,
   Context,
   instantiateClass,
   invokeMethod,
   ValueOrPromise,
+  BindingScope,
 } from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {OperationObject} from '@loopback/openapi-v3-types';
@@ -100,6 +100,12 @@ export class ControllerRoute<T> extends BaseRoute {
   }
 
   updateBindings(requestContext: Context) {
+    /*
+     * Bind current controller to the request context in `SINGLETON` scope
+     * so that each request gets its instance of the controller. Please
+     * note the controller class itself can still be bound to other scopes,
+     * such as SINGLETON or TRANSIENT (default).
+     */
     requestContext
       .bind(CoreBindings.CONTROLLER_CURRENT)
       .toDynamicValue(() => this._controllerFactory(requestContext))

--- a/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
+++ b/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, Component, Provider} from '@loopback/core';
+import {Application, Component, Provider, BindingScope} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {Class, ServiceMixin} from '../../../';
 
@@ -74,15 +74,17 @@ describe('ServiceMixin', () => {
   }
 
   async function expectGeocoderToBeBound(myApp: Application) {
-    const boundRepositories = myApp.find('services.*').map(b => b.key);
-    expect(boundRepositories).to.containEql('services.GeocoderService');
-    const repoInstance = await myApp.get('services.GeocoderService');
-    expect(repoInstance).to.equal(GeocoderSingleton);
+    const boundServices = myApp.find('services.*').map(b => b.key);
+    expect(boundServices).to.containEql('services.GeocoderService');
+    const binding = myApp.getBinding('services.GeocoderService');
+    expect(binding.scope).to.equal(BindingScope.TRANSIENT);
+    const serviceInstance = await myApp.get('services.GeocoderService');
+    expect(serviceInstance).to.equal(GeocoderSingleton);
   }
 
   function expectGeocoderToNotBeBound(myApp: Application) {
-    const boundRepos = myApp.find('services.*').map(b => b.key);
-    expect(boundRepos).to.be.empty();
+    const boundServices = myApp.find('services.*').map(b => b.key);
+    expect(boundServices).to.be.empty();
   }
 
   function expectComponentToBeBound(

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -3,12 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  Provider,
-  createBindingFromClass,
-  BindingScope,
-  Binding,
-} from '@loopback/context';
+import {Binding, createBindingFromClass, Provider} from '@loopback/context';
 import {Application} from '@loopback/core';
 
 /**
@@ -75,7 +70,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
         name: serviceName,
         namespace: 'services',
         type: 'service',
-      }).inScope(BindingScope.SINGLETON);
+      });
       this.add(binding);
       return binding;
     }


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/2495

**Analysis**
1. The Repository is a singleton but it has an injected getter function, which internally references the `request context` that triggers the creation.
2. After the `request context` closes, the getter function stops working.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
