### PR TITLE
feat(context): leave local bindings and parent unchanged in context.close()

### DIFF
--- a/packages/context/src/__tests__/unit/context.unit.ts
+++ b/packages/context/src/__tests__/unit/context.unit.ts
@@ -11,6 +11,7 @@ import {
   BindingScope,
   BindingType,
   Context,
+  ContextEventObserver,
   isPromiseLike,
 } from '../..';
 
@@ -19,12 +20,16 @@ import {
  * for assertions
  */
 class TestContext extends Context {
+  observers: Set<ContextEventObserver> | undefined;
   get parent() {
     return this._parent;
   }
   get bindingMap() {
     const map = new Map(this.registry);
     return map;
+  }
+  get parentEventListeners() {
+    return this._parentEventListeners;
   }
 }
 
@@ -725,18 +730,48 @@ describe('Context', () => {
   });
 
   describe('close()', () => {
-    it('clears all bindings', () => {
-      ctx.bind('foo').to('foo-value');
-      expect(ctx.bindingMap.size).to.eql(1);
-      ctx.close();
-      expect(ctx.bindingMap.size).to.eql(0);
+    it('clears all observers', () => {
+      const childCtx = new TestContext(ctx);
+      childCtx.subscribe(() => {});
+      expect(childCtx.observers!.size).to.eql(1);
+      childCtx.close();
+      expect(childCtx.observers).to.be.undefined();
     });
 
-    it('dereferences parent', () => {
+    it('removes listeners from parent context', () => {
       const childCtx = new TestContext(ctx);
-      expect(childCtx.parent).to.equal(ctx);
+      childCtx.subscribe(() => {});
+      // Now we have one observer
+      expect(childCtx.observers!.size).to.eql(1);
+      // Two listeners are also added to the parent context
+      const parentEventListeners = childCtx.parentEventListeners!;
+      expect(parentEventListeners.size).to.eql(2);
+
+      // The map contains listeners added to the parent context
+      // Take a snapshot into `copy`
+      const copy = new Map(parentEventListeners);
+      for (const [key, val] of copy.entries()) {
+        expect(val).to.be.a.Function();
+        expect(ctx.listeners(key)).to.containEql(val);
+      }
+
+      // Now clear subscriptions
       childCtx.close();
-      expect(childCtx.parent).to.be.undefined();
+
+      // observers are gone
+      expect(childCtx.observers).to.be.undefined();
+      // listeners are removed from parent context
+      for (const [key, val] of copy.entries()) {
+        expect(ctx.listeners(key)).to.not.containEql(val);
+      }
+    });
+
+    it('keeps parent and bindings', () => {
+      const childCtx = new TestContext(ctx);
+      childCtx.bind('foo').to('foo-value');
+      childCtx.close();
+      expect(childCtx.parent).to.equal(ctx);
+      expect(childCtx.contains('foo'));
     });
   });
 

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -403,9 +403,10 @@ export class Context extends EventEmitter {
   }
 
   /**
-   * Close the context and release references to other objects in the context
-   * chain.
+   * Close the context: clear observers, stop notifications, and remove event
+   * listeners from its parent context.
    *
+   * @remarks
    * This method MUST be called to avoid memory leaks once a context object is
    * no longer needed and should be recycled. An example is the `RequestContext`,
    * which is created per request.
@@ -426,8 +427,6 @@ export class Context extends EventEmitter {
       }
       this._parentEventListeners = undefined;
     }
-    this.registry.clear();
-    this._parent = undefined;
   }
 
   /**

--- a/packages/rest/src/request-context.ts
+++ b/packages/rest/src/request-context.ts
@@ -95,6 +95,8 @@ export class RequestContext extends Context implements HandlerContext {
     super(parent, name);
     this._setupBindings(request, response);
     onFinished(this.response, () => {
+      // Close the request context when the http response is finished so that
+      // it can be recycled by GC
       this.close();
     });
   }


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/2541

In some cases, the request context is still in use when the http response is finished. This PR changes `close` to only clear subscriptions and remove itself from the parent context so that the context is ready
for GC without destroying bindings.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
