### PR TITLE
fix: relax constrain check to allow input containing constrained values

### DIFF
--- a/packages/repository/src/__tests__/unit/repositories/constraint-utils.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/constraint-utils.unit.ts
@@ -5,14 +5,14 @@
 
 import {expect} from '@loopback/testlab';
 import {
-  FilterBuilder,
-  Filter,
-  Where,
-  constrainFilter,
-  constrainWhere,
   constrainDataObject,
   constrainDataObjects,
+  constrainFilter,
+  constrainWhere,
   Entity,
+  Filter,
+  FilterBuilder,
+  Where,
 } from '../../..';
 
 describe('constraint utility functions', () => {
@@ -87,7 +87,7 @@ describe('constraint utility functions', () => {
       });
     });
 
-    it('throws error when the query changes field in constrain', () => {
+    it('throws error when the query changes field in constraint', () => {
       const input = new Order({id: 1, description: 'order 1'});
       const constraint: Partial<Order> = {id: 2};
       expect(() => {
@@ -95,15 +95,49 @@ describe('constraint utility functions', () => {
       }).to.throwError(/Property "id" cannot be changed!/);
     });
 
+    it('allows constrained fields with the same values', () => {
+      const input = new Order({id: 2, description: 'order 1'});
+      const constraint: Partial<Order> = {id: 2};
+      const result = constrainDataObject(input, constraint);
+      expect(result).to.deepEqual(
+        new Order({
+          id: 2,
+          description: 'order 1',
+        }),
+      );
+    });
+  });
+
+  describe('constrainDataObjects', () => {
     it('constrains array of data objects', () => {
       const input = [
-        new Order({id: 1, description: 'order 1'}),
-        new Order({id: 2, description: 'order 2'}),
+        new Order({description: 'order 1'}),
+        new Order({description: 'order 2'}),
       ];
       const constraint: Partial<Order> = {id: 3};
       const result = constrainDataObjects(input, constraint);
       expect(result[0]).to.containDeep(Object.assign({}, input[0], constraint));
       expect(result[1]).to.containDeep(Object.assign({}, input[1], constraint));
+    });
+
+    it('throws error when the query changes field in constraint', () => {
+      const input = [new Order({id: 1, description: 'order 1'})];
+      const constraint: Partial<Order> = {id: 2};
+      expect(() => {
+        constrainDataObjects(input, constraint);
+      }).to.throwError(/Property "id" cannot be changed!/);
+    });
+
+    it('allows constrained fields with the same values', () => {
+      const input = [new Order({id: 2, description: 'order 1'})];
+      const constraint: Partial<Order> = {id: 2};
+      const result = constrainDataObjects(input, constraint);
+      expect(result).to.deepEqual([
+        new Order({
+          id: 2,
+          description: 'order 1',
+        }),
+      ]);
     });
   });
 


### PR DESCRIPTION
Consider a Product constraint like `{categoryId: 1}` and a request
to update (patch) Product with the following data:

    {
      name: 'updated',
      categoryId: 1
    }

Before this change, such request would be incorrectly rejected.

With this change in place, such requests are allowed.

Fixes #1719, resolves #2658 

/cc @foobarrrz 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈