### PR TITLE
fix(rest): assign all component properties to target spec

### DIFF
--- a/packages/rest/src/__tests__/unit/router/assign-router-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/assign-router-spec.unit.ts
@@ -7,7 +7,7 @@ import {expect} from '@loopback/testlab';
 import {assignRouterSpec, RouterSpec} from '../../../';
 
 describe('assignRouterSpec', () => {
-  it('duplicates the additions spec if the target spec is empty', async () => {
+  it('duplicates the additions spec if the target spec is empty', () => {
     const target: RouterSpec = {paths: {}};
     const additions: RouterSpec = {
       paths: {
@@ -37,15 +37,26 @@ describe('assignRouterSpec', () => {
             },
           },
         },
+        requestBodies: {
+          Greeting: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Greeting',
+                },
+              },
+            },
+          },
+        },
       },
       tags: [{name: 'greeting', description: 'greetings'}],
     };
 
     assignRouterSpec(target, additions);
-    expect(target).to.eql(additions);
+    expect(target).to.deepEqual(additions);
   });
 
-  it('does not assign components without schema', async () => {
+  it('assigns all components', () => {
     const target: RouterSpec = {
       paths: {},
       components: {},
@@ -54,15 +65,24 @@ describe('assignRouterSpec', () => {
     const additions: RouterSpec = {
       paths: {},
       components: {
-        parameters: {
-          addParam: {
-            name: 'add',
-            in: 'query',
-            description: 'number of items to add',
-            required: true,
-            schema: {
-              type: 'integer',
-              format: 'int32',
+        schemas: {
+          Greeting: {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        requestBodies: {
+          Greeting: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Greeting',
+                },
+              },
             },
           },
         },
@@ -75,10 +95,15 @@ describe('assignRouterSpec', () => {
     };
 
     assignRouterSpec(target, additions);
-    expect(target.components).to.be.empty();
+    expect(target.components).to.deepEqual(additions.components);
+    expect(target.components).to.have.properties([
+      'schemas',
+      'requestBodies',
+      'responses',
+    ]);
   });
 
-  it('uses the route registered first', async () => {
+  it('uses the route registered first', () => {
     const originalPath = {
       '/': {
         get: {
@@ -129,7 +154,7 @@ describe('assignRouterSpec', () => {
     expect(target.paths).to.eql(originalPath);
   });
 
-  it('does not duplicate tags from the additional spec', async () => {
+  it('does not duplicate tags from the additional spec', () => {
     const target: RouterSpec = {
       paths: {},
       tags: [{name: 'greeting', description: 'greetings'}],

--- a/packages/rest/src/router/router-spec.ts
+++ b/packages/rest/src/router/router-spec.ts
@@ -8,10 +8,12 @@ import {OpenApiSpec} from '@loopback/openapi-v3-types';
 export type RouterSpec = Pick<OpenApiSpec, 'paths' | 'components' | 'tags'>;
 
 export function assignRouterSpec(target: RouterSpec, additions: RouterSpec) {
-  if (additions.components && additions.components.schemas) {
+  if (additions.components) {
     if (!target.components) target.components = {};
-    if (!target.components.schemas) target.components.schemas = {};
-    Object.assign(target.components.schemas, additions.components.schemas);
+    for (const key in additions.components) {
+      if (!target.components[key]) target.components[key] = {};
+      Object.assign(target.components[key], additions.components[key]);
+    }
   }
 
   for (const url in additions.paths) {


### PR DESCRIPTION
When using `mountExpressRouter` to mount a LoopBack 3 application, the explorer complains when trying to do a `POST` request (for LB3 models), e.g.:

<img width="1649" alt="Screen Shot 2019-04-15 at 2 04 37 PM" src="https://user-images.githubusercontent.com/42985749/56154820-77fffe80-5f87-11e9-83e2-20a6fea0df90.png">

And this doesn't allow a `POST` (or similar) request to be made through the explorer:

<img width="1440" alt="Screen Shot 2019-04-15 at 2 06 24 PM" src="https://user-images.githubusercontent.com/42985749/56154896-ac73ba80-5f87-11e9-9389-7d900e491e03.png">

By adding all of `component`'s properties, `components.requestBodies` will be added to the spec and this allows requests to be made through the explorer:

<img width="1428" alt="Screen Shot 2019-04-15 at 2 10 47 PM" src="https://user-images.githubusercontent.com/42985749/56155181-52272980-5f88-11e9-996b-1d8baabdfd88.png">


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
