### PR TITLE
fix(context): instantiate class with non-injected arguments

### DIFF
--- a/packages/context/src/__tests__/unit/resolver.unit.ts
+++ b/packages/context/src/__tests__/unit/resolver.unit.ts
@@ -33,6 +33,23 @@ describe('constructor injection', () => {
     expect(t.foo).to.eql('FOO');
   });
 
+  it('allows non-injected arguments in constructor', () => {
+    class TestClass {
+      constructor(
+        @inject('foo') public foo: string,
+        public nonInjectedArg: string,
+      ) {}
+    }
+
+    let theNonInjectedArg = 'BAZ';
+
+    const test = instantiateClass(TestClass, ctx, undefined, [
+      theNonInjectedArg,
+    ]) as TestClass;
+    expect(test.foo).to.eql('FOO');
+    expect(test.nonInjectedArg).to.eql('BAZ');
+  });
+
   it('can report error for missing binding key', () => {
     class TestClass {
       constructor(@inject('', {x: 'bar'}) public fooBar: string) {}

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -55,7 +55,13 @@ export function instantiateClass<T>(
       debug('Non-injected arguments:', nonInjectedArgs);
     }
   }
-  const argsOrPromise = resolveInjectedArguments(ctor, '', ctx, session);
+  const argsOrPromise = resolveInjectedArguments(
+    ctor,
+    '',
+    ctx,
+    session,
+    nonInjectedArgs,
+  );
   const propertiesOrPromise = resolveInjectedProperties(ctor, ctx, session);
   const inst: ValueOrPromise<T> = transformValueOrPromise(
     argsOrPromise,


### PR DESCRIPTION
Passes non-injected arguments from instantiateClass to resolveInjectedArguments for resolution.

Fixes #2727 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
