### PR TITLE
feat(context): honor binding scope from @bind

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -229,6 +229,28 @@ const binding = createBindingFromClass(MyService);
 ctx.add(binding);
 ```
 
+Please note `createBindingFromClass` also accepts an optional `options`
+parameter of `BindingFromClassOptions` type with the following settings:
+
+- key: Binding key, such as `controllers.MyController`
+- type: Artifact type, such as `server`, `controller`, `repository` or `service`
+- name: Artifact name, such as `my-rest-server` and `my-controller`, default to
+  the name of the bound class
+- namespace: Namespace for the binding key, such as `servers` and `controllers`.
+  If `key` does not exist, its value is calculated as `<namespace>.<name>`.
+- typeNamespaceMapping: Mapping artifact type to binding key namespaces, such
+  as:
+
+  ```ts
+  {
+    controller: 'controllers',
+    repository: 'repositories'
+  }
+  ```
+
+- defaultScope: Default scope if the binding does not have an explicit scope
+  set. The `scope` from `@bind` of the bound class takes precedence.
+
 ### Encoding value types in binding keys
 
 String keys for bindings do not help enforce the value type. Consider the

--- a/packages/context/src/__tests__/acceptance/bind-decorator.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/bind-decorator.acceptance.ts
@@ -72,4 +72,42 @@ describe('@bind - customize classes with binding attributes', () => {
       'controllers.my-controller',
     ]);
   });
+
+  it('supports default binding scope in options', () => {
+    const binding = createBindingFromClass(MyController, {
+      defaultScope: BindingScope.SINGLETON,
+    });
+    expect(binding.scope).to.equal(BindingScope.SINGLETON);
+  });
+
+  describe('binding scope', () => {
+    @bind({
+      // Explicitly set the binding scope to be `SINGLETON` as the developer
+      // choose to implement the controller as a singleton without depending
+      // on request specific information
+      scope: BindingScope.SINGLETON,
+    })
+    class MySingletonController {}
+
+    it('allows singleton controller with @bind', () => {
+      const binding = createBindingFromClass(MySingletonController, {
+        type: 'controller',
+      });
+      expect(binding.key).to.equal('controllers.MySingletonController');
+      expect(binding.tagMap).to.containEql({controller: 'controller'});
+      expect(binding.scope).to.equal(BindingScope.SINGLETON);
+    });
+
+    it('honors binding scope from @bind over defaultScope', () => {
+      let binding = createBindingFromClass(MySingletonController, {
+        defaultScope: BindingScope.TRANSIENT,
+      });
+      expect(binding.scope).to.equal(BindingScope.SINGLETON);
+    });
+
+    it('honors binding scope from @bind', () => {
+      const binding = createBindingFromClass(MySingletonController);
+      expect(binding.scope).to.equal(BindingScope.SINGLETON);
+    });
+  });
 });

--- a/packages/context/src/__tests__/unit/binding.unit.ts
+++ b/packages/context/src/__tests__/unit/binding.unit.ts
@@ -29,6 +29,11 @@ describe('Binding', () => {
     it('sets the binding lock state to unlocked by default', () => {
       expect(binding.isLocked).to.be.false();
     });
+
+    it('leaves other states to `undefined` by default', () => {
+      expect(binding.type).to.be.undefined();
+      expect(binding.valueConstructor).to.be.undefined();
+    });
   });
 
   describe('lock', () => {
@@ -76,7 +81,7 @@ describe('Binding', () => {
   });
 
   describe('inScope', () => {
-    it('defaults the transient binding scope', () => {
+    it('defaults to `TRANSIENT` binding scope', () => {
       expect(binding.scope).to.equal(BindingScope.TRANSIENT);
     });
 
@@ -92,6 +97,19 @@ describe('Binding', () => {
 
     it('sets the transient binding scope', () => {
       binding.inScope(BindingScope.TRANSIENT);
+      expect(binding.scope).to.equal(BindingScope.TRANSIENT);
+    });
+  });
+
+  describe('applyDefaultScope', () => {
+    it('sets the scope if not set', () => {
+      binding.applyDefaultScope(BindingScope.SINGLETON);
+      expect(binding.scope).to.equal(BindingScope.SINGLETON);
+    });
+
+    it('does not override the existing scope', () => {
+      binding.inScope(BindingScope.TRANSIENT);
+      binding.applyDefaultScope(BindingScope.SINGLETON);
       expect(binding.scope).to.equal(BindingScope.TRANSIENT);
     });
   });

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -136,7 +136,9 @@ export function removeNameAndKeyTags(binding: Binding<unknown>) {
  *
  * @param cls A class with optional `@bind`
  */
-export function bindingTemplateFor(cls: Constructor<unknown>): BindingTemplate {
+export function bindingTemplateFor<T = unknown>(
+  cls: Constructor<T | Provider<T>>,
+): BindingTemplate<T> {
   const spec = getBindingMetadata(cls);
   const templateFunctions = (spec && spec.templates) || [
     asClassOrProvider(cls),
@@ -198,16 +200,16 @@ export type BindingFromClassOptions = {
  * @param cls A class
  * @param options Options to customize the binding key
  */
-export function createBindingFromClass(
-  cls: Constructor<unknown>,
+export function createBindingFromClass<T = unknown>(
+  cls: Constructor<T | Provider<T>>,
   options: BindingFromClassOptions = {},
-): Binding {
+): Binding<T> {
   const templateFn = bindingTemplateFor(cls);
   let key = options.key;
   if (!key) {
     key = buildBindingKey(cls, options);
   }
-  const binding = Binding.bind(key).apply(templateFn);
+  const binding = Binding.bind<T>(key).apply(templateFn);
   if (options.name) {
     binding.tag({name: options.name});
   }

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -193,11 +193,20 @@ export type BindingFromClassOptions = {
    * Mapping artifact type to binding key namespaces
    */
   typeNamespaceMapping?: TypeNamespaceMapping;
+  /**
+   * Default scope if the binding does not have an explicit scope
+   */
+  defaultScope?: BindingScope;
 };
 
 /**
- * Create a binding from a class with decorated metadata
- * @param cls A class
+ * Create a binding from a class with decorated metadata. The class is attached
+ * to the binding as follows:
+ * - `binding.toClass(cls)`: if `cls` is a plain class such as `MyController`
+ * - `binding.toProvider(cls)`: it `cls` is a value provider class with a
+ * prototype method `value()`
+ *
+ * @param cls A class. It can be either a plain class or  a value provider class
  * @param options Options to customize the binding key
  */
 export function createBindingFromClass<T = unknown>(
@@ -215,6 +224,9 @@ export function createBindingFromClass<T = unknown>(
   }
   if (options.type) {
     binding.tag({type: options.type}, options.type);
+  }
+  if (options.defaultScope) {
+    binding.applyDefaultScope(options.defaultScope);
   }
   return binding;
 }

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -141,18 +141,24 @@ export class Binding<T = BoundValue> {
   /**
    * Map for tag name/value pairs
    */
-
   public readonly tagMap: TagMap = {};
 
+  private _scope?: BindingScope;
   /**
    * Scope of the binding to control how the value is cached/shared
    */
-  public scope: BindingScope = BindingScope.TRANSIENT;
+  public get scope(): BindingScope {
+    // Default to TRANSIENT if not set
+    return this._scope || BindingScope.TRANSIENT;
+  }
 
+  private _type?: BindingType;
   /**
    * Type of the binding value getter
    */
-  public type: BindingType;
+  public get type(): BindingType | undefined {
+    return this._type;
+  }
 
   private _cache: WeakMap<Context, T>;
   private _getValue: (
@@ -160,11 +166,14 @@ export class Binding<T = BoundValue> {
     session?: ResolutionSession,
   ) => ValueOrPromise<T>;
 
+  private _valueConstructor?: Constructor<T>;
   /**
    * For bindings bound via toClass, this property contains the constructor
    * function
    */
-  public valueConstructor: Constructor<T>;
+  public get valueConstructor(): Constructor<T> | undefined {
+    return this._valueConstructor;
+  }
 
   constructor(key: string, public isLocked: boolean = false) {
     BindingKey.validate(key);
@@ -190,6 +199,7 @@ export class Binding<T = BoundValue> {
         // Cache the value at the current context
         this._cache.set(ctx, val);
       }
+      // Do not cache for `TRANSIENT`
       return val;
     });
   }
@@ -302,8 +312,24 @@ export class Binding<T = BoundValue> {
     return Object.keys(this.tagMap);
   }
 
+  /**
+   * Set the binding scope
+   * @param scope Binding scope
+   */
   inScope(scope: BindingScope): this {
-    this.scope = scope;
+    this._scope = scope;
+    return this;
+  }
+
+  /**
+   * Apply default scope to the binding. It only changes the scope if it's not
+   * set yet
+   * @param scope Default binding scope
+   */
+  applyDefaultScope(scope: BindingScope): this {
+    if (!this._scope) {
+      this._scope = scope;
+    }
     return this;
   }
 
@@ -345,7 +371,7 @@ export class Binding<T = BoundValue> {
     if (debug.enabled) {
       debug('Bind %s to constant:', this.key, value);
     }
-    this.type = BindingType.CONSTANT;
+    this._type = BindingType.CONSTANT;
     this._getValue = () => value;
     return this;
   }
@@ -373,7 +399,7 @@ export class Binding<T = BoundValue> {
     if (debug.enabled) {
       debug('Bind %s to dynamic value:', this.key, factoryFn);
     }
-    this.type = BindingType.DYNAMIC_VALUE;
+    this._type = BindingType.DYNAMIC_VALUE;
     this._getValue = ctx => factoryFn();
     return this;
   }
@@ -399,7 +425,7 @@ export class Binding<T = BoundValue> {
     if (debug.enabled) {
       debug('Bind %s to provider %s', this.key, providerClass.name);
     }
-    this.type = BindingType.PROVIDER;
+    this._type = BindingType.PROVIDER;
     this._getValue = (ctx, session) => {
       const providerOrPromise = instantiateClass<Provider<T>>(
         providerClass,
@@ -423,9 +449,9 @@ export class Binding<T = BoundValue> {
     if (debug.enabled) {
       debug('Bind %s to class %s', this.key, ctor.name);
     }
-    this.type = BindingType.CLASS;
+    this._type = BindingType.CLASS;
     this._getValue = (ctx, session) => instantiateClass(ctor, ctx!, session);
-    this.valueConstructor = ctor;
+    this._valueConstructor = ctor;
     return this;
   }
 

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -473,7 +473,7 @@ export class Binding<T = BoundValue> {
    * easy to read.
    * @param key Binding key
    */
-  static bind<T = unknown>(key: BindingAddress<T>): Binding {
+  static bind<T = unknown>(key: BindingAddress<T>): Binding<T> {
     return new Binding(key.toString());
   }
 }

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -50,6 +50,7 @@ export class Application extends Context {
       name,
       namespace: 'controllers',
       type: 'controller',
+      defaultScope: BindingScope.TRANSIENT,
     });
     this.add(binding);
     return binding;
@@ -80,7 +81,8 @@ export class Application extends Context {
       name,
       namespace: CoreBindings.SERVERS,
       type: 'server',
-    }).inScope(BindingScope.SINGLETON);
+      defaultScope: BindingScope.SINGLETON,
+    });
     this.add(binding);
     return binding;
   }
@@ -196,7 +198,8 @@ export class Application extends Context {
       name,
       namespace: 'components',
       type: 'component',
-    }).inScope(BindingScope.SINGLETON);
+      defaultScope: BindingScope.SINGLETON,
+    });
     this.add(binding);
     // Assuming components can be synchronously instantiated
     const instance = this.getSync<Component>(binding.key);

--- a/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
+++ b/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, BindingScope, Component} from '@loopback/core';
+import {Application, BindingScope, Component, bind} from '@loopback/core';
 import {expect, sinon} from '@loopback/testlab';
 import {
   Class,
@@ -30,6 +30,16 @@ describe('RepositoryMixin', () => {
     expectNoteRepoToNotBeBound(myApp);
     myApp.repository(NoteRepo);
     expectNoteRepoToBeBound(myApp);
+  });
+
+  it('binds singleton repository from app.repository()', () => {
+    @bind({scope: BindingScope.SINGLETON})
+    class SingletonNoteRepo extends NoteRepo {}
+
+    const myApp = new AppWithRepoMixin();
+
+    const binding = myApp.repository(SingletonNoteRepo);
+    expect(binding.scope).to.equal(BindingScope.SINGLETON);
   });
 
   it('mixed class has .getRepository()', () => {

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -71,6 +71,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
         name,
         namespace: 'repositories',
         type: 'repository',
+        defaultScope: BindingScope.TRANSIENT,
       });
       this.add(binding);
       return binding;
@@ -122,7 +123,8 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
           name: name || dataSource.dataSourceName,
           namespace: 'datasources',
           type: 'datasource',
-        }).inScope(BindingScope.SINGLETON);
+          defaultScope: BindingScope.SINGLETON,
+        });
         this.add(binding);
         return binding;
       } else {

--- a/packages/rest/src/__tests__/acceptance/bootstrapping/rest.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/bootstrapping/rest.acceptance.ts
@@ -24,11 +24,12 @@ describe('Bootstrapping with RestComponent', () => {
       // At this moment, the Sequence is not ready to be resolved
       // as RestBindings.Http.CONTEXT is not bound
       const binding = server.getBinding(RestBindings.SEQUENCE);
-      expect(binding.valueConstructor.name).to.equal('UserDefinedSequence');
+      expect(binding.valueConstructor).to.equal(UserDefinedSequence);
     });
 
+    class UserDefinedSequence extends DefaultSequence {}
+
     async function givenAppWithUserDefinedSequence() {
-      class UserDefinedSequence extends DefaultSequence {}
       app = new Application({
         rest: {
           sequence: UserDefinedSequence,

--- a/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
+++ b/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, Component, Provider, BindingScope} from '@loopback/core';
+import {
+  Application,
+  bind,
+  BindingScope,
+  Component,
+  Provider,
+} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {Class, ServiceMixin} from '../../../';
 
@@ -21,6 +27,15 @@ describe('ServiceMixin', () => {
     expectGeocoderToNotBeBound(myApp);
     myApp.serviceProvider(GeocoderServiceProvider);
     await expectGeocoderToBeBound(myApp);
+  });
+
+  it('binds singleton service from app.serviceProvider()', async () => {
+    @bind({scope: BindingScope.SINGLETON})
+    class SingletonGeocoderServiceProvider extends GeocoderServiceProvider {}
+    const myApp = new AppWithServiceMixin();
+
+    const binding = myApp.serviceProvider(SingletonGeocoderServiceProvider);
+    expect(binding.scope).to.equal(BindingScope.SINGLETON);
   });
 
   it('binds a component without services', () => {


### PR DESCRIPTION
The PR improves binding attributes as follows:

- Refine visibility for binding attributes
- Introduce `defaultScope` to only override binding scope if not set

Use case:

If a class is decorated with `@bind({scope: BindingScope.SINGLETON})`, we should honor it and not override it with a default scope. For example:

```
@bind({scope: BindingScope.SINGLETON})
class MyController {}

app.controller(MyController); // My controller should be bound as SINGLETON
```
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
