### PR TITLE
fix(build): honor tsconfig compilerOptions.rootDir to copy resources

### DIFF
--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -136,10 +136,23 @@ function run(argv, options) {
         ? tsConfig.include.join('|')
         : ['src', 'test'].join('|');
 
+      const compilerRootDir =
+        (tsConfig.compilerOptions && tsConfig.compilerOptions.rootDir) || '';
+
       const pattern = `@(${dirs})/**/!(*.ts)`;
       const files = glob.sync(pattern, {root: packageDir, nodir: true});
       for (const file of files) {
-        fse.copySync(path.join(packageDir, file), path.join(outDir, file));
+        /**
+         * Trim path that matches tsConfig.compilerOptions.rootDir
+         */
+        let targetFile = file;
+        if (compilerRootDir && file.startsWith(compilerRootDir + '/')) {
+          targetFile = file.substring(compilerRootDir.length + 1);
+        }
+        fse.copySync(
+          path.join(packageDir, file),
+          path.join(outDir, targetFile),
+        );
       }
     }
   }


### PR DESCRIPTION
For example:

`src/__tests__/fixtures/my.conf` -> `dist/__tests__/fixtures/my.conf`

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
