### PR TITLE
refactor: move unexpectedHttpErrorLogger to testlab

### DIFF
--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -12,7 +12,12 @@ import {
   ParameterObject,
   ResponseObject,
 } from '@loopback/openapi-v3-types';
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
+import {
+  Client,
+  createClientForHandler,
+  createUnexpectedHttpErrorLogger,
+  expect,
+} from '@loopback/testlab';
 import {
   ControllerClass,
   ControllerInstance,
@@ -28,7 +33,6 @@ import {
   RestServer,
   SequenceActions,
 } from '../../..';
-import {createUnexpectedHttpErrorLogger} from '../../helpers';
 
 /* # Feature: Routing
  * - In order to build REST APIs

--- a/packages/rest/src/__tests__/helpers.ts
+++ b/packages/rest/src/__tests__/helpers.ts
@@ -8,29 +8,7 @@ import {
   RequestBodyObject,
   SchemaObject,
 } from '@loopback/openapi-v3-types';
-import {IncomingMessage} from 'http';
-import {LogError} from '..';
 import {RestServerConfig, RestServerResolvedConfig} from '../rest.server';
-
-export function createUnexpectedHttpErrorLogger(
-  expectedStatusCode: number = 0,
-): LogError {
-  return function logUnexpectedHttpError(
-    err: Error,
-    statusCode: number,
-    req: IncomingMessage,
-  ) {
-    if (statusCode === expectedStatusCode) return;
-
-    console.error(
-      'Unhandled error in %s %s: %s %s',
-      req.method,
-      req.url,
-      statusCode,
-      err.stack || err,
-    );
-  };
-}
 
 /**
  * Create an OpenAPI request body spec with the given content

--- a/packages/rest/src/__tests__/integration/http-handler.integration.ts
+++ b/packages/rest/src/__tests__/integration/http-handler.integration.ts
@@ -7,7 +7,12 @@ import {Context} from '@loopback/context';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
 import {ControllerSpec, get} from '@loopback/openapi-v3';
 import {ParameterObject, RequestBodyObject} from '@loopback/openapi-v3-types';
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
+import {
+  Client,
+  createClientForHandler,
+  createUnexpectedHttpErrorLogger,
+  expect,
+} from '@loopback/testlab';
 import * as express from 'express';
 import * as HttpErrors from 'http-errors';
 import {is} from 'type-is';
@@ -30,7 +35,7 @@ import {
   UrlEncodedBodyParser,
   writeResultToResponse,
 } from '../..';
-import {createUnexpectedHttpErrorLogger, aRestServerConfig} from '../helpers';
+import {aRestServerConfig} from '../helpers';
 
 const SequenceActions = RestBindings.SequenceActions;
 

--- a/packages/testlab/src/http-error-logger.ts
+++ b/packages/testlab/src/http-error-logger.ts
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Request} from 'express';
+import {IncomingMessage} from 'http';
+
+/**
+ * Creates a Logger that logs an Error if the HTTP status code is not expected
+ *
+ * @param expectedStatusCode HTTP status code that is expected
+ */
+export function createUnexpectedHttpErrorLogger(
+  expectedStatusCode?: number,
+): LogError {
+  return function logUnexpectedHttpError(
+    err: Error,
+    statusCode: number,
+    req: IncomingMessage,
+  ) {
+    if (statusCode === expectedStatusCode) return;
+
+    /* istanbul ignore next */
+    console.error(
+      'Unhandled error in %s %s: %s %s',
+      req.method,
+      req.url,
+      statusCode,
+      err.stack || err,
+    );
+  };
+}
+
+type LogError = (err: Error, statusCode: number, request: Request) => void;

--- a/packages/testlab/src/index.ts
+++ b/packages/testlab/src/index.ts
@@ -3,13 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './expect';
-export * from './sinon';
 export * from './client';
-export * from './shot';
-export * from './validate-api-spec';
-export * from './test-sandbox';
-export * from './skip-travis';
-export * from './request';
+export * from './expect';
+export * from './http-error-logger';
 export * from './http-server-config';
+export * from './request';
+export * from './shot';
+export * from './sinon';
+export * from './skip-travis';
+export * from './test-sandbox';
 export * from './to-json';
+export * from './validate-api-spec';


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/pull/2803#discussion_r280324582 for motivation.

Moving the `unexpectedHttpErrorLogger` from `@loopback/rest` to `@loopback/testlab` so it can be used for tests in other packages/examples.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
