### PR TITLE
docs: add greeter-extension example to other example docs

### DIFF
--- a/docs/site/Tutorials.md
+++ b/docs/site/Tutorials.md
@@ -35,6 +35,7 @@ $ lb4 example
   rpc-server: A basic RPC server using a made-up protocol.
   soap-calculator: An example on how to integrate SOAP web services.
   express-composition: A simple Express application that uses LoopBack 4 REST API.
+  greeter-extension: An example showing how to implement the extension point/extension pattern.
 ```
 
 Please follow the instructions in

--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -43,6 +43,7 @@ application, follow these steps:
     log-extension: An example extension project for LoopBack 4.
     rpc-server: A basic RPC server using a made-up protocol.
     > express-composition: A simple Express application that uses LoopBack 4 REST API.
+    greeter-extension: An example showing how to implement the extension point/extension pattern.
     ```
 
 2.  Switch to the directory.

--- a/examples/express-composition/README.md
+++ b/examples/express-composition/README.md
@@ -47,6 +47,7 @@ application, follow these steps:
     rpc-server: A basic RPC server using a made-up protocol.
     soap-calculator: An example on how to integrate SOAP web services.
    > express-composition: A simple Express application that uses LoopBack 4 REST API.
+    greeter-extension: An example showing how to implement the extension point/extension pattern.
    ```
 
 2. Jump into the directory and then install the required dependencies:

--- a/examples/soap-calculator/README.md
+++ b/examples/soap-calculator/README.md
@@ -59,6 +59,7 @@ $ lb4 example
   rpc-server: A basic RPC server using a made-up protocol.
 > soap-calculator: An example on how to integrate SOAP web services.
   express-composition: A simple Express application that uses LoopBack 4 REST API.
+  greeter-extension: An example showing how to implement the extension point/extension pattern.
 ```
 
 2. Jump into the directory and then install the required dependencies:

--- a/examples/todo-list/README.md
+++ b/examples/todo-list/README.md
@@ -68,6 +68,7 @@ application, follow these steps:
       log-extension: An example extension project for LoopBack 4.
       rpc-server: A basic RPC server using a made-up protocol.
       express-composition: A simple Express application that uses LoopBack 4 REST API.
+      greeter-extension: An example showing how to implement the extension point/extension pattern.
     ```
 
 2.  Switch to the directory.

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -56,11 +56,12 @@ application, follow these steps:
     $ lb4 example
     ? What example would you like to clone? (Use arrow keys)
     > todo: Tutorial example on how to build an application with LoopBack 4.
-    todo-list: Continuation of the todo example using relations in LoopBack 4.
-    hello-world: A simple hello-world Application using LoopBack 4.
-    log-extension: An example extension project for LoopBack 4.
-    rpc-server: A basic RPC server using a made-up protocol.
-    express-composition: A simple Express application that uses LoopBack 4 REST API.
+      todo-list: Continuation of the todo example using relations in LoopBack 4.
+      hello-world: A simple hello-world Application using LoopBack 4.
+      log-extension: An example extension project for LoopBack 4.
+      rpc-server: A basic RPC server using a made-up protocol.
+      express-composition: A simple Express application that uses LoopBack 4 REST API.
+      greeter-extension: An example showing how to implement the extension point/extension pattern.
     ```
 
 2.  Switch to the directory.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -222,6 +222,7 @@ Run the following command to install the CLI.
       rpc-server: A basic RPC server using a made-up protocol.
       soap-calculator: An example on how to integrate SOAP web services
       express-composition: A simple Express application that uses LoopBack 4 REST API.
+      greeter-extension: An example showing how to implement the extension point/extension pattern.
     ```
 
 9.  To generate artifacts from an OpenAPI spec into your application


### PR DESCRIPTION
Add `greeter-extension` to docs that call `lb4 example`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
