### PR TITLE
fix(repository): change default binding scope to TRANSIENT for repos

### DIFF
--- a/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
@@ -82,6 +82,19 @@ describe('TodoListApplication', () => {
         .and.not.containEql(notMyTodo.toJSON());
     });
 
+    // https://github.com/strongloop/loopback-next/issues/2495
+    it('finds todos for a todoList more than once', async () => {
+      await client
+        .get(`/todo-lists/${persistedTodoList.id}/todos`)
+        .send()
+        .expect(200);
+
+      await client
+        .get(`/todo-lists/${persistedTodoList.id}/todos`)
+        .send()
+        .expect(200);
+    });
+
     it('updates todos for a todoList', async () => {
       const patchedIsCompleteTodo = {isComplete: true};
       const response = await client

--- a/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
+++ b/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
@@ -199,6 +199,8 @@ describe('RepositoryMixin', () => {
   function expectNoteRepoToBeBound(myApp: Application) {
     const boundRepositories = myApp.find('repositories.*').map(b => b.key);
     expect(boundRepositories).to.containEql('repositories.NoteRepo');
+    const binding = myApp.getBinding('repositories.NoteRepo');
+    expect(binding.scope).to.equal(BindingScope.TRANSIENT);
     const repoInstance = myApp.getSync('repositories.NoteRepo');
     expect(repoInstance).to.be.instanceOf(NoteRepo);
   }

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -71,7 +71,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
         name,
         namespace: 'repositories',
         type: 'repository',
-      }).inScope(BindingScope.SINGLETON);
+      });
       this.add(binding);
       return binding;
     }


### PR DESCRIPTION
First phase fix for https://github.com/strongloop/loopback-next/issues/2495

This is a spin-off from #2499 to provide the first phase for #2495 by changing the binding scope of repositories to `TRANSIENT`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
