### PR TITLE
fix(context): close invocation context only after async is done

### DIFF
--- a/packages/context/src/__tests__/unit/invocation-context.unit.ts
+++ b/packages/context/src/__tests__/unit/invocation-context.unit.ts
@@ -60,6 +60,12 @@ describe('InvocationContext', () => {
     expect(invocationCtxForCheckName.invokeTargetMethod()).to.eql(true);
   });
 
+  it('does not close when an interceptor is in processing', () => {
+    const result = invocationCtxForGreet.invokeTargetMethod();
+    expect(invocationCtxForGreet.isBound('abc'));
+    return result;
+  });
+
   class MyController {
     static checkName(name: string) {
       const firstLetter = name.substring(0, 1);
@@ -73,6 +79,7 @@ describe('InvocationContext', () => {
 
   function givenContext() {
     ctx = new Context();
+    ctx.bind('abc').to('xyz');
   }
 
   function givenInvocationContext() {


### PR DESCRIPTION
Before this fix, `invocation context` is closed synchronously and interceptors may fail to resolve bindings in parent contexts.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
