### PR TITLE
chore(boot): fix tsdoc comments so that apidocs can be generated

### DIFF
--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -38,15 +38,15 @@ export class BaseArtifactBooter implements Booter {
    */
   readonly projectRoot: string;
   /**
-   * {@link ArtifactOptions.dirs}
+   * Relative paths of directories to be searched
    */
   dirs: string[];
   /**
-   * {@link ArtifactOptions.extensions}
+   * File extensions to be searched
    */
   extensions: string[];
   /**
-   * {@link ArtifactOptions.glob}
+   * `glob` pattern to match artifact paths
    */
   glob: string;
 


### PR DESCRIPTION
api-documenter has trouble handling `@link` and it complains about circular dependencies.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
