### PR TITLE
fix(example-express-composition): use rest options

### DIFF
--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -234,7 +234,9 @@ export class ExpressServer {
   }
 
   async start() {
-    const server = this.app.listen(3000);
+    const port = this.lbApp.restServer.config.port || 3000;
+    const host = this.lbApp.restServer.config.host || '127.0.0.1';
+    const server = this.app.listen(port, host);
     await pEvent(server, 'listening');
   }
 }

--- a/examples/express-composition/src/server.ts
+++ b/examples/express-composition/src/server.ts
@@ -35,7 +35,9 @@ export class ExpressServer {
   }
 
   public async start() {
-    this.server = this.app.listen(3000);
+    const port = this.lbApp.restServer.config.port || 3000;
+    const host = this.lbApp.restServer.config.host || '127.0.0.1';
+    this.server = this.app.listen(port, host);
     await pEvent(this.server, 'listening');
   }
 


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/pull/2306#discussion_r262027071.

Updating the `express-composition` example to use the `host` and `port` from `ApplicationConfig`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
