### PR TITLE
build: add script to check package-lock files

### DIFF
--- a/bin/check-package-locks.js
+++ b/bin/check-package-locks.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * This is an internal script to verify that local monorepo dependencies
+ * are excluded from package-lock files.
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const promisify = require('util').promisify;
+
+const readFile = promisify(fs.readFile);
+
+const Project = require('@lerna/project');
+
+async function checkPackageLocks() {
+  const project = new Project(process.cwd());
+  const packages = await project.getPackages();
+  const rootPath = project.rootPath;
+  const lockFiles = packages.map(p =>
+    path.relative(rootPath, path.join(p.location, 'package-lock.json')),
+  );
+
+  const checkResults = await Promise.all(
+    lockFiles.map(async lockFile => {
+      return {lockFile, violations: await checkLockFile(lockFile)};
+    }),
+  );
+  const badPackages = checkResults.filter(r => r.violations.length > 0);
+  if (!badPackages.length) return true;
+
+  console.error('\nInvalid package-lock entries found!\n');
+  for (const {lockFile, violations} of badPackages) {
+    console.error('  %s', lockFile);
+    for (const v of violations) {
+      console.error('    -> %s', v);
+    }
+  }
+
+  console.error('\nRun the following command to fix the problems:');
+  console.error('\n  $ npm run update-package-locks\n');
+  return false;
+}
+
+if (require.main === module) {
+  checkPackageLocks().then(
+    ok => process.exit(ok ? 0 : 1),
+    err => {
+      console.error(err);
+      process.exit(2);
+    },
+  );
+}
+
+async function checkLockFile(lockFile) {
+  const data = JSON.parse(await readFile(lockFile, 'utf-8'));
+  return Object.keys(data.dependencies || []).filter(dep =>
+    dep.startsWith('@loopback/'),
+  );
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
     "precoverage": "npm test",
     "coverage": "open coverage/index.html",
-    "lint": "npm run prettier:check && npm run tslint",
+    "lint": "npm run prettier:check && npm run tslint && node bin/check-package-locks",
     "lint:fix": "npm run tslint:fix && npm run prettier:fix",
     "tslint": "node packages/build/bin/run-tslint --project tsconfig.json",
     "tslint:fix": "npm run tslint -- --fix",

--- a/sandbox/example/.npmrc
+++ b/sandbox/example/.npmrc
@@ -1,0 +1,1 @@
+package-lock=true

--- a/sandbox/example/package-lock.json
+++ b/sandbox/example/package-lock.json
@@ -1,15 +1,3 @@
 {
-  "name": "@loopback/sandbox-example",
-  "version": "1.0.4",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@loopback/tslint-config": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "tslint-consistent-codestyle": "^1.14.1"
-      }
-    }
-  }
+  "lockfileVersion": 1
 }


### PR DESCRIPTION
- Add a new script `bin/check-package-lock.js` to verify that local monorepo dependencies are excluded from package-lock files.
- Run this script as part of `npm run lint`.
- Fix `sandbox/example` package - add `.npmrc` to enable package-lock feature, remove a monorepo-local references from `sandbox/examples/package-lock.json`.

My intention is to prevent accidental addition of monorepo-local references to package locks, see https://github.com/strongloop/loopback-next/pull/2650#pullrequestreview-219976910

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated