### PR TITLE
fix(context): clear binding cache upon scope/getValue changes

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -212,6 +212,15 @@ export class Binding<T = BoundValue> {
   }
 
   /**
+   * Clear the cache
+   */
+  private _clearCache() {
+    if (!this._cache) return;
+    // WeakMap does not have a `clear` method
+    this._cache = new WeakMap();
+  }
+
+  /**
    * This is an internal function optimized for performance.
    * Users should use `@inject(key)` or `ctx.get(key)` instead.
    *
@@ -346,6 +355,7 @@ export class Binding<T = BoundValue> {
    * @param scope Binding scope
    */
   inScope(scope: BindingScope): this {
+    if (this._scope !== scope) this._clearCache();
     this._scope = scope;
     return this;
   }
@@ -357,7 +367,7 @@ export class Binding<T = BoundValue> {
    */
   applyDefaultScope(scope: BindingScope): this {
     if (!this._scope) {
-      this._scope = scope;
+      this.inScope(scope);
     }
     return this;
   }
@@ -367,6 +377,8 @@ export class Binding<T = BoundValue> {
    * @param getValue getValue function
    */
   private _setValueGetter(getValue: ValueGetter<T>) {
+    // Clear the cache
+    this._clearCache();
     this._getValue = getValue;
   }
 

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -3,18 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {DecoratorFactory} from '@loopback/metadata';
+import * as debugModule from 'debug';
 import {Binding} from './binding';
 import {Injection} from './inject';
-import {ValueOrPromise, BoundValue, tryWithFinally} from './value-promise';
-import * as debugModule from 'debug';
-import {DecoratorFactory} from '@loopback/metadata';
+import {BoundValue, tryWithFinally, ValueOrPromise} from './value-promise';
 
 const debugSession = debugModule('loopback:context:resolver:session');
 const getTargetName = DecoratorFactory.getTargetName;
-
-// NOTE(bajtos) The following import is required to satisfy TypeScript compiler
-// tslint:disable-next-line:no-unused
-import {BindingKey} from './binding-key';
 
 /**
  * A function to be executed with the resolution session
@@ -169,7 +165,7 @@ export class ResolutionSession {
     );
     return {
       targetName: name,
-      bindingKey: injection.bindingSelector,
+      bindingSelector: injection.bindingSelector,
       // Cast to Object so that we don't have to expose InjectionMetadata
       metadata: injection.metadata as Object,
     };
@@ -342,4 +338,23 @@ export interface ResolutionOptions {
    * will return `undefined` instead of throwing an error.
    */
   optional?: boolean;
+}
+
+/**
+ * Resolution options or session
+ */
+export type ResolutionOptionsOrSession = ResolutionOptions | ResolutionSession;
+
+/**
+ * Normalize ResolutionOptionsOrSession to ResolutionOptions
+ * @param optionsOrSession resolution options or session
+ */
+export function asResolutionOptions(
+  optionsOrSession?: ResolutionOptionsOrSession,
+): ResolutionOptions {
+  // backwards compatibility
+  if (optionsOrSession instanceof ResolutionSession) {
+    return {session: optionsOrSession};
+  }
+  return optionsOrSession || {};
 }

--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -262,7 +262,7 @@ describe('Routing', () => {
     server.bind('flag').to('original');
 
     // create a special binding returning the current context instance
-    server.bind('context').getValue = ctx => ctx;
+    server.bind('context').getValue = (ctx: Context) => ctx;
 
     const spec = anOpenApiSpec()
       .withOperationReturningString('put', '/flag', 'setFlag')


### PR DESCRIPTION
Extracted from #2635:

Make sure binding cache is cleared if the binding is bound to a new value provider or scope
- The binding instance may cache values for contexts based on the scope
- If an existing binding changes its value provider or scope, the cache should be invalidated.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
