### PR TITLE
chore: fix tsdoc comments for @example

### DIFF
--- a/examples/log-extension/src/mixins/log.mixin.ts
+++ b/examples/log-extension/src/mixins/log.mixin.ts
@@ -12,6 +12,7 @@ import {LogComponent} from '../component';
  * Also provides .logLevel() to bind application wide logLevel.
  * Functions with a log level set to logLevel or higher sill log data
  *
+ * @example
  * ```ts
  * class MyApplication extends LogMixin(Application) {}
  * ```
@@ -34,6 +35,7 @@ export function LogMixin<T extends Constructor<any>>(superClass: T) {
      *
      * @param level The log level to set for @log decorator
      *
+     * @example
      * ```ts
      * app.logLevel(LOG_LEVEL.INFO);
      * ```

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -16,6 +16,7 @@ export namespace AuthenticationBindings {
    * Key used to bind an authentication strategy to the context for the
    * authentication function to use.
    *
+   * @example
    * ```ts
    * server
    *   .bind(AuthenticationBindings.STRATEGY)
@@ -29,6 +30,7 @@ export namespace AuthenticationBindings {
   /**
    * Key used to inject the authentication function into the sequence.
    *
+   * @example
    * ```ts
    * class MySequence implements SequenceHandler {
    *   constructor(
@@ -64,6 +66,7 @@ export namespace AuthenticationBindings {
    * Key used to inject authentication metadata, which is used to determine
    * whether a request requires authentication or not.
    *
+   * @example
    * ```ts
    * class MyPassportStrategyProvider implements Provider<Strategy | undefined> {
    *   constructor(
@@ -86,6 +89,8 @@ export namespace AuthenticationBindings {
   /**
    * Key used to inject the user instance retrieved by the
    * authentication function
+   *
+   * @example
    * ```ts
    * class MyController {
    *   constructor(

--- a/packages/authentication/src/services/user.service.ts
+++ b/packages/authentication/src/services/user.service.ts
@@ -55,6 +55,7 @@ export interface UserService<U, C> {
    * Verify the identity of a user, construct a corresponding user profile using
    * the user information and return the user profile.
    *
+   * @example
    * A pseudo code for basic authentication:
    * ```ts
    * verifyCredentials(credentials: C): Promise<U> {

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -79,6 +79,7 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
      *
      * @param booterCls Booter classes to bind to the Application
      *
+     * @example
      * ```ts
      * app.booters(MyBooter, MyOtherBooter)
      * ```
@@ -94,6 +95,7 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
      *
      * @param component The component to add.
      *
+     * @example
      * ```ts
      *
      * export class ProductComponent {

--- a/packages/context/src/binding-filter.ts
+++ b/packages/context/src/binding-filter.ts
@@ -10,6 +10,7 @@ import {BindingAddress} from './binding-key';
  * A function that filters bindings. It returns `true` to select a given
  * binding.
  *
+ * @remarks
  * TODO(semver-major): We might change this type in the future to either remove
  * the `<ValueType>` or make it as type guard by asserting the matched binding
  * to be typed with `<ValueType>`.

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -155,7 +155,9 @@ export function bindingTemplateFor<T = unknown>(
 }
 
 /**
- * Mapping artifact types to binding key namespaces (prefixes). For example:
+ * Mapping artifact types to binding key namespaces (prefixes).
+ *
+ * @example
  * ```ts
  * {
  *   repository: 'repositories'

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -12,7 +12,7 @@ export class BindingKey<ValueType> {
   /**
    * Create a new key for a binding bound to a value of type `ValueType`.
    *
-   * **Example**
+   * @example
    *
    * ```ts
    * BindingKey.create<string>('application.name');

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -233,9 +233,10 @@ export class Binding<T = BoundValue> {
    *  - the bound value
    *  - a promise of the bound value
    *
-   * Consumers wishing to consume sync values directly should use `isPromise`
+   * Consumers wishing to consume sync values directly should use `isPromiseLike`
    * to check the type of the returned value to decide how to handle it.
    *
+   * @example
    * ```
    * const result = binding.getValue(ctx);
    * if (isPromiseLike(result)) {
@@ -540,7 +541,7 @@ export class Binding<T = BoundValue> {
    * Apply one or more template functions to set up the binding with scope,
    * tags, and other attributes as a group.
    *
-   * For example,
+   * @example
    * ```ts
    * const serverTemplate = (binding: Binding) =>
    *   binding.inScope(BindingScope.SINGLETON).tag('server');

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -97,7 +97,9 @@ export class Context extends EventEmitter {
   private notificationQueue: AsyncIterableIterator<Notification> | undefined;
 
   /**
-   * Create a new context. For example,
+   * Create a new context.
+   *
+   * @example
    * ```ts
    * // Create a new root context, let the framework to create a unique name
    * const rootCtx = new Context();
@@ -354,12 +356,15 @@ export class Context extends EventEmitter {
   }
 
   /**
-   * Unbind a binding from the context. No parent contexts will be checked. If
-   * you need to unbind a binding owned by a parent context, use the code below:
+   * Unbind a binding from the context. No parent contexts will be checked.
+   *
+   * @remarks
+   * If you need to unbind a binding owned by a parent context, use the code below:
    * ```ts
    * const ownerCtx = ctx.getOwnerContext(key);
    * return ownerCtx != null && ownerCtx.unbind(key);
    * ```
+   *
    * @param key Binding key
    * @returns true if the binding key is found and removed from this context
    */

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -81,6 +81,7 @@ export interface Injection<ValueType = BoundValue> {
  * A decorator to annotate method arguments for automatic injection
  * by LoopBack IoC container.
  *
+ * @example
  * Usage - Typescript:
  *
  * ```ts
@@ -206,7 +207,7 @@ export namespace Getter {
  * The function injected by `@inject.setter(bindingKey)`. It sets the underlying
  * binding to a constant value using `binding.to(value)`.
  *
- * For example:
+ * @example
  *
  * ```ts
  * setterFn('my-value');
@@ -282,7 +283,7 @@ export namespace inject {
    * `metadata.bindingCreation` option. See `BindingCreationPolicy` for more
    * details.
    *
-   * For example:
+   * @example
    *
    * ```ts
    * class MyAuthAction {
@@ -311,7 +312,7 @@ export namespace inject {
   /**
    * Inject an array of values by a tag pattern string or regexp
    *
-   * For example,
+   * @example
    * ```ts
    * class AuthenticationManager {
    *   constructor(
@@ -336,6 +337,7 @@ export namespace inject {
   /**
    * Inject matching bound values by the filter function
    *
+   * @example
    * ```ts
    * class MyControllerWithView {
    *   @inject.view(filterByTag('foo'))

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -51,6 +51,7 @@ export class Application extends Context implements LifeCycleObserver {
    * further modify the binding, e.g. lock the value to prevent further
    * modifications.
    *
+   * @example
    * ```ts
    * class MyController {
    * }
@@ -74,6 +75,7 @@ export class Application extends Context implements LifeCycleObserver {
    * Each server constructor added in this way must provide a unique prefix
    * to prevent binding overlap.
    *
+   * @example
    * ```ts
    * app.server(RestServer);
    * // This server constructor will be bound under "servers.RestServer".
@@ -107,6 +109,7 @@ export class Application extends Context implements LifeCycleObserver {
    * Each server added in this way will automatically be named based on the
    * class constructor name with the "servers." prefix.
    *
+   * @remarks
    * If you wish to control the binding keys for particular server instances,
    * use the app.server function instead.
    * ```ts
@@ -181,6 +184,7 @@ export class Application extends Context implements LifeCycleObserver {
    * @param componentCtor The component class to add.
    * @param {string=} name Optional component name, default to the class name
    *
+   * @example
    * ```ts
    *
    * export class ProductComponent {

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -40,7 +40,8 @@ export interface Component {
 
   /**
    * A map of providers to be bound to the application context
-   * * For example:
+   *
+   * @example
    * ```ts
    * {
    *   'authentication.strategies.ldap': LdapStrategyProvider
@@ -52,7 +53,7 @@ export interface Component {
   /**
    * A map of classes to be bound to the application context.
    *
-   * For example:
+   * @example
    * ```ts
    * {
    *   'rest.body-parsers.xml': XmlBodyParser
@@ -71,7 +72,9 @@ export interface Component {
   lifeCycleObservers?: Constructor<LifeCycleObserver>[];
 
   /**
-   * An array of bindings to be aded to the application context. For example,
+   * An array of bindings to be aded to the application context.
+   *
+   * @example
    * ```ts
    * const bindingX = Binding.bind('x').to('Value X');
    * this.bindings = [bindingX]

--- a/packages/core/src/extension-point.ts
+++ b/packages/core/src/extension-point.ts
@@ -21,8 +21,9 @@ import {CoreTags} from './keys';
 
 /**
  * Decorate a class as a named extension point. If the decoration is not
- * present, the name of the class will be used. For example:
+ * present, the name of the class will be used.
  *
+ * @example
  * ```ts
  * import {extensionPoint} from '@loopback/core';
  *
@@ -39,8 +40,9 @@ export function extensionPoint(name: string, ...specs: BindingSpec[]) {
 }
 
 /**
- * Shortcut to inject extensions for the given extension point. For example:
+ * Shortcut to inject extensions for the given extension point.
  *
+ * @example
  * ```ts
  * import {Getter} from '@loopback/context';
  * import {extensionPoint, extensions} from '@loopback/core';

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -623,8 +623,11 @@ export class ParameterDecoratorFactory<T> extends DecoratorFactory<
 }
 
 /**
- * Factory for method level parameter decorator. For example, the following
- * code uses `@param` to declare two parameters for `greet()`.
+ * Factory for method level parameter decorator.
+ *
+ * @example
+ * For example, the following code uses `@param` to declare two parameters for
+ * `greet()`.
  * ```ts
  * class MyController {
  *   @param('name') // Parameter 0

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -103,7 +103,9 @@ const builtinTypes = {
  * takes an argument of `ParameterObject` to define how to map the parameter
  * to OpenAPI specification.
  *
- * `@param(paramSpec)` must be applied to parameters. For example,
+ * `@param(paramSpec)` must be applied to parameters.
+ *
+ * @example
  * ```ts
  * class MyController {
  *   @get('/')

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -23,6 +23,7 @@ export const REQUEST_BODY_INDEX = 'x-parameter-index';
  * A typical OpenAPI requestBody spec contains property
  * `description`, `required`, and `content`:
  *
+ * @example
  * ```ts
  * requestBodySpec: {
  *   description: 'a user',

--- a/packages/repository/src/common-types.ts
+++ b/packages/repository/src/common-types.ts
@@ -19,8 +19,10 @@ export interface Class<T> {
 }
 
 /**
- * Interface for constructor functions without `new` operator, for example,
- * ```
+ * Interface for constructor functions without `new` operator.
+ *
+ * @example
+ * ```ts
  * function Foo(x) {
  *   if (!(this instanceof Foo)) { return new Foo(x); }
  *   this.x = x;

--- a/packages/repository/src/decorators/repository.decorator.ts
+++ b/packages/repository/src/decorators/repository.decorator.ts
@@ -85,6 +85,7 @@ export class RepositoryMetadata {
 /**
  * Decorator for repository injections on properties or method arguments
  *
+ * @example
  * ```ts
  * class CustomerController {
  *   @repository(CustomerRepository) public custRepo: CustomerRepository;
@@ -106,6 +107,7 @@ export function repository(
  * Decorator for DefaultCrudRepository generation and injection on properties
  * or method arguments based on the given model and dataSource (or their names)
  *
+ * @example
  * ```ts
  * class CustomerController {
  *   @repository('Customer', 'mySqlDataSource')

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -17,8 +17,8 @@ const debug = debugFactory('loopback:repository:mixin');
  * function to register a repository automatically. Also overrides
  * component function to allow it to register repositories automatically.
  *
+ * @example
  * ```ts
- *
  * class MyApplication extends RepositoryMixin(Application) {}
  * ```
  *
@@ -40,6 +40,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      *
      * @param repoClass The repository to add.
      *
+     * @example
      * ```ts
      *
      * class NoteRepo {
@@ -93,6 +94,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      * @param dataSource The dataSource to add.
      * @param name The binding name of the datasource; defaults to dataSource.name
      *
+     * @example
      * ```ts
      *
      * const ds: juggler.DataSource = new juggler.DataSource({
@@ -138,6 +140,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      *
      * @param component The component to add.
      *
+     * @example
      * ```ts
      *
      * export class ProductComponent {
@@ -257,6 +260,7 @@ export class RepositoryMixinDoc {
    *
    * @param repo The repository to add.
    *
+   * @example
    * ```ts
    *
    * class NoteRepo {
@@ -300,6 +304,7 @@ export class RepositoryMixinDoc {
    * @param dataSource The dataSource to add.
    * @param name The binding name of the datasource; defaults to dataSource.name
    *
+   * @example
    * ```ts
    *
    * const ds: juggler.DataSource = new juggler.DataSource({
@@ -328,6 +333,7 @@ export class RepositoryMixinDoc {
    *
    * @param component The component to add.
    *
+   * @example
    * ```ts
    *
    * export class ProductComponent {

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -131,8 +131,10 @@ export class ModelDefinition {
 
   /**
    * Get an array of names of ID properties, which are specified in
-   * the model settings or properties with `id` attribute. For example,
-   * ```
+   * the model settings or properties with `id` attribute.
+   *
+   * @example
+   * ```ts
    * {
    *   settings: {
    *     id: ['id']

--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {AnyObject} from './common-types';
 import * as assert from 'assert';
+import {AnyObject} from './common-types';
 
 // tslint:disable:no-any
 
@@ -78,7 +78,8 @@ export type KeyOf<MT extends object> = Exclude<
 
 /**
  * Condition clause
- * For example:
+ *
+ * @example
  * ```ts
  * {
  *   name: {inq: ['John', 'Mary']},
@@ -95,7 +96,8 @@ export type Condition<MT extends object> = {
 
 /**
  * Where clause
- * For example:
+ *
+ * @example
  * ```ts
  * {
  *   name: {inq: ['John', 'Mary']},
@@ -112,7 +114,8 @@ export type Where<MT extends object = AnyObject> =
 
 /**
  * And clause
- * For example:
+ *
+ * @example
  * ```ts
  * {
  *   and: [...],
@@ -125,7 +128,8 @@ export interface AndClause<MT extends object> {
 
 /**
  * Or clause
- * For example:
+ *
+ * @example
  * ```ts
  * {
  *   or: [...],

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -198,6 +198,7 @@ export class DefaultCrudRepository<T extends Entity, ID>
   /**
    * Function to create a constrained relation repository factory
    *
+   * @example
    * ```ts
    * class CustomerRepository extends DefaultCrudRepository<
    *   Customer,

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -3,20 +3,20 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, ValueObject, Model} from '../model';
 import {
-  DataObject,
-  Options,
   AnyObject,
   Command,
-  NamedParameters,
-  PositionalParameters,
   Count,
+  DataObject,
+  NamedParameters,
+  Options,
+  PositionalParameters,
 } from '../common-types';
-import {DataSource} from '../datasource';
 import {CrudConnector} from '../connectors';
-import {Filter, Where} from '../query';
+import {DataSource} from '../datasource';
 import {EntityNotFoundError} from '../errors';
+import {Entity, Model, ValueObject} from '../model';
+import {Filter, Where} from '../query';
 
 // tslint:disable:no-unused
 
@@ -190,7 +190,7 @@ export interface EntityCrudRepository<T extends Entity, ID>
 /**
  * Repository implementation
  *
- * Example:
+ * @example
  *
  * User can import `CrudRepositoryImpl` and call its functions like:
  * `CrudRepositoryImpl.find(somefilters, someoptions)`

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -124,6 +124,7 @@ export class RestApplication extends Application implements HttpServerLike {
   /**
    * Register a new Controller-based route.
    *
+   * @example
    * ```ts
    * class MyController {
    *   greet(name: string) {
@@ -152,6 +153,7 @@ export class RestApplication extends Application implements HttpServerLike {
   /**
    * Register a new route invoking a handler function.
    *
+   * @example
    * ```ts
    * function greet(name: string) {
    *  return `hello ${name}`;
@@ -175,6 +177,7 @@ export class RestApplication extends Application implements HttpServerLike {
   /**
    * Register a new route.
    *
+   * @example
    * ```ts
    * function greet(name: string) {
    *  return `hello ${name}`;
@@ -190,6 +193,7 @@ export class RestApplication extends Application implements HttpServerLike {
   /**
    * Register a new route.
    *
+   * @example
    * ```ts
    * function greet(name: string) {
    *  return `hello ${name}`;
@@ -237,6 +241,7 @@ export class RestApplication extends Application implements HttpServerLike {
   /**
    * Register a route redirecting callers to a different URL.
    *
+   * @example
    * ```ts
    * app.redirect('/explorer', '/explorer/');
    * ```

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -82,6 +82,8 @@ const cloneDeep: <T>(value: T) => T = require('lodash/cloneDeep');
 /**
  * A REST API server for use with Loopback.
  * Add this server to your application by importing the RestComponent.
+ *
+ * @example
  * ```ts
  * const app = new MyApplication();
  * app.component(RestComponent);
@@ -458,6 +460,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * further modify the binding, e.g. lock the value to prevent further
    * modifications.
    *
+   * @example
    * ```ts
    * class MyController {
    * }
@@ -474,6 +477,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Register a new Controller-based route.
    *
+   * @example
    * ```ts
    * class MyController {
    *   greet(name: string) {
@@ -502,6 +506,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Register a new route invoking a handler function.
    *
+   * @example
    * ```ts
    * function greet(name: string) {
    *  return `hello ${name}`;
@@ -525,6 +530,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Register a new generic route.
    *
+   * @example
    * ```ts
    * function greet(name: string) {
    *  return `hello ${name}`;
@@ -604,6 +610,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Register a route redirecting callers to a different URL.
    *
+   * @example
    * ```ts
    * server.redirect('/explorer', '/explorer/');
    * ```
@@ -687,6 +694,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Configure a custom sequence class for handling incoming requests.
    *
+   * @example
    * ```ts
    * class MySequence implements SequenceHandler {
    *   constructor(
@@ -708,6 +716,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Configure a custom sequence function for handling incoming requests.
    *
+   * @example
    * ```ts
    * app.handler(({request, response}, sequence) => {
    *   sequence.send(response, 'hello world');

--- a/packages/rest/src/sequence.ts
+++ b/packages/rest/src/sequence.ts
@@ -5,9 +5,9 @@
 
 const debug = require('debug')('loopback:rest:sequence');
 import {inject} from '@loopback/context';
-import {FindRoute, InvokeMethod, Send, Reject, ParseParams} from './types';
 import {RestBindings} from './keys';
 import {RequestContext} from './request-context';
+import {FindRoute, InvokeMethod, ParseParams, Reject, Send} from './types';
 
 const SequenceActions = RestBindings.SequenceActions;
 
@@ -37,6 +37,7 @@ export interface SequenceHandler {
 /**
  * The default implementation of SequenceHandler.
  *
+ * @remarks
  * This class implements default Sequence for the LoopBack framework.
  * Default sequence is used if user hasn't defined their own Sequence
  * for their application.
@@ -45,6 +46,7 @@ export interface SequenceHandler {
  * when the API request comes in. User defines APIs in their Application
  * Controller class.
  *
+ * @example
  * User can bind their own Sequence to app as shown below
  * ```ts
  * app.bind(CoreBindings.SEQUENCE).toClass(MySequence);

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -20,6 +20,7 @@ export interface Class<T> {
  * function to register a service automatically. Also overrides
  * component function to allow it to register repositories automatically.
  *
+ * @example
  * ```ts
  * class MyApplication extends ServiceMixin(Application) {}
  * ```
@@ -42,6 +43,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      *
      * @param provider The service provider to register.
      *
+     * @example
      * ```ts
      * export interface GeocoderService {
      *   geocode(address: string): Promise<GeoPoint[]>;
@@ -81,6 +83,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      *
      * @param component The component to add.
      *
+     * @example
      * ```ts
      *
      * export class ProductComponent {
@@ -150,6 +153,7 @@ export class ServiceMixinDoc {
    *
    * @param provider The service provider to register.
    *
+   * @example
    * ```ts
    * export interface GeocoderService {
    *   geocode(address: string): Promise<GeoPoint[]>;
@@ -179,6 +183,7 @@ export class ServiceMixinDoc {
    *
    * @param component The component to add.
    *
+   * @example
    * ```ts
    *
    * export class ProductComponent {


### PR DESCRIPTION
Embedded typescript code in comments cannot be rendered correctly inside
markdown tables. Add @example to extract example code snippets.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
