### PR TITLE
fix(cli): escape char sequences for javascript comments

### DIFF
--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -8,7 +8,7 @@
 const BaseGenerator = require('../../lib/base-generator');
 const {debug, debugJson} = require('./utils');
 const {loadAndBuildSpec} = require('./spec-loader');
-const {validateUrlOrFile} = require('./utils');
+const {validateUrlOrFile, escapeComment} = require('./utils');
 const {getControllerFileName} = require('./spec-helper');
 
 const updateIndex = require('../../lib/update-index');
@@ -135,7 +135,7 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
       if (debug.enabled) {
         debug('Copying artifact to: %s', dest);
       }
-      this.copyTemplatedFiles(source, dest, c);
+      this.copyTemplatedFiles(source, dest, mixinEscapeComment(c));
     }
   }
 
@@ -153,7 +153,7 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
         debug('Copying artifact to: %s', dest);
       }
       const source = m.kind === 'class' ? modelSource : typeSource;
-      this.copyTemplatedFiles(source, dest, m);
+      this.copyTemplatedFiles(source, dest, mixinEscapeComment(m));
     }
   }
 
@@ -173,3 +173,7 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
     if (this.shouldExit()) return;
   }
 };
+
+function mixinEscapeComment(context) {
+  return Object.assign(context, {escapeComment});
+}

--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -193,7 +193,7 @@ function buildMethodSpec(controllerSpec, op, options) {
   const paramNames = {};
   if (parameters) {
     args = parameters.map(p => {
-      const name = escapeIdentifier(p.name);
+      let name = escapeIdentifier(p.name);
       if (name in paramNames) {
         name = `${name}${paramNames[name]++}`;
       } else {
@@ -234,6 +234,7 @@ function buildMethodSpec(controllerSpec, op, options) {
     if (bodyName in paramNames) {
       bodyName = `${bodyName}${paramNames[bodyName]++}`;
     }
+    bodyName = escapeIdentifier(bodyName);
     if (contentType && contentType.schema) {
       registerAnonymousSchema(
         [methodName, bodyName],

--- a/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
@@ -11,7 +11,7 @@ imports.forEach(i => {
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
  * by <%- tag %>
- * <%- description %>
+ * <%- escapeComment(description) %>
  */
 export class <%- className %> {
   constructor() {}
@@ -19,7 +19,7 @@ export class <%- className %> {
   <%_ for (const m of methods) { -%>
   /**
   <%_ for (const c of m.comments) { -%>
-   * <%- c %>
+   * <%- escapeComment(c) %>
   <%_ } -%>
    */
   <%- m.decoration %>

--- a/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
@@ -20,7 +20,7 @@ imports.forEach(i => {
 
 /**
  * The model class is generated from OpenAPI schema - <%- name %>
- * <%- description %>
+ * <%- escapeComment(description) %>
  */
 @model({name: '<%- name %>'})
 export class <%- className %> {
@@ -32,7 +32,7 @@ export class <%- className %> {
 
   <%_ for (const p of _properties) { -%>
   /**
-   * <%- p.description || '' %>
+   * <%- escapeComment(p.description) %>
    */
   <%- p.decoration %>
   <%- p.signature %>

--- a/packages/cli/generators/openapi/templates/src/models/type-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/type-template.ts.ejs
@@ -8,6 +8,7 @@ imports.forEach(i => {
 -%>
 /**
  * The model type is generated from OpenAPI schema - <%- name %>
+ * <%- escapeComment(description) %>
  */
 export type <%- className %> = <%- declaration %>;
 

--- a/packages/cli/generators/openapi/utils.js
+++ b/packages/cli/generators/openapi/utils.js
@@ -128,6 +128,11 @@ const JS_KEYWORDS = [
   'false',
 ];
 
+/**
+ * Avoid tslint error - Shadowed name: 'requestBody'
+ */
+const DECORATOR_NAMES = ['operation', 'param', 'requestBody'];
+
 const SAFE_IDENTIFER = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
 
 /**
@@ -147,6 +152,9 @@ function escapeIdentifier(name) {
   }
   if (!name.match(SAFE_IDENTIFER)) {
     name = _.camelCase(name);
+  }
+  if (DECORATOR_NAMES.includes(name)) {
+    return '_' + name;
   }
   return name;
 }

--- a/packages/cli/generators/openapi/utils.js
+++ b/packages/cli/generators/openapi/utils.js
@@ -170,6 +170,16 @@ function escapePropertyName(name) {
   return name;
 }
 
+/**
+ * Escape a string to be used as a block comment
+ *
+ * @param {string} comment
+ */
+function escapeComment(comment) {
+  comment = comment || '';
+  return comment.replace(/\/\*/g, '\\/*').replace(/\*\//g, '*\\/');
+}
+
 function toJsonStr(val) {
   return json5.stringify(val, null, 2);
 }
@@ -183,6 +193,7 @@ module.exports = {
   camelCase: _.camelCase,
   escapeIdentifier,
   escapePropertyName,
+  escapeComment,
   toJsonStr,
   validateUrlOrFile,
 };

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -14,14 +14,14 @@ paths:
     parameters:
       - name: access-token
         in: query
-        description: Access token
+        description: Access token (/* access_token */)
         required: false
         schema:
           type: string
     get:
       tags:
         - Customer
-      description: Returns all customers
+      description: Returns all customers (/* customers */)
       operationId: getCustomers
       parameters:
         - name: if

--- a/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
@@ -55,7 +55,7 @@ describe('openapi-generator specific files', () => {
 
     assert.fileContent(
       searchController,
-      `async performSearch(@requestBody() requestBody: PerformSearchRequestBody, ` +
+      `async performSearch(@requestBody() _requestBody: PerformSearchRequestBody, ` +
         `@param({name: 'version', in: 'path'}) version: string, ` +
         `@param({name: 'dataset', in: 'path'}) dataset: string): ` +
         `Promise<PerformSearchResponseBody> {`,

--- a/packages/cli/test/unit/openapi/controller-spec.unit.js
+++ b/packages/cli/test/unit/openapi/controller-spec.unit.js
@@ -23,13 +23,13 @@ describe('openapi to controllers/models', () => {
         imports: ["import {Customer} from '../models/customer.model';"],
         methods: [
           {
-            description: 'Returns all customers',
+            description: 'Returns all customers (/* customers */)',
             comments: [
-              'Returns all customers',
+              'Returns all customers (/* customers */)',
               '\n',
               '@param _if if condition',
               '@param limit maximum number of results to return',
-              '@param accessToken Access token',
+              '@param accessToken Access token (/* access_token */)',
               '@returns customer response',
             ],
             decoration: "@operation('get', '/customers')",
@@ -45,7 +45,7 @@ describe('openapi to controllers/models', () => {
               'Creates a new customer',
               '\n',
               '@param _requestBody Customer to add',
-              '@param accessToken Access token',
+              '@param accessToken Access token (/* access_token */)',
               '@returns customer response',
             ],
             decoration: "@operation('post', '/customers')",

--- a/packages/cli/test/unit/openapi/controller-spec.unit.js
+++ b/packages/cli/test/unit/openapi/controller-spec.unit.js
@@ -44,13 +44,13 @@ describe('openapi to controllers/models', () => {
             comments: [
               'Creates a new customer',
               '\n',
-              '@param requestBody Customer to add',
+              '@param _requestBody Customer to add',
               '@param accessToken Access token',
               '@returns customer response',
             ],
             decoration: "@operation('post', '/customers')",
             signature:
-              'async createCustomer(@requestBody() requestBody: Customer, ' +
+              'async createCustomer(@requestBody() _requestBody: Customer, ' +
               "@param({name: 'access-token', in: 'query'}) accessToken: " +
               'string): Promise<Customer>',
           },

--- a/packages/cli/test/unit/openapi/openapi-utils.unit.js
+++ b/packages/cli/test/unit/openapi/openapi-utils.unit.js
@@ -41,4 +41,11 @@ describe('openapi utils', () => {
     expect(utils.escapePropertyName('customer_id')).to.eql('customer_id');
     expect(utils.escapePropertyName('customerid')).to.eql('customerid');
   });
+
+  it('escapes chars for comments', () => {
+    expect(utils.escapeComment('/* abc */')).to.eql('\\/* abc *\\/');
+    expect(utils.escapeComment('/* abc')).to.eql('\\/* abc');
+    expect(utils.escapeComment('abc */')).to.eql('abc *\\/');
+    expect(utils.escapeComment('abc')).to.eql('abc');
+  });
 });

--- a/packages/cli/test/unit/openapi/openapi-utils.unit.js
+++ b/packages/cli/test/unit/openapi/openapi-utils.unit.js
@@ -11,6 +11,12 @@ describe('openapi utils', () => {
     expect(utils.escapeIdentifier('for')).to.eql('_for');
   });
 
+  it('escapes an identifier conflicting with decorators for ', () => {
+    expect(utils.escapeIdentifier('requestBody')).to.eql('_requestBody');
+    expect(utils.escapeIdentifier('operation')).to.eql('_operation');
+    expect(utils.escapeIdentifier('param')).to.eql('_param');
+  });
+
   it('escapes illegal chars for an identifier', () => {
     expect(utils.escapeIdentifier('foo bar')).to.eql('fooBar');
     expect(utils.escapeIdentifier('foo-bar')).to.eql('fooBar');


### PR DESCRIPTION
1. Escape `/*` and `*/` inside `description` for generated code comments.
2. Use `_requestBody` to avoid tslint shadowed name complaints

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
