### PR TITLE
chore: remove dependency on `@types/p-event`

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -40,7 +40,6 @@
     "@loopback/rest": "^1.7.0",
     "@types/byline": "^4.2.31",
     "@types/debug": "^4.1.0",
-    "@types/p-event": "^2.3.0",
     "@types/request-promise-native": "^1.0.15",
     "autocannon": "^3.0.0",
     "byline": "^5.0.0",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -68,7 +68,6 @@
     "@loopback/tslint-config": "^2.0.1",
     "@types/express": "^4.16.1",
     "@types/node": "^10.11.2",
-    "@types/p-event": "^2.3.0",
     "tslint": "^5.12.0",
     "typescript": "^3.2.2"
   }

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -49,7 +49,6 @@
     "@loopback/tslint-config": "^2.0.1",
     "@types/express": "^4.11.1",
     "@types/node": "^10.11.2",
-    "@types/p-event": "^2.3.0",
     "tslint": "^5.12.0",
     "typescript": "^3.3.1"
   }

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -30,7 +30,6 @@
     "@loopback/tslint-config": "^2.0.1",
     "@types/debug": "^4.1.0",
     "@types/node": "^10.11.2",
-    "@types/p-event": "^2.3.0",
     "@types/request-promise-native": "^1.0.14",
     "@types/rimraf": "^2.0.2",
     "delay": "^4.0.1"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -25,7 +25,6 @@
     "@loopback/testlab": "^1.0.7",
     "@loopback/tslint-config": "^2.0.1",
     "@types/node": "^10.11.2",
-    "@types/p-event": "^2.3.0",
     "@types/request-promise-native": "^1.0.15",
     "request-promise-native": "^1.0.5"
   },


### PR DESCRIPTION
As of `p-event@3.0.0`, type definitions are shipped as part of the package itself.

This is a follow-up for #2521 that upgraded `p-event` to v3.

@raymondfeng feel free to land this PR yourself if it LGTY.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated