### PR TITLE
update express-composition example's npm files and include the example in `npm test`

### DIFF
--- a/examples/express-composition/index.d.ts
+++ b/examples/express-composition/index.d.ts
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './dist';

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -42,14 +42,6 @@
   },
   "author": "IBM Corp.",
   "license": "MIT",
-  "files": [
-    "README.md",
-    "index.js",
-    "index.d.ts",
-    "dist/src",
-    "dist/index*",
-    "src"
-  ],
   "dependencies": {
     "@loopback/boot": "^1.0.14",
     "@loopback/context": "^1.6.0",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -26,9 +26,9 @@
     "tslint": "lb-tslint",
     "tslint:fix": "npm run tslint -- --fix",
     "pretest": "npm run clean && npm run build",
-    "test": "lb-mocha --allow-console-logs \"dist/src/__tests__\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "posttest": "npm run lint",
-    "test:dev": "lb-mocha --allow-console-logs dist/src/__tests__/**/*.js && npm run posttest",
+    "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
     "migrate": "node ./dist/src/migrate",
     "prestart": "npm run build",
     "start": "node ."

--- a/examples/express-composition/src/__tests__/acceptance/note.acceptance.ts
+++ b/examples/express-composition/src/__tests__/acceptance/note.acceptance.ts
@@ -12,6 +12,7 @@ describe('NoteApplication', () => {
 
   before('setupApplication', async () => {
     ({server, client, lbApp} = await setupExpressApplication());
+    await changeDataSourceConfig();
     await givenNoteRepository();
   });
 
@@ -56,5 +57,16 @@ describe('NoteApplication', () => {
 
   async function givenNoteRepository() {
     noteRepo = await lbApp.getRepository(NoteRepository);
+  }
+
+  async function changeDataSourceConfig() {
+    /**
+     * Override default config for DataSource for testing so we don't write
+     * test data to file when using the memory connector.
+     */
+    lbApp.bind('datasources.config.ds').to({
+      name: 'ds',
+      connector: 'memory',
+    });
   }
 });

--- a/examples/express-composition/src/application.ts
+++ b/examples/express-composition/src/application.ts
@@ -25,7 +25,7 @@ export class NoteApplication extends BootMixin(
     this.sequence(MySequence);
 
     // Set up default home page
-    this.static('/', path.join(__dirname, '../../public'));
+    this.static('/', path.join(__dirname, '../public'));
 
     // Customize @loopback/rest-explorer configuration here
     this.bind(RestExplorerBindings.CONFIG).to({

--- a/examples/express-composition/src/server.ts
+++ b/examples/express-composition/src/server.ts
@@ -20,14 +20,14 @@ export class ExpressServer {
 
     // Custom Express routes
     this.app.get('/', function(_req: Request, res: Response) {
-      res.sendFile(path.resolve('public/express.html'));
+      res.sendFile(path.join(__dirname, '../public/express.html'));
     });
     this.app.get('/hello', function(_req: Request, res: Response) {
       res.send('Hello world!');
     });
 
     // Serve static files in the public folder
-    this.app.use(express.static('public'));
+    this.app.use(express.static(path.join(__dirname, '../public')));
   }
 
   public async boot() {

--- a/examples/express-composition/tsconfig.build.json
+++ b/examples/express-composition/tsconfig.build.json
@@ -1,18 +1,8 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "@loopback/build/config/tsconfig.common.json",
-  "include": [
-    "src",
-    "test",
-    "index.ts"
-  ],
-  "exclude": [
-    "node_modules/**",
-    "packages/*/node_modules/**",
-    "**/*.d.ts"
-  ],
   "compilerOptions": {
-    "experimentalDecorators": true
-  }
-
+    "rootDir": "src"
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Removed `files` from `package.json` of `express-composition` example so the correct files download when using `lb4 example express-composition`. Then changed the `express-composition` example based on how it's done in https://github.com/strongloop/loopback-next/pull/2316 so they're included when running `npm test` at the root of `loopback-next`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
