### PR TITLE
fix(example-express-composition): remove prepublishOnly and lbApp.start() and fix example's name

### DIFF
--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -234,7 +234,6 @@ export class ExpressServer {
   }
 
   async start() {
-    await this.lbApp.start();
     const server = this.app.listen(3000);
     await pEvent(server, 'listening');
   }

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -31,8 +31,7 @@
     "test:dev": "lb-mocha --allow-console-logs dist/src/__tests__/**/*.js && npm run posttest",
     "migrate": "node ./dist/src/migrate",
     "prestart": "npm run build",
-    "start": "node .",
-    "prepublishOnly": "npm run test"
+    "start": "node ."
   },
   "repository": {
     "type": "git",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-composition",
+  "name": "@loopback/example-express-composition",
   "version": "1.1.0",
   "description": "LoopBack 4 REST API on Express",
   "keywords": [
@@ -35,7 +35,11 @@
     "prepublishOnly": "npm run test"
   },
   "repository": {
-    "type": "git"
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-next.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "author": "IBM Corp.",
   "license": "MIT",

--- a/examples/express-composition/src/server.ts
+++ b/examples/express-composition/src/server.ts
@@ -35,7 +35,6 @@ export class ExpressServer {
   }
 
   public async start() {
-    await this.lbApp.start();
     this.server = this.app.listen(3000);
     await pEvent(this.server, 'listening');
   }


### PR DESCRIPTION
Removed `prepublishOnly` script and starting the `note` app (it starts without the explicit call). And updated name from `express-composition` to `@loopback/example-express-composition`. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
