### PR TITLE
feat(booter-lb3app): enable operation-scoped model schemas

### DIFF
--- a/packages/booter-lb3app/src/lb3app.booter.ts
+++ b/packages/booter-lb3app/src/lb3app.booter.ts
@@ -85,7 +85,9 @@ export class Lb3AppBooter implements Booter {
   }
 
   private async buildOpenApiSpec(lb3App: Lb3Application) {
-    const swaggerSpec = generateSwaggerSpec(lb3App);
+    const swaggerSpec = generateSwaggerSpec(lb3App, {
+      generateOperationScopedModels: true,
+    });
     const result = await swagger2openapi.convertObj(swaggerSpec, {
       // swagger2openapi options
     });


### PR DESCRIPTION
LB3 models with `forceId: true` require request bodies for CREATE operations to exclude the primary key (id property), because the value is always generated by the database (e.g. as auto-incremented number, or as a UUID/GUID value).

This patch turns on a loopback-swagger feature flag to describe this constraint in the emitted Swagger spec. See the internal story https://github.com/strongloop-internal/scrum-asteroid/issues/283 and the following LB3 pull requests:
- strongloop/loopback-swagger#99
- strongloop/loopback-component-explorer#219
- strongloop/loopback-workspace#496
- strongloop/generator-loopback#319
- strongloop/loopback-cli#54

I tested the change using LB3 example application from https://github.com/strongloop/loopback-next/pull/2803.

The `create` endpoint for `User` model DOES NOT accept "id" property now:

<img width="654" alt="Screen Shot 2019-05-02 at 12 34 19" src="https://user-images.githubusercontent.com/1140553/57070178-ea3a4800-6cd6-11e9-8491-596bae5e97da.png">

The `patchOrCreate` endpoint for `User` model DOES accept "id" property as before:

<img width="653" alt="Screen Shot 2019-05-02 at 12 34 51" src="https://user-images.githubusercontent.com/1140553/57070213-01793580-6cd7-11e9-9ad2-8427939a632e.png">


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈