### PR TITLE
Openapi and api explorer to honor basePath

### DIFF
--- a/packages/cli/generators/app/templates/public/index.html.ejs
+++ b/packages/cli/generators/app/templates/public/index.html.ejs
@@ -59,8 +59,8 @@
     <h1><%= project.name %></h1>
     <p>Version <%= project.version || '1.0.0' %></p>
 
-    <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h3>
-    <h3>API Explorer: <a href="/explorer">/explorer</a></h3>
+    <h3>OpenAPI spec: <a href="openapi.json">openapi.json</a></h3>
+    <h3>API Explorer: <a href="explorer">explorer</a></h3>
   </div>
 
   <footer class="power">

--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -771,9 +771,23 @@ paths:
 
     it('controls server urls', async () => {
       const response = await createClientForHandler(server.requestHandler).get(
-        '/openapi.json',
+        '/api/openapi.json',
       );
       expect(response.body.servers).to.containEql({url: '/api'});
+    });
+
+    it('controls /explorer route', async () => {
+      const response = await createClientForHandler(server.requestHandler).get(
+        '/api/explorer',
+      );
+      expect(response.status).to.eql(308);
+    });
+
+    it('controls /swagger-ui route', async () => {
+      const response = await createClientForHandler(server.requestHandler).get(
+        '/api/swagger-ui',
+      );
+      expect(response.status).to.eql(308);
     });
 
     it('controls redirect locations', async () => {

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -282,7 +282,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
       );
     }
 
-    const explorerPaths = [`${this._basePath}/swagger-ui`, `${this._basePath}/explorer`];
+    const explorerPaths = [
+      `${this._basePath}/swagger-ui`,
+      `${this._basePath}/explorer`,
+    ];
     this._expressApp.get(explorerPaths, (req, res, next) =>
       this._redirectToSwaggerUI(req, res, next),
     );
@@ -515,7 +518,9 @@ export class RestServer extends Context implements Server, HttpServerLike {
     debug('Redirecting to swagger-ui from %j.', request.originalUrl);
     const protocol = this._getProtocolForRequest(request);
     const baseUrl = protocol === 'http' ? config.httpUrl : config.url;
-    const openApiUrl = `${this._getUrlForClient(request)}${this._basePath}/openapi.json`;
+    const openApiUrl = `${this._getUrlForClient(request)}${
+      this._basePath
+    }/openapi.json`;
     const fullUrl = `${baseUrl}?url=${openApiUrl}`;
     response.redirect(308, fullUrl);
   }


### PR DESCRIPTION
<!--
Whenever basePath is specified in the rest server config it needs to be honored by /openapi.json and /explorer routes. These should be served at {basePath}/openapi.json and {basePath}/explorer ({basePath}/swagger-ui) routes.

Fixes #2329 
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
