### PR TITLE
feat(context): add support to sort bindings for `@inject.*` and `ContextView`

### DIFF
--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -435,7 +435,8 @@ should be able to pick up these new routes without restarting.
 To support the dynamic tracking of such artifacts registered within a context
 chain, we introduce `ContextObserver` interface and `ContextView` class that can
 be used to watch a list of bindings matching certain criteria depicted by a
-`BindingFilter` function.
+`BindingFilter` function and an optional `BindingComparator` function to sort
+matched bindings.
 
 ```ts
 import {Context, ContextView} from '@loopback/context';

--- a/docs/site/Decorators_inject.md
+++ b/docs/site/Decorators_inject.md
@@ -83,6 +83,23 @@ class MyControllerWithValues {
 }
 ```
 
+To sort matched bindings found by the binding filter function, `@inject` honors
+`bindingComparator` in `metadata`:
+
+```ts
+class MyControllerWithValues {
+  constructor(
+    @inject(binding => binding.tagNames.includes('foo'), {
+      bindingComparator: (a, b) => {
+        // Sort by value of `foo` tag
+        return a.tagMap.foo.localeCompare(b.tagMap.foo);
+      },
+    })
+    public values: string[],
+  ) {}
+}
+```
+
 A few variants of `@inject` are provided to declare special forms of
 dependencies.
 

--- a/packages/context/src/__tests__/unit/binding-sorter.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-sorter.unit.ts
@@ -1,0 +1,155 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Binding, compareByOrder, sortBindingsByPhase} from '../..';
+
+describe('BindingComparator', () => {
+  const FINAL = Symbol('final');
+  const orderOfPhases = ['log', 'auth', FINAL];
+  const phaseTagName = 'phase';
+  let bindings: Binding<unknown>[];
+  let sortedBindingKeys: string[];
+
+  beforeEach(givenBindings);
+  beforeEach(sortBindings);
+
+  it('sorts by phase', () => {
+    /**
+     * Phases
+     * - 'log': logger1, logger2
+     * - 'auth': auth1, auth2
+     */
+    assertOrder('logger1', 'logger2', 'auth1', 'auth2');
+  });
+
+  it('sorts by phase - unknown phase comes before known ones', () => {
+    /**
+     * Phases
+     * - 'metrics': metrics // not part of ['log', 'auth']
+     * - 'log': logger1
+     */
+    assertOrder('metrics', 'logger1');
+  });
+
+  it('sorts by phase alphabetically without orderOf phase', () => {
+    /**
+     * Phases
+     * - 'metrics': metrics // not part of ['log', 'auth']
+     * - 'rateLimit': rateLimit // not part of ['log', 'auth']
+     */
+    assertOrder('metrics', 'rateLimit');
+  });
+
+  it('sorts by binding order without phase tags', () => {
+    /**
+     * Phases
+     * - '': validator1, validator2 // not part of ['log', 'auth']
+     * - 'metrics': metrics // not part of ['log', 'auth']
+     * - 'log': logger1
+     */
+    assertOrder('validator1', 'validator2', 'metrics', 'logger1');
+  });
+
+  it('sorts by binding order without phase tags', () => {
+    /**
+     * Phases
+     * - '': validator1 // not part of ['log', 'auth']
+     * - 'metrics': metrics // not part of ['log', 'auth']
+     * - 'log': logger1
+     * - 'final': Symbol('final')
+     */
+    assertOrder('validator1', 'metrics', 'logger1', 'final');
+  });
+
+  /**
+   * The sorted bindings by phase:
+   * - '': validator1, validator2 // not part of ['log', 'auth']
+   * - 'metrics': metrics // not part of ['log', 'auth']
+   * - 'rateLimit': rateLimit // not part of ['log', 'auth']
+   * - 'log': logger1, logger2
+   * - 'auth': auth1, auth2
+   */
+  function givenBindings() {
+    bindings = [
+      Binding.bind('logger1').tag({[phaseTagName]: 'log'}),
+      Binding.bind('auth1').tag({[phaseTagName]: 'auth'}),
+      Binding.bind('auth2').tag({[phaseTagName]: 'auth'}),
+      Binding.bind('logger2').tag({[phaseTagName]: 'log'}),
+      Binding.bind('metrics').tag({[phaseTagName]: 'metrics'}),
+      Binding.bind('rateLimit').tag({[phaseTagName]: 'rateLimit'}),
+      Binding.bind('validator1'),
+      Binding.bind('validator2'),
+      Binding.bind('final').tag({[phaseTagName]: FINAL}),
+    ];
+  }
+
+  function sortBindings() {
+    sortBindingsByPhase(bindings, phaseTagName, orderOfPhases);
+    sortedBindingKeys = bindings.map(b => b.key);
+  }
+
+  function assertOrder(...keys: string[]) {
+    let prev: number = -1;
+    let prevKey: string = '';
+    for (const key of keys) {
+      const current = sortedBindingKeys.indexOf(key);
+      expect(current).to.greaterThan(
+        prev,
+        `Binding ${key} should come after ${prevKey}`,
+      );
+      prev = current;
+      prevKey = key;
+    }
+  }
+});
+
+describe('compareByOrder', () => {
+  it('honors order', () => {
+    expect(compareByOrder('a', 'b', ['b', 'a'])).to.greaterThan(0);
+  });
+
+  it('value not included in order comes first', () => {
+    expect(compareByOrder('a', 'c', ['a', 'b'])).to.greaterThan(0);
+  });
+
+  it('values not included are compared alphabetically', () => {
+    expect(compareByOrder('a', 'c', [])).to.lessThan(0);
+  });
+
+  it('null/undefined/"" values are treated as ""', () => {
+    expect(compareByOrder('', 'c')).to.lessThan(0);
+    expect(compareByOrder(null, 'c')).to.lessThan(0);
+    expect(compareByOrder(undefined, 'c')).to.lessThan(0);
+  });
+
+  it('returns 0 for equal values', () => {
+    expect(compareByOrder('c', 'c')).to.equal(0);
+    expect(compareByOrder(null, '')).to.equal(0);
+    expect(compareByOrder('', undefined)).to.equal(0);
+  });
+
+  it('allows symbols', () => {
+    const a = Symbol('a');
+    const b = Symbol('b');
+    expect(compareByOrder(a, b)).to.lessThan(0);
+    expect(compareByOrder(a, b, [b, a])).to.greaterThan(0);
+    expect(compareByOrder(a, 'b', [b, a])).to.greaterThan(0);
+  });
+
+  it('list symbols before strings', () => {
+    const a = 'a';
+    const b = Symbol('a');
+    expect(compareByOrder(a, b)).to.greaterThan(0);
+    expect(compareByOrder(b, a)).to.lessThan(0);
+  });
+
+  it('compare symbols by description', () => {
+    const a = Symbol('a');
+    const b = Symbol('b');
+    expect(compareByOrder(a, b)).to.lessThan(0);
+    expect(compareByOrder(b, a)).to.greaterThan(0);
+  });
+});

--- a/packages/context/src/binding-sorter.ts
+++ b/packages/context/src/binding-sorter.ts
@@ -1,0 +1,124 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Binding} from './binding';
+
+/**
+ * Compare function to sort an array of bindings.
+ * It is used by `Array.prototype.sort()`.
+ *
+ * @example
+ * ```ts
+ * const compareByKey: BindingComparator = (a, b) => a.key.localeCompare(b.key);
+ * ```
+ */
+export interface BindingComparator {
+  /**
+   * Compare two bindings
+   * @param bindingA First binding
+   * @param bindingB Second binding
+   * @returns A number to determine order of bindingA and bindingB
+   * - 0 leaves bindingA and bindingB unchanged
+   * - <0 bindingA comes before bindingB
+   * - >0 bindingA comes after bindingB
+   */
+  (
+    bindingA: Readonly<Binding<unknown>>,
+    bindingB: Readonly<Binding<unknown>>,
+  ): number;
+}
+
+/**
+ * Creates a binding compare function to sort bindings by tagged phase name.
+ *
+ * @remarks
+ * Two bindings are compared as follows:
+ *
+ * 1. Get values for the given tag as `phase` for bindings, if the tag is not
+ * present, default `phase` to `''`.
+ * 2. If both bindings have `phase` value in `orderOfPhases`, honor the order
+ * specified by `orderOfPhases`.
+ * 3. If a binding's `phase` does not exist in `orderOfPhases`, it comes before
+ * the one with `phase` exists in `orderOfPhases`.
+ * 4. If both bindings have `phase` value outside of `orderOfPhases`, they are
+ * ordered by phase names alphabetically and symbol values come before string
+ * values.
+ *
+ * @param phaseTagName Name of the binding tag for phase
+ * @param orderOfPhases An array of phase names as the predefined order
+ */
+export function compareBindingsByTag(
+  phaseTagName: string = 'phase',
+  orderOfPhases: (string | symbol)[] = [],
+): BindingComparator {
+  return (a: Readonly<Binding<unknown>>, b: Readonly<Binding<unknown>>) => {
+    return compareByOrder(
+      a.tagMap[phaseTagName],
+      b.tagMap[phaseTagName],
+      orderOfPhases,
+    );
+  };
+}
+
+/**
+ * Compare two values by the predefined order
+ *
+ * @remarks
+ *
+ * The comparison is performed as follows:
+ *
+ * 1. If both values are included in `order`, they are sorted by their indexes in
+ * `order`.
+ * 2. The value included in `order` comes after the value not included in `order`.
+ * 3. If neither values are included in `order`, they are sorted:
+ *   - symbol values come before string values
+ *   - alphabetical order for two symbols or two strings
+ *
+ * @param a First value
+ * @param b Second value
+ * @param order An array of values as the predefined order
+ */
+export function compareByOrder(
+  a: string | symbol | undefined | null,
+  b: string | symbol | undefined | null,
+  order: (string | symbol)[] = [],
+) {
+  a = a || '';
+  b = b || '';
+  const i1 = order.indexOf(a);
+  const i2 = order.indexOf(b);
+  if (i1 !== -1 || i2 !== -1) {
+    // Honor the order
+    return i1 - i2;
+  } else {
+    // Neither value is in the pre-defined order
+
+    // symbol comes before string
+    if (typeof a === 'symbol' && typeof b === 'string') return -1;
+    if (typeof a === 'string' && typeof b === 'symbol') return 1;
+
+    // both a and b are symbols or both a and b are strings
+    if (typeof a === 'symbol') a = a.toString();
+    if (typeof b === 'symbol') b = b.toString();
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+}
+
+/**
+ * Sort bindings by phase names denoted by a tag and the predefined order
+ *
+ * @param bindings An array of bindings
+ * @param phaseTagName Tag name for phase, for example, we can use the value
+ * `'a'` of tag `order` as the phase name for `binding.tag({order: 'a'})`.
+ *
+ * @param orderOfPhases An array of phase names as the predefined order
+ */
+export function sortBindingsByPhase(
+  bindings: Readonly<Binding<unknown>>[],
+  phaseTagName?: string,
+  orderOfPhases?: (string | symbol)[],
+) {
+  return bindings.sort(compareBindingsByTag(phaseTagName, orderOfPhases));
+}

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -9,6 +9,7 @@ import {v1 as uuidv1} from 'uuid';
 import {Binding, BindingTag} from './binding';
 import {BindingFilter, filterByKey, filterByTag} from './binding-filter';
 import {BindingAddress, BindingKey} from './binding-key';
+import {BindingComparator} from './binding-sorter';
 import {
   ContextEventObserver,
   ContextEventType,
@@ -441,9 +442,10 @@ export class Context extends EventEmitter {
   /**
    * Create a view of the context chain with the given binding filter
    * @param filter A function to match bindings
+   * @param sorter A function to sort matched bindings
    */
-  createView<T = unknown>(filter: BindingFilter) {
-    const view = new ContextView<T>(this, filter);
+  createView<T = unknown>(filter: BindingFilter, sorter?: BindingComparator) {
+    const view = new ContextView<T>(this, filter, sorter);
     view.open();
     return view;
   }

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -9,6 +9,7 @@ export * from './binding-decorator';
 export * from './binding-filter';
 export * from './binding-inspector';
 export * from './binding-key';
+export * from './binding-sorter';
 export * from './context';
 export * from './context-observer';
 export * from './context-view';

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -16,6 +16,7 @@ import * as debugFactory from 'debug';
 import {Binding, BindingTemplate} from './binding';
 import {filterByTag} from './binding-filter';
 import {BindingAddress} from './binding-key';
+import {sortBindingsByPhase} from './binding-sorter';
 import {Context} from './context';
 import {ContextBindings, ContextTags} from './keys';
 import {
@@ -91,21 +92,11 @@ export class InvocationContext extends Context {
       this.getSync(ContextBindings.GLOBAL_INTERCEPTOR_ORDERED_GROUPS, {
         optional: true,
       }) || [];
-    bindings.sort((a, b) => {
-      const g1: string = a.tagMap[ContextTags.GLOBAL_INTERCEPTOR_GROUP] || '';
-      const g2: string = b.tagMap[ContextTags.GLOBAL_INTERCEPTOR_GROUP] || '';
-      const i1 = orderedGroups.indexOf(g1);
-      const i2 = orderedGroups.indexOf(g2);
-      if (i1 !== -1 || i2 !== -1) {
-        // Honor the group order
-        return i1 - i2;
-      } else {
-        // Neither group is in the pre-defined order
-        // Use alphabetical order instead so that `1-group` is invoked before
-        // `2-group`
-        return g1 < g2 ? -1 : g1 > g2 ? 1 : 0;
-      }
-    });
+    return sortBindingsByPhase(
+      bindings,
+      ContextTags.GLOBAL_INTERCEPTOR_GROUP,
+      orderedGroups,
+    );
   }
 
   /**

--- a/packages/core/src/extension-point.ts
+++ b/packages/core/src/extension-point.ts
@@ -71,7 +71,12 @@ export function extensions(extensionPointName?: string) {
       inferExtensionPointName(injection.target, session.currentBinding);
 
     const bindingFilter = extensionFilter(extensionPointName);
-    return createViewGetter(ctx, bindingFilter, session);
+    return createViewGetter(
+      ctx,
+      bindingFilter,
+      injection.metadata.bindingComparator,
+      session,
+    );
   });
 }
 

--- a/packages/core/src/lifecycle-registry.ts
+++ b/packages/core/src/lifecycle-registry.ts
@@ -3,7 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, ContextView, inject} from '@loopback/context';
+import {
+  Binding,
+  ContextView,
+  inject,
+  sortBindingsByPhase,
+} from '@loopback/context';
 import {CoreBindings, CoreTags} from './keys';
 import {LifeCycleObserver, lifeCycleObserverFilter} from './lifecycle';
 import debugFactory = require('debug');
@@ -111,6 +116,11 @@ export class LifeCycleObserverRegistry implements LifeCycleObserver {
       string,
       Readonly<Binding<LifeCycleObserver>>[]
     > = new Map();
+    sortBindingsByPhase(
+      bindings,
+      CoreTags.LIFE_CYCLE_OBSERVER_GROUP,
+      this.options.orderedGroups,
+    );
     for (const binding of bindings) {
       const group = this.getObserverGroup(binding);
       let bindingsInGroup = groupMap.get(group);
@@ -125,20 +135,7 @@ export class LifeCycleObserverRegistry implements LifeCycleObserver {
     for (const [group, bindingsInGroup] of groupMap) {
       groups.push({group, bindings: bindingsInGroup});
     }
-    // Sort the groups
-    return groups.sort((g1, g2) => {
-      const i1 = this.options.orderedGroups.indexOf(g1.group);
-      const i2 = this.options.orderedGroups.indexOf(g2.group);
-      if (i1 !== -1 || i2 !== -1) {
-        // Honor the group order
-        return i1 - i2;
-      } else {
-        // Neither group is in the pre-defined order
-        // Use alphabetical order instead so that `1-group` is invoked before
-        // `2-group`
-        return g1.group < g2.group ? -1 : g1.group > g2.group ? 1 : 0;
-      }
-    });
+    return groups;
   }
 
   /**

--- a/packages/rest/src/body-parsers/body-parser.ts
+++ b/packages/rest/src/body-parsers/body-parser.ts
@@ -4,8 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  compareByOrder,
   Constructor,
   Context,
+  filterByTag,
   inject,
   instantiateClass,
 } from '@loopback/context';
@@ -32,7 +34,7 @@ export class RequestBodyParser {
   readonly parsers: BodyParser[];
 
   constructor(
-    @inject.tag(REQUEST_BODY_PARSER_TAG, {optional: true})
+    @inject(filterByTag(REQUEST_BODY_PARSER_TAG), {optional: true})
     parsers?: BodyParser[],
     @inject.context() private readonly ctx?: Context,
   ) {
@@ -197,9 +199,7 @@ function isBodyParserClass(
  * @param parsers
  */
 function sortParsers(parsers: BodyParser[]) {
-  return parsers.sort((a, b) => {
-    const i1 = builtinParsers.names.indexOf(a.name);
-    const i2 = builtinParsers.names.indexOf(b.name);
-    return i1 - i2;
-  });
+  return parsers.sort((a, b) =>
+    compareByOrder(a.name, b.name, builtinParsers.names),
+  );
 }


### PR DESCRIPTION
This PR introduces BindingSorter to help sort bindings discovered from contexts. Some extension points need to control the order of bound extensions. Such APIs can be used to sort life cycle observers
and global interceptors after the PR is landed. 

It has two commits:

1. Add `BindingComparator` interface and a utility to sort by group tag.
2. Add support of `bindingComparator` for `ContextView` and `@inject.*`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
