### PR TITLE
chore: fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -235,16 +235,16 @@
       }
     },
     "@lerna/changed": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.3.tgz",
-      "integrity": "sha512-REMZ/1UvYrizUhN7ktlbfMUa0vhMf1ogAe97WQC4I8r3s973Orfhs3aselo1GwudUwM4tMHBH8A9vnll9or3iA==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.4.tgz",
+      "integrity": "sha512-9lfOyRVObasw6L/z7yCSfsEl1QKy0Eamb8t2Krg1deIoAt+cE3JXOdGGC1MhOSli+7f/U9LyLXjJzIOs/pc9fw==",
       "dev": true,
       "requires": {
         "@lerna/collect-updates": "3.13.3",
         "@lerna/command": "3.13.3",
         "@lerna/listable": "3.13.0",
         "@lerna/output": "3.13.0",
-        "@lerna/version": "3.13.3"
+        "@lerna/version": "3.13.4"
       }
     },
     "@lerna/check-working-tree": {
@@ -594,29 +594,6 @@
         "fs-extra": "^7.0.0",
         "ssri": "^6.0.1",
         "tar": "^4.4.8"
-      },
-      "dependencies": {
-        "tar": {
-          "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
       }
     },
     "@lerna/github-client": {
@@ -649,9 +626,9 @@
       }
     },
     "@lerna/import": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.13.3.tgz",
-      "integrity": "sha512-gDjLAFVavG/CMvj9leBfiwd7vrXqtdFXPIz1oXmghBMnje7nCTbodbNWFe4VDDWx7reDaZIN+6PxTSvrPcF//A==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.13.4.tgz",
+      "integrity": "sha512-dn6eNuPEljWsifBEzJ9B6NoaLwl/Zvof7PBUPA4hRyRlqG5sXRn6F9DnusMTovvSarbicmTURbOokYuotVWQQA==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "3.13.3",
@@ -820,29 +797,6 @@
         "npmlog": "^4.1.2",
         "tar": "^4.4.8",
         "temp-write": "^3.4.0"
-      },
-      "dependencies": {
-        "tar": {
-          "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
       }
     },
     "@lerna/package": {
@@ -939,9 +893,9 @@
       }
     },
     "@lerna/publish": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.3.tgz",
-      "integrity": "sha512-Ni3pZKueIfgJJoL0OXfbAuWhGlJrDNwGx3CYWp2dbNqJmKD6uBZmsDtmeARKDp92oUK60W0drXCMydkIFFHMDQ==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.4.tgz",
+      "integrity": "sha512-v03pabiPlqCDwX6cVNis1PDdT6/jBgkVb5Nl4e8wcJXevIhZw3ClvtI94gSZu/wdoVFX0RMfc8QBVmaimSO0qg==",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -961,7 +915,7 @@
         "@lerna/run-lifecycle": "3.13.0",
         "@lerna/run-parallel-batches": "3.13.0",
         "@lerna/validation-error": "3.13.0",
-        "@lerna/version": "3.13.3",
+        "@lerna/version": "3.13.4",
         "figgy-pudding": "^3.5.1",
         "fs-extra": "^7.0.0",
         "libnpmaccess": "^3.0.1",
@@ -1090,9 +1044,9 @@
       }
     },
     "@lerna/version": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.13.3.tgz",
-      "integrity": "sha512-o/yQGAwDHmyu17wTj4Kat1/uDhjYFMeG+H0Y0HC4zJ4a/T6rEiXx7jJrnucPTmTQTDcUBoH/It5LrPYGOPsExA==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.13.4.tgz",
+      "integrity": "sha512-pptWUEgN/lUTQZu34+gfH1g4Uhs7TDKRcdZY9A4T9k6RTOwpKC2ceLGiXdeR+ZgQJAey2C4qiE8fo5Z6Rbc6QA==",
       "dev": true,
       "requires": {
         "@lerna/batch-packages": "3.13.0",
@@ -1165,15 +1119,32 @@
       "dev": true
     },
     "@octokit/endpoint": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-4.0.0.tgz",
-      "integrity": "sha512-b8sptNUekjREtCTJFpOfSIL4SKh65WaakcyxWzRcSPOk5RxkZJ/S8884NGZFxZ+jCB2rDURU66pSHn14cVgWVg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.1.1.tgz",
+      "integrity": "sha512-kCv3ZyqFTWGYmvuU0TETzC4jPGzyLCJrjXp65kRe9DHyQULZak+dpwmEbT7M2rpdr/O2im8ivrPGT6J+2WsKNg==",
       "dev": true,
       "requires": {
         "deepmerge": "3.2.0",
-        "is-plain-object": "^2.0.4",
+        "is-plain-object": "^3.0.0",
         "universal-user-agent": "^2.0.1",
         "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
       }
     },
     "@octokit/plugin-enterprise-rest": {
@@ -1183,26 +1154,43 @@
       "dev": true
     },
     "@octokit/request": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.0.tgz",
-      "integrity": "sha512-DZqmbm66tq+a9FtcKrn0sjrUpi0UaZ9QPUCxxyk/4CJ2rseTMpAWRf6gCwOSUCzZcx/4XVIsDk+kz5BVdaeenA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.3.tgz",
+      "integrity": "sha512-M7pUfsiaiiUMEP4/SMysTeWxyGrkoQg6FBPEtCBIFgeDnzHaPboTpUZGTh6u1GQXdrlzMfPVn/vQs98js1QtwQ==",
       "dev": true,
       "requires": {
-        "@octokit/endpoint": "^4.0.0",
+        "@octokit/endpoint": "^5.1.0",
         "deprecation": "^1.0.1",
-        "is-plain-object": "^2.0.4",
+        "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
         "universal-user-agent": "^2.0.1"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
       }
     },
     "@octokit/rest": {
-      "version": "16.24.3",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.24.3.tgz",
-      "integrity": "sha512-fBr2ziN4WT9G9sYTfnNVI/0wCb68ZI5isNU48lfWXQDyAy4ftlrh0SkIbhL7aigXUjcY0cX5J46ypyRPH0/U0g==",
+      "version": "16.25.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.25.4.tgz",
+      "integrity": "sha512-62G8sb5PmIDhnu6K4W39If0BdA+P6VLuY83nMjjHyQiXH1QbjiKKeEv9uwRHe7XTcyZbVNG9M5zt5uxOpMW8CQ==",
       "dev": true,
       "requires": {
-        "@octokit/request": "3.0.0",
+        "@octokit/request": "3.0.3",
         "atob-lite": "^2.0.0",
         "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
@@ -1582,15 +1570,6 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
       "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
       "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
     },
     "bluebird": {
       "version": "3.5.4",
@@ -2034,13 +2013,13 @@
       }
     },
     "conventional-changelog-core": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz",
-      "integrity": "sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz",
+      "integrity": "sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^4.0.3",
-        "conventional-commits-parser": "^3.0.1",
+        "conventional-changelog-writer": "^4.0.5",
+        "conventional-commits-parser": "^3.0.2",
         "dateformat": "^3.0.0",
         "get-pkg-repo": "^1.0.0",
         "git-raw-commits": "2.0.0",
@@ -2051,13 +2030,13 @@
         "q": "^1.5.1",
         "read-pkg": "^3.0.0",
         "read-pkg-up": "^3.0.0",
-        "through2": "^2.0.0"
+        "through2": "^3.0.0"
       },
       "dependencies": {
         "conventional-commits-parser": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
-          "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.2.tgz",
+          "integrity": "sha512-y5eqgaKR0F6xsBNVSQ/5cI5qIF3MojddSUi1vKIggRkqUTbkqFKH9P5YX/AT1BVZp9DtSzBTIkvjyVLotLsVog==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.0.4",
@@ -2065,7 +2044,7 @@
             "lodash": "^4.2.1",
             "meow": "^4.0.0",
             "split2": "^2.0.0",
-            "through2": "^2.0.0",
+            "through2": "^3.0.0",
             "trim-off-newlines": "^1.0.0"
           }
         },
@@ -2080,6 +2059,18 @@
             "meow": "^4.0.0",
             "split2": "^2.0.0",
             "through2": "^2.0.0"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+              }
+            }
           }
         },
         "meow": {
@@ -2098,6 +2089,15 @@
             "redent": "^2.0.0",
             "trim-newlines": "^2.0.0"
           }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
         }
       }
     },
@@ -2108,13 +2108,13 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
-      "integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.5.tgz",
+      "integrity": "sha512-g/Myp4MaJ1A+f7Ai+SnVhkcWtaHk6flw0SYN7A+vQ+MTu0+gSovQWs4Pg4NtcNUcIztYQ9YHsoxHP+GGQplI7Q==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^2.0.1",
+        "conventional-commits-filter": "^2.0.2",
         "dateformat": "^3.0.0",
         "handlebars": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -2122,7 +2122,7 @@
         "meow": "^4.0.0",
         "semver": "^5.5.0",
         "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "through2": "^3.0.0"
       },
       "dependencies": {
         "meow": {
@@ -2141,6 +2141,15 @@
             "redent": "^2.0.0",
             "trim-newlines": "^2.0.0"
           }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
         }
       }
     },
@@ -2151,12 +2160,12 @@
       "dev": true
     },
     "conventional-commits-filter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
-      "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
+      "integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
+        "lodash.ismatch": "^4.4.0",
         "modify-values": "^1.0.0"
       }
     },
@@ -2220,16 +2229,6 @@
             "inherits": "^2.0.3",
             "readable-stream": "^3.0.2",
             "typedarray": "^0.0.6"
-          }
-        },
-        "conventional-commits-filter": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
-          "integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
-          "dev": true,
-          "requires": {
-            "lodash.ismatch": "^4.4.0",
-            "modify-values": "^1.0.0"
           }
         },
         "conventional-commits-parser": {
@@ -3039,18 +3038,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -4186,12 +4173,6 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
-    "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
-    },
     "is-text-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
@@ -4338,26 +4319,26 @@
       "dev": true
     },
     "lerna": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.13.3.tgz",
-      "integrity": "sha512-0TkG40F02A4wjKraJBztPtj87BjUezFmaZKAha8eLdtngZkSpAdrSANa5K7jnnA8mywmpQwrKJuBmjdNpm9cBw==",
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.13.4.tgz",
+      "integrity": "sha512-qTp22nlpcgVrJGZuD7oHnFbTk72j2USFimc2Pj4kC0/rXmcU2xPtCiyuxLl8y6/6Lj5g9kwEuvKDZtSXujjX/A==",
       "dev": true,
       "requires": {
         "@lerna/add": "3.13.3",
         "@lerna/bootstrap": "3.13.3",
-        "@lerna/changed": "3.13.3",
+        "@lerna/changed": "3.13.4",
         "@lerna/clean": "3.13.3",
         "@lerna/cli": "3.13.0",
         "@lerna/create": "3.13.3",
         "@lerna/diff": "3.13.3",
         "@lerna/exec": "3.13.3",
-        "@lerna/import": "3.13.3",
+        "@lerna/import": "3.13.4",
         "@lerna/init": "3.13.3",
         "@lerna/link": "3.13.3",
         "@lerna/list": "3.13.3",
-        "@lerna/publish": "3.13.3",
+        "@lerna/publish": "3.13.4",
         "@lerna/run": "3.13.3",
-        "@lerna/version": "3.13.3",
+        "@lerna/version": "3.13.4",
         "import-local": "^1.0.0",
         "npmlog": "^4.1.2"
       }
@@ -4872,9 +4853,9 @@
       }
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nice-try": {
@@ -4884,9 +4865,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
       "dev": true
     },
     "node-fetch-npm": {
@@ -4901,12 +4882,11 @@
       }
     },
     "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
+      "integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
       "dev": true,
       "requires": {
-        "fstream": "^1.0.0",
         "glob": "^7.0.3",
         "graceful-fs": "^4.1.2",
         "mkdirp": "^0.5.0",
@@ -4916,7 +4896,7 @@
         "request": "^2.87.0",
         "rimraf": "2",
         "semver": "~5.3.0",
-        "tar": "^2.0.0",
+        "tar": "^4.4.8",
         "which": "1"
       },
       "dependencies": {
@@ -4962,14 +4942,14 @@
       "dev": true
     },
     "npm-lifecycle": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz",
-      "integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.1.tgz",
+      "integrity": "sha512-+Vg6I60Z75V/09pdcH5iUo/99Q/vop35PaI99elvxk56azSVVsdsSsS/sXqKDNwbRRNN1qSxkcO45ZOu0yOWew==",
       "dev": true,
       "requires": {
         "byline": "^5.0.0",
-        "graceful-fs": "^4.1.11",
-        "node-gyp": "^3.8.0",
+        "graceful-fs": "^4.1.15",
+        "node-gyp": "^4.0.0",
         "resolve-from": "^4.0.0",
         "slide": "^1.1.6",
         "uid-number": "0.0.6",
@@ -5364,21 +5344,6 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "tar": {
-          "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -6012,9 +5977,9 @@
       }
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -6478,14 +6443,26 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
       }
     },
     "temp-dir": {
@@ -6690,9 +6667,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
-      "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
+      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6775,9 +6752,9 @@
       }
     },
     "universal-user-agent": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
-      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
+      "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
       "dev": true,
       "requires": {
         "os-name": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coveralls": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^2.0.0",
-    "lerna": "^3.13.3",
+    "lerna": "^3.13.4",
     "tslint": "^5.15.0",
     "typescript": "^3.4.3"
   },


### PR DESCRIPTION
Fix the vulnerabilities reported by `npm audit`

```
found 8 high severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
jannyhous-mbp:loopback-next jannyhou$ npm audit fix
+ lerna@3.13.4
added 7 packages from 8 contributors, removed 8 packages, updated 20 packages and moved 1 package in 18.094s
fixed 8 of 8 vulnerabilities in 43076 scanned packages
jannyhous-mbp:loopback-next jannyhou$ npm audit fix
up to date in 3.403s
fixed 0 of 0 vulnerabilities in 42851 scanned packages
```