### PR TITLE
docs: fix a broken link to model decorators

### DIFF
--- a/docs/site/Decorators_openapi.md
+++ b/docs/site/Decorators_openapi.md
@@ -235,7 +235,7 @@ class User {
 ```
 
 _To learn more about decorating models and the corresponding OpenAPI schema, see
-[model decorators](#model-decorators)._
+[model decorators](Model.md#model-decorator)._
 
 The model decorators allow type information of the model to be visible to the
 spec generator so that `@requestBody` can be used on the parameter:


### PR DESCRIPTION
Fixes a broken link to model decorators

This document : https://loopback.io/doc/en/lb4/Decorators_openapi.html

has a link

![image](https://user-images.githubusercontent.com/6864736/53590875-bd47a880-3b60-11e9-8f5c-77bae9a5c8f9.png)

which is broken.

It most likely needs to link to:

https://loopback.io/doc/en/lb4/Model.html#model-decorator

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
