### PR TITLE
fix(cli): make sure the item type is imported for an array in openapi spec

### DIFF
--- a/packages/cli/generators/openapi/schema-helper.js
+++ b/packages/cli/generators/openapi/schema-helper.js
@@ -175,6 +175,7 @@ function mapObjectType(schema, options) {
         if (itemType) {
           // Use `@property.array` for array types
           propDecoration = `@property.array(${itemType}, {name: '${p}'})`;
+          collectImports(typeSpec, propertyType.itemType);
         }
       }
       const propSpec = {

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -95,6 +95,10 @@ components:
   schemas:
     Name:
       type: string
+    AddressList:
+      items:
+        $ref: '#/components/schemas/Address'
+      type: array
     Address:
       type: object
       properties:
@@ -122,6 +126,4 @@ components:
           items:
             type: string
         addresses:
-          type: array
-          items:
-            $ref: '#/components/schemas/Address'
+          $ref: '#/components/schemas/AddressList'

--- a/packages/cli/test/unit/openapi/schema-model.unit.js
+++ b/packages/cli/test/unit/openapi/schema-model.unit.js
@@ -283,6 +283,51 @@ describe('schema to model', () => {
         signature: 'Name',
       },
       {
+        description: 'AddressList',
+        name: 'Address[]',
+        className: 'AddressList',
+        fileName: 'address-list.model.ts',
+        properties: [],
+        imports: ["import {Address} from './address.model';"],
+        import: "import {AddressList} from './address-list.model';",
+        declaration: 'Address[]',
+        signature: 'AddressList',
+        itemType: {
+          description: 'Address',
+          name: 'Address',
+          className: 'Address',
+          fileName: 'address.model.ts',
+          properties: [
+            {
+              name: 'street',
+              signature: 'street?: string;',
+              decoration: "@property({name: 'street'})",
+            },
+            {
+              name: 'city',
+              signature: 'city?: string;',
+              decoration: "@property({name: 'city'})",
+            },
+            {
+              name: 'state',
+              signature: 'state?: string;',
+              decoration: "@property({name: 'state'})",
+            },
+            {
+              name: 'zipCode',
+              signature: 'zipCode?: string;',
+              decoration: "@property({name: 'zipCode'})",
+            },
+          ],
+          imports: [],
+          import: "import {Address} from './address.model';",
+          kind: 'class',
+          declaration:
+            '{\n  street?: string;\n  city?: string;\n  state?: string;\n  zipCode?: string;\n}',
+          signature: 'Address',
+        },
+      },
+      {
         description: 'Address',
         name: 'Address',
         className: 'Address',
@@ -313,8 +358,7 @@ describe('schema to model', () => {
         import: "import {Address} from './address.model';",
         kind: 'class',
         declaration:
-          '{\n  street?: string;\n  city?: string;\n  state?: string;\n  ' +
-          'zipCode?: string;\n}',
+          '{\n  street?: string;\n  city?: string;\n  state?: string;\n  zipCode?: string;\n}',
         signature: 'Address',
       },
       {
@@ -339,25 +383,26 @@ describe('schema to model', () => {
             decoration: "@property({name: 'last-name'})",
           },
           {
-            decoration: "@property.array(String, {name: 'emails'})",
             name: 'emails',
             signature: 'emails?: string[];',
+            decoration: "@property.array(String, {name: 'emails'})",
           },
           {
             name: 'addresses',
-            signature: 'addresses?: Address[];',
+            signature: 'addresses?: AddressList;',
             decoration: "@property.array(Address, {name: 'addresses'})",
           },
         ],
         imports: [
           "import {Name} from './name.model';",
           "import {Address} from './address.model';",
+          "import {AddressList} from './address-list.model';",
         ],
         import: "import {Customer} from './customer.model';",
         kind: 'class',
         declaration:
           "{\n  id: number;\n  'first-name'?: string;\n  'last-name'?: Name;\n" +
-          '  emails?: string[];\n  addresses?: Address[];\n}',
+          '  emails?: string[];\n  addresses?: AddressList;\n}',
         signature: 'Customer',
       },
     ]);


### PR DESCRIPTION
Make sure item types referenced in `@property.array()` is imported in the generated model TypeScript source code.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
