### PR TITLE
chore: use a simpler pattern for npm test to run all tests

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -16,7 +16,7 @@
     "build": "lb-tsc es2017 --outDir dist",
     "clean": "lb-clean dist",
     "pretest": "npm run clean && npm run build",
-    "test": "lb-mocha \"dist/__tests__\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "prestart": "npm run build",
     "benchmark:routing": "node ./dist/rest-routing/routing-table",
     "start": "node ."

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -22,7 +22,7 @@
     "tslint": "lb-tslint",
     "tslint:fix": "npm run tslint -- --fix",
     "pretest": "npm run clean && npm run build",
-    "test": "lb-mocha dist/__tests__/**/*.js",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "posttest": "npm run lint",
     "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
     "prestart": "npm run build",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -12,7 +12,7 @@
     "clean": "lb-clean loopback-authentication*.tgz dist package api-docs",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/integration/**/*.js\" \"dist/__tests__/acceptance/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-authentication*.tgz && tree package && npm run clean"
   },

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -15,7 +15,7 @@
     "clean": "lb-clean loopback-boot*.tgz dist package api-docs",
     "pretest": "npm run build",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/integration/**/*.js\" \"dist/__tests__/acceptance/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-boot*.tgz && tree package && npm run clean"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "clean": "lb-clean loopback-core*.tgz dist package api-docs",
     "pretest": "npm run build",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/integration/**/*.js\" \"dist/__tests__/acceptance/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-core*.tgz && tree package && npm run clean"
   },

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -10,7 +10,7 @@
     "build": "lb-tsc es2017 --outDir dist",
     "clean": "lb-clean loopback-caching-proxy*.tgz dist package api-docs",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-caching-proxy*.tgz && tree package && npm run clean"
   },
   "author": "IBM Corp.",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -11,7 +11,7 @@
     "build": "lb-tsc es2017 --outDir dist",
     "clean": "lb-clean loopback-metadata*.tgz dist package api-docs",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/acceptance/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-metadata*.tgz && tree package && npm run clean"
   },

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -21,7 +21,7 @@
     "clean": "lb-clean loopback-openapi-v3*.tgz dist package",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/integration/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-openapi-v3*.tgz && tree package && npm run clean"
   },

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -10,7 +10,7 @@
     "build": "lb-tsc es2017 --outDir dist",
     "clean": "lb-clean loopback-json-schema*.tgz dist package api-docs",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/integration/**/*.js\" \"dist/__tests__/acceptance/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-json-schema*.tgz && tree package && npm run clean"
   },
   "author": "IBM Corp.",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -12,7 +12,7 @@
     "clean": "lb-clean loopback-rest*.tgz dist package api-docs",
     "pretest": "npm run build",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/integration/**/*.js\" \"dist/__tests__/acceptance/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-rest*.tgz && tree package && npm run clean"
   },

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -13,7 +13,7 @@
     "clean": "lb-clean loopback-service-proxy*.tgz dist package api-docs",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/unit/**/*.js\" \"dist/__tests__/acceptance/**/*.js\" \"dist/__tests__/integration/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-service-proxy*.tgz && tree package && npm run clean"
   },

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -10,7 +10,7 @@
     "build:apidocs": "lb-apidocs",
     "clean": "lb-clean loopback-testlab*.tgz dist package api-docs",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-testlab*.tgz && tree package && npm run clean"
   },
   "author": "IBM Corp.",


### PR DESCRIPTION
Update package.json for all packages to use a consistent glob pattern for tests.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
