### PR TITLE
feat(rest): allow `-` to be used for path template variable names

### DIFF
--- a/packages/rest/src/__tests__/unit/router/openapi-path.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/openapi-path.unit.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-
 import {validateApiPath} from '../../..';
 
 describe('validateApiPath', () => {
@@ -40,6 +39,16 @@ describe('validateApiPath', () => {
   it('allows /{_foo}/{bar}', () => {
     const path = validateApiPath('/{_foo}/{bar}');
     expect(path).to.eql('/{_foo}/{bar}');
+  });
+
+  it('allows /{foo-bar}', () => {
+    const path = validateApiPath('/{foo-bar}');
+    expect(path).to.eql('/{foo-bar}');
+  });
+
+  it('allows /{foo}-{bar}', () => {
+    const path = validateApiPath('/{foo}-{bar}');
+    expect(path).to.eql('/{foo}-{bar}');
   });
 
   it('disallows /:foo/bar', () => {

--- a/packages/rest/src/router/openapi-path.ts
+++ b/packages/rest/src/router/openapi-path.ts
@@ -13,7 +13,7 @@ import pathToRegExp = require('path-to-regexp');
  * allows `[A-Za-z0-9_]`
  */
 const POSSIBLE_VARNAME_PATTERN = /\{([^\}]+)\}/g;
-const INVALID_VARNAME_PATTERN = /\{([^\}]*[^\w\}][^\}]*)\}/;
+const INVALID_VARNAME_PATTERN = /\{([^\}]*[^\w\-\}][^\}]*)\}/;
 
 /**
  * Validate the path to be compatible with OpenAPI path template. No parameter


### PR DESCRIPTION
An [OpenAPI spec for banking](https://berlingroup.stackstorage.com/s/3UAMIfD9WCGt9So) uses `{account-id}` as path variable names. Before this change, `@loopback/rest` reports it as invalid parameter name.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
