### PR TITLE
feat(http-server): add support for unix socket path

### DIFF
--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -3,11 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {IncomingMessage, ServerResponse} from 'http';
+import * as assert from 'assert';
 import * as http from 'http';
+import {IncomingMessage, ServerResponse} from 'http';
 import * as https from 'https';
-import {AddressInfo} from 'net';
-
+import {AddressInfo, ListenOptions} from 'net';
+import * as os from 'os';
 import pEvent from 'p-event';
 
 export type RequestListener = (
@@ -16,23 +17,12 @@ export type RequestListener = (
 ) => void;
 
 /**
- * Basic HTTP server listener options
- *
- * @export
- * @interface ListenerOptions
- */
-export interface ListenerOptions {
-  host?: string;
-  port?: number;
-}
-
-/**
  * HTTP server options
  *
  * @export
  * @interface HttpOptions
  */
-export interface HttpOptions extends ListenerOptions {
+export interface HttpOptions extends ListenOptions {
   protocol?: 'http';
 }
 
@@ -42,7 +32,7 @@ export interface HttpOptions extends ListenerOptions {
  * @export
  * @interface HttpsOptions
  */
-export interface HttpsOptions extends ListenerOptions, https.ServerOptions {
+export interface HttpsOptions extends ListenOptions, https.ServerOptions {
   protocol: 'https';
 }
 
@@ -69,14 +59,12 @@ export type HttpProtocol = 'http' | 'https'; // Will be extended to `http2` in t
  * @class HttpServer
  */
 export class HttpServer {
-  private _port: number;
-  private _host?: string;
   private _listening: boolean = false;
   private _protocol: HttpProtocol;
-  private _address: AddressInfo;
+  private _address: string | AddressInfo;
   private requestListener: RequestListener;
   readonly server: http.Server | https.Server;
-  private serverOptions?: HttpServerOptions;
+  private serverOptions: HttpServerOptions;
 
   /**
    * @param requestListener
@@ -87,9 +75,16 @@ export class HttpServer {
     serverOptions?: HttpServerOptions,
   ) {
     this.requestListener = requestListener;
-    this.serverOptions = serverOptions;
-    this._port = serverOptions ? serverOptions.port || 0 : 0;
-    this._host = serverOptions ? serverOptions.host : undefined;
+    this.serverOptions = Object.assign(
+      {port: 0, host: undefined},
+      serverOptions,
+    );
+    if (this.serverOptions.path) {
+      const ipcPath = this.serverOptions.path;
+      checkNamedPipe(ipcPath);
+      // Remove `port` so that `path` is honored
+      delete this.serverOptions.port;
+    }
     this._protocol = serverOptions ? serverOptions.protocol || 'http' : 'http';
     if (this._protocol === 'https') {
       this.server = https.createServer(
@@ -105,17 +100,17 @@ export class HttpServer {
    * Starts the HTTP / HTTPS server
    */
   public async start() {
-    this.server.listen(this._port, this._host);
+    this.server.listen(this.serverOptions);
     await pEvent(this.server, 'listening');
     this._listening = true;
-    this._address = this.server.address() as AddressInfo;
+    this._address = this.server.address();
   }
 
   /**
    * Stops the HTTP / HTTPS server
    */
   public async stop() {
-    if (!this.server) return;
+    if (!this._listening) return;
     this.server.close();
     await pEvent(this.server, 'close');
     this._listening = false;
@@ -132,20 +127,30 @@ export class HttpServer {
    * Port number of the HTTP / HTTPS server
    */
   public get port(): number {
-    return (this._address && this._address.port) || this._port;
+    if (typeof this._address === 'string') return 0;
+    return (this._address && this._address.port) || this.serverOptions.port!;
   }
 
   /**
    * Host of the HTTP / HTTPS server
    */
   public get host(): string | undefined {
-    return (this._address && this._address.address) || this._host;
+    if (typeof this._address === 'string') return undefined;
+    return (this._address && this._address.address) || this.serverOptions.host;
   }
 
   /**
    * URL of the HTTP / HTTPS server
    */
   public get url(): string {
+    if (typeof this._address === 'string') {
+      /* istanbul ignore if */
+      if (isWin32()) {
+        return this._address;
+      }
+      const basePath = encodeURIComponent(this._address);
+      return `${this.protocol}+unix://${basePath}`;
+    }
     let host = this.host;
     if (this._address.family === 'IPv6') {
       if (host === '::') host = '::1';
@@ -166,7 +171,32 @@ export class HttpServer {
   /**
    * Address of the HTTP / HTTPS server
    */
-  public get address(): AddressInfo | undefined {
+  public get address(): string | AddressInfo | undefined {
     return this._listening ? this._address : undefined;
   }
+}
+
+/**
+ * Makes sure `path` conform to named pipe naming requirement on Windows
+ *
+ * See https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections
+ *
+ * @param ipcPath Named pipe path
+ */
+function checkNamedPipe(ipcPath: string) {
+  /* istanbul ignore if */
+  if (isWin32()) {
+    const pipes = ['\\\\?\\pipe\\', '\\\\.\\pipe\\'];
+    assert(
+      pipes.some(p => ipcPath.startsWith(p)),
+      `Named pipe ${ipcPath} does NOT start with + ${pipes.join(' or ')}`,
+    );
+  }
+}
+
+/**
+ * Check if it's Windows OS
+ */
+function isWin32() {
+  return os.platform() === 'win32';
 }


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/2811

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
