### PR TITLE
fix(rest): aggressive redirection to Swagger UI

### DIFF
--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -530,6 +530,7 @@ paths:
         '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/openapi.json',
       ].join(''),
     );
+    expect(response.status).to.equal(302);
     expect(response.get('Location')).match(expectedUrl);
     expect(response.get('Access-Control-Allow-Origin')).to.equal('*');
     expect(response.get('Access-Control-Allow-Credentials')).to.equal('true');
@@ -640,6 +641,7 @@ paths:
         '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/openapi.json',
       ].join(''),
     );
+    expect(response.status).to.equal(302);
     expect(response.get('Location')).match(expectedUrl);
   });
 
@@ -663,6 +665,7 @@ paths:
         '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/openapi.json',
       ].join(''),
     );
+    expect(response.status).to.equal(302);
     expect(response.get('Location')).match(expectedUrl);
   });
 

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -451,7 +451,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
     const baseUrl = protocol === 'http' ? config.httpUrl : config.url;
     const openApiUrl = `${requestContext.requestedBaseUrl}/openapi.json`;
     const fullUrl = `${baseUrl}?url=${openApiUrl}`;
-    response.redirect(308, fullUrl);
+    response.redirect(302, fullUrl);
   }
 
   /**


### PR DESCRIPTION
Send 302, instead of 308 for Swagger UI redirection.

Fixes https://github.com/strongloop/loopback-next/issues/2808
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
