### PR TITLE
fix(docs): add steps to call SOAP services

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for all the API usages in each package.
 | Version    | Status          | Published | EOL                  |
 | ---------- | --------------- | --------- | -------------------- |
 | LoopBack 4 | Current         | Oct 2018  | Apr 2021 _(minimum)_ |
-| Loopback 3 | Active LTS      | Dec 2016  | Dec 2019             |
+| Loopback 3 | Active LTS      | Dec 2016  | Dec 2020             |
 | Loopback 2 | Maintenance LTS | Jul 2014  | Apr 2019             |
 
 Please refer to our


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/1766

## Description
### UPDATED 3/14/2019
The [Calling other APIs docs page](https://loopback.io/doc/en/lb4/Calling-other-APIs-and-web-services.html) is updated because we no longer need to manually install `@loopback/service-proxy`.  Instead, we can use `lb4 service`. 

The code snippets and instructions are verified with my repo: https://github.com/dhmlau/loopback4-external-apis.  


-----
## Old description 
Since we no longer need to install `@loopback/service-proxy` manually and can use `lb4 service` instead, I'm updating this doc: https://loopback.io/doc/en/lb4/Calling-other-APIs-and-web-services.html. 

_I think_ my changes can be generalized to be used for calling REST APIs as well, just that the datasource generation will be different.  Will need some work on that. 

This is currently a draft PR, because I have a question:
- Do I need to specify the `Maps WSDL binding operations to Node.js methods` when creating datasource? (see my comment in the actual code changes)