### PR TITLE
chore: update copyright headers for `authentication` and `boot` packages

### DIFF
--- a/packages/authentication/src/__tests__/acceptance/basic-auth.acceptance.ts
+++ b/packages/authentication/src/__tests__/acceptance/basic-auth.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/__tests__/integration/smoke.integration.ts
+++ b/packages/authentication/src/__tests__/integration/smoke.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/__tests__/unit/decorators/authenticate.decorator.unit.ts
+++ b/packages/authentication/src/__tests__/unit/decorators/authenticate.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/__tests__/unit/fixtures/mock-strategy.ts
+++ b/packages/authentication/src/__tests__/unit/fixtures/mock-strategy.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/__tests__/unit/providers/auth-metadata.provider.unit.ts
+++ b/packages/authentication/src/__tests__/unit/providers/auth-metadata.provider.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/__tests__/unit/providers/authentication.provider.unit.ts
+++ b/packages/authentication/src/__tests__/unit/providers/authentication.provider.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/__tests__/unit/strategy-adapter.unit.ts
+++ b/packages/authentication/src/__tests__/unit/strategy-adapter.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/authentication.component.ts
+++ b/packages/authentication/src/authentication.component.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/decorators/authenticate.decorator.ts
+++ b/packages/authentication/src/decorators/authenticate.decorator.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/decorators/index.ts
+++ b/packages/authentication/src/decorators/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2017. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/providers/auth-metadata.provider.ts
+++ b/packages/authentication/src/providers/auth-metadata.provider.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/providers/authentication.provider.ts
+++ b/packages/authentication/src/providers/authentication.provider.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/providers/index.ts
+++ b/packages/authentication/src/providers/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/strategy-adapter.ts
+++ b/packages/authentication/src/strategy-adapter.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/authentication/src/types.ts
+++ b/packages/authentication/src/types.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/authentication
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/fixtures/application.ts
+++ b/packages/boot/src/__tests__/fixtures/application.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/fixtures/datasource.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/datasource.artifact.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/fixtures/empty.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/empty.artifact.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/fixtures/multiple.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/multiple.artifact.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/fixtures/service-class.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/service-class.artifact.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/fixtures/service-provider.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/service-provider.artifact.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/integration/controller.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/controller.booter.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/integration/repository.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/repository.booter.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/integration/service.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/service.booter.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/boot.component.unit.ts
+++ b/packages/boot/src/__tests__/unit/boot.component.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/booters/base-artifact.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/base-artifact.booter.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/booters/controller.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/controller.booter.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/bootstrapper.unit.ts
+++ b/packages/boot/src/__tests__/unit/bootstrapper.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
+++ b/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/booters/datasource.booter.ts
+++ b/packages/boot/src/booters/datasource.booter.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/booters/repository.booter.ts
+++ b/packages/boot/src/booters/repository.booter.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/boot/src/interfaces.ts
+++ b/packages/boot/src/interfaces.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
-// Node module: @loopback/core
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/boot
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
Update copyright headers for `authentication` and `boot` packages
The changes in this PR are generated by running `slt copyright` in each package. 

FYI - the copyright year is in the format of <year1, year2>, where year1 is the year that the file was created, year2 is the year that the file was last touched.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
