### PR TITLE
chore: update copyright headers for examples

### DIFF
--- a/examples/express-composition/src/__tests__/acceptance/express.acceptance.ts
+++ b/examples/express-composition/src/__tests__/acceptance/express.acceptance.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Client} from '@loopback/testlab';
 import {setupExpressApplication} from './test-helper';
 import {ExpressServer} from '../../server';

--- a/examples/express-composition/src/__tests__/acceptance/note.acceptance.ts
+++ b/examples/express-composition/src/__tests__/acceptance/note.acceptance.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Client, expect} from '@loopback/testlab';
 import {setupExpressApplication, givenNote} from './test-helper';
 import {NoteApplication} from '../../application';

--- a/examples/express-composition/src/__tests__/acceptance/ping.controller.acceptance.ts
+++ b/examples/express-composition/src/__tests__/acceptance/ping.controller.acceptance.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Client, expect} from '@loopback/testlab';
 import {setupExpressApplication} from './test-helper';
 import {ExpressServer} from '../../server';

--- a/examples/express-composition/src/__tests__/acceptance/test-helper.ts
+++ b/examples/express-composition/src/__tests__/acceptance/test-helper.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {givenHttpServerConfig, Client, supertest} from '@loopback/testlab';
 import {NoteApplication} from '../../application';
 import {ExpressServer} from '../../server';

--- a/examples/express-composition/src/controllers/note.controller.ts
+++ b/examples/express-composition/src/controllers/note.controller.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {
   Count,
   CountSchema,

--- a/examples/express-composition/src/controllers/ping.controller.ts
+++ b/examples/express-composition/src/controllers/ping.controller.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Request, RestBindings, get, ResponseObject} from '@loopback/rest';
 import {inject} from '@loopback/context';
 

--- a/examples/express-composition/src/datasources/ds.datasource.ts
+++ b/examples/express-composition/src/datasources/ds.datasource.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {inject} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 import * as config from './ds.datasource.json';

--- a/examples/express-composition/src/index.ts
+++ b/examples/express-composition/src/index.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {ExpressServer} from './server';
 import {ApplicationConfig} from '@loopback/core';
 

--- a/examples/express-composition/src/migrate.ts
+++ b/examples/express-composition/src/migrate.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {ExpressServer} from './server';
 
 export async function migrate(args: string[]) {

--- a/examples/express-composition/src/models/note.model.ts
+++ b/examples/express-composition/src/models/note.model.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Entity, model, property} from '@loopback/repository';
 
 @model()

--- a/examples/express-composition/src/repositories/note.repository.ts
+++ b/examples/express-composition/src/repositories/note.repository.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {DefaultCrudRepository} from '@loopback/repository';
 import {Note} from '../models';
 import {DsDataSource} from '../datasources';

--- a/examples/express-composition/src/sequence.ts
+++ b/examples/express-composition/src/sequence.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {inject} from '@loopback/context';
 import {
   FindRoute,

--- a/examples/express-composition/src/server.ts
+++ b/examples/express-composition/src/server.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {NoteApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 import {Request, Response} from 'express';

--- a/examples/hello-world/src/__tests__/acceptance/application.acceptance.ts
+++ b/examples/hello-world/src/__tests__/acceptance/application.acceptance.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
-// Node module: @loopback/example-todo
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-hello-world
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
+++ b/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/__tests__/in-memory-logger.ts
+++ b/examples/log-extension/src/__tests__/in-memory-logger.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/__tests__/log-spy.ts
+++ b/examples/log-extension/src/__tests__/log-spy.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/__tests__/unit/decorators/log.decorator.unit.ts
+++ b/examples/log-extension/src/__tests__/unit/decorators/log.decorator.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/__tests__/unit/mixins/log.mixin.unit.ts
+++ b/examples/log-extension/src/__tests__/unit/mixins/log.mixin.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/__tests__/unit/providers/log-action.provider.unit.ts
+++ b/examples/log-extension/src/__tests__/unit/providers/log-action.provider.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/__tests__/unit/providers/timer.provider.unit.ts
+++ b/examples/log-extension/src/__tests__/unit/providers/timer.provider.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/mixins/log.mixin.ts
+++ b/examples/log-extension/src/mixins/log.mixin.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/providers/log-action.provider.ts
+++ b/examples/log-extension/src/providers/log-action.provider.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/log-extension/src/types.ts
+++ b/examples/log-extension/src/types.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-log-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/rpc-server/index.d.ts
+++ b/examples/rpc-server/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-rpc-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/rpc-server/index.js
+++ b/examples/rpc-server/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-rpc-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/rpc-server/src/__tests__/unit/controllers/greet.controller.unit.ts
+++ b/examples/rpc-server/src/__tests__/unit/controllers/greet.controller.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-rpc-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/rpc-server/src/__tests__/unit/rpc.router.unit.ts
+++ b/examples/rpc-server/src/__tests__/unit/rpc.router.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-rpc-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/rpc-server/src/rpc.router.ts
+++ b/examples/rpc-server/src/rpc.router.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-rpc-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/rpc-server/src/rpc.server.ts
+++ b/examples/rpc-server/src/rpc.server.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-rpc-server
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/soap-calculator/index.d.ts
+++ b/examples/soap-calculator/index.d.ts
@@ -2,4 +2,5 @@
 // Node module: @loopback/example-soap-calculator
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 export * from './dist';

--- a/examples/soap-calculator/index.js
+++ b/examples/soap-calculator/index.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 const application = require('./dist');
 
 module.exports = application;

--- a/examples/soap-calculator/index.ts
+++ b/examples/soap-calculator/index.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './src';

--- a/examples/soap-calculator/src/__tests__/acceptance/application.acceptance.ts
+++ b/examples/soap-calculator/src/__tests__/acceptance/application.acceptance.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Client, createRestAppClient, expect} from '@loopback/testlab';
 import {SoapCalculatorApplication} from '../../application';
 

--- a/examples/soap-calculator/src/__tests__/acceptance/home-page.acceptance.ts
+++ b/examples/soap-calculator/src/__tests__/acceptance/home-page.acceptance.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/examples/soap-calculator/src/__tests__/acceptance/test-helper.ts
+++ b/examples/soap-calculator/src/__tests__/acceptance/test-helper.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {SoapCalculatorApplication} from '../..';
 import {
   createRestAppClient,

--- a/examples/soap-calculator/src/__tests__/helpers.ts
+++ b/examples/soap-calculator/src/__tests__/helpers.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {CalculatorDataSource} from '../datasources/calculator.datasource';
 
 export async function givenAConnectedDataSource(): Promise<

--- a/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
+++ b/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {
   CalculatorService,
   CalculatorParameters,

--- a/examples/soap-calculator/src/application.ts
+++ b/examples/soap-calculator/src/application.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
 import {RestExplorerComponent} from '@loopback/rest-explorer';

--- a/examples/soap-calculator/src/controllers/calculator.controller.ts
+++ b/examples/soap-calculator/src/controllers/calculator.controller.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {inject} from '@loopback/core';
 import {get, param, HttpErrors} from '@loopback/rest';
 

--- a/examples/soap-calculator/src/controllers/index.ts
+++ b/examples/soap-calculator/src/controllers/index.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './calculator.controller';

--- a/examples/soap-calculator/src/datasources/calculator.datasource.ts
+++ b/examples/soap-calculator/src/datasources/calculator.datasource.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {inject} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 import * as config from './calculator.datasource.json';

--- a/examples/soap-calculator/src/datasources/index.ts
+++ b/examples/soap-calculator/src/datasources/index.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './calculator.datasource';

--- a/examples/soap-calculator/src/index.ts
+++ b/examples/soap-calculator/src/index.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {SoapCalculatorApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
 

--- a/examples/soap-calculator/src/sequence.ts
+++ b/examples/soap-calculator/src/sequence.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {inject} from '@loopback/context';
 import {
   FindRoute,

--- a/examples/soap-calculator/src/services/calculator.service.ts
+++ b/examples/soap-calculator/src/services/calculator.service.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {getService, juggler} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
 import {CalculatorDataSource} from '../datasources/calculator.datasource';

--- a/examples/soap-calculator/src/services/index.ts
+++ b/examples/soap-calculator/src/services/index.ts
@@ -1,1 +1,6 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-soap-calculator
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 export * from './calculator.service';

--- a/examples/todo-list/src/__tests__/acceptance/home-page.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/home-page.acceptance.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/examples/todo-list/src/__tests__/acceptance/test-helper.ts
+++ b/examples/todo-list/src/__tests__/acceptance/test-helper.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-todo-list
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {TodoListApplication} from '../..';
 import {
   createRestAppClient,

--- a/examples/todo-list/src/__tests__/acceptance/todo-list-image.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-image.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/__tests__/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/__tests__/helpers.ts
+++ b/examples/todo-list/src/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/__tests__/unit/controllers/todo-list-todo.controller.unit.ts
+++ b/examples/todo-list/src/__tests__/unit/controllers/todo-list-todo.controller.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/__tests__/unit/controllers/todo-list.controller.unit.ts
+++ b/examples/todo-list/src/__tests__/unit/controllers/todo-list.controller.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/__tests__/unit/controllers/todo.controller.unit.ts
+++ b/examples/todo-list/src/__tests__/unit/controllers/todo.controller.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/application.ts
+++ b/examples/todo-list/src/application.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/controllers/todo-list-image.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-image.controller.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-todo-list
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {TodoListRepository} from '../repositories';
 import {repository} from '@loopback/repository';
 import {param, post, requestBody, get} from '@loopback/rest';

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/migrate.ts
+++ b/examples/todo-list/src/migrate.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
-// Node module: @loopback/example-todo
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/examples/todo-list/src/models/todo-list-image.model.ts
+++ b/examples/todo-list/src/models/todo-list-image.model.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/example-todo-list
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Entity, model, property, belongsTo} from '@loopback/repository';
 import {TodoList} from './todo-list.model';
 

--- a/examples/todo-list/src/models/todo-list.model.ts
+++ b/examples/todo-list/src/models/todo-list.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/models/todo.model.ts
+++ b/examples/todo-list/src/models/todo.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/repositories/todo-list-image.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list-image.repository.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/example-todo-list
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {
   DefaultCrudRepository,
   repository,

--- a/examples/todo-list/src/repositories/todo-list.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list.repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo-list/src/repositories/todo.repository.ts
+++ b/examples/todo-list/src/repositories/todo.repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/index.d.ts
+++ b/examples/todo/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/index.js
+++ b/examples/todo/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/index.ts
+++ b/examples/todo/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/__tests__/acceptance/home-page.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/home-page.acceptance.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/examples/todo/src/__tests__/acceptance/test-helper.ts
+++ b/examples/todo/src/__tests__/acceptance/test-helper.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-todo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {TodoListApplication} from '../..';
 import {
   createRestAppClient,

--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/__tests__/helpers.ts
+++ b/examples/todo/src/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
+++ b/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/__tests__/unit/controllers/todo.controller.unit.ts
+++ b/examples/todo/src/__tests__/unit/controllers/todo.controller.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/application.ts
+++ b/examples/todo/src/application.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/controllers/index.ts
+++ b/examples/todo/src/controllers/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/datasources/db.datasource.ts
+++ b/examples/todo/src/datasources/db.datasource.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/datasources/geocoder.datasource.ts
+++ b/examples/todo/src/datasources/geocoder.datasource.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/datasources/index.ts
+++ b/examples/todo/src/datasources/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/index.ts
+++ b/examples/todo/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/migrate.ts
+++ b/examples/todo/src/migrate.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/models/index.ts
+++ b/examples/todo/src/models/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/models/todo.model.ts
+++ b/examples/todo/src/models/todo.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/repositories/index.ts
+++ b/examples/todo/src/repositories/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/repositories/todo.repository.ts
+++ b/examples/todo/src/repositories/todo.repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/sequence.ts
+++ b/examples/todo/src/sequence.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/services/geocoder.service.ts
+++ b/examples/todo/src/services/geocoder.service.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/examples/todo/src/services/index.ts
+++ b/examples/todo/src/services/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
Update copyright headers for the example packages, i.e.
- express-composition
- hello-world
- log-extension
- rpc-server
- soap-calculator
- todo
- todo-list

The changes in this PR are generated by running slt copyright in each package.

FYI - the copyright year is in the format of <year1, year2>, where year1 is the year that the file was created, year2 is the year that the file was last touched.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
