### PR TITLE
feat(core): extension point/extension decorators and helper functions

### DIFF
--- a/docs/site/Extension-point-and-extensions.md
+++ b/docs/site/Extension-point-and-extensions.md
@@ -1,0 +1,69 @@
+---
+lang: en
+title: 'Extension point and extensions'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Extension-point-and-extensions.html
+---
+
+## Extension point/extension pattern
+
+[Extension Point/extension](https://wiki.eclipse.org/FAQ_What_are_extensions_and_extension_points%3F)
+is a very powerful design pattern that promotes loose coupling and offers great
+extensibility. There are many use cases in LoopBack 4 that fit into design
+pattern. For example:
+
+- `@loopback/boot` uses `BootStrapper` that delegates to `Booters` to handle
+  different types of artifacts
+- `@loopback/rest` uses `RequestBodyParser` that finds the corresponding
+  `BodyParsers` to parse request body encoded in different media types
+- `@loopback/core` uses `LifeCycleObserver` to observe `start` and `stop` events
+  of the application life cycles.
+
+To add a feature to the framework and allow it to be extended, we divide the
+responsibility into two roles:
+
+- Extension point: it represents a **common** functionality that the framework
+  depends on and interacts with, such as, booting the application, parsing http
+  request bodies, and handling life cycle events. Meanwhile, the extension point
+  also defines contracts for its extensions to follow so that it can discover
+  corresponding extensions and delegate control to them without having to hard
+  code such dependencies.
+
+- Extensions: they are implementations of **specific** logic for an extension
+  point, such as, a booter for controllers, a body parser for xml, and a life
+  cycle observer to load some data when the application is started. Extensions
+  must conform to the contracts defined by the extension point.
+
+**NOTE**: Applications can also benefit from the extension point/extensions
+pattern by separating common functionality and specific behaviors for the
+business logic.
+
+## Helper decorators and functions
+
+To simplify implementations of extension point and extensions pattern on top of
+LoopBack 4's [Inversion of Control](Context.md) and
+[Dependency Injection](Dependency-injection.md) container, the following helper
+decorators and functions are provided to ensure consistency and convention.
+
+- `@extensionPoint`: decorates a class to be an extension point with an optional
+  custom name
+- `@extensions`: injects a getter function to access extensions to the target
+  extension point
+- `extensionFilter`: creates a binding filter function to find extensions for
+  the named extension point
+- `extensionFor`: creates a binding template function to set the binding to be
+  an extension for the named extension point
+- `addExtension`: registers an extension class to the context for the named
+  extension point
+
+The usage of these helper decorators and functions are illustrated in the
+`greeter-extension` tutorial.
+
+## Tutorial
+
+The
+[greeter-extension example](https://github.com/strongloop/loopback-next/tree/master/examples/greeter-extension)
+provides a walk-through on how to implement the extension point/extension
+pattern using LoopBack 4's [Context](Context.md) and
+[Dependency injection](Dependency-injection.md) container.

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -349,6 +349,10 @@ children:
     url: Creating-servers.html
     output: 'web, pdf'
 
+  - title: 'Extension point and extensions'
+    url: Extension-point-and-extensions.html
+    output: 'web, pdf'
+
   - title: 'Extending request body parsing'
     url: Extending-request-body-parsing.html
     output: 'web, pdf'

--- a/examples/greeter-extension/README.md
+++ b/examples/greeter-extension/README.md
@@ -51,6 +51,8 @@ context. In our case, we mark `GreetingService` as the extension point that
 needs to access a list of greeters.
 
 ```ts
+import {Getter} from '@loopback/context';
+import {extensionFilter, CoreTags} from '@loopback/core';
 /**
  * An extension point for greeters that can greet in different languages
  */
@@ -58,21 +60,21 @@ export class GreetingService {
   constructor(
     /**
      * Inject a getter function to fetch greeters (bindings tagged with
-     * `{extensionPoint: GREETER_EXTENSION_POINT_NAME}`)
+     * `{extensionFor: GREETER_EXTENSION_POINT_NAME}`)
      */
-    @inject.getter(
-      bindingTagFilter({extensionPoint: GREETER_EXTENSION_POINT_NAME}),
-    )
+    @inject.getter(extensionFilter(GREETER_EXTENSION_POINT_NAME))
     private getGreeters: Getter<Greeter[]>,
   ) {}
   // ...
 }
 ```
 
-To customize metadata such as `id` for the extension point, we can use
+To customize metadata such as `name` for the extension point, we can use
 `@extensionPoint` to decorate the class, such as:
 
 ```ts
+import {extensionPoint} from '@loopback/core';
+
 @extensionPoint(GREETER_EXTENSION_POINT_NAME)
 export class GreetingService {}
 ```
@@ -83,14 +85,16 @@ To simplify access to extensions for a given extension point, we use dependency
 injection to receive a `getter` function that gives us a list of greeters.
 
 ```ts
+import {extensions, extensionPoint} from '@loopback/core';
+
 @extensionPoint(GREETER_EXTENSION_POINT_NAME)
 export class GreetingService {
   constructor(
     /**
      * Inject a getter function to fetch greeters (bindings tagged with
-     * `{extensionPoint: GREETER_EXTENSION_POINT_NAME}`)
+     * `{extensionFor: GREETER_EXTENSION_POINT_NAME}`)
      */
-    @extensions() // Sugar for @inject.getter(filterByTag({extensionPoint: GREETER_EXTENSION_POINT_NAME}))
+    @extensions()
     private getGreeters: Getter<Greeter[]>, // ...
   ) {}
 }
@@ -203,7 +207,7 @@ Please note we use
 [`@bind`](https://loopback.io/doc/en/lb4/Binding.html#configure-binding-attributes-for-a-class)
 to customize how the class can be bound. In this case, `asGreeter` is a binding
 template function, which is equivalent as configuring a binding with
-`{extensionPoint: 'greeter'}` tag and in the `SINGLETON` scope.
+`{extensionFor: 'greeter'}` tag and in the `SINGLETON` scope.
 
 ```ts
 /**
@@ -211,7 +215,7 @@ template function, which is equivalent as configuring a binding with
  * @param binding
  */
 export const asGreeter: BindingTemplate = binding =>
-  binding.inScope(BindingScope.SINGLETON).tag({extensionPoint: 'greeter'});
+  binding.inScope(BindingScope.SINGLETON).tag({extensionFor: 'greeter'});
 ```
 
 ## Register an extension point
@@ -254,7 +258,14 @@ export class GreeterComponent implements Component {
 
 To connect an extension to an extension point, we just have to bind the
 extension to the `Context` and tag the binding with
-`{extensionPoint: 'greeters'}`.
+`{extensionFor: 'greeters'}`.
+
+```ts
+import {addExtension} from '@loopback/core';
+addExtension(app, 'greeters', FrenchGreeter);
+```
+
+Or:
 
 ```ts
 app
@@ -263,7 +274,7 @@ app
   .apply(asGreeter);
 ```
 
-Or
+Or:
 
 ```ts
 app.add(createBindingFromClass(FrenchGreeter));

--- a/examples/greeter-extension/README.md
+++ b/examples/greeter-extension/README.md
@@ -354,6 +354,16 @@ app.bind('greeters.ChineseGreeter.options').to({nameFirst: false});
 - [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md)
 - [Join the team](https://github.com/strongloop/loopback-next/issues/110)
 
+## Try out
+
+Run `npm start` from the root folder to run the sample application. You should
+see the following message:
+
+```
+English: Hello, Raymond
+Chinese: Raymond，你好
+```
+
 ## Tests
 
 Run `npm test` from the root folder.

--- a/examples/greeter-extension/index.js
+++ b/examples/greeter-extension/index.js
@@ -4,3 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 module.exports = require('./dist');
+
+if (require.main === module) {
+  const app = new module.exports.GreetingApplication();
+  app.main();
+}

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -22,6 +22,8 @@
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "posttest": "npm run lint",
     "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
+    "prestart": "npm run build",
+    "start": "node .",
     "verify": "npm pack && tar xf *example-greeter-extension*.tgz && tree package && npm run clean"
   },
   "repository": {

--- a/examples/greeter-extension/src/__tests__/greeter-extension.acceptance.ts
+++ b/examples/greeter-extension/src/__tests__/greeter-extension.acceptance.ts
@@ -3,19 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, bind, createBindingFromClass} from '@loopback/core';
+import {bind, createBindingFromClass} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import chalk from 'chalk';
-import {
-  asGreeter,
-  Greeter,
-  GreeterComponent,
-  GreetingService,
-  GREETING_SERVICE,
-} from '..';
+import {asGreeter, Greeter, GreetingService, GREETING_SERVICE} from '..';
+import {GreetingApplication} from '../application';
 
 describe('greeter-extension-pont', () => {
-  let app: Application;
+  let app: GreetingApplication;
   let greetingService: GreetingService;
 
   beforeEach(givenAppWithGreeterComponent);
@@ -71,11 +66,10 @@ describe('greeter-extension-pont', () => {
   });
 
   function givenAppWithGreeterComponent() {
-    app = new Application();
-    app.component(GreeterComponent);
+    app = new GreetingApplication();
   }
 
   async function findGreetingService() {
-    greetingService = await app.get(GREETING_SERVICE);
+    greetingService = await app.getGreetingService();
   }
 });

--- a/examples/greeter-extension/src/application.ts
+++ b/examples/greeter-extension/src/application.ts
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/example-greeter-extension
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/* istanbul ignore file */
+import {Application} from '@loopback/core';
+import {GreeterComponent} from './component';
+import {GREETING_SERVICE} from './keys';
+
+export class GreetingApplication extends Application {
+  constructor() {
+    super();
+    this.component(GreeterComponent);
+  }
+
+  async main() {
+    const greetingService = await this.getGreetingService();
+    let msg = await greetingService.greet('en', 'Raymond');
+    console.log('English:', msg);
+    msg = await greetingService.greet('zh', 'Raymond');
+    console.log('Chinese:', msg);
+  }
+
+  async getGreetingService() {
+    return await this.get(GREETING_SERVICE);
+  }
+}

--- a/examples/greeter-extension/src/decorators.ts
+++ b/examples/greeter-extension/src/decorators.ts
@@ -3,62 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  ClassDecoratorFactory,
-  createViewGetter,
-  filterByTag,
-  inject,
-  MetadataInspector,
-} from '@loopback/context';
-import {EXTENSION_POINT_NAME} from './keys';
-
-/**
- * Decorate a class as a named extension point. If the decoration is not
- * present, the name of the class will be used.
- *
- * TODO: to be promoted to `@loopback/core` module.
- * @param name Name of the extension point
- */
-export function extensionPoint(name: string) {
-  return ClassDecoratorFactory.createDecorator(EXTENSION_POINT_NAME, {name});
-}
-
-/**
- * Shortcut to inject extensions for the given extension point.
- *
- * TODO: to be promoted to `@loopback/core` module possibly as
- * `@inject.extensions`.
- *
- * @param extensionPoint Name of the extension point. If not supplied, we use
- * the name from `@extensionPoint` or the class name of the extension point.
- */
-export function extensions(extensionPointName?: string) {
-  return inject('', {decorator: '@extensions'}, (ctx, injection, session) => {
-    // Find the key of the target binding
-    if (!session.currentBinding) return undefined;
-
-    if (!extensionPointName) {
-      let target: Function;
-      if (typeof injection.target === 'function') {
-        // Constructor injection
-        target = injection.target;
-      } else {
-        // Injection on the prototype
-        target = injection.target.constructor;
-      }
-      const meta:
-        | {name: string}
-        | undefined = MetadataInspector.getClassMetadata(
-        EXTENSION_POINT_NAME,
-        target,
-      );
-      extensionPointName = (meta && meta.name) || target.name;
-    }
-
-    const bindingFilter = filterByTag({extensionPoint: extensionPointName});
-    return createViewGetter(ctx, bindingFilter, session);
-  });
-}
+import {inject} from '@loopback/context';
 
 /**
  * Shortcut to inject configuration for the target binding. To be promoted

--- a/examples/greeter-extension/src/greeting-service.ts
+++ b/examples/greeter-extension/src/greeting-service.ts
@@ -4,8 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Getter} from '@loopback/context';
+import {extensionPoint, extensions} from '@loopback/core';
 import chalk from 'chalk';
-import {configuration, extensionPoint, extensions} from './decorators';
+import {configuration} from './decorators';
 import {Greeter, GREETER_EXTENSION_POINT_NAME} from './types';
 
 /**
@@ -23,9 +24,9 @@ export class GreetingService {
   constructor(
     /**
      * Inject a getter function to fetch greeters (bindings tagged with
-     * `{extensionPoint: GREETER_EXTENSION_POINT_NAME}`)
+     * `{[CoreTags.EXTENSION_POINT]: GREETER_EXTENSION_POINT_NAME}`)
      */
-    @extensions() // Sugar for @inject.getter(filterByTag({extensionPoint: GREETER_EXTENSION_POINT_NAME}))
+    @extensions()
     private getGreeters: Getter<Greeter[]>,
     /**
      * An extension point should be able to receive its options via dependency

--- a/examples/greeter-extension/src/index.ts
+++ b/examples/greeter-extension/src/index.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+export * from './application';
 export * from './component';
 export * from './greeting-service';
 export * from './keys';

--- a/examples/greeter-extension/src/keys.ts
+++ b/examples/greeter-extension/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey, MetadataAccessor} from '@loopback/context';
+import {BindingKey} from '@loopback/context';
 import {GreetingService} from './greeting-service';
 
 /**
@@ -12,8 +12,3 @@ import {GreetingService} from './greeting-service';
 export const GREETING_SERVICE = BindingKey.create<GreetingService>(
   'services.GreetingService',
 );
-
-export const EXTENSION_POINT_NAME = MetadataAccessor.create<
-  {name: string},
-  ClassDecorator
->('extensionPoint.name');

--- a/examples/greeter-extension/src/types.ts
+++ b/examples/greeter-extension/src/types.ts
@@ -3,7 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingScope, BindingTemplate} from '@loopback/context';
+import {BindingTemplate} from '@loopback/context';
+import {extensionFor} from '@loopback/core';
 
 /**
  * Typically an extension point defines an interface as the contract for
@@ -12,16 +13,6 @@ import {BindingScope, BindingTemplate} from '@loopback/context';
 export interface Greeter {
   language: string;
   greet(name: string): string;
-}
-
-/**
- * A factory function to create binding template for extensions of the given
- * extension point
- * @param extensionPoint Name/id of the extension point
- */
-export function extensionFor(extensionPoint: string): BindingTemplate {
-  return binding =>
-    binding.inScope(BindingScope.SINGLETON).tag({extensionPoint});
 }
 
 /**

--- a/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
+++ b/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
@@ -1,0 +1,187 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  BindingScope,
+  BINDING_METADATA_KEY,
+  Context,
+  createBindingFromClass,
+  Getter,
+  MetadataInspector,
+} from '@loopback/context';
+import {expect} from '@loopback/testlab';
+import {addExtension, extensionPoint, extensions} from '../..';
+import {CoreTags} from '../../keys';
+
+describe('extension point', () => {
+  describe('@extensionPoint', () => {
+    it('specifies name of the extension point as a binding tag', () => {
+      @extensionPoint('greeters', {scope: BindingScope.SINGLETON})
+      class GreetingService {
+        @extensions()
+        public greeters: Getter<Greeter[]>;
+      }
+
+      const bindingMetadata = MetadataInspector.getClassMetadata(
+        BINDING_METADATA_KEY,
+        GreetingService,
+      );
+
+      expect(bindingMetadata).to.not.undefined();
+      expect(bindingMetadata!.templates).to.be.an.Array();
+
+      const binding = createBindingFromClass(GreetingService);
+      expect(binding.tagMap).to.containEql({
+        [CoreTags.EXTENSION_POINT]: 'greeters',
+      });
+      expect(binding.scope).to.eql(BindingScope.SINGLETON);
+    });
+  });
+
+  describe('@extensions', () => {
+    let ctx: Context;
+
+    beforeEach(givenContext);
+
+    it('injects a getter function of extensions', async () => {
+      @extensionPoint('greeters')
+      class GreetingService {
+        @extensions()
+        public greeters: Getter<Greeter[]>;
+      }
+
+      // `@extensionPoint` is a sugar decorator for `@bind`
+      const binding = createBindingFromClass(GreetingService, {
+        key: 'greeter-service',
+      });
+      ctx.add(binding);
+      registerGreeters('greeters');
+      const greeterService = await ctx.get<GreetingService>('greeter-service');
+      const greeters = await greeterService.greeters();
+      assertGreeterExtensions(greeters);
+    });
+
+    it('injects extensions based on `name` tag of the extension point binding', async () => {
+      class GreetingService {
+        @extensions()
+        public greeters: Getter<Greeter[]>;
+      }
+      ctx
+        .bind('greeter-service')
+        .toClass(GreetingService)
+        .tag({name: 'greeters'}); // Tag the extension point with a name
+      registerGreeters('greeters');
+      const greeterService = await ctx.get<GreetingService>('greeter-service');
+      const greeters = await greeterService.greeters();
+      assertGreeterExtensions(greeters);
+    });
+
+    it('injects extensions based on class name of the extension point', async () => {
+      class GreetingService {
+        constructor(
+          @extensions()
+          public greeters: Getter<Greeter[]>,
+        ) {}
+      }
+      ctx.bind('greeter-service').toClass(GreetingService);
+      registerGreeters(GreetingService.name);
+      const greeterService = await ctx.get<GreetingService>('greeter-service');
+      const loadedGreeters = await greeterService.greeters();
+      assertGreeterExtensions(loadedGreeters);
+    });
+
+    it('injects extensions based on class name of the extension point using property', async () => {
+      class GreetingService {
+        @extensions()
+        public greeters: Getter<Greeter[]>;
+      }
+      ctx.bind('greeter-service').toClass(GreetingService);
+      registerGreeters(GreetingService.name);
+      const greeterService = await ctx.get<GreetingService>('greeter-service');
+      const greeters = await greeterService.greeters();
+      assertGreeterExtensions(greeters);
+    });
+
+    it('injects extensions based on extension point name from @extensions', async () => {
+      class GreetingService {
+        @extensions('greeters')
+        public greeters: Getter<Greeter[]>;
+      }
+      ctx.bind('greeter-service').toClass(GreetingService);
+      registerGreeters('greeters');
+      const greeterService = await ctx.get<GreetingService>('greeter-service');
+      const greeters = await greeterService.greeters();
+      assertGreeterExtensions(greeters);
+    });
+
+    it('injects multiple types of extensions', async () => {
+      interface Logger {
+        log(message: string): void;
+      }
+
+      class ConsoleLogger implements Logger {
+        log(message: string) {
+          console.log(message);
+        }
+      }
+
+      class GreetingService {
+        constructor(
+          @extensions('greeters')
+          public greeters: Getter<Greeter[]>,
+          @extensions('loggers')
+          public loggers: Getter<Greeter[]>,
+        ) {}
+      }
+      ctx.bind('greeter-service').toClass(GreetingService);
+      registerGreeters('greeters');
+      addExtension(ctx, 'loggers', ConsoleLogger);
+      const greeterService = await ctx.get<GreetingService>('greeter-service');
+      const loadedGreeters = await greeterService.greeters();
+      assertGreeterExtensions(loadedGreeters);
+      const loadedLoggers = await greeterService.loggers();
+      expect(loadedLoggers).to.be.an.Array();
+      expect(loadedLoggers.length).to.equal(1);
+      expect(loadedLoggers[0]).to.be.instanceOf(ConsoleLogger);
+    });
+
+    function givenContext() {
+      ctx = new Context();
+    }
+
+    function registerGreeters(extensionPointName: string) {
+      addExtension(ctx, extensionPointName, EnglishGreeter, {
+        namespace: 'greeters',
+      });
+      addExtension(ctx, extensionPointName, ChineseGreeter, {
+        namespace: 'greeters',
+      });
+    }
+  });
+
+  interface Greeter {
+    language: string;
+    greet(name: string): string;
+  }
+
+  class EnglishGreeter implements Greeter {
+    language = 'en';
+    greet(name: string) {
+      return `Hello, ${name}!`;
+    }
+  }
+
+  class ChineseGreeter implements Greeter {
+    language = 'zh';
+    greet(name: string) {
+      return `你好，${name}！`;
+    }
+  }
+
+  function assertGreeterExtensions(greeters: Greeter[]) {
+    const languages = greeters.map(greeter => greeter.language).sort();
+    expect(languages).to.eql(['en', 'zh']);
+  }
+});

--- a/packages/core/src/extension-point.ts
+++ b/packages/core/src/extension-point.ts
@@ -1,0 +1,142 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/core
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  bind,
+  Binding,
+  BindingFromClassOptions,
+  BindingSpec,
+  BindingTemplate,
+  Constructor,
+  Context,
+  ContextTags,
+  createBindingFromClass,
+  createViewGetter,
+  filterByTag,
+  inject,
+} from '@loopback/context';
+import {CoreTags} from './keys';
+
+/**
+ * Decorate a class as a named extension point. If the decoration is not
+ * present, the name of the class will be used. For example:
+ *
+ * ```ts
+ * import {extensionPoint} from '@loopback/core';
+ *
+ * @extensionPoint(GREETER_EXTENSION_POINT_NAME)
+ * export class GreetingService {
+ *   // ...
+ * }
+ * ```
+ *
+ * @param name Name of the extension point
+ */
+export function extensionPoint(name: string, ...specs: BindingSpec[]) {
+  return bind({tags: {[CoreTags.EXTENSION_POINT]: name}}, ...specs);
+}
+
+/**
+ * Shortcut to inject extensions for the given extension point. For example:
+ *
+ * ```ts
+ * import {Getter} from '@loopback/context';
+ * import {extensionPoint, extensions} from '@loopback/core';
+ *
+ * @extensionPoint(GREETER_EXTENSION_POINT_NAME)
+ * export class GreetingService {
+ *  constructor(
+ *    @extensions() // Inject extensions for the extension point
+ *    private getGreeters: Getter<Greeter[]>,
+ *    // ...
+ * ) {
+ *   // ...
+ * }
+ * ```
+ *
+ * @param extensionPointName Name of the extension point. If not supplied, we
+ * use the `name` tag from the extension point binding or the class name of the
+ * extension point class. If a class needs to inject extensions from multiple
+ * extension points, use different `extensionPointName` for different types of
+ * extensions.
+ */
+export function extensions(extensionPointName?: string) {
+  return inject('', {decorator: '@extensions'}, (ctx, injection, session) => {
+    extensionPointName =
+      extensionPointName ||
+      inferExtensionPointName(injection.target, session.currentBinding);
+
+    const bindingFilter = extensionFilter(extensionPointName);
+    return createViewGetter(ctx, bindingFilter, session);
+  });
+}
+
+/**
+ * Infer the extension point name from binding tags/class name
+ * @param injectionTarget Target class or prototype
+ * @param currentBinding Current binding
+ */
+function inferExtensionPointName(
+  injectionTarget: object,
+  currentBinding?: Readonly<Binding<unknown>>,
+): string {
+  if (currentBinding) {
+    let name =
+      currentBinding.tagMap[CoreTags.EXTENSION_POINT] ||
+      currentBinding.tagMap[ContextTags.NAME];
+
+    if (name) return name;
+  }
+
+  let target: Function;
+  if (typeof injectionTarget === 'function') {
+    // Constructor injection
+    target = injectionTarget;
+  } else {
+    // Injection on the prototype
+    target = injectionTarget.constructor;
+  }
+  return target.name;
+}
+
+/**
+ * A factory function to create binding filter for extensions of a named
+ * extension point
+ * @param extensionPointName Name of the extension point
+ */
+export function extensionFilter(extensionPointName: string) {
+  return filterByTag({
+    [CoreTags.EXTENSION_FOR]: extensionPointName,
+  });
+}
+
+/**
+ * A factory function to create binding template for extensions of the given
+ * extension point
+ * @param extensionPointName Name of the extension point
+ */
+export function extensionFor(extensionPointName: string): BindingTemplate {
+  return binding => binding.tag({[CoreTags.EXTENSION_FOR]: extensionPointName});
+}
+
+/**
+ * Register an extension for the given extension point to the context
+ * @param context Context object
+ * @param extensionPointName Name of the extension point
+ * @param extensionClass Class or a provider for an extension
+ * @param options Options Options for the creation of binding from class
+ */
+export function addExtension(
+  context: Context,
+  extensionPointName: string,
+  extensionClass: Constructor<unknown>,
+  options?: BindingFromClassOptions,
+) {
+  const binding = createBindingFromClass(extensionClass, options).apply(
+    extensionFor(extensionPointName),
+  );
+  context.add(binding);
+  return binding;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,13 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export {Component, ProviderMap} from './component';
-export * from './server';
+// Re-export public Core API coming from dependencies
+export * from '@loopback/context';
+
+// Export APIs
 export * from './application';
 export * from './component';
+export * from './extension-point';
 export * from './keys';
 export * from './lifecycle';
 export * from './lifecycle-registry';
-
-// Re-export public Core API coming from dependencies
-export * from '@loopback/context';
+export * from './server';

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -120,4 +120,15 @@ export namespace CoreTags {
    * Binding tag for group name of life cycle observers
    */
   export const LIFE_CYCLE_OBSERVER_GROUP = 'lifeCycleObserverGroup';
+
+  /**
+   * Binding tag for extensions to specify name of the extension point that an
+   * extension contributes to.
+   */
+  export const EXTENSION_FOR = 'extensionFor';
+
+  /**
+   * Binding tag for an extension point to specify name of the extension point
+   */
+  export const EXTENSION_POINT = 'extensionPoint';
 }


### PR DESCRIPTION
Add helper/decorator functions for extension point/extension pattern to `@loopback/core`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
