### PR TITLE
refactor(rest-explorer): use request.originalUrl when available

### DIFF
--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -33,11 +33,8 @@ export class ExplorerController {
   }
 
   indexRedirect() {
-    let url = this.request.url + '/';
-    if (this.request.baseUrl && this.request.baseUrl !== '/') {
-      url = this.request.baseUrl + url;
-    }
-    this.response.redirect(301, url);
+    const url = this.request.originalUrl || this.request.url;
+    this.response.redirect(301, url + '/');
   }
 
   index() {


### PR DESCRIPTION
Simplify the code building redirect location to leverage [`req.originalUrl`](https://expressjs.com/en/4x/api.html#req.originalUrl provided by Express.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated