### PR TITLE
docs: add MAINTAINING.md for maintainers guide

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+## Project Maintainers
+
+Below is the list of maintainers for this repo (in alphabetical order). For SMEs
+on particular package, please see the [CODEOWNERS file](CODEOWNERS).
+
+Core maintainers:
+
+- Biniam Admikew ([@b-admike](https://github.com/b-admike))
+- Diana Lau ([@dhmlau](https://github.com/dhmlau))
+- Dominique Emond ([@emonddr](https://github.com/emonddr))
+- Janny Hou ([@jannyhou](https://github.com/jannyhou))
+- Miroslav Bajtos ([@bajtos](https://github.com/bajtos))
+- Nora Abdelgadir ([@nabdelgadir](https://github.com/nabdelgadir))
+- Raymond Feng ([@raymondfeng](https://github.com/raymondfeng))
+- Yaapa Hage ([@hacksparrow](https://github.com/hacksparrow))
+
+Community maintainers:
+
+- Hugo Da Roit ([@Yaty](https://github.com/Yaty))
+- Mario Estrada ([@marioestradarosa](https://github.com/marioestradarosa))
+- TN ([@thinusn](https://github.com/thinusn))

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,0 +1,46 @@
+# Maintaining LoopBack
+
+Congratulations! Since you're reading this page, you are probably already a
+maintainer of this repo or close to be one. Thank you for your contributions so
+far!
+
+## Why do I want to be a maintainer?
+
+- Greater influence on LoopBack's future direction
+- Commit (write) rights to `loopback-next` repo
+- Ability to review and land pull requests, edit/categorize/close issues
+
+## What are a maintainer's responsibilities?
+
+We ask you to follow the existing processes, see
+http://loopback.io/doc/en/contrib/Governance.html. This means mostly:
+
+- Be nice to others
+- Try to reach consensus with other maintainers before making a decision
+- Always use pull requests to make code changes
+- Honour our current conventions, see
+  http://loopback.io/doc/en/contrib/triaging-pull-requests.html and
+  http://loopback.io/doc/en/contrib/style-guide.html (but feel free to propose
+  changes to these conventions!)
+- To avoid possible confusion, we don't have any specific requirements about the
+  amount of time you should spend on the project - just keep working on things
+  that you find important to you, in a pace that suits you. We may ask you to
+  take a look at issues and pull requests related to code you contributed
+  yourself.
+
+## More questions?
+
+**Q: Now that I have rights to merge pull requests, how many approvals from
+other maintainers before I can merge?**
+
+A: If the changes are straightforward and you're confident about the changes,
+please go ahead to merge it. Otherwise you can always mention
+[@strongloop/loopback-maintainers](https://github.com/orgs/strongloop/teams/loopback-maintainers)
+in the GitHub issues/pull requests.
+
+**Q: If I have questions/suggestions on the contribution process, what should I
+do?**
+
+A: We are always open for suggestions on how to make the process for
+contributors or maintainers smooth. If you have any feedback, please open a
+GitHub ticket for discussion.


### PR DESCRIPTION
Add `MAINTAINING.md` for maintainers' guide. 

Some of the contents are coming from the email content when we're inviting maintainers, regarding the benefits, expectation and responsibilities.  

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
