### PR TITLE
[WIP] feat(rest) : redirect route accept function

### DIFF
--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -244,7 +244,7 @@ export class RestApplication extends Application implements HttpServerLike {
    */
   redirect(
     fromPath: string,
-    toPathOrUrl: string,
+    toPathOrUrl: string | Function,
     statusCode?: number,
   ): Binding {
     return this.restServer.redirect(fromPath, toPathOrUrl, statusCode);

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -683,11 +683,11 @@ export class RestServer extends Context implements Server, HttpServerLike {
    */
   redirect(
     fromPath: string,
-    toPathOrUrl: string,
+    toPathOrUrl: string | Function,
     statusCode?: number,
   ): Binding {
     return this.route(
-      new RedirectRoute(fromPath, this._basePath + toPathOrUrl, statusCode),
+      new RedirectRoute(fromPath, toPathOrUrl, statusCode),
     );
   }
 

--- a/packages/rest/src/router/redirect-route.ts
+++ b/packages/rest/src/router/redirect-route.ts
@@ -2,7 +2,7 @@ import {RouteEntry, ResolvedRoute} from '.';
 import {RequestContext} from '../request-context';
 import {OperationObject, SchemasObject} from '@loopback/openapi-v3-types';
 import {OperationArgs, OperationRetval, PathParameterValues} from '../types';
-
+import {Request} from "express";
 export class RedirectRoute implements RouteEntry, ResolvedRoute {
   // ResolvedRoute API
   readonly pathParams: PathParameterValues = [];
@@ -19,15 +19,22 @@ export class RedirectRoute implements RouteEntry, ResolvedRoute {
 
   constructor(
     private readonly sourcePath: string,
-    private readonly targetLocation: string,
+    private readonly targetLocation: string | Function,
     private readonly statusCode: number = 303,
   ) {}
 
   async invokeHandler(
-    {response}: RequestContext,
+    {response,request}: RequestContext,
     args: OperationArgs,
   ): Promise<OperationRetval> {
-    response.redirect(this.statusCode, this.targetLocation);
+    let basePath = this._getBasePath(request) || '';
+    let targetLocation :string = typeof this.targetLocation === 'function'
+        ? this.targetLocation(
+          this._getProtocolForRequest(request),
+          this._getHost(request),
+          basePath
+      ) : basePath + this.targetLocation;
+    response.redirect(this.statusCode,targetLocation);
   }
 
   updateBindings(requestContext: RequestContext) {
@@ -39,4 +46,24 @@ export class RedirectRoute implements RouteEntry, ResolvedRoute {
       this.targetLocation
     }"`;
   }
+
+  private _getHost(request: Request) {
+      return request.get('x-forwarded-host') || request.headers.host;
+  }
+
+  private _getProtocolForRequest(request: Request) {
+      return (
+          (request.get('x-forwarded-proto') || '').split(',')[0] ||
+          request.protocol ||
+          'http'
+      );
+  }
+
+   private _getBasePath(request: Request) {
+        let basePath = '';
+        if (request.baseUrl && request.baseUrl !== '/') {
+            basePath = request.baseUrl + basePath;
+        }
+        return basePath;
+    }
 }

--- a/packages/rest/src/run.ts
+++ b/packages/rest/src/run.ts
@@ -1,0 +1,29 @@
+import {RestApplication, RestServer, RestServerConfig, get} from '.';
+
+function givenApplication(options?: {rest: RestServerConfig}) {
+    options = options || {rest: {port: 4000, host: '127.0.0.1'}};
+    return new RestApplication(options);
+}
+
+async function main() {
+    let restApp = givenApplication();
+    class PingController {
+        @get('/ping')
+        ping(): string {
+            return 'Hi';
+        }
+        @get('/bye')
+        bye(): string {
+            return 'Bye';
+        }
+    }
+    restApp.controller(PingController);
+    restApp.redirect('/ping',(protocol:string, host:string, basePath:string)=>{
+        console.log(protocol+host+basePath);
+        return protocol+'://'+host+basePath+'/bye';
+    });
+    //restApp.redirect('/ping','/bye');
+    await restApp.start();
+}
+
+main();


### PR DESCRIPTION
Implements a part of #2022
This is a follow-up for #2512

change redirect method signature to accept function , 
the RedirectRoute class check if target is a function and call it else redirect the path .
with adding some functions to extract basePath,host,protocol from request . 
delete basePath from server and added it later on Redirect-route to avoid if statement in redirect method on server class . 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
