### PR TITLE
chore: automatically organize imports on save in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,9 @@
   "[html]": {
     "editor.formatOnSave": false
   },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true,
+  },
   "files.exclude": {
     "**/.DS_Store": true,
     "**/.git": true,


### PR DESCRIPTION
With this change in place, VSCode will automatically organize imports on every save, thus keeping imports consistently ordered.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated
