### PR TITLE
doc: fix broken link in authentication

### DIFF
--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -12,7 +12,7 @@ provided by LoopBack 4 to implement an authentication layer.
 
 To handle multiple authentication strategies without using the Passport module,
 please read
-[Multiple Authentication strategies](./packages/authentication/docs/authentication-system.md).
+[Multiple Authentication strategies](./docs/authentication-system.md).
 
 ## Installation
 


### PR DESCRIPTION
broken link in the packages/authentication/README.md

## Checklist

- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated

 