### PR TITLE
fix(rest-explorer): exclude basePath from /openapi URL

### DIFF
--- a/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.acceptance.ts
+++ b/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.acceptance.ts
@@ -125,10 +125,12 @@ describe('API Explorer (acceptance)', () => {
 
     it('uses correct URLs', async () => {
       // static assets (including swagger-ui) honor basePath
-      const response = await request.get('/api/explorer/').expect(200);
-      const body = response.body;
-      // OpenAPI endpoints DO NOT honor basePath
-      expect(body).to.match(/^\s*url: '\/openapi.json',\s*$/m);
+      await request
+        .get('/api/explorer/')
+        .expect(200)
+        .expect('content-type', /html/)
+        // OpenAPI endpoints DO NOT honor basePath
+        .expect(/url\: '\/openapi\.json'\,/);
     });
   });
 

--- a/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
+++ b/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
@@ -7,7 +7,6 @@ import {RestApplication, RestServer, RestServerConfig} from '@loopback/rest';
 import {
   Client,
   createClientForHandler,
-  expect,
   givenHttpServerConfig,
 } from '@loopback/testlab';
 import * as express from 'express';
@@ -38,10 +37,13 @@ describe('REST Explorer mounted as an express router', () => {
 
   it('honors basePath config', async () => {
     server.basePath('/v1');
-    // static assets (including swagger-ui) honor basePath
-    const response = await client.get('/api/v1/explorer/').expect(200);
-    // OpenAPI endpoints DO NOT honor basePath
-    expect(response.body).to.match(/^\s*url: '\/api\/openapi.json',\s*$/m);
+    await client
+      // static assets (including swagger-ui) honor basePath
+      .get('/api/v1/explorer/')
+      .expect(200)
+      .expect('content-type', /html/)
+      // OpenAPI endpoints DO NOT honor basePath
+      .expect(/url\: '\/api\/openapi\.json'\,/);
   });
 
   async function givenLoopBackApp(

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -53,7 +53,7 @@ export class ExplorerController {
     }
 
     if (rootPath && rootPath !== '/') {
-      openApiSpecUrl = this.request.baseUrl + openApiSpecUrl;
+      openApiSpecUrl = rootPath + openApiSpecUrl;
     }
     const data = {
       openApiSpecUrl,

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -5,11 +5,11 @@
 
 import {inject} from '@loopback/context';
 import {
-  RestBindings,
-  RestServerConfig,
   OpenApiSpecForm,
   Request,
   Response,
+  RestBindings,
+  RestServerConfig,
 } from '@loopback/rest';
 import * as ejs from 'ejs';
 import * as fs from 'fs';
@@ -26,6 +26,7 @@ export class ExplorerController {
   constructor(
     @inject(RestBindings.CONFIG, {optional: true})
     restConfig: RestServerConfig = {},
+    @inject(RestBindings.BASE_PATH) private serverBasePath: string,
     @inject(RestBindings.Http.REQUEST) private request: Request,
     @inject(RestBindings.Http.RESPONSE) private response: Response,
   ) {
@@ -39,7 +40,19 @@ export class ExplorerController {
 
   index() {
     let openApiSpecUrl = this.openApiSpecUrl;
-    if (this.request.baseUrl && this.request.baseUrl !== '/') {
+
+    // baseURL is composed from mountPath and basePath
+    // OpenAPI endpoints ignore basePath but do honor mountPath
+    let rootPath = this.request.baseUrl;
+    if (
+      this.serverBasePath &&
+      this.serverBasePath !== '/' &&
+      rootPath.endsWith(this.serverBasePath)
+    ) {
+      rootPath = rootPath.slice(0, -this.serverBasePath.length);
+    }
+
+    if (rootPath && rootPath !== '/') {
       openApiSpecUrl = this.request.baseUrl + openApiSpecUrl;
     }
     const data = {


### PR DESCRIPTION
Endpoints serving OpenAPI spec ignore basePath setting, i.e. even if basePath is set to `/api`, the spec is served at `/openapi.json`.

This pull request is fixing the problem and supersedes #2554 and #2854.

The following four use cases are correctly supported now (when sending requests directly to the application):

1. No base path, everything is at `/`.
2. basePath is set via `app.basePath()`. Explorer is served at `/api/explorer`, OpenAPI spec is served at `/openapi.json`.
3. LB app mounted on Express at `/api`, no LB basePath is set. Explorer is served at `/api/explorer`, OpenAPI spec is served at `/api/openapi.json`.
4. LB app mounted on Express at `/api`, basePath is set to `v1`. Explorer is served at `/api/v1/explorer`, OpenAPI spec is served at `/api/openapi.json`.

Support for reverse proxies like nginx is OUT OF SCOPE of this pull request.

/cc @gordancso @dkrantsberg @sanadHaj

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈