### PR TITLE
chore: fix invalid tsdoc tags in comments

### DIFF
--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -27,13 +27,13 @@ const debug = debugFactory('loopback:boot:base-artifact-booter');
  *
  * Currently supports the following boot phases: configure, discover, load
  *
- * @property options Options being used by the Booter
- * @property projectRoot Project root relative to which all other paths are resovled
- * @property dirs Directories to look for an artifact in
- * @property extensions File extensions to look for to match an artifact (this is a convention based booter)
- * @property glob Glob pattern to use to discover artifacts. Takes precedence over (dirs + extensions)
- * @property discovered List of files discovered by the Booter that matched artifact requirements
- * @property classes List of exported classes discovered in the files
+ * - options: Options being used by the Booter
+ * - projectRoot: Project root relative to which all other paths are resovled
+ * - dirs: Directories to look for an artifact in
+ * - extensions: File extensions to look for to match an artifact (this is a convention based booter)
+ * - glob: Glob pattern to use to discover artifacts. Takes precedence over (dirs + extensions)
+ * - discovered: List of files discovered by the Booter that matched artifact requirements
+ * - classes: List of exported classes discovered in the files
  */
 export class BaseArtifactBooter implements Booter {
   /**

--- a/packages/boot/src/interfaces.ts
+++ b/packages/boot/src/interfaces.ts
@@ -32,9 +32,6 @@ export type ArtifactOptions = {
  * load(): Promise<void>
  *
  * A Booter will run through the above methods in order.
- *
- * @export
- * @interface Booter
  */
 export interface Booter {
   /**
@@ -60,10 +57,10 @@ export const BOOTER_PHASES = ['configure', 'discover', 'load'];
 /**
  * Type Object for Options passed into .boot()
  *
- * @property projectRoot Root of project. All other artifacts are resolved relative to this
- * @property booters An array of booters to bind to the application before running bootstrapper
- * @property filter.booters An array of booters that should be run by the bootstrapper
- * @property filter.phases An array of phases that should be run
+ * - projectRoot: Root of project. All other artifacts are resolved relative to this
+ * - booters: An array of booters to bind to the application before running bootstrapper
+ * - filter.booters: An array of booters that should be run by the bootstrapper
+ * - filter.phases: An array of phases that should be run
  */
 export type BootOptions = {
   controllers?: ArtifactOptions;

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -84,7 +84,7 @@ export class Application extends Context implements LifeCycleObserver {
    * @param {Constructor<Server>} server The server constructor.
    * @param {string=} name Optional override for key name.
    * @returns {Binding} Binding for the server class
-   * @memberof Application
+   *
    */
   public server<T extends Server>(
     ctor: Constructor<T>,
@@ -120,7 +120,7 @@ export class Application extends Context implements LifeCycleObserver {
    *
    * @param {Constructor<Server>[]} ctors An array of Server constructors.
    * @returns {Binding[]} An array of bindings for the registered server classes
-   * @memberof Application
+   *
    */
   public servers<T extends Server>(ctors: Constructor<T>[]): Binding[] {
     return ctors.map(ctor => this.server(ctor));
@@ -129,11 +129,11 @@ export class Application extends Context implements LifeCycleObserver {
   /**
    * Retrieve the singleton instance for a bound constructor.
    *
-   * @template T
+   * @typeparam T
    * @param {Constructor<T>=} ctor The constructor that was used to make the
    * binding.
    * @returns {Promise<T>}
-   * @memberof Application
+   *
    */
   public async getServer<T extends Server>(
     target: Constructor<T> | string,
@@ -153,7 +153,7 @@ export class Application extends Context implements LifeCycleObserver {
    * Start the application, and all of its registered observers.
    *
    * @returns {Promise}
-   * @memberof Application
+   *
    */
   public async start(): Promise<void> {
     const registry = await this.getLifeCycleObserverRegistry();
@@ -163,7 +163,7 @@ export class Application extends Context implements LifeCycleObserver {
   /**
    * Stop the application instance and all of its registered observers.
    * @returns {Promise}
-   * @memberof Application
+   *
    */
   public async stop(): Promise<void> {
     const registry = await this.getLifeCycleObserverRegistry();

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -89,7 +89,6 @@ export interface Component {
 /**
  * Mount a component to an Application.
  *
- * @export
  * @param {Application} app
  * @param {Component} component
  */

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -13,9 +13,6 @@ import {LifeCycleObserver} from './lifecycle';
  * Context, which inherits from the parent Application context. This way,
  * any Server-specific bindings will remain local to the Server instance,
  * and will avoid polluting its parent module scope.
- *
- * @export
- * @interface Server
  */
 export interface Server extends LifeCycleObserver {
   /**

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -19,8 +19,6 @@ export type RequestListener = (
 /**
  * HTTP server options
  *
- * @export
- * @interface HttpOptions
  */
 export interface HttpOptions extends ListenOptions {
   protocol?: 'http';
@@ -29,8 +27,6 @@ export interface HttpOptions extends ListenOptions {
 /**
  * HTTPS server options
  *
- * @export
- * @interface HttpsOptions
  */
 export interface HttpsOptions extends ListenOptions, https.ServerOptions {
   protocol: 'https';
@@ -39,24 +35,17 @@ export interface HttpsOptions extends ListenOptions, https.ServerOptions {
 /**
  * Possible server options
  *
- * @export
- * @type HttpServerOptions
  */
 export type HttpServerOptions = HttpOptions | HttpsOptions;
 
 /**
  * Supported protocols
  *
- * @export
- * @type HttpProtocol
  */
 export type HttpProtocol = 'http' | 'https'; // Will be extended to `http2` in the future
 
 /**
  * HTTP / HTTPS server used by LoopBack's RestServer
- *
- * @export
- * @class HttpServer
  */
 export class HttpServer {
   private _listening: boolean = false;

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {MetadataInspector, ParameterDecoratorFactory} from '@loopback/context';
 import {
+  ReferenceObject,
   RequestBodyObject,
   SchemaObject,
-  ReferenceObject,
 } from '@loopback/openapi-v3-types';
-import {MetadataInspector, ParameterDecoratorFactory} from '@loopback/context';
-import {resolveSchema} from '../generate-schema';
-import {OAI3Keys} from '../keys';
 import * as _ from 'lodash';
 import {inspect} from 'util';
+import {resolveSchema} from '../generate-schema';
+import {OAI3Keys} from '../keys';
 
 const debug = require('debug')('loopback:openapi3:metadata:requestbody');
 export const REQUEST_BODY_INDEX = 'x-parameter-index';
@@ -38,7 +38,8 @@ export const REQUEST_BODY_INDEX = 'x-parameter-index';
  * as `application/json` by default.
  * If the `schema` object is not provided in a media type, this decorator
  * generates it for you based on the argument's type. In this case, please
- * make sure the argument type is a class decorated by @model from `@loopback/repository`
+ * make sure the argument type is a class decorated by `@model` from
+ * `@loopback/repository`
  *
  * The simplest usage is:
  *

--- a/packages/openapi-v3/src/generate-schema.ts
+++ b/packages/openapi-v3/src/generate-schema.ts
@@ -10,7 +10,7 @@ import {SchemaObject} from '@loopback/openapi-v3-types';
  * parameter's type.
  * `type` and `format` will be preserved if provided in `schema`
  *
- * @private
+ * @internal
  * @param type The JavaScript type of a parameter
  * @param schema The schema object provided in an parameter object
  */

--- a/packages/repository/src/type-resolver.ts
+++ b/packages/repository/src/type-resolver.ts
@@ -14,10 +14,10 @@ import {Class} from './common-types';
  * the actual reference to the class itself until later, when both sides
  * of the relation are created as JavaScript classes.
  *
- * @template Type The type we are resolving, for example `Entity` or `Product`.
+ * @typeparam Type The type we are resolving, for example `Entity` or `Product`.
  * This parameter is required.
  *
- * @template StaticMembers The static properties available on the
+ * @typeparam StaticMembers The static properties available on the
  * type class. For example, all models have static `modelName` property.
  * When `StaticMembers` are not provided, we default to static properties of
  * a `Function` - `name`, `length`, `apply`, `call`, etc.

--- a/packages/rest/src/providers/parse-params.provider.ts
+++ b/packages/rest/src/providers/parse-params.provider.ts
@@ -3,18 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Provider, inject} from '@loopback/context';
-import {parseOperationArgs} from '../parser';
-import {RestBindings} from '../keys';
-import {ResolvedRoute} from '../router';
-import {Request, ParseParams} from '../types';
+import {inject, Provider} from '@loopback/context';
 import {RequestBodyParser} from '../body-parsers';
+import {RestBindings} from '../keys';
+import {parseOperationArgs} from '../parser';
+import {ResolvedRoute} from '../router';
+import {ParseParams, Request} from '../types';
 /**
  * Provides the function for parsing args in requests at runtime.
  *
- * @export
- * @class ParseParamsProvider
- * @implements {Provider<ParseParams>}
  * @returns {ParseParams} The handler function that will parse request args.
  */
 export class ParseParamsProvider implements Provider<ParseParams> {

--- a/packages/rest/src/providers/send.provider.ts
+++ b/packages/rest/src/providers/send.provider.ts
@@ -9,9 +9,6 @@ import {writeResultToResponse} from '../writer';
  * Provides the function that populates the response object with
  * the results of the operation.
  *
- * @export
- * @class SendProvider
- * @implements {Provider<BoundValue>}
  * @returns {BoundValue} The handler function that will populate the
  * response with operation results.
  */

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -103,11 +103,6 @@ const cloneDeep: <T>(value: T) => T = require('lodash/cloneDeep');
  * // OR
  * const server = await app.get('servers.foo');
  * ```
- *
- * @export
- * @class RestServer
- * @extends {Context}
- * @implements {Server}
  */
 export class RestServer extends Context implements Server, HttpServerLike {
   /**
@@ -175,7 +170,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   }
 
   /**
-   * @memberof RestServer
+   *
    * Creates an instance of RestServer.
    *
    * @param {Application} app The application instance (injected via
@@ -657,7 +652,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    *
    * @param {OpenApiSpec} spec The OpenAPI specification, as an object.
    * @returns {Binding}
-   * @memberof RestServer
+   *
    */
   api(spec: OpenApiSpec): Binding {
     return this.bind(RestBindings.API_SPEC).to(spec);
@@ -778,7 +773,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * Start this REST API's HTTP/HTTPS server.
    *
    * @returns {Promise<void>}
-   * @memberof RestServer
+   *
    */
   async start(): Promise<void> {
     // Set up the Express app if not done yet
@@ -810,7 +805,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * Stop this REST API's HTTP/HTTPS server.
    *
    * @returns {Promise<void>}
-   * @memberof RestServer
+   *
    */
   async stop() {
     // Kill the server instance.
@@ -872,8 +867,6 @@ export function createBodyParserBinding(
 
 /**
  * The form of OpenAPI specs to be served
- *
- * @interface OpenApiSpecForm
  */
 export interface OpenApiSpecForm {
   version?: string;
@@ -962,9 +955,6 @@ export interface RestServerResolvedOptions {
 
 /**
  * Valid configuration for the RestServer constructor.
- *
- * @export
- * @interface RestServerConfig
  */
 export type RestServerConfig = RestServerOptions & HttpServerOptions;
 

--- a/packages/rest/src/router/external-express-routes.ts
+++ b/packages/rest/src/router/external-express-routes.ts
@@ -34,7 +34,7 @@ export type ExpressRequestHandler = express.RequestHandler;
  * _after_ no LB4 route (controller or handler based) matched the incoming
  * request.
  *
- * @private
+ * @internal
  */
 export class ExternalExpressRoutes {
   protected _externalRoutes: express.Router = express.Router();

--- a/packages/testlab/src/sinon.ts
+++ b/packages/testlab/src/sinon.ts
@@ -26,7 +26,7 @@ export type StubbedInstanceWithSinonAccessor<T> = T & {
  *  - https://github.com/Microsoft/TypeScript/issues/13543
  *  - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14811
  *
- * @template TType Type being stubbed.
+ * @typeparam TType Type being stubbed.
  * @param constructor  Object or class to stub.
  * @returns A stubbed version of the constructor, with an extra property `stubs`
  * providing access to stub API for individual methods.


### PR DESCRIPTION
Invalid block tags prevent api-documenter from generating apidocs.

Relates to #2834 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
