### PR TITLE
feat(rest): add mountExpressRouter

### DIFF
--- a/docs/site/Routes.md
+++ b/docs/site/Routes.md
@@ -226,3 +226,64 @@ export class MyApplication extends RestApplication {
   }
 }
 ```
+
+## Mounting an Express Router
+
+If you have an existing [Express](https://expressjs.com/) application that you
+want to use with LoopBack 4, you can mount the Express application on top of a
+LoopBack 4 application. This way you can mix and match both frameworks, while
+using LoopBack as the host. You can also do the opposite and use Express as the
+host by mounting LoopBack 4 REST API on an Express application. See
+[Creating an Express Application with LoopBack REST API](express-with-lb4-rest-tutorial.md)
+for the tutorial.
+
+Mounting an Express router on a LoopBack 4 application can be done using the
+`mountExpressRouter` function provided by both
+[`RestApplication`](http://apidocs.loopback.io/@loopback%2fdocs/rest.html#RestApplication)
+and
+[`RestServer`](http://apidocs.loopback.io/@loopback%2fdocs/rest.html#RestServer).
+
+Example use:
+
+{% include note.html content="
+Make sure [express](https://www.npmjs.com/package/express) is installed.
+" %}
+
+{% include code-caption.html content="src/express-app.ts" %}
+
+```ts
+import {Request, Response} from 'express';
+import * as express from 'express';
+
+const legacyApp = express();
+
+// your existing Express routes
+legacyApp.get('/pug', function(_req: Request, res: Response) {
+  res.send('Pug!');
+});
+
+export {legacyApp};
+```
+
+{% include code-caption.html content="src/application.ts" %}
+
+```ts
+import {RestApplication} from '@loopback/rest';
+
+const legacyApp = require('./express-app').legacyApp;
+
+const openApiSpecForLegacyApp: RouterSpec = {
+  // insert your spec here, your 'paths', 'components', and 'tags' will be used
+};
+
+class MyApplication extends RestApplication {
+  constructor(/* ... */) {
+    // ...
+
+    this.mountExpressRouter('/dogs', legacyApp, openApiSpecForLegacyApp);
+  }
+}
+```
+
+Any routes you define in your `legacyApp` will be mounted on top of the `/dogs`
+base path, e.g. if you visit the `/dogs/pug` endpoint, you'll see `Pug!`.

--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -14,6 +14,12 @@ REST API can be mounted to an Express application and be used as middleware.
 This way the user can mix and match features from both frameworks to suit their
 needs.
 
+{% include note.html content="
+If you want to use LoopBack as the host instead and mount your Express
+application on a LoopBack 4 application, see
+[Mounting an Express Router](Routes.md#mounting-an-express-router).
+" %}
+
 This tutorial assumes familiarity with scaffolding a LoopBack 4 application,
 [`Models`](Model.md), [`DataSources`](DataSources.md),
 [`Repositories`](Repositories.md), and [`Controllers`](Controllers.md). To see

--- a/packages/rest/src/__tests__/unit/router/assign-router-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/assign-router-spec.unit.ts
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {assignRouterSpec, RouterSpec} from '../../../';
+
+describe('assignRouterSpec', () => {
+  it('duplicates the additions spec if the target spec is empty', async () => {
+    const target: RouterSpec = {paths: {}};
+    const additions: RouterSpec = {
+      paths: {
+        '/': {
+          get: {
+            responses: {
+              '200': {
+                description: 'greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Greeting: {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+      tags: [{name: 'greeting', description: 'greetings'}],
+    };
+
+    assignRouterSpec(target, additions);
+    expect(target).to.eql(additions);
+  });
+
+  it('does not assign components without schema', async () => {
+    const target: RouterSpec = {
+      paths: {},
+      components: {},
+    };
+
+    const additions: RouterSpec = {
+      paths: {},
+      components: {
+        parameters: {
+          addParam: {
+            name: 'add',
+            in: 'query',
+            description: 'number of items to add',
+            required: true,
+            schema: {
+              type: 'integer',
+              format: 'int32',
+            },
+          },
+        },
+        responses: {
+          Hello: {
+            description: 'Hello.',
+          },
+        },
+      },
+    };
+
+    assignRouterSpec(target, additions);
+    expect(target.components).to.be.empty();
+  });
+
+  it('uses the route registered first', async () => {
+    const originalPath = {
+      '/': {
+        get: {
+          responses: {
+            '200': {
+              description: 'greeting',
+              content: {
+                'application/json': {
+                  schema: {type: 'string'},
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const target: RouterSpec = {paths: originalPath};
+
+    const additions: RouterSpec = {
+      paths: {
+        '/': {
+          get: {
+            responses: {
+              '200': {
+                description: 'additional greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+              '404': {
+                description: 'Error: no greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    assignRouterSpec(target, additions);
+    expect(target.paths).to.eql(originalPath);
+  });
+
+  it('does not duplicate tags from the additional spec', async () => {
+    const target: RouterSpec = {
+      paths: {},
+      tags: [{name: 'greeting', description: 'greetings'}],
+    };
+    const additions: RouterSpec = {
+      paths: {},
+      tags: [
+        {name: 'greeting', description: 'additional greetings'},
+        {name: 'salutation', description: 'salutations!'},
+      ],
+    };
+
+    assignRouterSpec(target, additions);
+    expect(target.tags).to.containDeep([
+      {name: 'greeting', description: 'greetings'},
+      {name: 'salutation', description: 'salutations!'},
+    ]);
+  });
+});

--- a/packages/rest/src/__tests__/unit/router/rebase-openapi-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/rebase-openapi-spec.unit.ts
@@ -1,0 +1,144 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {rebaseOpenApiSpec} from '../../../router';
+
+describe('rebaseOpenApiSpec', () => {
+  it('does not modify an OpenAPI spec if it does not have paths', async () => {
+    const spec = {
+      title: 'Greetings',
+      components: {
+        responses: {
+          Hello: {
+            description: 'Hello.',
+          },
+        },
+      },
+      tags: [{name: 'greeting', description: 'greetings'}],
+    };
+    const rebasedSpec = rebaseOpenApiSpec(spec, '/api');
+
+    expect(rebasedSpec).to.eql(spec);
+  });
+
+  it('does not modify the OpenApiSpec if basePath is empty or `/`', async () => {
+    const spec = {
+      paths: {
+        '/': {
+          get: {
+            responses: {
+              '200': {
+                description: 'greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/hello': {
+          post: {
+            summary: 'says hello',
+            consumes: 'application/json',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    let rebasedSpec = rebaseOpenApiSpec(spec, '');
+    expect(spec).to.eql(rebasedSpec);
+
+    rebasedSpec = rebaseOpenApiSpec(spec, '/');
+    expect(rebasedSpec).to.eql(spec);
+  });
+
+  it('rebases OpenApiSpec if there is a basePath', async () => {
+    const spec = {
+      paths: {
+        '/': {
+          get: {
+            responses: {
+              '200': {
+                description: 'greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/hello': {
+          post: {
+            responses: {
+              '200': {
+                description: 'greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const rebasedSpec = rebaseOpenApiSpec(spec, '/greetings');
+    const rebasedPaths = Object.keys(rebasedSpec.paths);
+
+    expect(rebasedPaths).to.eql(['/greetings/', '/greetings/hello']);
+  });
+
+  it('does not modify the original OpenApiSpec', async () => {
+    const spec = {
+      paths: {
+        '/': {
+          get: {
+            responses: {
+              '200': {
+                description: 'greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/hello': {
+          post: {
+            responses: {
+              '200': {
+                description: 'greeting',
+                content: {
+                  'application/json': {
+                    schema: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    rebaseOpenApiSpec(spec, '/greetings');
+
+    const specPaths = Object.keys(spec.paths);
+    expect(specPaths).to.deepEqual(['/', '/hello']);
+  });
+});

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -38,13 +38,16 @@ import {
   ControllerInstance,
   ControllerRoute,
   createControllerFactoryForBinding,
+  ExpressRequestHandler,
   ExternalExpressRoutes,
   RedirectRoute,
   RestRouterOptions,
   Route,
   RouteEntry,
+  RouterSpec,
   RoutingTable,
 } from './router';
+import {assignRouterSpec} from './router/router-spec';
 import {DefaultSequence, SequenceFunction, SequenceHandler} from './sequence';
 import {
   FindRoute,
@@ -681,6 +684,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
       spec.components = spec.components || {};
       spec.components.schemas = cloneDeep(defs);
     }
+
+    assignRouterSpec(spec, this._externalRoutes.routerSpec);
     return spec;
   }
 
@@ -826,6 +831,25 @@ export class RestServer extends Context implements Server, HttpServerLike {
     process.nextTick(() => {
       throw err;
     });
+  }
+
+  /**
+   * Mount an Express router to expose additional REST endpoints handled
+   * via legacy Express-based stack.
+   *
+   * @param basePath Path where to mount the router at, e.g. `/` or `/api`.
+   * @param router The Express router to handle the requests.
+   * @param spec A partial OpenAPI spec describing endpoints provided by the
+   * router. LoopBack will prepend `basePath` to all endpoints automatically.
+   * This argument is optional. You can leave it out if you don't want to
+   * document the routes.
+   */
+  mountExpressRouter(
+    basePath: string,
+    router: ExpressRequestHandler,
+    spec?: RouterSpec,
+  ): void {
+    this._externalRoutes.mountRouter(basePath, router, spec);
   }
 }
 

--- a/packages/rest/src/router/index.ts
+++ b/packages/rest/src/router/index.ts
@@ -21,3 +21,4 @@ export * from './routing-table';
 export * from './route-sort';
 export * from './openapi-path';
 export * from './trie';
+export * from './router-spec';

--- a/packages/rest/src/router/router-spec.ts
+++ b/packages/rest/src/router/router-spec.ts
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {OpenApiSpec} from '@loopback/openapi-v3-types';
+
+export type RouterSpec = Pick<OpenApiSpec, 'paths' | 'components' | 'tags'>;
+
+export function assignRouterSpec(target: RouterSpec, additions: RouterSpec) {
+  if (additions.components && additions.components.schemas) {
+    if (!target.components) target.components = {};
+    if (!target.components.schemas) target.components.schemas = {};
+    Object.assign(target.components.schemas, additions.components.schemas);
+  }
+
+  for (const url in additions.paths) {
+    if (!(url in target.paths)) target.paths[url] = {};
+    for (const verbOrKey in additions.paths[url]) {
+      // routes registered earlier takes precedence
+      if (verbOrKey in target.paths[url]) continue;
+      target.paths[url][verbOrKey] = additions.paths[url][verbOrKey];
+    }
+  }
+
+  if (additions.tags && additions.tags.length > 0) {
+    if (!target.tags) target.tags = [];
+    for (const tag of additions.tags) {
+      // tags defined earlier take precedence
+      if (target.tags.some(t => t.name === tag.name)) continue;
+      target.tags.push(tag);
+    }
+  }
+}

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -19,10 +19,10 @@ import {
   ControllerFactory,
   ControllerRoute,
 } from './controller-route';
+import {ExternalExpressRoutes} from './external-express-routes';
 import {validateApiPath} from './openapi-path';
 import {RestRouter} from './rest-router';
 import {ResolvedRoute, RouteEntry} from './route-entry';
-import {ExternalExpressRoutes} from './external-express-routes';
 import {TrieRouter} from './trie-router';
 
 const debug = debugFactory('loopback:rest:routing-table');
@@ -137,7 +137,7 @@ export class RoutingTable {
 
     if (this._externalRoutes) {
       debug(
-        'No API route found for %s %s, trying to find a static asset',
+        'No API route found for %s %s, trying to find an external Express route',
         request.method,
         request.path,
       );


### PR DESCRIPTION
Closes https://github.com/strongloop/loopback-next/issues/2389.

Add `mountExpressRouter` to `RestApplication` and `RestServer` and include in `Routes.md`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
