### PR TITLE
Refactor metaToJsonProperty to accept AJV keywords

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -415,6 +415,45 @@ describe('build-schema', () => {
           expectValidJsonSchema(jsonSchema);
         });
 
+        it('properly handles AJV keywords in property decorator', () => {
+          @model()
+          class TestModel {
+            @property({
+              type: 'string',
+              required: true,
+              jsonSchema: {
+                format: 'email',
+                maxLength: 50,
+                minLength: 5,
+              },
+            })
+            email: string;
+
+            @property({
+              type: 'string',
+              required: true,
+              jsonSchema: {
+                pattern: '(a|b|c)',
+              },
+            })
+            type: string;
+          }
+
+          const jsonSchema = modelToJsonSchema(TestModel);
+          expect(jsonSchema.properties).to.eql({
+            email: {
+              type: 'string',
+              format: 'email',
+              maxLength: 50,
+              minLength: 5,
+            },
+            type: {
+              type: 'string',
+              pattern: '(a|b|c)',
+            },
+          });
+        });
+
         it('properly converts decorated custom array type with a resolver', () => {
           @model()
           class Address {

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -169,5 +169,25 @@ describe('build-schema', () => {
         description: 'test',
       });
     });
+
+    it('keeps AJV keywords', () => {
+      const schema = metaToJsonProperty({
+        type: String,
+        jsonSchema: {
+          pattern: '(a|b|c)',
+          format: 'email',
+          maxLength: 50,
+          minLength: 5,
+        },
+      });
+
+      expect(schema).to.eql({
+        type: 'string',
+        pattern: '(a|b|c)',
+        format: 'email',
+        maxLength: 50,
+        minLength: 5,
+      });
+    });
   });
 });

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -127,6 +127,10 @@ export function metaToJsonProperty(meta: PropertyDefinition): JSONSchema {
     });
   }
 
+  if (meta.jsonSchema) {
+    Object.assign(propDef, meta.jsonSchema);
+  }
+
   return result;
 }
 

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -30,6 +30,7 @@ export interface PropertyDefinition {
   type: PropertyType; // For example, 'string', String, or {}
   id?: boolean | number;
   json?: PropertyForm;
+  jsonSchema?: {[attribute: string]: any};
   store?: PropertyForm;
   itemType?: PropertyType; // type of array
   [attribute: string]: any; // Other attributes


### PR DESCRIPTION
We need to add additional attributes (AJV keywords) from PropertyDefinition so they will be written to openapi.json and we can use it as validation. Currently, only type, description, items (for arrays), and $ref are written (and a hard-coded format: 'date-time' for Date instances).

issue #2684

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
