### PR TITLE
chore: update copyright header for core, http-*, metadata and openapi-* packages

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/__tests__/acceptance/application.acceptance.ts
+++ b/packages/core/src/__tests__/acceptance/application.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/core
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
+++ b/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/http-caching-proxy
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/http-caching-proxy/src/__tests__/unit/http-caching-proxy.test.ts
+++ b/packages/http-caching-proxy/src/__tests__/unit/http-caching-proxy.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/http-caching-proxy
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/http-caching-proxy/src/http-caching-proxy.ts
+++ b/packages/http-caching-proxy/src/http-caching-proxy.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/http-caching-proxy
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/http-server/index.d.ts
+++ b/packages/http-server/index.d.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/http-server
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './dist';

--- a/packages/http-server/index.js
+++ b/packages/http-server/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/http-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/http-server/index.ts
+++ b/packages/http-server/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/http-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/http-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 import {HttpServer, HttpOptions, HttpServerOptions} from '../../';
 import {
   supertest,

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/http-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/http-server
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './http-server';

--- a/packages/metadata/index.d.ts
+++ b/packages/metadata/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/__tests__/unit/decorator-factory.unit.ts
+++ b/packages/metadata/src/__tests__/unit/decorator-factory.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/__tests__/unit/inspector.unit.ts
+++ b/packages/metadata/src/__tests__/unit/inspector.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/__tests__/unit/metadata-accessor.test.ts
+++ b/packages/metadata/src/__tests__/unit/metadata-accessor.test.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/__tests__/unit/reflect.unit.ts
+++ b/packages/metadata/src/__tests__/unit/reflect.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/inspector.ts
+++ b/packages/metadata/src/inspector.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/reflect.ts
+++ b/packages/metadata/src/reflect.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/metadata/src/types.ts
+++ b/packages/metadata/src/types.ts
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/metadata
 // This file is licensed under the MIT License.
-// License text available at https://opensource.org/licenses/MIT'
+// License text available at https://opensource.org/licenses/MIT
 
 /**
  * Decorator function types

--- a/packages/openapi-spec-builder/index.d.ts
+++ b/packages/openapi-spec-builder/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
+// Copyright IBM Corp. 2017,2018. All Rights Reserved.
 // Node module: @loopback/openapi-spec-builder
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-spec-builder/src/__tests__/unit/openapi-spec-builder.unit.ts
+++ b/packages/openapi-spec-builder/src/__tests__/unit/openapi-spec-builder.unit.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/openapi-v3
+// Node module: @loopback/openapi-spec-builder
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2017,2019. All Rights Reserved.
 // Node module: @loopback/openapi-spec-builder
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3-types/src/__tests__/unit/openapi-v3-spec-types.unit.ts
+++ b/packages/openapi-v3-types/src/__tests__/unit/openapi-v3-spec-types.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3-types
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3-types/src/__tests__/unit/type-guards.unit.ts
+++ b/packages/openapi-v3-types/src/__tests__/unit/type-guards.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3-types
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/operation.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/operation.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-header.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-header.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-path.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-path.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-primitives.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-primitives.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-shortcut.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-shortcut.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/openapi-v3.
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v3/src/__tests__/unit/generate-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/generate-schema.unit.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/openapi-v3.
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/openapi-v3.
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/openapi-v3/src/keys.ts
+++ b/packages/openapi-v3/src/keys.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {MetadataAccessor} from '@loopback/context';
 import {RestEndpoint, ControllerSpec} from '.';
 import {ParameterObject, RequestBodyObject} from '@loopback/openapi-v3-types';


### PR DESCRIPTION
Update copyright headers for the following packages:
- core
- http-caching-proxy
- http-server
- metadata
- openapi-spec-builder
- openapi-v3
- openapi-v3-types

The changes in this PR are generated by running slt copyright in each package.

FYI - the copyright year is in the format of <year1, year2>, where year1 is the year that the file was created, year2 is the year that the file was last touched.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
