### PR TITLE
fix(rest): make sure basePath is included in RestServer.url

### DIFF
--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -151,7 +151,23 @@ export class RestServer extends Context implements Server, HttpServerLike {
     return this._httpServer ? this._httpServer.listening : false;
   }
 
+  /**
+   * The base url for the server, including the basePath if set. For example,
+   * the value will be 'http://localhost:3000/api' if `basePath` is set to
+   * '/api'.
+   */
   get url(): string | undefined {
+    let serverUrl = this.rootUrl;
+    if (!serverUrl) return serverUrl;
+    serverUrl = serverUrl + (this._basePath || '');
+    return serverUrl;
+  }
+
+  /**
+   * The root url for the server without the basePath. For example, the value
+   * will be 'http://localhost:3000' regardless of the `basePath`.
+   */
+  get rootUrl(): string | undefined {
     return this._httpServer && this._httpServer.url;
   }
 

--- a/packages/testlab/src/client.ts
+++ b/packages/testlab/src/client.ts
@@ -33,7 +33,7 @@ export function createClientForHandler(
  * @param app A running (listening) instance of a RestApplication.
  */
 export function createRestAppClient(app: RestApplicationLike) {
-  const url = app.restServer.url;
+  const url = app.restServer.rootUrl || app.restServer.url;
   if (!url) {
     throw new Error(
       `Cannot create client for ${app.constructor.name}, it is not listening.`,
@@ -53,4 +53,5 @@ export interface RestApplicationLike {
 
 export interface RestServerLike {
   url?: string;
+  rootUrl?: string;
 }


### PR DESCRIPTION
RestServer.url does not reflect `basePath`. The problem can be reproduced by adding basePath: '/api' to [examples/todo/index.js](https://github.com/strongloop/loopback-next/blob/master/examples/todo/index.js#L15) and run `npm build`:

The url is printed as http://127.0.0.1:3000, which returns 404. I think the url should include the basePath, i.e., 'http://127.0.0.1:3000/api'.

See https://github.com/strongloop/loopback-next/pull/2554#issuecomment-471089213

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
