### PR TITLE
fix(rest-explorer): exclude basePath from /openapi URL

### DIFF
--- a/examples/express-composition/src/__tests__/acceptance/express.acceptance.ts
+++ b/examples/express-composition/src/__tests__/acceptance/express.acceptance.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Client} from '@loopback/testlab';
-import {setupExpressApplication} from './test-helper';
 import {ExpressServer} from '../../server';
+import {setupExpressApplication} from './test-helper';
 
 describe('ExpressApplication', () => {
   let server: ExpressServer;
@@ -53,7 +53,7 @@ describe('ExpressApplication', () => {
       .get('/api/explorer/')
       .expect(200)
       .expect('content-type', /html/)
-      .expect(/url\: '\/api\/openapi\.json'\,/)
+      .expect(/url\: '\/openapi\.json'\,/)
       .expect(/<title>LoopBack API Explorer/);
   });
 });

--- a/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
+++ b/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
@@ -31,7 +31,7 @@ describe('REST Explorer mounted as an express router', () => {
       .get('/api/explorer/')
       .expect(200)
       .expect('content-type', /html/)
-      .expect(/url\: '\/api\/openapi\.json'\,/);
+      .expect(/url\: '\/openapi\.json'\,/);
   });
 
   it('redirects from "/api/explorer" to "/api/explorer/"', async () => {

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -5,11 +5,11 @@
 
 import {inject} from '@loopback/context';
 import {
-  RestBindings,
-  RestServerConfig,
   OpenApiSpecForm,
   Request,
   Response,
+  RestBindings,
+  RestServerConfig,
 } from '@loopback/rest';
 import * as ejs from 'ejs';
 import * as fs from 'fs';
@@ -39,9 +39,13 @@ export class ExplorerController {
 
   index() {
     let openApiSpecUrl = this.openApiSpecUrl;
-    if (this.request.baseUrl && this.request.baseUrl !== '/') {
-      openApiSpecUrl = this.request.baseUrl + openApiSpecUrl;
-    }
+
+    // NOTE(bajtos) OpenAPI routes do not honor basePath setting (yet)
+    // See https://github.com/strongloop/loopback-next/pull/2554
+    // if (this.request.baseUrl && this.request.baseUrl !== '/') {
+    //  openApiSpecUrl = this.request.baseUrl + openApiSpecUrl;
+    // }
+
     const data = {
       openApiSpecUrl,
     };


### PR DESCRIPTION
Endpoints serving OpenAPI spec ignore basePath setting, i.e. even if basePath is set to `/api`, the spec is served at `/openapi.json`.

This pull request is fixing the problem and supersedes https://github.com/strongloop/loopback-next/pull/2554.

/cc @gordancso @dkrantsberg

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈