### PR TITLE
feat(context): improve @inject.setter and add @inject.binding

### DIFF
--- a/docs/site/Dependency-injection.md
+++ b/docs/site/Dependency-injection.md
@@ -245,6 +245,7 @@ There are a few special decorators from the `inject` namespace.
 
 - [`@inject.getter`](Decorators_inject.md#@inject.getter)
 - [`@inject.setter`](Decorators_inject.md#@inject.setter)
+- [`@inject.binding`](Decorators_inject.md#@inject.binding)
 - [`@inject.context`](Decorators_inject.md#@inject.context)
 - [`@inject.tag`](Decorators_inject.md#@inject.tag)
 - [`@inject.view`](Decorators_inject.md#@inject.view)

--- a/packages/authentication/src/__tests__/unit/providers/authentication.provider.unit.ts
+++ b/packages/authentication/src/__tests__/unit/providers/authentication.provider.unit.ts
@@ -3,13 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
 import {Context, instantiateClass} from '@loopback/context';
 import {Request} from '@loopback/rest';
-import {AuthenticateFn, UserProfile, AuthenticationBindings} from '../../..';
-import {MockStrategy} from '../fixtures/mock-strategy';
+import {expect} from '@loopback/testlab';
 import {Strategy} from 'passport';
+import {AuthenticateFn, AuthenticationBindings, UserProfile} from '../../..';
 import {AuthenticateActionProvider} from '../../../providers';
+import {MockStrategy} from '../fixtures/mock-strategy';
 
 describe('AuthenticateActionProvider', () => {
   describe('constructor()', () => {

--- a/packages/context/src/__tests__/unit/binding.unit.ts
+++ b/packages/context/src/__tests__/unit/binding.unit.ts
@@ -258,6 +258,19 @@ describe('Binding', () => {
       expect(binding.tagNames).to.eql(['myTag']);
     });
 
+    it('applies multiple template functions', async () => {
+      binding.apply(
+        b => {
+          b.inScope(BindingScope.SINGLETON);
+        },
+        b => {
+          b.tag('myTag');
+        },
+      );
+      expect(binding.scope).to.eql(BindingScope.SINGLETON);
+      expect(binding.tagNames).to.eql(['myTag']);
+    });
+
     it('sets up a placeholder value', async () => {
       const toBeBound = (b: Binding<unknown>) => {
         b.toDynamicValue(() => {

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -537,8 +537,8 @@ export class Binding<T = BoundValue> {
   }
 
   /**
-   * Apply a template function to set up the binding with scope, tags, and
-   * other attributes as a group.
+   * Apply one or more template functions to set up the binding with scope,
+   * tags, and other attributes as a group.
    *
    * For example,
    * ```ts
@@ -548,10 +548,12 @@ export class Binding<T = BoundValue> {
    * const serverBinding = new Binding<RestServer>('servers.RestServer1');
    * serverBinding.apply(serverTemplate);
    * ```
-   * @param templateFn A function to configure the binding
+   * @param templateFns One or more functions to configure the binding
    */
-  apply(templateFn: BindingTemplate<T>): this {
-    templateFn(this);
+  apply(...templateFns: BindingTemplate<T>[]): this {
+    for (const fn of templateFns) {
+      fn(this);
+    }
     return this;
   }
 


### PR DESCRIPTION
Extracted from https://github.com/strongloop/loopback-next/pull/2635

1. Allow `@inject.setter` to set other forms of value providers than constant

```ts
// Set the binding to a constant value, this is the current behavior
injectedSetter('my-value'); 

// or use the returned binding to configure it
const binding = injectedSetter();
binding.toClass(MyClass);
```

2. Allows `bindingCreation` option to control how the underlying binding is resolved/created.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
