### PR TITLE
feat(openapi-v3): allow controller to reference models via openapispec

### DIFF
--- a/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
@@ -3,10 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ParameterObject, SchemaObject} from '@loopback/openapi-v3-types';
-import {model, property} from '@loopback/repository';
+import {
+  OperationObject,
+  ParameterObject,
+  SchemaObject,
+} from '@loopback/openapi-v3-types';
+import {Entity, model, property} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
 import {
+  api,
   ControllerSpec,
   get,
   getControllerSpec,
@@ -200,6 +205,313 @@ describe('controller spec', () => {
       '200': {
         description: 'hello world',
       },
+    });
+  });
+
+  context('reference models via spec', () => {
+    it('allows operations to provide definitions of referenced models through #/components/schema', () => {
+      class MyController {
+        @get('/todos', {
+          responses: {
+            '200': {
+              description: 'Array of Category model instances',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Todo',
+                    definitions: {
+                      Todo: {
+                        title: 'Todo',
+                        properties: {
+                          title: {type: 'string'},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+        async find(): Promise<object[]> {
+          return []; // dummy implementation, it's never called
+        }
+      }
+
+      const spec = getControllerSpec(MyController);
+      const opSpec: OperationObject = spec.paths['/todos'].get;
+      const responseSpec = opSpec.responses['200'].content['application/json'];
+      expect(responseSpec.schema).to.deepEqual({
+        $ref: '#/components/schemas/Todo',
+      });
+
+      const globalSchemas = (spec.components || {}).schemas;
+      expect(globalSchemas).to.deepEqual({
+        Todo: {
+          title: 'Todo',
+          properties: {
+            title: {
+              type: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    it('allows operations to provide definitions of referenced models through #/definitions', () => {
+      class MyController {
+        @get('/todos', {
+          responses: {
+            '200': {
+              description: 'Array of Category model instances',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/definitions/Todo',
+                    definitions: {
+                      Todo: {
+                        title: 'Todo',
+                        properties: {
+                          title: {type: 'string'},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+        async find(): Promise<object[]> {
+          return []; // dummy implementation, it's never called
+        }
+      }
+
+      const spec = getControllerSpec(MyController);
+      const opSpec: OperationObject = spec.paths['/todos'].get;
+      const responseSpec = opSpec.responses['200'].content['application/json'];
+      expect(responseSpec.schema).to.deepEqual({
+        $ref: '#/definitions/Todo',
+      });
+
+      const globalSchemas = (spec.components || {}).schemas;
+      expect(globalSchemas).to.deepEqual({
+        Todo: {
+          title: 'Todo',
+          properties: {
+            title: {
+              type: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    it('allows operations to get definitions of models when defined through a different method', async () => {
+      @model()
+      class Todo extends Entity {
+        @property({
+          type: 'string',
+          required: true,
+        })
+        title: string;
+      }
+
+      class MyController {
+        @get('/todos', {
+          responses: {
+            '200': {
+              description: 'Array of Category model instances',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/definitions/Todo',
+                    definitions: {
+                      Todo: {
+                        title: 'Todo',
+                        properties: {
+                          title: {type: 'string'},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+        async find(): Promise<object[]> {
+          return []; // dummy implementation, it's never called
+        }
+
+        @get('/todos/{id}', {
+          responses: {
+            '200': {
+              content: {
+                'application/json': {
+                  schema: {$ref: '#/components/schemas/Todo'},
+                },
+              },
+            },
+          },
+        })
+        async findById(): Promise<Todo> {
+          return new Todo();
+        }
+      }
+
+      const spec = getControllerSpec(MyController);
+      const opSpec: OperationObject = spec.paths['/todos/{id}'].get;
+      const responseSpec = opSpec.responses['200'].content['application/json'];
+      expect(responseSpec.schema).to.deepEqual({
+        $ref: '#/components/schemas/Todo',
+      });
+
+      const controller = new MyController();
+      const todo = await controller.findById();
+      expect(todo instanceof Todo).to.be.true();
+    });
+
+    it('returns undefined when it cannot find definition of referenced model', () => {
+      class MyController {
+        @get('/todos', {
+          responses: {
+            '200': {
+              description: 'Array of Category model instances',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/definitions/Todo',
+                  },
+                },
+              },
+            },
+          },
+        })
+        async find(): Promise<object[]> {
+          return []; // dummy implementation, it's never called
+        }
+      }
+
+      const spec = getControllerSpec(MyController);
+      const globalSchemas = (spec.components || {}).schemas;
+      expect(globalSchemas).to.be.undefined();
+    });
+
+    it('gets definition from outside the method decorator when it is not provided', () => {
+      @api({
+        paths: {},
+        components: {
+          schemas: {
+            Todo: {
+              title: 'Todo',
+              properties: {
+                title: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      })
+      class MyController {
+        @get('/todos', {
+          responses: {
+            '200': {
+              description: 'Array of Category model instances',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/definitions/Todo',
+                  },
+                },
+              },
+            },
+          },
+        })
+        async find(): Promise<object[]> {
+          return []; // dummy implementation, it's never called
+        }
+      }
+
+      const spec = getControllerSpec(MyController);
+      const opSpec: OperationObject = spec.paths['/todos'].get;
+      const responseSpec = opSpec.responses['200'].content['application/json'];
+      expect(responseSpec.schema).to.deepEqual({
+        $ref: '#/definitions/Todo',
+      });
+
+      const globalSchemas = (spec.components || {}).schemas;
+      expect(globalSchemas).to.deepEqual({
+        Todo: {
+          title: 'Todo',
+          properties: {
+            title: {
+              type: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    it('allows a class to reference schemas at @api level', () => {
+      @api({
+        paths: {
+          '/todos': {
+            get: {
+              'x-operation-name': 'find',
+              'x-controller-name': 'MyController',
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        $ref: '#/components/schemas/Todo',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Todo: {
+              title: 'Todo',
+              properties: {
+                title: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      })
+      class MyController {
+        async find(): Promise<object[]> {
+          return []; // dummy implementation, it's never called
+        }
+      }
+
+      const spec = getControllerSpec(MyController);
+      const opSpec: OperationObject = spec.paths['/todos'].get;
+      const responseSpec = opSpec.responses['200'].content['application/json'];
+      expect(responseSpec.schema).to.deepEqual({
+        $ref: '#/components/schemas/Todo',
+      });
+
+      const globalSchemas = (spec.components || {}).schemas;
+      expect(globalSchemas).to.deepEqual({
+        Todo: {
+          title: 'Todo',
+          properties: {
+            title: {
+              type: 'string',
+            },
+          },
+        },
+      });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/strongloop/loopback-next/issues/2629.

Controller methods can now reference model schema directly via OpenAPI spec and without using the `x-ts-type` extension

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
