### PR TITLE
fix(docs): add life cycle observer cli to sidebar

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -148,7 +148,7 @@ children:
   - title: 'Components'
     url: Components.html
     output: 'web, pdf'
-    
+
   - title: 'Interceptors'
     url: Interceptors.html
     output: 'web, pdf'
@@ -321,6 +321,10 @@ children:
 
   - title: 'OpenAPI generator'
     url: OpenAPI-generator.html
+    output: 'web, pdf'
+
+  - title: 'Life cycle observer generator'
+    url: Life-cycle-observer-generator.html
     output: 'web, pdf'
 
   - title: 'Extension generator'


### PR DESCRIPTION
Add the life cycle observer generator to the sidebar under CLI section https://loopback.io/doc/en/lb4/Command-line-interface.html

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
