### PR TITLE
docs: update cli options and descriptions

### DIFF
--- a/docs/site/Examples.md
+++ b/docs/site/Examples.md
@@ -25,6 +25,7 @@ $ lb4 example
   log-extension: An example extension project for LoopBack 4.
   rpc-server: A basic RPC server using a made-up protocol.
   soap-calculator: An example on how to integrate SOAP web services.
+  express-composition: A simple Express application that uses LoopBack 4 REST API.
 ```
 
 Please follow the instructions in

--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -43,10 +43,11 @@ Answer the prompts as follows:
 ? Application class name: StarterApplication
 ? Select features to enable in the project:
 ❯◉ Enable tslint: add a linter with pre-configured lint rules
- ◉ Enable prettier: add new npm scripts to facilitate consistent code formatting
- ◉ Enable mocha: install mocha to assist with running tests
+ ◉ Enable prettier: install prettier to format code conforming to rules
+ ◉ Enable mocha: install mocha to run tests
  ◉ Enable loopbackBuild: use @loopback/build helpers (e.g. lb-tslint)
  ◉ Enable vscode: add VSCode config files
+ ◉ Enable docker: include Dockerfile and .dockerignore
  ◉ Enable repositories: include repository imports and RepositoryMixin
  ◉ Enable services: include service-proxy imports and ServiceMixin
 ```

--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -53,9 +53,9 @@ application, follow these steps:
     Server is running at http://127.0.0.1:3000
     ```
 
-### Create your LoopBack Application
+## Create your LoopBack Application
 
-#### Scaffold your Application
+### Scaffold your Application
 
 Run `lb4 app note` to scaffold your application and fill out the following
 prompts as follows:
@@ -65,24 +65,25 @@ $ lb4 app
 ? Project description: An application for recording notes.
 ? Project root directory: (note)
 ? Application class name: (NoteApplication)
-❯◉ Enable tslint: add a linter with pre-configured lint rules
- ◉ Enable prettier: add new npm scripts to facilitate consistent code formatting
- ◉ Enable mocha: install mocha to assist with running tests
+ ◉ Enable tslint: add a linter with pre-configured lint rules
+ ◉ Enable prettier: install prettier to format code conforming to rules
+ ◉ Enable mocha: install mocha to run tests
  ◉ Enable loopbackBuild: use @loopback/build helpers (e.g. lb-tslint)
  ◉ Enable vscode: add VSCode config files
+❯◯ Enable docker: include Dockerfile and .dockerignore
  ◉ Enable repositories: include repository imports and RepositoryMixin
  ◉ Enable services: include service-proxy imports and ServiceMixin
  # npm will install dependencies now
  Application note was created in note.
 ```
 
-#### Add Note Model
+### Add Note Model
 
 Inside the project folder, run `lb4 model` to create the `Note` model with
 `Entity` model base class. Add an `id` property with type `number`, a required
 `title` property with type `string`, and a `content` property of type `string`.
 
-#### Add a DataSource
+### Add a DataSource
 
 Now, let's create a simple in-memory datasource by running the
 `lb4 datasource ds` command and the following full path to file:
@@ -112,19 +113,19 @@ Then copy and paste the following into the `ds.json` file:
 }
 ```
 
-#### Add Note Repository
+### Add Note Repository
 
 To create the repository, run the `lb4 repository` command and choose the
 `DsDataSource` as the datasource and `Note` model as the model.
 
-#### Add Note Controller
+### Add Note Controller
 
 To complete the `Note` application, create a controller using the
 `lb4 controller note` command, with the `REST Controller with CRUD functions`
 type, `Note` model, and `NoteRepository` repository. The `id`'s type will be
 `number` and base HTTP path name is the default `/notes`.
 
-### Create a Facade Express Application
+## Create a Facade Express Application
 
 Let's start by installing dependencies for the `express` module:
 

--- a/docs/site/soap-calculator-tutorial-scaffolding.md
+++ b/docs/site/soap-calculator-tutorial-scaffolding.md
@@ -37,16 +37,19 @@ specify `--repositories` and `--services` in the last command, then you will see
 them in this list, make sure you enable both the repository and the services for
 the application.
 
-**Note:** Enable all options, unless you know what you are doing, see
+{% include note.html content="
+Enable all options besides `docker`, unless you know what you are doing, see
 [The Getting Started guide](Getting-started.md) for more information.
+" %}
 
 ```sh
 ? Select features to enable in the project:
-❯◉ Enable tslint: add a linter with pre-configured lint rules
- ◉ Enable prettier: add new npm scripts to facilitate consistent code formatting
- ◉ Enable mocha: install mocha to assist with running tests
+ ◉ Enable tslint: add a linter with pre-configured lint rules
+ ◉ Enable prettier: install prettier to format code conforming to rules
+ ◉ Enable mocha: install mocha to run tests
  ◉ Enable loopbackBuild: use @loopback/build helpers (e.g. lb-tslint)
  ◉ Enable vscode: add VSCode config files
+❯◯ Enable docker: include Dockerfile and .dockerignore
  ◉ Enable repositories: include repository imports and RepositoryMixin
  ◉ Enable services: include service-proxy imports and ServiceMixin
 ```

--- a/docs/site/todo-tutorial-scaffolding.md
+++ b/docs/site/todo-tutorial-scaffolding.md
@@ -23,11 +23,12 @@ $ lb4 app
 ? Project root directory: (todo-list)
 ? Application class name: (TodoListApplication)
 ? Select features to enable in the project:
-❯◉ Enable tslint: add a linter with pre-configured lint rules
- ◉ Enable prettier: add new npm scripts to facilitate consistent code formatting
- ◉ Enable mocha: install mocha to assist with running tests
+ ◉ Enable tslint: add a linter with pre-configured lint rules
+ ◉ Enable prettier: install prettier to format code conforming to rules
+ ◉ Enable mocha: install mocha to run tests
  ◉ Enable loopbackBuild: use @loopback/build helpers (e.g. lb-tslint)
  ◉ Enable vscode: add VSCode config files
+❯◯ Enable docker: include Dockerfile and .dockerignore
  ◉ Enable repositories: include repository imports and RepositoryMixin
  ◉ Enable services: include service-proxy imports and ServiceMixin
  # npm will install dependencies now
@@ -35,7 +36,8 @@ $ lb4 app
 ```
 
 For this tutorial, when prompted with the options for enabling certain project
-features (LoopBack's build, tslint, mocha, etc.), leave them all enabled.
+features (LoopBack's build, tslint, mocha, etc.), leave them all enabled except
+for `docker`.
 
 ### Structure
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,23 +12,32 @@ Run the following command to install the CLI.
 
 1.  To scaffold a LoopBack 4 application
 
-    `lb4`
+    `lb4` (or `lb4 app`)
 
     ```sh
     Usage:
-      lb4 [options] [<name>]
+      lb4 [<name>] [options]
 
     Options:
       -h,   --help             # Print the generator's options and usage
             --skip-cache       # Do not remember prompt answers              Default: false
             --skip-install     # Do not automatically install dependencies   Default: false
+            --force-install    # Fail on install dependencies error          Default: false
             --applicationName  # Application name
+            --docker           # Include Dockerfile and .dockerignore
+            --repositories     # Include repository imports and RepositoryMixin
+            --services         # Include service-proxy imports and ServiceMixin
             --description      # Description for the application
             --outdir           # Project root directory for the application
             --tslint           # Enable tslint
             --prettier         # Enable prettier
             --mocha            # Enable mocha
             --loopbackBuild    # Use @loopback/build
+            --vscode           # Use preconfigured VSCode settings
+            --private          # Mark the project private (excluded from npm publish)
+      -c,   --config           # JSON file name or value to configure options
+      -y,   --yes              # Skip all confirmation prompts with default or provided value
+            --format           # Format generated code using npm run lint:fix
 
     Arguments:
       name  # Project name for the application  Type: String  Required: false
@@ -40,19 +49,28 @@ Run the following command to install the CLI.
 
     ```sh
     Usage:
-      lb4 extension [options] [<name>]
+      lb4 extension [<name>] [options]
 
     Options:
       -h,   --help           # Print the generator's options and usage
             --skip-cache     # Do not remember prompt answers             Default: false
             --skip-install   # Do not automatically install dependencies  Default: false
+            --force-install  # Fail on install dependencies error         Default: false
+            --componentName  # Component name
             --description    # Description for the extension
             --outdir         # Project root directory for the extension
             --tslint         # Enable tslint
             --prettier       # Enable prettier
             --mocha          # Enable mocha
             --loopbackBuild  # Use @loopback/build
-            --componentName  # Component name
+            --vscode         # Use preconfigured VSCode settings
+            --private        # Mark the project private (excluded from npm publish)
+      -c,   --config         # JSON file name or value to configure options
+      -y,   --yes            # Skip all confirmation prompts with default or provided value
+            --format         # Format generated code using npm run lint:fix
+
+    Arguments:
+      name  # Project name for the extension  Type: String  Required: false
     ```
 
 3.  To scaffold a Controller into your application
@@ -64,12 +82,16 @@ Run the following command to install the CLI.
 
     ```sh
     Usage:
-      lb4 controller [options] [<name>]
+      lb4 controller [<name>] [options]
 
     Options:
       -h,   --help            # Print the generator's options and usage
-            --skip-cache      # Do not remember prompt answers             Default: false
-            --skip-install    # Do not automatically install dependencies  Default: false
+            --skip-cache      # Do not remember prompt answers                                Default: false
+            --skip-install    # Do not automatically install dependencies                     Default: false
+            --force-install   # Fail on install dependencies error                            Default: false
+      -c,   --config          # JSON file name or value to configure options
+      -y,   --yes             # Skip all confirmation prompts with default or provided value
+            --format          # Format generated code using npm run lint:fix
             --controllerType  # Type for the controller
 
     Arguments:
@@ -85,11 +107,16 @@ Run the following command to install the CLI.
 
     ```sh
     Usage:
-      lb4 datasource [options] [<name>]
+      lb4 datasource [<name>] [options]
 
     Options:
-      -h,   --help            # Print the generator's options and usage
-            --connector       # Name of datasource connector
+      -h,   --help           # Print the generator's options and usage
+            --skip-cache     # Do not remember prompt answers                                Default: false
+            --skip-install   # Do not automatically install dependencies                     Default: false
+            --force-install  # Fail on install dependencies error                            Default: false
+      -c,   --config         # JSON file name or value to configure options
+      -y,   --yes            # Skip all confirmation prompts with default or provided value
+            --format         # Format generated code using npm run lint:fix
 
     Arguments:
       name  # Name for the datasource  Type: String  Required: true
@@ -104,7 +131,7 @@ Run the following command to install the CLI.
 
     ```sh
     Usage:
-      lb4 model [options] [<name>]
+      lb4 model [<name>] [options]
 
     Options:
       -h,   --help            # Print the generator's options and usage
@@ -123,13 +150,20 @@ Run the following command to install the CLI.
 
     ```sh
     Usage:
-      lb4 repository [options] [<name>]
+      lb4 repository [<name>] [options]
 
     Options:
-      -h,   --help           # Print the generator's options and usage
-            --model          # A valid model name
-            --id             # A valid ID property name for the specified model
-            --datasource     # A valid datasource name
+      -h,   --help                 # Print the generator's options and usage
+            --skip-cache           # Do not remember prompt answers                                Default: false
+            --skip-install         # Do not automatically install dependencies                     Default: false
+            --force-install        # Fail on install dependencies error                            Default: false
+            --model                # A valid model name
+            --id                   # A valid ID property name for the specified model
+            --datasource           # A valid datasource name
+            --repositoryBaseClass  # A valid repository base class                                 Default: DefaultCrudRepository
+      -c,   --config               # JSON file name or value to configure options
+      -y,   --yes                  # Skip all confirmation prompts with default or provided value
+            --format               # Format generated code using npm run lint:fix
 
     Arguments:
       name  # Name for the repository   Type: String  Required: false
@@ -148,7 +182,13 @@ Run the following command to install the CLI.
 
     Options:
       -h,   --help           # Print the generator's options and usage
+            --skip-cache     # Do not remember prompt answers                                Default: false
+            --skip-install   # Do not automatically install dependencies                     Default: false
+            --force-install  # Fail on install dependencies error                            Default: false
             --datasource     # A valid datasource name
+      -c,   --config         # JSON file name or value to configure options
+      -y,   --yes            # Skip all confirmation prompts with default or provided value
+            --format         # Format generated code using npm run lint:fix
 
     Arguments:
       name  # Name for the service  Type: String  Required: false
@@ -160,12 +200,28 @@ Run the following command to install the CLI.
 
     ```sh
     Usage:
-      lb4 example [options] [<example-name>]
+      lb4 example [<example-name>] [options]
 
     Options:
       -h,   --help           # Print the generator's options and usage
-            --skip-cache     # Do not remember prompt answers             Default: false
-            --skip-install   # Do not automatically install dependencies  Default: false
+            --skip-cache     # Do not remember prompt answers                                Default: false
+            --skip-install   # Do not automatically install dependencies                     Default: false
+            --force-install  # Fail on install dependencies error                            Default: false
+      -c,   --config         # JSON file name or value to configure options
+      -y,   --yes            # Skip all confirmation prompts with default or provided value
+            --format         # Format generated code using npm run lint:fix
+
+    Arguments:
+      example-name  # Name of the example to clone  Type: String  Required: false
+
+    Available examples:
+      todo: Tutorial example on how to build an application with LoopBack 4.
+      todo-list: Continuation of the todo example using relations in LoopBack 4.
+      hello-world: A simple hello-world Application using LoopBack 4.
+      log-extension: An example extension project for LoopBack 4.
+      rpc-server: A basic RPC server using a made-up protocol.
+      soap-calculator: An example on how to integrate SOAP web services
+      express-composition: A simple Express application that uses LoopBack 4 REST API.
     ```
 
 9.  To generate artifacts from an OpenAPI spec into your application
@@ -181,9 +237,15 @@ Run the following command to install the CLI.
 
     Options:
       -h,   --help                       # Print the generator's options and usage
+            --skip-cache                 # Do not remember prompt answers                                Default: false
+            --skip-install               # Do not automatically install dependencies                     Default: false
+            --force-install              # Fail on install dependencies error                            Default: false
             --url                        # URL or file path of the OpenAPI spec
             --validate                   # Validate the OpenAPI spec                                     Default: false
             --promote-anonymous-schemas  # Promote anonymous schemas as models                           Default: false
+      -c,   --config                     # JSON file name or value to configure options
+      -y,   --yes                        # Skip all confirmation prompts with default or provided value
+            --format                     # Format generated code using npm run lint:fix
 
     Arguments:
       url  # URL or file path of the OpenAPI spec  Type: String  Required: false
@@ -213,23 +275,27 @@ Run the following command to install the CLI.
     `lb4 --version` (or `lb4 -v`)
 
     ```sh
-    @loopback/cli version: 1.5.1
+    @loopback/cli version: 1.8.1
 
     @loopback/* dependencies:
-      - @loopback/authentication: ^1.0.10
-      - @loopback/boot: ^1.0.10
-      - @loopback/build: ^1.2.0
-      - @loopback/context: ^1.4.1
-      - @loopback/core: ^1.1.4
-      - @loopback/metadata: ^1.0.4
-      - @loopback/openapi-spec-builder: ^1.0.4
-      - @loopback/openapi-v3-types: ^1.0.4
-      - @loopback/openapi-v3: ^1.1.7
-      - @loopback/repository-json-schema: ^1.2.7
-      - @loopback/repository: ^1.1.3
-      - @loopback/rest: ^1.5.3
-      - @loopback/testlab: ^1.0.4
-      - @loopback/docs: ^1.7.1
+      - @loopback/authentication: ^1.0.14
+      - @loopback/boot: ^1.0.14
+      - @loopback/build: ^1.3.1
+      - @loopback/context: ^1.6.0
+      - @loopback/core: ^1.1.7
+      - @loopback/metadata: ^1.0.7
+      - @loopback/openapi-spec-builder: ^1.0.7
+      - @loopback/openapi-v3-types: ^1.0.7
+      - @loopback/openapi-v3: ^1.2.3
+      - @loopback/repository-json-schema: ^1.3.3
+      - @loopback/repository: ^1.1.7
+      - @loopback/rest: ^1.7.0
+      - @loopback/testlab: ^1.0.7
+      - @loopback/docs: ^1.9.1
+      - @loopback/service-proxy: ^1.0.9
+      - @loopback/http-caching-proxy: ^1.0.8
+      - @loopback/http-server: ^1.1.7
+      - @loopback/rest-explorer: ^1.1.10
     ```
 
 ## Contributions


### PR DESCRIPTION
CLI options and their descriptions were updated in [this commit](https://github.com/strongloop/loopback-next/commit/4cd24424f6ec937a3308b8e3c542677e5e59618f), so this an update to the docs to match. I disabled the `docker` option on the examples because the examples don't have docker files. Also, fixed the levels of the `express-composition`'s docs. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
