### PR TITLE
build: enable "skipLibCheck", remove "dom" library

### DIFF
--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -9,7 +9,7 @@
     "strictBindCallApply": true,
     "skipLibCheck": true,
 
-    "lib": ["es2018", "dom", "esnext.asynciterable"],
+    "lib": ["es2018", "esnext.asynciterable"],
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2017",

--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -7,6 +7,7 @@
     "strictNullChecks": true,
     "resolveJsonModule": true,
     "strictBindCallApply": true,
+    "skipLibCheck": true,
 
     "lib": ["es2018", "dom", "esnext.asynciterable"],
     "module": "commonjs",

--- a/packages/cli/generators/project/templates/tsconfig.json.ejs
+++ b/packages/cli/generators/project/templates/tsconfig.json.ejs
@@ -15,8 +15,9 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
 
-    "lib": ["es2018", "dom", "esnext.asynciterable"],
+    "lib": ["es2018", "esnext.asynciterable"],
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2017",


### PR DESCRIPTION
- Disable type checking of declaration files.

  Declaration files are typically shipped by our dependencies, we cannot apply our compiler checks (e.g. noImplicitAny) on them.

- Remove "dom" from the list of global libraries.

  Historically, we were including "dom" because it was required by `supertest`'s type declarations to pass the compilation. Now that we are not type-checking declaration files, we don't need "dom" library any more.

  Please note that "dom" library is for HTML/Browser environment only, no Node.js code should be depending on DOM types, e.g. the global `Request` object provided by browsers.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated