### PR TITLE
fix(boot): improve booter bindings

### DIFF
--- a/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
+++ b/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
@@ -5,7 +5,7 @@
 
 import {expect} from '@loopback/testlab';
 import {BootMixin, Booter, BootBindings} from '../../..';
-import {Application} from '@loopback/core';
+import {Application, bind} from '@loopback/core';
 
 describe('BootMxiin unit tests', () => {
   let app: AppWithBootMixin;
@@ -26,6 +26,14 @@ describe('BootMxiin unit tests', () => {
     app.booters(TestBooter);
     const booter = await app.get(`${BootBindings.BOOTER_PREFIX}.TestBooter`);
     expect(booter).to.be.an.instanceOf(TestBooter);
+  });
+
+  it('binds booter with `@bind` from app.booters()', async () => {
+    app.booters(TestBooterWithBind);
+    const booterBinding = app.getBinding(
+      `${BootBindings.BOOTER_PREFIX}.TestBooterWithBind`,
+    );
+    expect(booterBinding.tagMap).to.containEql({artifactType: 'xsd'});
   });
 
   it('binds multiple booter classes from app.booters()', async () => {
@@ -62,6 +70,15 @@ describe('BootMxiin unit tests', () => {
   });
 
   class TestBooter implements Booter {
+    configured = false;
+
+    async configure() {
+      this.configured = true;
+    }
+  }
+
+  @bind({tags: {artifactType: 'xsd'}})
+  class TestBooterWithBind implements Booter {
     configured = false;
 
     async configure() {

--- a/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
+++ b/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
@@ -36,6 +36,13 @@ describe('BootMxiin unit tests', () => {
     expect(booterBinding.tagMap).to.containEql({artifactType: 'xsd'});
   });
 
+  it('binds booter from app.booters() as singletons by default', async () => {
+    app.booters(TestBooter);
+    const booter1 = await app.get(`${BootBindings.BOOTER_PREFIX}.TestBooter`);
+    const booter2 = await app.get(`${BootBindings.BOOTER_PREFIX}.TestBooter`);
+    expect(booter1).to.be.exactly(booter2);
+  });
+
   it('binds multiple booter classes from app.booters()', async () => {
     app.booters(TestBooter, AnotherTestBooter);
     const booter = await app.get(`${BootBindings.BOOTER_PREFIX}.TestBooter`);

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -69,10 +69,7 @@ export class Bootstrapper {
     // Bind booters passed in as a part of BootOptions
     // We use _bindBooter so this Class can be used without the Mixin
     if (execOptions && execOptions.booters) {
-      execOptions.booters.forEach(booter =>
-        // tslint:disable-next-line:no-any
-        _bindBooter(this.app, booter),
-      );
+      execOptions.booters.forEach(booter => _bindBooter(this.app, booter));
     }
 
     // Determine the phases to be run. If a user set a phases filter, those
@@ -94,7 +91,7 @@ export class Bootstrapper {
       binding.key.slice(prefix_length),
     );
 
-    // Determing the booters to be run. If a user set a booters filter (class
+    // Determining the booters to be run. If a user set a booters filter (class
     // names of booters that should be run), that is the value, otherwise it
     // is all the registered booters by default.
     const names = execOptions

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -8,6 +8,7 @@ import {
   Constructor,
   Context,
   createBindingFromClass,
+  BindingScope,
 } from '@loopback/context';
 import {BootComponent} from '../boot.component';
 import {Bootstrapper} from '../bootstrapper';
@@ -142,7 +143,9 @@ export function _bindBooter(
 ): Binding {
   const binding = createBindingFromClass(booterCls, {
     namespace: BootBindings.BOOTER_PREFIX,
-  }).tag(BootBindings.BOOTER_TAG);
+  })
+    .tag(BootBindings.BOOTER_TAG)
+    .inScope(BindingScope.SINGLETON);
   ctx.add(binding);
   return binding;
 }

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -3,10 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor, Binding, BindingScope, Context} from '@loopback/context';
-import {Booter, BootOptions, Bootable} from '../interfaces';
+import {
+  Binding,
+  Constructor,
+  Context,
+  createBindingFromClass,
+} from '@loopback/context';
 import {BootComponent} from '../boot.component';
 import {Bootstrapper} from '../bootstrapper';
+import {Bootable, Booter, BootOptions} from '../interfaces';
 import {BootBindings} from '../keys';
 
 // Binding is re-exported as Binding / Booter types are needed when consuming
@@ -78,8 +83,9 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
      * ```
      */
     booters(...booterCls: Constructor<Booter>[]): Binding[] {
-      // tslint:disable-next-line:no-any
-      return booterCls.map(cls => _bindBooter(<Context>(<any>this), cls));
+      return booterCls.map(cls =>
+        _bindBooter((this as unknown) as Context, cls),
+      );
     }
 
     /**
@@ -134,9 +140,9 @@ export function _bindBooter(
   ctx: Context,
   booterCls: Constructor<Booter>,
 ): Binding {
-  return ctx
-    .bind(`${BootBindings.BOOTER_PREFIX}.${booterCls.name}`)
-    .toClass(booterCls)
-    .inScope(BindingScope.CONTEXT)
-    .tag(BootBindings.BOOTER_TAG);
+  const binding = createBindingFromClass(booterCls, {
+    namespace: BootBindings.BOOTER_PREFIX,
+  }).tag(BootBindings.BOOTER_TAG);
+  ctx.add(binding);
+  return binding;
 }


### PR DESCRIPTION
The PR introduces two minor enhancements to booter class bindings.

1. Honor `@bind` for booter classes
2. Bind booter classes using `SINGLETON` scope by default

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
