### PR TITLE
chore(example-soap-calculator): increase timeout for integration tests

### DIFF
--- a/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
+++ b/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
@@ -12,8 +12,13 @@ import {givenAConnectedDataSource} from '../../helpers';
 
 import {expect} from '@loopback/testlab';
 
-describe('CalculatorService', () => {
+describe('CalculatorService', function() {
   let calculatorService: CalculatorService;
+
+  // The calculator soap server is hosted in the cloud and it takes some time
+  // to wake up and respond to api requests
+  // tslint:disable-next-line:no-invalid-this
+  this.timeout(30000);
 
   before(givenACalculatorService);
 


### PR DESCRIPTION
We observe that timeouts happen for the soap calculator example integration test.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
