### PR TITLE
feat(context): add more getters for InvocationContext

### DIFF
--- a/packages/context/src/__tests__/unit/invocation-context.unit.ts
+++ b/packages/context/src/__tests__/unit/invocation-context.unit.ts
@@ -1,0 +1,107 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {Context, InvocationContext} from '../..';
+
+describe('InvocationContext', () => {
+  let ctx: Context;
+  let invocationCtxForGreet: InvocationContext;
+  let invocationCtxForCheckName: InvocationContext;
+  let invalidInvocationCtx: InvocationContext;
+  let invalidInvocationCtxForStaticMethod: InvocationContext;
+
+  before(givenContext);
+  before(givenInvocationContext);
+
+  it('has a getter for targetClass', () => {
+    expect(invocationCtxForGreet.targetClass).to.equal(MyController);
+    expect(invocationCtxForCheckName.targetClass).to.equal(MyController);
+  });
+
+  it('has a getter for targetName', () => {
+    expect(invocationCtxForGreet.targetName).to.equal(
+      'MyController.prototype.greet',
+    );
+    expect(invocationCtxForCheckName.targetName).to.equal(
+      'MyController.checkName',
+    );
+  });
+
+  it('has a getter for description', () => {
+    expect(invocationCtxForGreet.description).to.equal(
+      `InvocationContext(${
+        invocationCtxForGreet.name
+      }): MyController.prototype.greet`,
+    );
+    expect(invocationCtxForCheckName.description).to.equal(
+      `InvocationContext(${
+        invocationCtxForCheckName.name
+      }): MyController.checkName`,
+    );
+  });
+
+  it('throws error if method does not exist', () => {
+    expect(() => invalidInvocationCtx.assertMethodExists()).to.throw(
+      'Method MyController.prototype.invalid-method not found',
+    );
+
+    expect(() =>
+      invalidInvocationCtxForStaticMethod.assertMethodExists(),
+    ).to.throw('Method MyController.invalid-static-method not found');
+  });
+
+  it('invokes target method', async () => {
+    expect(await invocationCtxForGreet.invokeTargetMethod()).to.eql(
+      'Hello, John',
+    );
+    expect(invocationCtxForCheckName.invokeTargetMethod()).to.eql(true);
+  });
+
+  class MyController {
+    static checkName(name: string) {
+      const firstLetter = name.substring(0, 1);
+      return firstLetter === firstLetter.toUpperCase();
+    }
+
+    async greet(name: string) {
+      return `Hello, ${name}`;
+    }
+  }
+
+  function givenContext() {
+    ctx = new Context();
+  }
+
+  function givenInvocationContext() {
+    invocationCtxForGreet = new InvocationContext(
+      ctx,
+      new MyController(),
+      'greet',
+      ['John'],
+    );
+
+    invocationCtxForCheckName = new InvocationContext(
+      ctx,
+      MyController,
+      'checkName',
+      ['John'],
+    );
+
+    invalidInvocationCtx = new InvocationContext(
+      ctx,
+      new MyController(),
+      'invalid-method',
+      ['John'],
+    );
+
+    invalidInvocationCtxForStaticMethod = new InvocationContext(
+      ctx,
+      MyController,
+      'invalid-static-method',
+      ['John'],
+    );
+  }
+});

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -105,6 +105,33 @@ export class InvocationContext extends Context {
   }
 
   /**
+   * The target class, such as `OrderController`
+   */
+  get targetClass() {
+    return typeof this.target === 'function'
+      ? this.target
+      : this.target.constructor;
+  }
+
+  /**
+   * The target name, such as `OrderController.prototype.cancelOrder`
+   */
+  get targetName() {
+    return DecoratorFactory.getTargetName(this.target, this.methodName);
+  }
+
+  /**
+   * Description of the invocation
+   */
+  get description() {
+    return `InvocationContext(${this.name}): ${this.targetName}`;
+  }
+
+  toString() {
+    return this.description;
+  }
+
+  /**
    * Load all interceptors for the given invocation context. It adds
    * interceptors from possibly three sources:
    * 1. method level `@intercept`
@@ -177,9 +204,7 @@ export class InvocationContext extends Context {
  * by tagging it with `ContextTags.INTERCEPTOR`
  * @param binding Binding object
  */
-export function asGlobalInterceptor(
-  group?: string,
-): BindingTemplate<Interceptor> {
+export function asGlobalInterceptor(group?: string): BindingTemplate {
   return binding => {
     binding.tag(ContextTags.GLOBAL_INTERCEPTOR);
     if (group) binding.tag({[ContextTags.GLOBAL_INTERCEPTOR_GROUP]: group});


### PR DESCRIPTION
Add more getters for `InvocationContext` as discovered during the development of `authorization` component using `Interceptor`.

See https://github.com/strongloop/loopback-next/pull/1205 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
