### PR TITLE
chore(boot): fix tsdoc comments

### DIFF
--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -25,26 +25,38 @@ const debug = debugFactory('loopback:boot:base-artifact-booter');
  * 2. Provide it's own logic for 'load' after calling 'await super.load()' to
  * actually boot the Artifact classes.
  *
- * Currently supports the following boot phases: configure, discover, load
+ * Currently supports the following boot phases: configure, discover, load.
  *
- * - options: Options being used by the Booter
- * - projectRoot: Project root relative to which all other paths are resovled
- * - dirs: Directories to look for an artifact in
- * - extensions: File extensions to look for to match an artifact (this is a convention based booter)
- * - glob: Glob pattern to use to discover artifacts. Takes precedence over (dirs + extensions)
- * - discovered: List of files discovered by the Booter that matched artifact requirements
- * - classes: List of exported classes discovered in the files
  */
 export class BaseArtifactBooter implements Booter {
   /**
    * Options being used by the Booter.
    */
   readonly options: ArtifactOptions;
+  /**
+   * Project root relative to which all other paths are resolved
+   */
   readonly projectRoot: string;
+  /**
+   * {@link ArtifactOptions.dirs}
+   */
   dirs: string[];
+  /**
+   * {@link ArtifactOptions.extensions}
+   */
   extensions: string[];
+  /**
+   * {@link ArtifactOptions.glob}
+   */
   glob: string;
+
+  /**
+   * List of files discovered by the Booter that matched artifact requirements
+   */
   discovered: string[];
+  /**
+   * List of exported classes discovered in the files
+   */
   classes: Array<Constructor<{}>>;
 
   constructor(projectRoot: string, options: ArtifactOptions) {

--- a/packages/boot/src/interfaces.ts
+++ b/packages/boot/src/interfaces.ts
@@ -3,33 +3,40 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor, Binding} from '@loopback/context';
+import {Binding, Constructor} from '@loopback/context';
 
 /**
  * Type definition for ArtifactOptions. These are the options supported by
  * this Booter.
- *
- * @param dirs String / String Array of directories to check for artifacts.
- * Paths must be relative. Defaults to ['controllers']
- * @param extensions String / String Array of file extensions to match artifact
- * files in dirs. Defaults to ['.controller.js']
- * @param nested Boolean to control if artifact discovery should check nested
- * folders or not. Default to true
- * @param glob  Optional. A `glob` string to use when searching for files. This takes
- * precendence over other options.
  */
 export type ArtifactOptions = {
+  /**
+   * Array of directories to check for artifacts.
+   * Paths must be relative. Defaults to ['controllers']
+   */
   dirs?: string | string[];
+  /**
+   * Array of file extensions to match artifact
+   * files in dirs. Defaults to ['.controller.js']
+   */
   extensions?: string | string[];
+  /**
+   * A flag to control if artifact discovery should check nested
+   * folders or not. Default to true
+   */
   nested?: boolean;
+  /**
+   * A `glob` string to use when searching for files. This takes
+   * precedence over other options.
+   */
   glob?: string;
 };
 
 /**
  * Defines the requirements to implement a Booter for LoopBack applications:
- * configure() : Promise<void>
- * discover() : Promise<void>
- * load(): Promise<void>
+ * - configure()
+ * - discover()
+ * - load()
  *
  * A Booter will run through the above methods in order.
  */
@@ -55,12 +62,7 @@ export interface Booter {
 export const BOOTER_PHASES = ['configure', 'discover', 'load'];
 
 /**
- * Type Object for Options passed into .boot()
- *
- * - projectRoot: Root of project. All other artifacts are resolved relative to this
- * - booters: An array of booters to bind to the application before running bootstrapper
- * - filter.booters: An array of booters that should be run by the bootstrapper
- * - filter.phases: An array of phases that should be run
+ * Options to configure `Bootstrapper`
  */
 export type BootOptions = {
   controllers?: ArtifactOptions;
@@ -72,6 +74,9 @@ export type BootOptions = {
   [prop: string]: any;
 };
 
+/**
+ * Options for boot() execution
+ */
 export type BootExecutionOptions = {
   /**
    * Optional array of Booter Classes to bind to the application before running bootstrapper.
@@ -102,8 +107,21 @@ export type BootExecutionOptions = {
  * that uses BootMixin.
  */
 export interface Bootable {
+  /**
+   * Root directory for the project to be booted
+   */
   projectRoot: string;
+  /**
+   * Options for boot
+   */
   bootOptions?: BootOptions;
+  /**
+   * Boot up the project
+   */
   boot(): Promise<void>;
-  booters(...booterCls: Constructor<Booter>[]): Binding[];
+  /**
+   * Register booters
+   * @param booterClasses A list of booter classes
+   */
+  booters(...booterClasses: Constructor<Booter>[]): Binding[];
 }


### PR DESCRIPTION
Follow-up fix for https://github.com/strongloop/loopback-next/pull/2836

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
