### PR TITLE
feat(context): add events to ContextView

### DIFF
--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -492,3 +492,41 @@ the context with `listen()`.
 If your dependency needs to follow the context for values from bindings matching
 a filter, use [`@inject.view`](Decorators_inject.md#@inject.view) for dependency
 injection.
+
+### ContextView events
+
+A `ContextView` object can emit one of the following events:
+
+- 'refresh': when the view is refreshed as bindings are added/removed
+- 'resolve': when the cached values are resolved and updated
+- 'close': when the view is closed (stopped observing context events)
+
+Such as events can be used to update other states/cached values other than the
+values watched by the `ContextView` object itself. For example:
+
+```ts
+class MyController {
+  private _total: number | undefined = undefined;
+  constructor(
+    @inject.view(filterByTag('counter'))
+    private taggedAsFoo: ContextView<Counter>,
+  ) {
+    // Invalidate cached `_total` if the view is refreshed
+    taggedAsFoo.on('refresh', () => {
+      this._total = undefined;
+    });
+  }
+
+  async total() {
+    if (this._total != null) return this._total;
+    // Calculate the total of all counters
+    const counters = await this.taggedAsFoo.values();
+    let result = 0;
+    for (const c of counters) {
+      result += c.value;
+    }
+    this._total = result;
+    return this._total;
+  }
+}
+```


### PR DESCRIPTION
Extension points that use ContextView can then listen on events to update
its state/cache beyond the view accordingly.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
