### PR TITLE
Improve HTTP server config used by tests

### DIFF
--- a/packages/cli/generators/app/templates/src/__tests__/acceptance/test-helper.ts.ejs
+++ b/packages/cli/generators/app/templates/src/__tests__/acceptance/test-helper.ts.ejs
@@ -6,17 +6,16 @@ import {
 } from '@loopback/testlab';
 
 export async function setupApplication(): Promise<AppWithClient> {
-  const config = givenHttpServerConfig();
-
-  // Set host to `HOST` env var or ipv4 loopback interface
-  // By default, docker container has ipv6 disabled.
-  config.host = config.host || process.env.HOST || '127.0.0.1';
-
-  // Set port to `PORT` env var or `0`
-  config.port = config.port || +(process.env.PORT || 0);
+  const restConfig = givenHttpServerConfig({
+    // Customize the server configuration here.
+    // Empty values (undefined, '') will be ignored by the helper.
+    //
+    // host: process.env.HOST,
+    // port: +process.env.PORT,
+  });
 
   const app = new <%= project.applicationName %>({
-    rest: config,
+    rest: restConfig,
   });
 
   await app.boot();

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -82,11 +82,11 @@ describe('app-generator specific files', () => {
     );
     assert.fileContent(
       'src/__tests__/acceptance/test-helper.ts',
-      "process.env.HOST || '127.0.0.1'",
+      'process.env.HOST',
     );
     assert.fileContent(
       'src/__tests__/acceptance/test-helper.ts',
-      '+(process.env.PORT || 0)',
+      '+process.env.PORT',
     );
   });
 

--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -154,6 +154,22 @@ describe('HttpServer (integration)', () => {
     await expect(anotherServer.start()).to.be.rejectedWith(/EADDRINUSE/);
   });
 
+  it('supports HTTP over IPv4', async () => {
+    server = new HttpServer(dummyRequestHandler, {host: '127.0.0.1'});
+    await server.start();
+    expect(server.address!.family).to.equal('IPv4');
+    const response = await httpGetAsync(server.url);
+    expect(response.statusCode).to.equal(200);
+  });
+
+  itSkippedOnTravis('supports HTTP over IPv6', async () => {
+    server = new HttpServer(dummyRequestHandler, {host: '::1'});
+    await server.start();
+    expect(server.address!.family).to.equal('IPv6');
+    const response = await httpGetAsync(server.url);
+    expect(response.statusCode).to.equal(200);
+  });
+
   it('supports HTTPS protocol with key and certificate files', async () => {
     const serverOptions = givenHttpServerConfig();
     const httpsServer: HttpServer = givenHttpsServer(serverOptions);

--- a/packages/testlab/src/__tests__/unit/http-server-config.test.ts
+++ b/packages/testlab/src/__tests__/unit/http-server-config.test.ts
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {givenHttpServerConfig} from '../../http-server-config';
+import {expect} from '../../expect';
+
+describe('givenHttpServerConfig', () => {
+  it('sets port to 0 by default', () => {
+    const config = givenHttpServerConfig();
+    expect(config.port).to.equal(0);
+  });
+
+  it('sets host to "127.0.0.1" by default', () => {
+    const config = givenHttpServerConfig();
+    expect(config.host).to.equal('127.0.0.1');
+  });
+
+  it('honors custom port', () => {
+    const config = givenHttpServerConfig({port: 3000});
+    expect(config.port).to.equal(3000);
+  });
+
+  it('honors custom host', () => {
+    const config = givenHttpServerConfig({host: '::1'});
+    expect(config.host).to.equal('::1');
+  });
+
+  it('ignores custom port set to undefined', () => {
+    const config = givenHttpServerConfig({port: undefined});
+    expect(config.port).to.equal(0);
+  });
+
+  it('ignores custom host set to undefined', () => {
+    const config = givenHttpServerConfig({host: undefined});
+    expect(config.host).to.equal('127.0.0.1');
+  });
+});

--- a/packages/testlab/src/http-server-config.ts
+++ b/packages/testlab/src/http-server-config.ts
@@ -6,14 +6,20 @@
 /**
  * Create an HTTP-server configuration that works well in test environments.
  *  - Ask the operating system to assign a free (ephemeral) port.
- *  - Use IPv4 localhost `127.0.0.1` on Travis-CI to avoid known IPv6 issues.
+ *  - Use IPv4 localhost `127.0.0.1` to avoid known IPv6 issues in Docker-based
+ *    environments like Travis-CI.
  *
  * @param customConfig Additional configuration options to apply.
  */
 export function givenHttpServerConfig<T extends object>(
   customConfig?: T,
-): T & {host?: string; port: number} {
-  const defaults = {port: 0};
-  const hostConfig = process.env.TRAVIS ? {host: '127.0.0.1'} : {};
-  return Object.assign(defaults, hostConfig, customConfig);
+): T & {host: string; port: number} {
+  const defaults = {
+    host: '127.0.0.1',
+    port: 0,
+  };
+  const config = Object.assign({}, defaults, customConfig);
+  if (config.host === undefined) config.host = defaults.host;
+  if (config.port === undefined) config.port = defaults.port;
+  return config;
 }


### PR DESCRIPTION
#1995 modified the project template to use the following configuration for HTTP server host & port:

```ts
  const config = givenHttpServerConfig();
	
  // Set host to `HOST` env var or ipv4 loopback interface
  // By default, docker container has ipv6 disabled.
  config.host = config.host || process.env.HOST || '127.0.0.1';

  // Set port to `PORT` env var or `0`
  config.port = config.port || +(process.env.PORT || 0);
```

I find such approach problematic.

1. Acceptance tests are sort of self-contained. Both the server and the client are running in the same Node.js process and the server is running only for the duration of the test suite. There is no need to expose the server to public by honoring HOST/PORT environment variables.

2. By honoring HOST/PORT environment variables, we can actually break the test suite for people that are not running inside docker, because there may be already another process listening on that address.

3. I find the configuration rather complex. By placing it into a project template, we are forcing this complexity on all framework users. There are also no tests to verify correctness of the implementation.

In this pull request, I am proposing a different approach:

- The first commit modifies `givenHttpServerConfig` to always use `127.0.0.1` as the host. I believe this should fix the problem with Docker IPv6 setup as described in #1995. 

- `givenHttpServerConfig` is also changed to ignore empty values in custom host/port config, to make the customization even easier.

- The second commit modifies the project template to run the acceptance tests with the default config provided by `givenHttpServerConfig`. The template also contains a code comment showing users how they can customize the host & port values.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated