### PR TITLE
feat(cli): improve scaffolding of complex model settings

### DIFF
--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -14,6 +14,7 @@ const inspect = require('util').inspect;
 const utils = require('../../lib/utils');
 const chalk = require('chalk');
 const path = require('path');
+const stringifyObject = require('stringify-object');
 
 const PROMPT_BASE_MODEL_CLASS = 'Please select the model base class';
 const ERROR_NO_MODELS_FOUND = 'Model was not found in';
@@ -512,6 +513,17 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
         delete val.id;
       }
     });
+
+    if (this.artifactInfo.modelSettings) {
+      this.artifactInfo.modelSettings = stringifyObject(
+        {settings: this.artifactInfo.modelSettings},
+        {
+          indent: '  ', // two spaces
+          singleQuotes: true,
+          inlineCharacterLimit: 80,
+        },
+      );
+    }
 
     this.copyTemplatedFiles(
       this.templatePath(MODEL_TEMPLATE_PATH),

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -5,8 +5,8 @@ import {model, property} from '@loopback/repository';
 import {<%= modelBaseClass %>} from '.';
 <% } -%>
 
-<% if(Object.keys(modelSettings).length > 0) { -%>
-@model({settings: <%- JSON.stringify(modelSettings) %>})
+<% if (modelSettings) { -%>
+@model(<%- modelSettings %>)
 <% } else { -%>
 @model()
 <% } -%>

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1476,6 +1476,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -2114,6 +2119,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -4221,6 +4231,16 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
     "pluralize": "^7.0.0",
     "regenerate": "^1.3.3",
     "semver": "^6.0.0",
+    "stringify-object": "^3.3.0",
     "swagger-parser": "^6.0.5",
     "swagger2openapi": "^5.1.0",
     "typescript": "^3.1.1",

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -192,7 +192,7 @@ describe('lb4 model integration', () => {
       );
       assert.fileContent(
         expectedModelFile,
-        /@model\({settings: {"strict":false}}\)/,
+        /@model\({settings: {strict: false}}\)/,
       );
       assert.fileContent(
         expectedModelFile,
@@ -236,5 +236,29 @@ describe('model generator using --config option', () => {
           '--yes',
         ]),
     ).to.be.rejectedWith(/Model was not found in/);
+  });
+
+  describe('model generator using --config option with model settings', () => {
+    it('creates a model with valid settings', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withArguments([
+          '--config',
+          '{"name":"test", "base":"Entity", \
+          "modelSettings": {"annotations": \
+          [{"destinationClass": "class1","argument": 0}],\
+          "foreignKeys": {"fk_destination": {"name": "fk_destination"}}},\
+          "allowAdditionalProperties":true}',
+          '--yes',
+        ]);
+
+      basicModelFileChecks(expectedModelFile, expectedIndexFile);
+
+      assert.fileContent(
+        expectedModelFile,
+        /@model\({\n  settings: {\n    annotations: \[{destinationClass: 'class1', argument: 0}],\n    foreignKeys: {fk_destination: {name: 'fk_destination'}},\n    strict: false\n  }\n}\)/,
+      );
+    });
   });
 });


### PR DESCRIPTION
Leverage stringify-object package to convert model settings object into well-formatted TypeScript source code.

An example of a simple settings object:

```ts
@model({settings: {strict: false}})
export class MyModel extends Entity {
  // ...
}
```

A more complex example:

```ts
@model({
  settings: {
    annotations: [{destinationClass: 'class1', argument: 0}],
    foreignKeys: {fk_destination: {name: 'fk_destination'}},
    strict: false
  }
})
export class MyModel extends Entity {
  // ...
}
```

See #2604 /cc @yanamg7

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈