### PR TITLE
feat(build): add more TypeScript "strict" checks

### DIFF
--- a/benchmark/src/benchmark.ts
+++ b/benchmark/src/benchmark.ts
@@ -5,7 +5,7 @@
 
 import * as byline from 'byline';
 import {ChildProcess, spawn} from 'child_process';
-import pEvent from 'p-event';
+import pEvent, {Emitter} from 'p-event';
 import {Autocannon, EndpointStats} from './autocannon';
 import {Client} from './client';
 import {scenarios} from './scenarios';
@@ -111,5 +111,10 @@ function startWorker() {
 
 async function closeWorker(worker: ChildProcess) {
   worker.kill();
-  await pEvent(worker, 'close');
+  await pEvent(
+    // workaround for a bug in pEvent types which makes them
+    // incompatible with "strictFunctionTypes"
+    worker as Emitter<[unknown]>,
+    'close',
+  );
 }

--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -3,11 +3,12 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
     "resolveJsonModule": true,
-    "strictBindCallApply": true,
     "skipLibCheck": true,
+    "strict": true,
+
+    // FIXME(bajtos) LB4 is not compatible with this setting yet
+    "strictPropertyInitialization": false,
 
     "lib": ["es2018", "esnext.asynciterable"],
     "module": "commonjs",

--- a/packages/context/src/context-view.ts
+++ b/packages/context/src/context-view.ts
@@ -85,10 +85,11 @@ export class ContextView<T = unknown> extends EventEmitter
   /**
    * Find matching bindings and refresh the cache
    */
-  protected findBindings() {
+  protected findBindings(): Readonly<Binding<T>>[] {
     debug('Finding matching bindings');
-    this._cachedBindings = this.context.find(this.filter);
-    return this._cachedBindings;
+    const found = this.context.find(this.filter);
+    this._cachedBindings = found;
+    return found;
   }
 
   /**

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -62,7 +62,7 @@ export function asLifeCycleObserver<T = unknown>(binding: Binding<T>) {
  * Find all life cycle observer bindings. By default, a binding tagged with
  * `CoreTags.LIFE_CYCLE_OBSERVER`. It's used as `BindingFilter`.
  */
-export function lifeCycleObserverFilter(binding: Binding<unknown>): boolean {
+export function lifeCycleObserverFilter(binding: Readonly<Binding>): boolean {
   return binding.tagMap[CoreTags.LIFE_CYCLE_OBSERVER] != null;
 }
 

--- a/packages/repository/src/__tests__/unit/type-resolver.unit.ts
+++ b/packages/repository/src/__tests__/unit/type-resolver.unit.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {isBuiltinType, isTypeResolver, resolveType} from '../../type-resolver';
+import {
+  isBuiltinType,
+  isTypeResolver,
+  resolveType,
+  TypeResolver,
+} from '../../type-resolver';
 
 class SomeModel {
   constructor(public name: string) {}
@@ -60,7 +65,8 @@ describe('isTypeResolver', () => {
 
 describe('resolveType', () => {
   it('resolves the arg when the value is a resolver', () => {
-    const ctor = resolveType(() => SomeModel);
+    const resolver: TypeResolver<SomeModel> = () => SomeModel;
+    const ctor = resolveType(resolver);
     expect(ctor).to.eql(SomeModel);
 
     const inst = new ctor('a-name');


### PR DESCRIPTION
Enable all "strict" checks with the exception of `strictPropertyInitialization` which would require significant changes.

The following additional checks are added:

 - noImplicitThis
 - alwaysStrict
 - strictFunctionTypes

In the future, any checks added to TypeScript "strict" mode will be automatically enabled for LoopBack projects too.

See also [TypeScript Compiler Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈