### PR TITLE
feat(context): add `binding.toAlias()`

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -113,6 +113,21 @@ class MyValueProvider implements Provider<string> {
 binding.toProvider(MyValueProvider);
 ```
 
+#### An alias
+
+An alias is the key with optional path to resolve the value from another
+binding. For example, if we want to get options from RestServer for the API
+explorer, we can configure the `apiExplorer.options` to be resolved from
+`servers.RestServer.options#apiExplorer`.
+
+```ts
+ctx.bind('servers.RestServer.options').to({apiExplorer: {path: '/explorer'}});
+ctx
+  .bind('apiExplorer.options')
+  .toAlias('servers.RestServer.options#apiExplorer');
+const apiExplorerOptions = await ctx.get('apiExplorer.options'); // => {path: '/explorer'}
+```
+
 ### Configure the scope
 
 We allow a binding to be resolved within a context using one of the following

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -118,6 +118,10 @@ export enum BindingType {
    * A provider class with `value()` function to get the value
    */
   PROVIDER = 'Provider',
+  /**
+   * A alias to another binding key with optional path
+   */
+  ALIAS = 'Alias',
 }
 
 // tslint:disable-next-line:no-any
@@ -503,6 +507,24 @@ export class Binding<T = BoundValue> {
       instantiateClass(ctor, ctx, options.session),
     );
     this._valueConstructor = ctor;
+    return this;
+  }
+
+  /**
+   * Bind the key to an alias of another binding
+   * @param keyWithPath Target binding key with optional path,
+   * such as `servers.RestServer.options#apiExplorer`
+   */
+  toAlias(keyWithPath: BindingAddress<T>) {
+    /* istanbul ignore if */
+    if (debug.enabled) {
+      debug('Bind %s to alias %s', this.key, keyWithPath);
+    }
+    this._type = BindingType.ALIAS;
+    this._setValueGetter((ctx, optionsOrSession) => {
+      const options = asResolutionOptions(optionsOrSession);
+      return ctx.getValueOrPromise(keyWithPath, options);
+    });
     return this;
   }
 


### PR DESCRIPTION
A few improvements for `@loopback/context` related to #2259 

- Add `binding.toAlias()`
Use case:
  ```ts
  ctx.bind('parent.options').to({child: {disabled: true}});
  ctx.bind('child.options').toAlias('parent.options#child');
  const childOptions = ctx.getSync('child.options');
  expect(childOptions).to.eql({disabled: true});
  ```
Related to #2657 
Depends on #2656 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
