### PR TITLE
test(rest): add express router on top of basePath test

### DIFF
--- a/packages/rest/src/__tests__/integration/rest.application.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.application.integration.ts
@@ -268,6 +268,22 @@ describe('RestApplication (integration)', () => {
     });
   });
 
+  it('mounts Express Router on top of rest basePath', async () => {
+    givenApplication();
+
+    const router = express.Router();
+    router.get('/poodle', function(_req: Request, res: Response) {
+      res.send('Poodle!');
+    });
+    restApp.mountExpressRouter('/dogs', router);
+
+    restApp.basePath('/api');
+    await restApp.start();
+    client = createRestAppClient(restApp);
+
+    await client.get('/api/dogs/poodle').expect(200, 'Poodle!');
+  });
+
   function givenApplication(options?: {rest: RestServerConfig}) {
     options = options || {rest: {port: 0, host: '127.0.0.1'}};
     restApp = new RestApplication(options);


### PR DESCRIPTION
Added a test to verify that `mountExpressRouter` mounts the router on top of a `RestApplication`'s `basePath`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
