### PR TITLE
Spike: Constrain the OpenAPI schema emitted for a model [DO NOT MERGE]

### DIFF
--- a/_SPIKE_.md
+++ b/_SPIKE_.md
@@ -7,3 +7,178 @@ issue for the discussions we already have had in the past.
 The code in this spike is building on top of the spike for Inclusion of related
 models ([PR#2592)(https://github.com/strongloop/loopback-next/pull/2592)),
 please ignore the first commit.
+
+## Overview
+
+I am proposing to leverage the interface `JsonSchemaOptions` and
+`getModelSchemaRef` helper to build schema with additional constraints. Later
+on, we can explore different ways how to enable includeRelations flag via
+OpenAPI spec extensions.
+
+### Exclude properties from CREATE requests
+
+An example showing a controller method excluding the property `id`:
+
+```ts
+class TodoListController {
+  // ...
+
+  @post('/todo-lists', {
+    responses: {
+      // left out for brevity
+    },
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(TodoList, {exclude: ['id']}),
+          /***** ^^^ THIS IS IMPORTANT - OPENAPI SCHEMA ^^^ ****/
+        },
+      },
+    })
+    obj: Pick<TodoList, Exclude<keyof TodoList, 'id'>>,
+    /***** ^^^ THIS IS IMPORTANT - TYPESCRIPT TYPE ^^^ ****/
+  ): Promise<TodoList> {
+    return await this.todoListRepository.create(obj);
+  }
+}
+```
+
+An example schema produced by the helper in the request body spec:
+
+```json
+{
+  "requestBody": {
+    "content": {
+      "application/json": {
+        "schema": {
+          "$ref": "#/components/schemas/TodoListWithout(id)"
+        }
+      }
+    }
+  }
+}
+```
+
+The full schema in component schemas:
+
+```json
+{
+  "TodoListWithout(id)": {
+    "title": "TodoListWithout(id)",
+    "properties": {
+      "title": {
+        "type": "string"
+      },
+      "color": {
+        "type": "string"
+      }
+    },
+    "required": ["title"]
+  }
+}
+```
+
+### Mark all properties as optional
+
+An example showing a controller method accepting a partial model instance:
+
+```ts
+class TodoListController {
+  // ...
+
+  @patch('/todo-lists/{id}', {
+    responses: {
+      // left out for brevity
+    },
+  })
+  async updateById(
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(TodoList, {partial: true}),
+          /***** ^^^ THIS IS IMPORTANT - OPENAPI SCHEMA ^^^ ****/
+        },
+      },
+    })
+    obj: Partial<TodoList>,
+    /***** ^^^ THIS IS IMPORTANT - TYPESCRIPT TYPE ^^^ ****/
+  ): Promise<void> {
+    await this.todoListRepository.updateById(id, obj);
+  }
+}
+```
+
+An example schema in components:
+
+```json
+{
+  "TodoListPartial": {
+    "title": "TodoListPartial",
+    "properties": {
+      "id": {
+        "type": "number"
+      },
+      "title": {
+        "type": "string"
+      },
+      "color": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+### Using spec extension instead of a code-first helper
+
+Later on, we can explore different ways how to enable `partial` and `exclude`
+flags via OpenAPI spec extensions. For example:
+
+```
+schema: {'x-ts-type': Category, 'x-partial': true},
+schema: {'x-ts-type': Category, 'x-exclude': ['id']},
+```
+
+In
+https://github.com/strongloop/loopback-next/issues/1722#issuecomment-422439405,
+a different format was proposed:
+
+```
+schema: {
+  'x-ts-type': Order,
+  'x-ts-type-options': {
+    partial: true,
+    exclude: []
+  }
+}
+```
+
+Either way, I am proposing to leave this part out of the initial implementation.
+
+## Follow-up stories
+
+1. Wait until the following stories from "Inclusion of related models" are
+   implemented:
+
+   1. Support `schema: {$ref, definitions}` in resolveControllerSpec
+      [#2629](https://github.com/strongloop/loopback-next/issues/2629)
+
+   2. Implement `getJsonSchemaRef` and `getModelSchemaRef` helpers
+      [#2631](https://github.com/strongloop/loopback-next/issues/2631)
+
+2. Enhance `getJsonSchema` with a new flag: `partial?: boolean`, also update CLI
+   templates and example apps accordingly.
+
+   --> https://github.com/strongloop/loopback-next/issues/2652
+
+3. Enhance `getJsonSchema` with a new flag: `exclude?: string[]`, also update
+   CLI templates and example apps accordingly.
+
+   --> https://github.com/strongloop/loopback-next/issues/2653
+
+4. Spike: configure `JsonSchemaOptions` via an OpenAPI spec extension
+
+   --> https://github.com/strongloop/loopback-next/issues/2654

--- a/_SPIKE_.md
+++ b/_SPIKE_.md
@@ -1,0 +1,9 @@
+# Spike documentation
+
+See the discussion in
+[#2082](https://github.com/strongloop/loopback-next/issues/2082) and linked
+issue for the discussions we already have had in the past.
+
+The code in this spike is building on top of the spike for Inclusion of related
+models ([PR#2592)(https://github.com/strongloop/loopback-next/pull/2592)),
+please ignore the first commit.

--- a/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
@@ -149,6 +149,20 @@ describe('TodoListApplication', () => {
       .expect(200, [toJSON(todoInProgress)]);
   });
 
+  it('includes TodoList in query result', async () => {
+    const list = await givenTodoListInstance();
+    const todo = await givenTodoInstance({todoListId: list.id});
+
+    const response = await client.get('/todos').query({
+      filter: JSON.stringify({include: [{relation: 'todoList'}]}),
+    });
+    expect(response.body).to.have.length(1);
+    expect(response.body[0]).to.deepEqual({
+      ...toJSON(todo),
+      todoList: toJSON(list),
+    });
+  });
+
   /*
    ============================================================================
    TEST HELPERS

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -14,8 +14,8 @@ import {
   del,
   get,
   getFilterSchemaFor,
-  getWhereSchemaFor,
   getModelSchemaRef,
+  getWhereSchemaFor,
   param,
   patch,
   post,
@@ -38,7 +38,16 @@ export class TodoListController {
       },
     },
   })
-  async create(@requestBody() obj: TodoList): Promise<TodoList> {
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(TodoList, {exclude: ['id']}),
+        },
+      },
+    })
+    obj: Pick<TodoList, Exclude<keyof TodoList, 'id'>>,
+  ): Promise<TodoList> {
     return await this.todoListRepository.create(obj);
   }
 
@@ -86,7 +95,14 @@ export class TodoListController {
     },
   })
   async updateAll(
-    @requestBody() obj: Partial<TodoList>,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(TodoList, {partial: true}),
+        },
+      },
+    })
+    obj: Partial<TodoList>,
     @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
   ): Promise<Count> {
     return await this.todoListRepository.updateAll(obj, where);
@@ -113,7 +129,14 @@ export class TodoListController {
   })
   async updateById(
     @param.path.number('id') id: number,
-    @requestBody() obj: TodoList,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(TodoList, {partial: true}),
+        },
+      },
+    })
+    obj: Partial<TodoList>,
   ): Promise<void> {
     await this.todoListRepository.updateById(id, obj);
   }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -15,6 +15,7 @@ import {
   get,
   getFilterSchemaFor,
   getWhereSchemaFor,
+  getModelSchemaRef,
   param,
   patch,
   post,
@@ -59,7 +60,14 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'Array of TodoList model instances',
-        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(TodoList, {includeRelations: true}),
+            },
+          },
+        },
       },
     },
   })

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -13,6 +13,7 @@ import {
   post,
   put,
   requestBody,
+  getModelSchemaRef,
 } from '@loopback/rest';
 import {Todo, TodoList} from '../models';
 import {TodoRepository} from '../repositories';
@@ -53,7 +54,10 @@ export class TodoController {
         description: 'Array of Todo model instances',
         content: {
           'application/json': {
-            schema: {type: 'array', items: {'x-ts-type': Todo}},
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(Todo, {includeRelations: true}),
+            },
           },
         },
       },

--- a/examples/todo-list/src/models/todo-list-image.model.ts
+++ b/examples/todo-list/src/models/todo-list-image.model.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property, belongsTo} from '@loopback/repository';
-import {TodoList} from './todo-list.model';
+import {belongsTo, Entity, model, property} from '@loopback/repository';
+import {TodoList, TodoListWithRelations} from './todo-list.model';
 
 @model()
 export class TodoListImage extends Entity {
@@ -29,3 +29,9 @@ export class TodoListImage extends Entity {
     super(data);
   }
 }
+
+export interface TodoListImageRelations {
+  todoList?: TodoListWithRelations;
+}
+
+export type TodoListImageWithRelations = TodoListImage & TodoListImageRelations;

--- a/examples/todo-list/src/models/todo-list.model.ts
+++ b/examples/todo-list/src/models/todo-list.model.ts
@@ -3,9 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property, hasMany, hasOne} from '@loopback/repository';
-import {Todo} from './todo.model';
-import {TodoListImage} from './todo-list-image.model';
+import {Entity, hasMany, hasOne, model, property} from '@loopback/repository';
+import {
+  TodoListImage,
+  TodoListImageWithRelations,
+} from './todo-list-image.model';
+import {Todo, TodoWithRelations} from './todo.model';
 
 @model()
 export class TodoList extends Entity {
@@ -36,3 +39,10 @@ export class TodoList extends Entity {
     super(data);
   }
 }
+
+export interface TodoListRelations {
+  todos?: TodoWithRelations[];
+  image?: TodoListImageWithRelations;
+}
+
+export type TodoListWithRelations = TodoList & TodoListRelations;

--- a/examples/todo-list/src/models/todo.model.ts
+++ b/examples/todo-list/src/models/todo.model.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, property, model, belongsTo} from '@loopback/repository';
-import {TodoList} from './todo-list.model';
+import {belongsTo, Entity, model, property} from '@loopback/repository';
+import {TodoList, TodoListRelations} from './todo-list.model';
 
 @model()
 export class Todo extends Entity {
@@ -41,3 +41,9 @@ export class Todo extends Entity {
     super(data);
   }
 }
+
+export interface TodoRelations {
+  todoList?: TodoList & TodoListRelations;
+}
+
+export type TodoWithRelations = Todo & TodoRelations;

--- a/examples/todo-list/src/repositories/todo-list.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list.repository.ts
@@ -10,14 +10,23 @@ import {
   juggler,
   repository,
   HasOneRepositoryFactory,
+  Filter,
+  Options,
 } from '@loopback/repository';
-import {Todo, TodoList, TodoListImage} from '../models';
+import {
+  Todo,
+  TodoList,
+  TodoListImage,
+  TodoListRelations,
+  TodoListWithRelations,
+} from '../models';
 import {TodoRepository} from './todo.repository';
 import {TodoListImageRepository} from './todo-list-image.repository';
 
 export class TodoListRepository extends DefaultCrudRepository<
   TodoList,
-  typeof TodoList.prototype.id
+  typeof TodoList.prototype.id,
+  TodoListRelations
 > {
   public readonly todos: HasManyRepositoryFactory<
     Todo,
@@ -48,5 +57,28 @@ export class TodoListRepository extends DefaultCrudRepository<
 
   public findByTitle(title: string) {
     return this.findOne({where: {title}});
+  }
+
+  async find(
+    filter?: Filter<TodoList>,
+    options?: Options,
+  ): Promise<TodoListWithRelations[]> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = filter && Object.assign(filter, {include: undefined});
+
+    const result = await super.find(filter, options);
+
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todos in fewer DB queries
+    if (include && include.length && include[0].relation === 'todos') {
+      await Promise.all(
+        result.map(async r => {
+          r.todos = await this.todos(r.id).find();
+        }),
+      );
+    }
+    return result;
   }
 }

--- a/examples/todo-list/src/repositories/todo.repository.ts
+++ b/examples/todo-list/src/repositories/todo.repository.ts
@@ -7,15 +7,18 @@ import {Getter, inject} from '@loopback/core';
 import {
   BelongsToAccessor,
   DefaultCrudRepository,
+  Filter,
   juggler,
+  Options,
   repository,
 } from '@loopback/repository';
-import {Todo, TodoList} from '../models';
+import {Todo, TodoRelations, TodoList, TodoWithRelations} from '../models';
 import {TodoListRepository} from './todo-list.repository';
 
 export class TodoRepository extends DefaultCrudRepository<
   Todo,
-  typeof Todo.prototype.id
+  typeof Todo.prototype.id,
+  TodoRelations
 > {
   public readonly todoList: BelongsToAccessor<
     TodoList,
@@ -33,5 +36,28 @@ export class TodoRepository extends DefaultCrudRepository<
       'todoList',
       todoListRepositoryGetter,
     );
+  }
+
+  async find(
+    filter?: Filter<Todo>,
+    options?: Options,
+  ): Promise<TodoWithRelations[]> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = filter && Object.assign(filter, {include: undefined});
+
+    const result = await super.find(filter, options);
+
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todos in fewer DB queries
+    if (include && include.length && include[0].relation === 'todoList') {
+      await Promise.all(
+        result.map(async r => {
+          r.todoList = await this.todoList(r.id);
+        }),
+      );
+    }
+    return result;
   }
 }

--- a/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
@@ -3,13 +3,24 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ParameterObject, SchemaObject} from '@loopback/openapi-v3-types';
-import {model, property} from '@loopback/repository';
+import {
+  OperationObject,
+  ParameterObject,
+  SchemaObject,
+} from '@loopback/openapi-v3-types';
+import {
+  belongsTo,
+  Entity,
+  hasMany,
+  model,
+  property,
+} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
 import {
   ControllerSpec,
   get,
   getControllerSpec,
+  getModelSchemaRef,
   param,
   post,
   requestBody,
@@ -420,5 +431,68 @@ describe('controller spec', () => {
       }
       return MyController;
     }
+  });
+
+  it('supports getModelSchemaRef with relations', () => {
+    @model()
+    class Product extends Entity {
+      @belongsTo(() => Category)
+      categoryId: number;
+    }
+
+    @model()
+    class Category extends Entity {
+      @hasMany(() => Product)
+      products?: Product[];
+    }
+
+    class CategoryController {
+      @get('/categories', {
+        responses: {
+          '200': {
+            description: 'Array of Category model instances',
+            content: {
+              'application/json': {
+                schema: getModelSchemaRef(Category, {includeRelations: true}),
+              },
+            },
+          },
+        },
+      })
+      async find(): Promise<Category[]> {
+        return []; // dummy implementation, it's never called
+      }
+    }
+
+    const spec = getControllerSpec(CategoryController);
+    const opSpec: OperationObject = spec.paths['/categories'].get;
+    const responseSpec = opSpec.responses['200'].content['application/json'];
+    expect(responseSpec.schema).to.deepEqual({
+      $ref: '#/components/schemas/CategoryWithRelations',
+    });
+
+    const globalSchemas = (spec.components || {}).schemas;
+    expect(globalSchemas).to.deepEqual({
+      CategoryWithRelations: {
+        title: 'CategoryWithRelations',
+        properties: {
+          products: {
+            type: 'array',
+            items: {$ref: '#/components/schemas/ProductWithRelations'},
+          },
+        },
+      },
+      ProductWithRelations: {
+        title: 'ProductWithRelations',
+        properties: {
+          categoryId: {
+            type: 'number',
+          },
+          category: {
+            $ref: '#/components/schemas/CategoryWithRelations',
+          },
+        },
+      },
+    });
   });
 });

--- a/packages/openapi-v3/src/__tests__/integration/spike.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/spike.integration.ts
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {OperationObject} from '@loopback/openapi-v3-types';
+import {expect} from '@loopback/testlab';
+import {get, getControllerSpec} from '../..';
+
+describe('controller spec', () => {
+  it('allows operations to provide definition of referenced models', () => {
+    class MyController {
+      @get('/todos', {
+        responses: {
+          '200': {
+            description: 'Array of Category model instances',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Todo',
+                  definitions: {
+                    Todo: {
+                      title: 'Todo',
+                      properties: {
+                        title: {type: 'string'},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+      async find(): Promise<object[]> {
+        return []; // dummy implementation, it's never called
+      }
+    }
+
+    const spec = getControllerSpec(MyController);
+    const opSpec: OperationObject = spec.paths['/todos'].get;
+    const responseSpec = opSpec.responses['200'].content['application/json'];
+    expect(responseSpec.schema).to.deepEqual({
+      $ref: '#/components/schemas/Todo',
+    });
+
+    const globalSchemas = (spec.components || {}).schemas;
+    expect(globalSchemas).to.deepEqual({
+      Todo: {
+        title: 'Todo',
+        properties: {
+          title: {
+            type: 'string',
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -3,29 +3,28 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector, DecoratorFactory} from '@loopback/context';
-
+import {DecoratorFactory, MetadataInspector} from '@loopback/context';
 import {
+  ComponentsObject,
+  ISpecificationExtension,
+  isReferenceObject,
   OperationObject,
   ParameterObject,
   PathObject,
-  ComponentsObject,
+  ReferenceObject,
   RequestBodyObject,
   ResponseObject,
-  ReferenceObject,
   SchemaObject,
-  isReferenceObject,
-  ISpecificationExtension,
 } from '@loopback/openapi-v3-types';
 import {
   getJsonSchema,
-  JsonSchemaOptions,
   getJsonSchemaRef,
+  JsonSchemaOptions,
 } from '@loopback/repository-json-schema';
-import {OAI3Keys} from './keys';
-import {jsonToSchemaObject} from './json-to-schema';
 import * as _ from 'lodash';
 import {resolveSchema} from './generate-schema';
+import {jsonToSchemaObject} from './json-to-schema';
+import {OAI3Keys} from './keys';
 
 const debug = require('debug')('loopback:openapi3:metadata:controller-spec');
 
@@ -349,9 +348,9 @@ export function getControllerSpec(constructor: Function): ControllerSpec {
   return spec;
 }
 
-export function getModelSchemaRef(
-  modelCtor: Function,
-  options: JsonSchemaOptions,
+export function getModelSchemaRef<T extends object = any>(
+  modelCtor: Function & {prototype: T},
+  options: JsonSchemaOptions<T> = {},
 ) {
   const jsonSchema = getJsonSchemaRef(modelCtor, options);
   return jsonToSchemaObject(jsonSchema);

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -15,8 +15,13 @@ import {
   ReferenceObject,
   SchemaObject,
   isReferenceObject,
+  ISpecificationExtension,
 } from '@loopback/openapi-v3-types';
-import {getJsonSchema} from '@loopback/repository-json-schema';
+import {
+  getJsonSchema,
+  JsonSchemaOptions,
+  getJsonSchemaRef,
+} from '@loopback/repository-json-schema';
 import {OAI3Keys} from './keys';
 import {jsonToSchemaObject} from './json-to-schema';
 import * as _ from 'lodash';
@@ -55,6 +60,8 @@ export interface RestEndpoint {
 }
 
 export const TS_TYPE_KEY = 'x-ts-type';
+
+type ComponentSchemaMap = {[key: string]: SchemaObject};
 
 /**
  * Build the api spec from class and method level decorations
@@ -120,8 +127,8 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
       if (isReferenceObject(responseObject)) continue;
       const content = responseObject.content || {};
       for (const c in content) {
-        debug('  evaluating response code %s with content: %o', code, c);
-        resolveTSType(spec, content[c].schema);
+        debug('  processing response code %s with content-type %', code, c);
+        processSchemaExtensions(spec, content[c].schema);
       }
     }
 
@@ -180,7 +187,7 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
 
         const content = requestBody.content || {};
         for (const mediaType in content) {
-          resolveTSType(spec, content[mediaType].schema);
+          processSchemaExtensions(spec, content[mediaType].schema);
         }
       }
     }
@@ -235,12 +242,18 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
  * @param spec Controller spec
  * @param schema Schema object
  */
-function resolveTSType(
+function processSchemaExtensions(
   spec: ControllerSpec,
-  schema?: SchemaObject | ReferenceObject,
+  schema?: SchemaObject | (ReferenceObject & ISpecificationExtension),
 ) {
-  debug('  evaluating schema: %j', schema);
-  if (!schema || isReferenceObject(schema)) return;
+  debug('  processing extensions in schema: %j', schema);
+  if (!schema) return;
+
+  assignRelatedSchemas(spec, schema.definitions);
+  delete schema.definitions;
+
+  if (isReferenceObject(schema)) return;
+
   const tsType = schema[TS_TYPE_KEY];
   debug('  %s => %o', TS_TYPE_KEY, tsType);
   if (tsType) {
@@ -252,11 +265,11 @@ function resolveTSType(
     return;
   }
   if (schema.type === 'array') {
-    resolveTSType(spec, schema.items);
+    processSchemaExtensions(spec, schema.items);
   } else if (schema.type === 'object') {
     if (schema.properties) {
       for (const p in schema.properties) {
-        resolveTSType(spec, schema.properties[p]);
+        processSchemaExtensions(spec, schema.properties[p]);
       }
     }
   }
@@ -281,20 +294,38 @@ function generateOpenAPISchema(spec: ControllerSpec, tsType: Function) {
   }
   const jsonSchema = getJsonSchema(tsType);
   const openapiSchema = jsonToSchemaObject(jsonSchema);
-  const outputSchemas = spec.components.schemas;
-  if (openapiSchema.definitions) {
-    for (const key in openapiSchema.definitions) {
-      // Preserve user-provided definitions
-      if (key in outputSchemas) continue;
-      const relatedSchema = openapiSchema.definitions[key];
-      debug('    defining referenced schema for %j: %j', key, relatedSchema);
-      outputSchemas[key] = relatedSchema;
-    }
-    delete openapiSchema.definitions;
-  }
+
+  assignRelatedSchemas(spec, openapiSchema.definitions);
+  delete openapiSchema.definitions;
 
   debug('    defining schema for %j: %j', tsType.name, openapiSchema);
-  outputSchemas[tsType.name] = openapiSchema;
+  spec.components.schemas[tsType.name] = openapiSchema;
+}
+
+function assignRelatedSchemas(
+  spec: ControllerSpec,
+  definitions?: ComponentSchemaMap,
+) {
+  if (!definitions) return;
+  debug(
+    '    assigning related schemas: ',
+    definitions && Object.keys(definitions),
+  );
+  if (!spec.components) {
+    spec.components = {};
+  }
+  if (!spec.components.schemas) {
+    spec.components.schemas = {};
+  }
+  const outputSchemas = spec.components.schemas;
+
+  for (const key in definitions) {
+    // Preserve user-provided definitions
+    if (key in outputSchemas) continue;
+    const relatedSchema = definitions[key];
+    debug('    defining referenced schema for %j: %j', key, relatedSchema);
+    outputSchemas[key] = relatedSchema;
+  }
 }
 
 /**
@@ -316,4 +347,12 @@ export function getControllerSpec(constructor: Function): ControllerSpec {
     );
   }
   return spec;
+}
+
+export function getModelSchemaRef(
+  modelCtor: Function,
+  options: JsonSchemaOptions,
+) {
+  const jsonSchema = getJsonSchemaRef(modelCtor, options);
+  return jsonToSchemaObject(jsonSchema);
 }

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -582,7 +582,7 @@ describe('build-schema', () => {
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
-        {modelOnly: cachedSchema},
+        {'config:{}': cachedSchema},
         TestModel,
       );
       const jsonSchema = getJsonSchema(TestModel);

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -582,7 +582,7 @@ describe('build-schema', () => {
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
-        cachedSchema,
+        {modelOnly: cachedSchema},
         TestModel,
       );
       const jsonSchema = getJsonSchema(TestModel);

--- a/packages/repository-json-schema/src/__tests__/integration/spike.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/spike.integration.ts
@@ -1,0 +1,129 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository-json-schema
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  belongsTo,
+  Entity,
+  hasMany,
+  model,
+  property,
+} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import * as Ajv from 'ajv';
+import {JsonSchema, modelToJsonSchema} from '../..';
+
+describe('build-schema', () => {
+  describe('modelToJsonSchema', () => {
+    it('converts basic model', () => {
+      @model()
+      class TestModel {
+        @property()
+        foo: string;
+      }
+
+      const jsonSchema = modelToJsonSchema(TestModel);
+      expectValidJsonSchema(jsonSchema);
+      expect(jsonSchema.properties).to.containDeep({
+        foo: <JsonSchema>{
+          type: 'string',
+        },
+      });
+    });
+
+    it('handles circular references', () => {
+      @model()
+      class Category {
+        @property.array(() => Product)
+        products?: Product[];
+      }
+
+      @model()
+      class Product {
+        @property(() => Category)
+        category?: Category;
+      }
+
+      const schema = modelToJsonSchema(Category);
+      expect(schema).to.deepEqual({
+        title: 'Category',
+        properties: {
+          products: {
+            type: 'array',
+            items: {$ref: '#/definitions/Product'},
+          },
+        },
+        definitions: {
+          Product: {
+            title: 'Product',
+            properties: {
+              category: {
+                $ref: '#/definitions/Category',
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('converts HasMany and BelongsTo relation links', () => {
+      @model()
+      class Product extends Entity {
+        @property({id: true})
+        id: number;
+
+        @belongsTo(() => Category)
+        categoryId: number;
+      }
+
+      @model()
+      class Category extends Entity {
+        @property({id: true})
+        id: number;
+
+        @hasMany(() => Product)
+        products?: Product[];
+      }
+
+      const jsonSchema = modelToJsonSchema(Category, {includeRelations: true});
+      expectValidJsonSchema(jsonSchema);
+      expect(jsonSchema).to.deepEqual({
+        title: 'CategoryWithRelations',
+        properties: {
+          // TODO(bajtos): inherit these properties from Category schema
+          // See https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+          id: {type: 'number'},
+          products: {
+            type: 'array',
+            items: {$ref: '#/definitions/ProductWithRelations'},
+          },
+        },
+        definitions: {
+          ProductWithRelations: {
+            title: 'ProductWithRelations',
+            properties: {
+              // TODO(bajtos): inherit these properties from Product schema
+              // See https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+              id: {type: 'number'},
+              categoryId: {type: 'number'},
+              category: {$ref: '#/definitions/CategoryWithRelations'},
+            },
+          },
+        },
+      });
+    });
+  });
+});
+
+function expectValidJsonSchema(schema: JsonSchema) {
+  const ajv = new Ajv();
+  const validate = ajv.compile(
+    require('ajv/lib/refs/json-schema-draft-06.json'),
+  );
+  const isValid = validate(schema);
+  const result = isValid
+    ? 'JSON Schema is valid'
+    : ajv.errorsText(validate.errors!);
+  expect(result).to.equal('JSON Schema is valid');
+}

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -14,21 +14,60 @@ import {
 import {JSONSchema6 as JSONSchema} from 'json-schema';
 import {JSON_SCHEMA_KEY} from './keys';
 
+export interface JsonSchemaOptions {
+  includeRelations?: boolean;
+  visited?: {[key: string]: JSONSchema};
+}
+
 /**
  * Gets the JSON Schema of a TypeScript model/class by seeing if one exists
  * in a cache. If not, one is generated and then cached.
  * @param ctor Contructor of class to get JSON Schema from
  */
-export function getJsonSchema(ctor: Function): JSONSchema {
+export function getJsonSchema(
+  ctor: Function,
+  options: JsonSchemaOptions = {},
+): JSONSchema {
   // NOTE(shimks) currently impossible to dynamically update
-  const jsonSchema = MetadataInspector.getClassMetadata(JSON_SCHEMA_KEY, ctor);
-  if (jsonSchema) {
-    return jsonSchema;
+  const cached = MetadataInspector.getClassMetadata(JSON_SCHEMA_KEY, ctor);
+  const key = options.includeRelations ? 'modelWithRelations' : 'modelOnly';
+
+  if (cached && cached[key]) {
+    return cached[key];
   } else {
-    const newSchema = modelToJsonSchema(ctor);
-    MetadataInspector.defineMetadata(JSON_SCHEMA_KEY.key, newSchema, ctor);
+    const newSchema = modelToJsonSchema(ctor, options);
+    if (cached) {
+      cached[key] = newSchema;
+    } else {
+      MetadataInspector.defineMetadata(
+        JSON_SCHEMA_KEY.key,
+        {[key]: newSchema},
+        ctor,
+      );
+    }
     return newSchema;
   }
+}
+
+export function getJsonSchemaRef(
+  ctor: Function,
+  options: JsonSchemaOptions = {},
+): JSONSchema {
+  const schemaWithDefinitions = getJsonSchema(ctor, options);
+  const key = schemaWithDefinitions.title;
+
+  // ctor is not a model
+  if (!key) return schemaWithDefinitions;
+
+  const definitions = Object.assign({}, schemaWithDefinitions.definitions);
+  const schema = Object.assign({}, schemaWithDefinitions);
+  delete schema.definitions;
+  definitions[key] = schema;
+
+  return {
+    $ref: `#/definitions/${key}`,
+    definitions,
+  };
 }
 
 /**
@@ -130,6 +169,27 @@ export function metaToJsonProperty(meta: PropertyDefinition): JSONSchema {
   return result;
 }
 
+export function modelToJsonSchemaRef(
+  ctor: Function,
+  options: JsonSchemaOptions = {},
+): JSONSchema {
+  const schemaWithDefinitions = modelToJsonSchema(ctor, options);
+  const key = schemaWithDefinitions.title;
+
+  // ctor is not a model
+  if (!key) return schemaWithDefinitions;
+
+  const definitions = Object.assign({}, schemaWithDefinitions.definitions);
+  const schema = Object.assign({}, schemaWithDefinitions);
+  delete schema.definitions;
+  definitions[key] = schema;
+
+  return {
+    $ref: `#/definitions/${key}`,
+    definitions,
+  };
+}
+
 // NOTE(shimks) no metadata for: union, optional, nested array, any, enum,
 // string literal, anonymous types, and inherited properties
 
@@ -138,16 +198,30 @@ export function metaToJsonProperty(meta: PropertyDefinition): JSONSchema {
  * reflection API
  * @param ctor Constructor of class to convert from
  */
-export function modelToJsonSchema(ctor: Function): JSONSchema {
+export function modelToJsonSchema(
+  ctor: Function,
+  options: JsonSchemaOptions = {},
+): JSONSchema {
+  options.visited = options.visited || {};
+
   const meta: ModelDefinition | {} = ModelMetadataHelper.getModelMetadata(ctor);
-  const result: JSONSchema = {};
 
   // returns an empty object if metadata is an empty object
+  // FIXME(bajtos) this pretty much breaks type validation.
+  // We should return `undefined` instead of an empty object.
   if (!(meta instanceof ModelDefinition)) {
     return {};
   }
 
-  result.title = meta.title || ctor.name;
+  let title = meta.title || ctor.name;
+  if (options.includeRelations) {
+    title += 'WithRelations';
+  }
+
+  if (title in options.visited) return options.visited[title];
+
+  const result: JSONSchema = {title};
+  options.visited[title] = result;
 
   if (meta.description) {
     result.description = meta.description;
@@ -186,21 +260,54 @@ export function modelToJsonSchema(ctor: Function): JSONSchema {
       continue;
     }
 
-    const propSchema = getJsonSchema(referenceType);
+    const propSchema = getJsonSchema(referenceType, options);
+    includeReferencedSchema(referenceType.name, propSchema);
+  }
 
-    if (propSchema && Object.keys(propSchema).length > 0) {
-      result.definitions = result.definitions || {};
-
-      // delete nested definition
-      if (propSchema.definitions) {
-        for (const key in propSchema.definitions) {
-          result.definitions[key] = propSchema.definitions[key];
-        }
-        delete propSchema.definitions;
+  if (options.includeRelations) {
+    for (const r in meta.relations) {
+      result.properties = result.properties || {};
+      const relMeta = meta.relations[r];
+      const targetType = resolveType(relMeta.target);
+      const targetSchema = getJsonSchema(targetType, options);
+      const targetTitle = targetSchema.title;
+      if (!targetTitle) {
+        throw new Error(
+          `The target of the relation ${title}.${relMeta.name} is not a model!`,
+        );
       }
+      const targetRef = {$ref: `#/definitions/${targetTitle}`};
 
-      result.definitions[referenceType.name] = propSchema;
+      const propDef = relMeta.targetsMany
+        ? <JSONSchema>{
+            type: 'array',
+            items: targetRef,
+          }
+        : targetRef;
+
+      // IMPORTANT: r !== relMeta.name
+      // E.g. belongsTo sets r="categoryId" but name="category"
+      result.properties[relMeta.name] =
+        result.properties[relMeta.name] || propDef;
+      includeReferencedSchema(targetTitle, targetSchema);
     }
   }
   return result;
+
+  function includeReferencedSchema(name: string, propSchema: JSONSchema) {
+    if (!propSchema || !Object.keys(propSchema).length) return;
+
+    result.definitions = result.definitions || {};
+
+    // promote nested definition to the top level
+    if (propSchema.definitions) {
+      for (const key in propSchema.definitions) {
+        if (key === title) continue;
+        result.definitions[key] = propSchema.definitions[key];
+      }
+      delete propSchema.definitions;
+    }
+
+    result.definitions[name] = propSchema;
+  }
 }

--- a/packages/repository-json-schema/src/keys.ts
+++ b/packages/repository-json-schema/src/keys.ts
@@ -10,6 +10,6 @@ import {JSONSchema6 as JSONSchema} from 'json-schema';
  * Metadata key used to set or retrieve repository JSON Schema
  */
 export const JSON_SCHEMA_KEY = MetadataAccessor.create<
-  JSONSchema,
+  {[options: string]: JSONSchema},
   ClassDecorator
 >('loopback:json-schema');

--- a/packages/repository/src/__tests__/integration/repositories/relation.factory.integration.ts
+++ b/packages/repository/src/__tests__/integration/repositories/relation.factory.integration.ts
@@ -217,6 +217,7 @@ class Order extends Entity {
     .addRelation({
       name: 'customer',
       type: RelationType.belongsTo,
+      targetsMany: false,
       source: Order,
       target: () => Customer,
       keyFrom: 'customerId',
@@ -253,6 +254,7 @@ class Customer extends Entity {
     .addRelation({
       name: 'orders',
       type: RelationType.hasMany,
+      targetsMany: true,
       source: Customer,
       target: () => Order,
       keyTo: 'customerId',
@@ -260,6 +262,7 @@ class Customer extends Entity {
     .addRelation({
       name: 'reviewsAuthored',
       type: RelationType.hasMany,
+      targetsMany: true,
       source: Customer,
       target: () => Review,
       keyTo: 'authorId',
@@ -267,6 +270,7 @@ class Customer extends Entity {
     .addRelation({
       name: 'reviewsApproved',
       type: RelationType.hasMany,
+      targetsMany: true,
       source: Customer,
       target: () => Review,
       keyTo: 'approvedId',

--- a/packages/repository/src/__tests__/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/relation.decorator.unit.ts
@@ -49,6 +49,7 @@ describe('relation decorator', () => {
       );
       expect(meta).to.eql({
         type: RelationType.hasMany,
+        targetsMany: true,
         name: 'addresses',
         source: AddressBook,
         target: () => Address,
@@ -60,6 +61,7 @@ describe('relation decorator', () => {
       expect(AddressBook.definition.relations).to.eql({
         addresses: {
           type: RelationType.hasMany,
+          targetsMany: true,
           name: 'addresses',
           source: AddressBook,
           target: () => Address,
@@ -93,6 +95,7 @@ describe('relation decorator', () => {
       );
       expect(meta).to.eql({
         type: RelationType.hasMany,
+        targetsMany: true,
         name: 'addresses',
         source: AddressBook,
         target: () => Address,
@@ -131,6 +134,7 @@ describe('relation decorator', () => {
           keyFrom: 'addressBookId',
           name: 'addressBook',
           type: 'belongsTo',
+          targetsMany: false,
         },
       });
     });
@@ -156,6 +160,7 @@ describe('relation decorator', () => {
       );
       expect(meta).to.eql({
         type: RelationType.belongsTo,
+        targetsMany: false,
         name: 'addressBook',
         source: Address,
         target: () => AddressBook,

--- a/packages/repository/src/__tests__/unit/errors/invalid-relation-error.test.ts
+++ b/packages/repository/src/__tests__/unit/errors/invalid-relation-error.test.ts
@@ -48,6 +48,7 @@ function givenAnErrorInstance() {
   return new InvalidRelationError('a reason', {
     name: 'products',
     type: RelationType.hasMany,
+    targetsMany: true,
     source: Category,
     target: () => Product,
   });

--- a/packages/repository/src/__tests__/unit/repositories/belongs-to-repository-factory.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/belongs-to-repository-factory.unit.ts
@@ -98,6 +98,7 @@ describe('createBelongsToAccessor', () => {
 
     const relationMeta: BelongsToDefinition = {
       type: RelationType.belongsTo,
+      targetsMany: false,
       name: 'category',
       source: Product,
       target: () => Category,
@@ -165,6 +166,7 @@ describe('createBelongsToAccessor', () => {
   ): BelongsToDefinition {
     const defaults: BelongsToDefinition = {
       type: RelationType.belongsTo,
+      targetsMany: false,
       name: 'company',
       source: Company,
       target: () => Customer,

--- a/packages/repository/src/__tests__/unit/repositories/has-many-repository-factory.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/has-many-repository-factory.unit.ts
@@ -114,6 +114,7 @@ describe('createHasManyRepositoryFactory', () => {
 
     const defaults: HasManyDefinition = {
       type: RelationType.hasMany,
+      targetsMany: true,
       name: 'customers',
       target: () => Customer,
       source: Company,

--- a/packages/repository/src/__tests__/unit/repositories/has-one-repository-factory.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/has-one-repository-factory.unit.ts
@@ -125,6 +125,7 @@ describe('createHasOneRepositoryFactory', () => {
   ): HasOneDefinition {
     const defaults: HasOneDefinition = {
       type: RelationType.hasOne,
+      targetsMany: false,
       name: 'address',
       target: () => Address,
       source: Customer,

--- a/packages/repository/src/decorators/metadata.ts
+++ b/packages/repository/src/decorators/metadata.ts
@@ -10,7 +10,8 @@ import {
   MODEL_WITH_PROPERTIES_KEY,
   PropertyMap,
 } from './model.decorator';
-import {ModelDefinition} from '../model';
+import {ModelDefinition, RelationDefinitionMap} from '../model';
+import {RELATIONS_KEY} from '../relations';
 
 export class ModelMetadataHelper {
   /**
@@ -60,6 +61,16 @@ export class ModelMetadataHelper {
             options,
           ),
         );
+
+        meta.relations = Object.assign(
+          <RelationDefinitionMap>{},
+          MetadataInspector.getAllPropertyMetadata(
+            RELATIONS_KEY,
+            target.prototype,
+            options,
+          ),
+        );
+
         MetadataInspector.defineMetadata(
           MODEL_WITH_PROPERTIES_KEY.key,
           meta,

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -209,6 +209,12 @@ export abstract class Model {
         json[p] = asJSON((this as AnyObject)[p]);
       }
     }
+    // Include relational links in the JSON representation
+    for (const r in def.relations) {
+      if (r in this) {
+        json[r] = asJSON((this as AnyObject)[r]);
+      }
+    }
     return json;
   }
 

--- a/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
@@ -55,6 +55,7 @@ export function belongsTo<T extends Entity>(
       // properties enforced by the decorator
       {
         type: RelationType.belongsTo,
+        targetsMany: false,
         source: decoratedTarget.constructor,
         target: targetResolver,
       },

--- a/packages/repository/src/relations/has-many/has-many.decorator.ts
+++ b/packages/repository/src/relations/has-many/has-many.decorator.ts
@@ -28,6 +28,7 @@ export function hasMany<T extends Entity>(
       // properties enforced by the decorator
       {
         type: RelationType.hasMany,
+        targetsMany: true,
         source: decoratedTarget.constructor,
         target: targetResolver,
       },

--- a/packages/repository/src/relations/has-one/has-one.decorator.ts
+++ b/packages/repository/src/relations/has-one/has-one.decorator.ts
@@ -29,6 +29,7 @@ export function hasOne<T extends Entity>(
       // properties enforced by the decorator
       {
         type: RelationType.hasOne,
+        targetsMany: false,
         name: key,
         source: decoratedTarget.constructor,
         target: targetResolver,

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -23,6 +23,13 @@ export interface RelationDefinitionBase {
   type: RelationType;
 
   /**
+   * True for relations targeting multiple instances (e.g. HasMany),
+   * false for relations with a single target (e.g. BelongsTo, HasOne).
+   * This property is need by OpenAPI/JSON Schema generator.
+   */
+  targetsMany: boolean;
+
+  /**
    * The relation name, typically matching the name of the accessor property
    * defined on the source model. For example "orders" or "customer".
    */
@@ -45,6 +52,7 @@ export interface RelationDefinitionBase {
 
 export interface HasManyDefinition extends RelationDefinitionBase {
   type: RelationType.hasMany;
+  targetsMany: true;
 
   /**
    * The foreign key used by the target model.
@@ -58,6 +66,7 @@ export interface HasManyDefinition extends RelationDefinitionBase {
 
 export interface BelongsToDefinition extends RelationDefinitionBase {
   type: RelationType.belongsTo;
+  targetsMany: false;
 
   /*
    * The foreign key in the source model, e.g. Order#customerId.
@@ -72,6 +81,7 @@ export interface BelongsToDefinition extends RelationDefinitionBase {
 
 export interface HasOneDefinition extends RelationDefinitionBase {
   type: RelationType.hasOne;
+  targetsMany: false;
 
   /**
    * The foreign key used by the target model.

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -3,20 +3,20 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, ValueObject, Model} from '../model';
 import {
-  DataObject,
-  Options,
   AnyObject,
   Command,
-  NamedParameters,
-  PositionalParameters,
   Count,
+  DataObject,
+  NamedParameters,
+  Options,
+  PositionalParameters,
 } from '../common-types';
-import {DataSource} from '../datasource';
 import {CrudConnector} from '../connectors';
-import {Filter, Where} from '../query';
+import {DataSource} from '../datasource';
 import {EntityNotFoundError} from '../errors';
+import {Entity, Model, ValueObject} from '../model';
+import {Filter, Where} from '../query';
 
 // tslint:disable:no-unused
 
@@ -40,8 +40,10 @@ export interface ExecutableRepository<T extends Model> extends Repository<T> {
 /**
  * Basic CRUD operations for ValueObject and Entity. No ID is required.
  */
-export interface CrudRepository<T extends ValueObject | Entity>
-  extends Repository<T> {
+export interface CrudRepository<
+  T extends ValueObject | Entity,
+  Relations extends object = {}
+> extends Repository<T> {
   /**
    * Create a new record
    * @param dataObject The data to be created
@@ -64,7 +66,7 @@ export interface CrudRepository<T extends ValueObject | Entity>
    * @param options Options for the operations
    * @returns A promise of an array of records found
    */
-  find(filter?: Filter<T>, options?: Options): Promise<T[]>;
+  find(filter?: Filter<T>, options?: Options): Promise<(T & Relations)[]>;
 
   /**
    * Updating matching records with attributes from the data object
@@ -105,9 +107,11 @@ export interface EntityRepository<T extends Entity, ID>
 /**
  * CRUD operations for a repository of entities
  */
-export interface EntityCrudRepository<T extends Entity, ID>
-  extends EntityRepository<T, ID>,
-    CrudRepository<T> {
+export interface EntityCrudRepository<
+  T extends Entity,
+  ID,
+  Relations extends object = {}
+> extends EntityRepository<T, ID>, CrudRepository<T, Relations> {
   // entityClass should have type "typeof T", but that's not supported by TSC
   entityClass: typeof Entity & {prototype: T};
 
@@ -146,7 +150,11 @@ export interface EntityCrudRepository<T extends Entity, ID>
    * @param options Options for the operations
    * @returns A promise of an entity found for the id
    */
-  findById(id: ID, filter?: Filter<T>, options?: Options): Promise<T>;
+  findById(
+    id: ID,
+    filter?: Filter<T>,
+    options?: Options,
+  ): Promise<T & Relations>;
 
   /**
    * Update an entity by id with property/value pairs in the data object


### PR DESCRIPTION
This pull request offers a PoC implementation demonstrating how to modify the schema generated from a LB4 model depending on configurable options. In particular, the following two use cases are covered:

- PATCH - all properties are optional
- CREATE - id and possibly _rev must not be present

The first commit imports code from https://github.com/strongloop/loopback-next/pull/2592 and should be ignored.

The second commit contains PoC and SPIKE notes with a high-level overview.

Related stories:
 - the spike story: https://github.com/strongloop/loopback-next/issues/2082
 - #1722
 - #1179
 - #1470
 - #1719
 - #1894

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated