### PR TITLE
feat(context): make Injection.metadata a required property

### DIFF
--- a/examples/greeter-extension/src/decorators.ts
+++ b/examples/greeter-extension/src/decorators.ts
@@ -33,8 +33,7 @@ export function extensionPoint(name: string) {
  * the name from `@extensionPoint` or the class name of the extension point.
  */
 export function extensions(extensionPointName?: string) {
-  return inject('', {decorator: '@extensions'}, (ctx, injection, session?) => {
-    if (!session) return undefined;
+  return inject('', {decorator: '@extensions'}, (ctx, injection, session) => {
     // Find the key of the target binding
     if (!session.currentBinding) return undefined;
 
@@ -71,14 +70,13 @@ export function configuration() {
   return inject(
     '',
     {decorator: '@inject.config', optional: true},
-    (ctx, injection, session?) => {
-      if (!session) return undefined;
+    (ctx, injection, session) => {
       // Find the key of the target binding
       if (!session.currentBinding) return undefined;
       const key = session.currentBinding!.key;
       return ctx.get(`${key}.options`, {
         session,
-        optional: injection.metadata && injection.metadata.optional,
+        optional: injection.metadata.optional,
       });
     },
   );

--- a/packages/context/src/__tests__/unit/resolution-session.unit.ts
+++ b/packages/context/src/__tests__/unit/resolution-session.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {ResolutionSession, Binding, Injection, inject} from '../..';
+import {Binding, inject, Injection, ResolutionSession} from '../..';
 
 describe('ResolutionSession', () => {
   class MyController {
@@ -16,6 +16,7 @@ describe('ResolutionSession', () => {
       target: MyController,
       bindingSelector: 'b',
       methodDescriptorOrParameterIndex: 0,
+      metadata: {},
     };
   }
 

--- a/packages/context/src/__tests__/unit/resolver.unit.ts
+++ b/packages/context/src/__tests__/unit/resolver.unit.ts
@@ -81,7 +81,7 @@ describe('constructor injection', () => {
     class TestClass {
       constructor(
         @inject('foo', {x: 'bar'}, (c: Context, injection: Injection) => {
-          const barKey = injection.metadata && injection.metadata.x;
+          const barKey = injection.metadata.x;
           const b = c.getSync(barKey);
           const f = c.getSync(injection.bindingSelector as BindingAddress);
           return f + ':' + b;
@@ -99,7 +99,7 @@ describe('constructor injection', () => {
     class TestClass {
       constructor(
         @inject('', {x: 'bar'}, (c: Context, injection: Injection) => {
-          const barKey = injection.metadata && injection.metadata.x;
+          const barKey = injection.metadata.x;
           const b = c.getSync(barKey);
           return 'foo' + ':' + b;
         })
@@ -254,7 +254,7 @@ describe('constructor injection', () => {
         (c: Context, injection: Injection, session: ResolutionSession) => {
           bindingPath = session.getBindingPath();
           resolutionPath = session.getResolutionPath();
-          decorators = session.injectionStack.map(i => i.metadata!.decorator);
+          decorators = session.injectionStack.map(i => i.metadata.decorator);
         },
       )
       myProp: string;
@@ -376,7 +376,7 @@ describe('property injection', () => {
   it('resolves injected properties with custom resolve function', () => {
     class TestClass {
       @inject('foo', {x: 'bar'}, (c: Context, injection: Injection) => {
-        const barKey = injection.metadata && injection.metadata.x;
+        const barKey = injection.metadata.x;
         const b = c.getSync(barKey);
         const f = c.getSync(injection.bindingSelector as BindingAddress);
         return f + ':' + b;
@@ -392,7 +392,7 @@ describe('property injection', () => {
   it('resolves inject properties with custom resolve function and no binding key', () => {
     class TestClass {
       @inject('', {x: 'bar'}, (c: Context, injection: Injection) => {
-        const barKey = injection.metadata && injection.metadata.x;
+        const barKey = injection.metadata.x;
         const b = c.getSync(barKey);
         return 'foo' + ':' + b;
       })
@@ -585,7 +585,7 @@ describe('sync constructor & async property injection', () => {
 
 function customDecorator(def: Object) {
   return inject('foo', def, (c: Context, injection: Injection) => {
-    const barKey = injection.metadata && injection.metadata.x;
+    const barKey = injection.metadata.x;
     const b = c.getSync(barKey);
     const f = c.getSync(injection.bindingSelector as BindingAddress);
     return f + ':' + b;
@@ -594,7 +594,7 @@ function customDecorator(def: Object) {
 
 function customAsyncDecorator(def: Object) {
   return inject('foo', def, async (c: Context, injection: Injection) => {
-    const barKey = injection.metadata && injection.metadata.x;
+    const barKey = injection.metadata.x;
     const b = await c.get(barKey);
     const f = await c.get(injection.bindingSelector as BindingAddress);
     return f + ':' + b;

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -73,7 +73,7 @@ export interface Injection<ValueType = BoundValue> {
     | number;
 
   bindingSelector: BindingSelector<ValueType>; // Binding selector
-  metadata?: InjectionMetadata; // Related metadata
+  metadata: InjectionMetadata; // Related metadata
   resolve?: ResolverFunction; // A custom resolve function
 }
 
@@ -111,7 +111,7 @@ export function inject(
   if (typeof bindingSelector === 'function' && !resolve) {
     resolve = resolveValuesByFilter;
   }
-  metadata = Object.assign({decorator: '@inject'}, metadata);
+  const injectionMetadata = Object.assign({decorator: '@inject'}, metadata);
   return function markParameterOrPropertyAsInjected(
     target: Object,
     member: string,
@@ -131,7 +131,7 @@ export function inject(
           member,
           methodDescriptorOrParameterIndex,
           bindingSelector,
-          metadata,
+          metadata: injectionMetadata,
           resolve,
         },
         // Do not deep clone the spec as only metadata is mutable and it's
@@ -167,7 +167,7 @@ export function inject(
           member,
           methodDescriptorOrParameterIndex,
           bindingSelector,
-          metadata,
+          metadata: injectionMetadata,
           resolve,
         },
         // Do not deep clone the spec as only metadata is mutable and it's
@@ -327,7 +327,7 @@ function resolveAsGetter(
   return function getter() {
     return ctx.get(bindingSelector, {
       session,
-      optional: injection.metadata && injection.metadata.optional,
+      optional: injection.metadata.optional,
     });
   };
 }

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -146,7 +146,7 @@ function resolve<T>(
           session: s,
           // If the `optional` flag is set for the injection, the resolution
           // will return `undefined` instead of throwing an error
-          optional: injection.metadata && injection.metadata.optional,
+          optional: injection.metadata.optional,
         });
       }
     },


### PR DESCRIPTION
The `Injection` interface now has `metadata` as a required property. We always set `decorator` name internally.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
