### PR TITLE
fix(service-proxy): change default binding scope to TRANSIENT for service proxies

### DIFF
--- a/packages/service-proxy/src/__tests__/acceptance/service.mixin.acceptance.ts
+++ b/packages/service-proxy/src/__tests__/acceptance/service.mixin.acceptance.ts
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/service-proxy
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Application, Context, inject, Provider} from '@loopback/core';
+import {expect} from '@loopback/testlab';
+import {ServiceMixin} from '../..';
+
+describe('ServiceMixin - service providers and proxies', () => {
+  class AppWithServiceMixin extends ServiceMixin(Application) {}
+
+  interface GeoPoint {
+    lat: number;
+    lng: number;
+  }
+
+  interface GeocoderService {
+    geocode(address: string): Promise<GeoPoint>;
+  }
+
+  class DummyGeocoder implements GeocoderService {
+    constructor(public apiKey: string) {}
+
+    geocode(address: string) {
+      return Promise.resolve({lat: 0, lng: 0});
+    }
+  }
+
+  class GeocoderServiceProvider implements Provider<GeocoderService> {
+    constructor(@inject('apiKey') private apiKey: string) {}
+    value(): Promise<GeocoderService> {
+      // Returns different instances so that we can verify the TRANSIENT
+      // binding scope, which is now the default for service proxies
+      return Promise.resolve(new DummyGeocoder(this.apiKey));
+    }
+  }
+
+  it('binds a service provider in TRANSIENT scope by default', async () => {
+    const myApp = new AppWithServiceMixin();
+    myApp.serviceProvider(GeocoderServiceProvider);
+    const myReq1 = new Context(myApp, 'request1');
+    myReq1.bind('apiKey').to('123');
+    const service1 = await myReq1.get<DummyGeocoder>(
+      'services.GeocoderService',
+    );
+    expect(service1.apiKey).to.eql('123');
+
+    const myReq2 = new Context(myApp, 'request2');
+    myReq2.bind('apiKey').to('456');
+    const service2 = await myReq2.get<DummyGeocoder>(
+      'services.GeocoderService',
+    );
+    expect(service2.apiKey).to.eql('456');
+  });
+});

--- a/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
+++ b/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, Component, Provider} from '@loopback/core';
+import {Application, Component, Provider, BindingScope} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {Class, ServiceMixin} from '../../../';
 
@@ -15,7 +15,7 @@ describe('ServiceMixin', () => {
     expect(typeof myApp.serviceProvider).to.be.eql('function');
   });
 
-  it('binds repository from app.serviceProvider()', async () => {
+  it('binds service from app.serviceProvider()', async () => {
     const myApp = new AppWithServiceMixin();
 
     expectGeocoderToNotBeBound(myApp);
@@ -56,16 +56,17 @@ describe('ServiceMixin', () => {
     geocode(address: string): Promise<GeoPoint>;
   }
 
-  // A dummy service instance to make unit testing easier
-  const GeocoderSingleton: GeocoderService = {
+  class DummyGeocoder implements GeocoderService {
     geocode(address: string) {
       return Promise.resolve({lat: 0, lng: 0});
-    },
-  };
+    }
+  }
 
   class GeocoderServiceProvider implements Provider<GeocoderService> {
     value(): Promise<GeocoderService> {
-      return Promise.resolve(GeocoderSingleton);
+      // Returns different instances so that we can verify the TRANSIENT
+      // binding scope, which is now the default for service proxies
+      return Promise.resolve(new DummyGeocoder());
     }
   }
 
@@ -74,15 +75,19 @@ describe('ServiceMixin', () => {
   }
 
   async function expectGeocoderToBeBound(myApp: Application) {
-    const boundRepositories = myApp.find('services.*').map(b => b.key);
-    expect(boundRepositories).to.containEql('services.GeocoderService');
-    const repoInstance = await myApp.get('services.GeocoderService');
-    expect(repoInstance).to.equal(GeocoderSingleton);
+    const boundServices = myApp.find('services.*').map(b => b.key);
+    expect(boundServices).to.containEql('services.GeocoderService');
+    const binding = myApp.getBinding('services.GeocoderService');
+    expect(binding.scope).to.equal(BindingScope.TRANSIENT);
+    const serviceInstance1 = await myApp.get('services.GeocoderService');
+    expect(serviceInstance1).to.be.instanceOf(DummyGeocoder);
+    const serviceInstance2 = await myApp.get('services.GeocoderService');
+    expect(serviceInstance2).to.not.be.equal(serviceInstance1);
   }
 
   function expectGeocoderToNotBeBound(myApp: Application) {
-    const boundRepos = myApp.find('services.*').map(b => b.key);
-    expect(boundRepos).to.be.empty();
+    const boundServices = myApp.find('services.*').map(b => b.key);
+    expect(boundServices).to.be.empty();
   }
 
   function expectComponentToBeBound(

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -3,12 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  Provider,
-  createBindingFromClass,
-  BindingScope,
-  Binding,
-} from '@loopback/context';
+import {Binding, createBindingFromClass, Provider} from '@loopback/context';
 import {Application} from '@loopback/core';
 
 /**
@@ -75,7 +70,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
         name: serviceName,
         namespace: 'services',
         type: 'service',
-      }).inScope(BindingScope.SINGLETON);
+      });
       this.add(binding);
       return binding;
     }


### PR DESCRIPTION
A spin-off from #2499 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
