### PR TITLE
feat(context): allow namespace tag for createBindingFromClass

### DIFF
--- a/packages/context/src/__tests__/unit/binding-inspector.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-inspector.unit.ts
@@ -185,6 +185,27 @@ describe('createBindingFromClass()', () => {
     expect(binding.key).to.eql('classes.MyClass');
   });
 
+  it('honors namespace with @bind', () => {
+    @bind({tags: {namespace: 'services'}})
+    class MyService {}
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyService, ctx);
+
+    expect(binding.key).to.eql('services.MyService');
+  });
+
+  it('honors namespace with options', () => {
+    class MyService {}
+
+    const ctx = new Context();
+    const binding = givenBindingFromClass(MyService, ctx, {
+      namespace: 'services',
+    });
+
+    expect(binding.key).to.eql('services.MyService');
+  });
+
   function givenBindingFromClass(
     cls: Constructor<unknown>,
     ctx: Context = new Context(),

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -255,6 +255,7 @@ function getNamespace(type: string, typeNamespaces = DEFAULT_TYPE_NAMESPACES) {
  * `<namespace>.<name>`.
  *   - namespace
  *     - `options.namespace`
+ *     - `namespace` tag value
  *     - Map `options.type` or `type` tag value to a namespace, for example,
  *       'controller` to 'controller'.
  *   - name
@@ -276,7 +277,8 @@ function buildBindingKey(
   let key: string = options.key || bindingTemplate.tagMap[ContextTags.KEY];
   if (key) return key;
 
-  let namespace = options.namespace;
+  let namespace =
+    options.namespace || bindingTemplate.tagMap[ContextTags.NAMESPACE];
   if (!namespace) {
     const namespaces = Object.assign(
       {},

--- a/packages/context/src/keys.ts
+++ b/packages/context/src/keys.ts
@@ -12,6 +12,10 @@ export namespace ContextTags {
    */
   export const TYPE = 'type';
   /**
+   * Namespace of the artifact
+   */
+  export const NAMESPACE = 'namespace';
+  /**
    * Name of the artifact
    */
   export const NAME = 'name';


### PR DESCRIPTION
This fixes an issue discovered for #2249. It now allows `namespace` tag to customize class bindings.

```ts
@bind({tags: {namespace: 'services'}})
class MyService () {
}

const binding = createBindingFromClass(MyService);
// binding.key is now `services.MyService`
``` 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
