### PR TITLE
fix(cli): improve openapi code generation for naming and typing

### DIFF
--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -203,7 +203,13 @@ function buildMethodSpec(controllerSpec, op, options) {
       const pType = mapSchemaType(p.schema, options);
       addImportsForType(pType);
       comments.push(`@param ${name} ${p.description || ''}`);
-      return `@param({name: '${p.name}', in: '${p.in}'}) ${name}: ${
+
+      // Normalize parameter name to match `\w`
+      let paramName = p.name;
+      if (p.in === 'path') {
+        paramName = paramName.replace(/[^\w]+/g, '_');
+      }
+      return `@param({name: '${paramName}', in: '${p.in}'}) ${name}: ${
         pType.signature
       }`;
     });
@@ -285,10 +291,17 @@ function buildMethodSpec(controllerSpec, op, options) {
     returnType.signature
   }>`;
   comments.unshift(op.spec.description || '', '\n');
+
+  // Normalize path variable names to alphanumeric characters including the
+  // underscore (Equivalent to [A-Za-z0-9_]). Please note `@loopback/rest`
+  // does not allow other characters that don't match `\w`.
+  const opPath = op.path.replace(/\{[^\}]+\}/g, varName =>
+    varName.replace(/[^\w\{\}]+/g, '_'),
+  );
   const methodSpec = {
     description: op.spec.description,
     comments,
-    decoration: `@operation('${op.verb}', '${op.path}')`,
+    decoration: `@operation('${op.verb}', '${opPath}')`,
     signature,
   };
   if (op.spec['x-implementation']) {

--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -97,8 +97,9 @@ function groupOperationsByController(apiSpec) {
       let controllers = ['OpenApiController'];
       if (op['x-controller-name']) {
         controllers = [op['x-controller-name']];
-      } else if (op.tags) {
-        controllers = op.tags.map(t => titleCase(t + 'Controller'));
+      } else if (Array.isArray(op.tags) && op.tags.length) {
+        // Only add the operation to first tag to avoid duplicate routes
+        controllers = [titleCase(op.tags[0] + 'Controller')];
       }
       controllers.forEach((c, index) => {
         /**

--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -14,7 +14,6 @@ const {
   kebabCase,
   camelCase,
   escapeIdentifier,
-  escapePropertyOrMethodName,
 } = require('./utils');
 
 const HTTP_VERBS = [
@@ -134,10 +133,7 @@ function groupOperationsByController(apiSpec) {
  * @param {object} opSpec OpenAPI operation spec
  */
 function getMethodName(opSpec) {
-  return (
-    opSpec['x-operation-name'] ||
-    escapePropertyOrMethodName(camelCase(opSpec.operationId))
-  );
+  return opSpec['x-operation-name'] || escapeIdentifier(opSpec.operationId);
 }
 
 function registerAnonymousSchema(names, schema, typeRegistry) {

--- a/packages/cli/generators/openapi/utils.js
+++ b/packages/cli/generators/openapi/utils.js
@@ -146,25 +146,7 @@ function escapeIdentifier(name) {
     return '_' + name;
   }
   if (!name.match(SAFE_IDENTIFER)) {
-    return _.camelCase(name);
-  }
-  return name;
-}
-
-/**
- * Escape a property/method name by quoting it if it's not a safe JavaScript
- * identifier
- *
- * For example,
- * - `default` -> `'default'`
- * - `my-name` -> `'my-name'`
- *
- * @param {string} name
- */
-function escapePropertyOrMethodName(name) {
-  if (JS_KEYWORDS.includes(name) || !name.match(SAFE_IDENTIFER)) {
-    // Encode the name with ', for example: 'my-name'
-    return `'${name}'`;
+    name = _.camelCase(name);
   }
   return name;
 }
@@ -181,6 +163,6 @@ module.exports = {
   kebabCase: utils.kebabCase,
   camelCase: _.camelCase,
   escapeIdentifier,
-  escapePropertyOrMethodName,
   toJsonStr,
+  validateUrlOrFile,
 };

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -69,7 +69,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Customer'
-  /customers/{id}:
+  /customers/{customer-id}:
     get:
       tags:
         - Customer
@@ -77,7 +77,7 @@ paths:
       x-implementation: "return {id: id, 'first-name': 'John', last-name: 'Smith'};"
       operationId: find customer by id
       parameters:
-        - name: id
+        - name: customer-id
           in: path
           description: ID of customer to fetch
           required: true

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -95,6 +95,8 @@ components:
   schemas:
     Name:
       type: string
+    profileId:
+      type: string
     AddressList:
       items:
         $ref: '#/components/schemas/Address'
@@ -110,6 +112,8 @@ components:
           type: string
         zipCode:
           type: string
+    USAddress:
+      $ref: '#/components/schemas/Address'
     Customer:
       required:
         - id
@@ -121,9 +125,15 @@ components:
           type: string
         last-name:
           $ref: '#/components/schemas/Name'
+        profiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/profileId'
         emails:
           type: array
           items:
             type: string
         addresses:
           $ref: '#/components/schemas/AddressList'
+        us-office:
+          $ref: '#/components/schemas/USAddress'

--- a/packages/cli/test/unit/openapi/controller-spec.unit.js
+++ b/packages/cli/test/unit/openapi/controller-spec.unit.js
@@ -59,13 +59,13 @@ describe('openapi to controllers/models', () => {
             comments: [
               'Returns a customer based on a single ID',
               '\n',
-              '@param id ID of customer to fetch',
+              '@param customerId ID of customer to fetch',
               '@returns customer response',
             ],
-            decoration: "@operation('get', '/customers/{id}')",
+            decoration: "@operation('get', '/customers/{customer_id}')",
             signature:
-              "async findCustomerById(@param({name: 'id', in: 'path'}) " +
-              'id: number): Promise<Customer>',
+              "async findCustomerById(@param({name: 'customer_id', " +
+              "in: 'path'}) customerId: number): Promise<Customer>",
             implementation:
               "return {id: id, 'first-name': 'John', last-name: 'Smith'};",
           },

--- a/packages/cli/test/unit/openapi/openapi-utils.unit.js
+++ b/packages/cli/test/unit/openapi/openapi-utils.unit.js
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const expect = require('@loopback/testlab').expect;
+const utils = require('../../../generators/openapi/utils');
+
+describe('openapi utils', () => {
+  it('escapes keywords for an identifier', () => {
+    expect(utils.escapeIdentifier('for')).to.eql('_for');
+  });
+
+  it('escapes illegal chars for an identifier', () => {
+    expect(utils.escapeIdentifier('foo bar')).to.eql('fooBar');
+    expect(utils.escapeIdentifier('foo-bar')).to.eql('fooBar');
+    expect(utils.escapeIdentifier('foo.bar')).to.eql('fooBar');
+  });
+
+  it('does not escape legal chars for an identifier', () => {
+    expect(utils.escapeIdentifier('foobar')).to.eql('foobar');
+    expect(utils.escapeIdentifier('fooBar')).to.eql('fooBar');
+    expect(utils.escapeIdentifier('Foobar')).to.eql('Foobar');
+  });
+});

--- a/packages/cli/test/unit/openapi/schema-model.unit.js
+++ b/packages/cli/test/unit/openapi/schema-model.unit.js
@@ -283,6 +283,17 @@ describe('schema to model', () => {
         signature: 'Name',
       },
       {
+        description: 'profileId',
+        name: 'profileId',
+        className: 'ProfileId',
+        fileName: 'profile-id.model.ts',
+        properties: [],
+        imports: [],
+        import: "import {ProfileId} from './profile-id.model';",
+        declaration: 'string',
+        signature: 'ProfileId',
+      },
+      {
         description: 'AddressList',
         name: 'Address[]',
         className: 'AddressList',
@@ -374,13 +385,18 @@ describe('schema to model', () => {
           },
           {
             name: 'first-name',
-            signature: "'first-name'?: string;",
+            signature: 'firstName?: string;',
             decoration: "@property({name: 'first-name'})",
           },
           {
             name: 'last-name',
-            signature: "'last-name'?: Name;",
+            signature: 'lastName?: Name;',
             decoration: "@property({name: 'last-name'})",
+          },
+          {
+            name: 'profiles',
+            signature: 'profiles?: ProfileId[];',
+            decoration: "@property.array(String, {name: 'profiles'})",
           },
           {
             name: 'emails',
@@ -392,17 +408,24 @@ describe('schema to model', () => {
             signature: 'addresses?: AddressList;',
             decoration: "@property.array(Address, {name: 'addresses'})",
           },
+          {
+            name: 'us-office',
+            signature: 'usOffice?: Address;',
+            decoration: "@property({name: 'us-office'})",
+          },
         ],
         imports: [
           "import {Name} from './name.model';",
+          "import {ProfileId} from './profile-id.model';",
           "import {Address} from './address.model';",
           "import {AddressList} from './address-list.model';",
         ],
         import: "import {Customer} from './customer.model';",
         kind: 'class',
         declaration:
-          "{\n  id: number;\n  'first-name'?: string;\n  'last-name'?: Name;\n" +
-          '  emails?: string[];\n  addresses?: AddressList;\n}',
+          '{\n  id: number;\n  firstName?: string;\n  lastName?: Name;\n' +
+          '  profiles?: ProfileId[];\n  emails?: string[];\n' +
+          '  addresses?: AddressList;\n  usOffice?: Address;\n}',
         signature: 'Customer',
       },
     ]);


### PR DESCRIPTION
Fixing issues to generate code from OpenAPI specs from https://www.berlin-group.org/psd2-access-to-bank-accounts. Here is the [swagger doc](https://github.com/strongloop/loopback-next/files/3064625/berlin-group-swagger-2.yaml.txt).

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
