### PR TITLE
refactor(rest): rework StaticAssetsRoute into ExternalExpressRoutes

### DIFF
--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -41,7 +41,7 @@ import {
   Route,
   RouteEntry,
   RoutingTable,
-  StaticAssetsRoute,
+  ExternalExpressRoutes,
   RedirectRoute,
 } from './router';
 import {DefaultSequence, SequenceFunction, SequenceHandler} from './sequence';
@@ -298,7 +298,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
      * Check if there is custom router in the context
      */
     const router = this.getSync(RestBindings.ROUTER, {optional: true});
-    const routingTable = new RoutingTable(router, this._staticAssetRoute);
+    const routingTable = new RoutingTable(router, this._externalRoutes);
 
     this._httpHandler = new HttpHandler(this, routingTable);
     for (const b of this.find('controllers.*')) {
@@ -691,8 +691,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
     );
   }
 
-  // The route for static assets
-  private _staticAssetRoute = new StaticAssetsRoute();
+  /*
+   * Registry of external routes & static assets
+   */
+  private _externalRoutes = new ExternalExpressRoutes();
 
   /**
    * Mount static assets to the REST server.
@@ -703,7 +705,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param options Options for serve-static
    */
   static(path: PathParams, rootDir: string, options?: ServeStaticOptions) {
-    this._staticAssetRoute.registerAssets(path, rootDir, options);
+    this._externalRoutes.registerAssets(path, rootDir, options);
   }
 
   /**

--- a/packages/rest/src/router/index.ts
+++ b/packages/rest/src/router/index.ts
@@ -8,7 +8,7 @@ export * from './route-entry';
 export * from './base-route';
 export * from './controller-route';
 export * from './handler-route';
-export * from './static-assets-route';
+export * from './external-express-routes';
 export * from './redirect-route';
 
 // routers

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -22,7 +22,7 @@ import {
 import {validateApiPath} from './openapi-path';
 import {RestRouter} from './rest-router';
 import {ResolvedRoute, RouteEntry} from './route-entry';
-import {StaticAssetsRoute} from './static-assets-route';
+import {ExternalExpressRoutes} from './external-express-routes';
 import {TrieRouter} from './trie-router';
 
 const debug = debugFactory('loopback:rest:routing-table');
@@ -31,18 +31,10 @@ const debug = debugFactory('loopback:rest:routing-table');
  * Routing table
  */
 export class RoutingTable {
-  /**
-   * A route for static assets
-   */
-  private _staticAssetsRoute: StaticAssetsRoute;
   constructor(
     private readonly _router: RestRouter = new TrieRouter(),
-    staticAssetsRoute?: StaticAssetsRoute,
-  ) {
-    if (staticAssetsRoute) {
-      this._staticAssetsRoute = staticAssetsRoute;
-    }
-  }
+    private _externalRoutes?: ExternalExpressRoutes,
+  ) {}
 
   /**
    * Register a controller as the route
@@ -143,15 +135,14 @@ export class RoutingTable {
       return found;
     }
 
-    // this._staticAssetsRoute will be set only if app.static() was called
-    if (this._staticAssetsRoute) {
+    if (this._externalRoutes) {
       debug(
         'No API route found for %s %s, trying to find a static asset',
         request.method,
         request.path,
       );
 
-      return this._staticAssetsRoute;
+      return this._externalRoutes.find(request);
     }
 
     debug('No route found for %s %s', request.method, request.path);


### PR DESCRIPTION
Refactor the code handling static assets routes to make it open to extension and allow adding additional types of external routes later in the (near) future.

This commit is a pure refactoring. The only visible change is removal of `StaticAssetsRoute` from the public API.

See #2389 and the PoC in #2318.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated