### PR TITLE
fix(cli): setup controller generator after adding properties

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -28,7 +28,6 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
   }
 
   _setupGenerator() {
-    super._setupGenerator();
     this.artifactInfo = {
       type: 'controller',
       rootDir: 'src',
@@ -55,6 +54,8 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
       required: false,
       description: 'Type for the ' + this.artifactInfo.type,
     });
+
+    return super._setupGenerator();
   }
 
   setOptions() {


### PR DESCRIPTION
When using the command `lb4 controller -h`, I noticed that in the arguments it said:
```
Arguments:
  name  # Name for the undefined  Type: String  Required: false
```
This was because for the controller, it was setting up the generator before attaching the properties (e.g. [`this.artifactInfo.type`](https://github.com/strongloop/loopback-next/blob/master/packages/cli/lib/artifact-generator.js#L26)) causing them to be undefined. I changed it to call `_setupGenerator()` after attaching the properties (similar to what [`model`](https://github.com/strongloop/loopback-next/blob/master/packages/cli/generators/model/index.js#L90), [`datasource`](https://github.com/strongloop/loopback-next/blob/master/packages/cli/generators/datasource/index.js#L60), [`repository`](https://github.com/strongloop/loopback-next/blob/master/packages/cli/generators/repository/index.js#L193)...etc do).

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
