### PR TITLE
chore(context): use name comparator consistently

### DIFF
--- a/packages/context/src/__tests__/acceptance/inject-multiple-values.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/inject-multiple-values.acceptance.ts
@@ -104,7 +104,7 @@ describe('@inject.* to receive multiple values matching a filter', async () => {
             public values: number[],
           ) {}
         }
-      }).to.throw('Binding sorter is only allowed with a binding filter');
+      }).to.throw('Binding comparator is only allowed with a binding filter');
     });
   });
 

--- a/packages/context/src/__tests__/unit/context-view.unit.ts
+++ b/packages/context/src/__tests__/unit/context-view.unit.ts
@@ -165,7 +165,7 @@ describe('ContextView', () => {
       expect(await getter()).to.eql(['BAR', 'XYZ', 'FOO']);
     });
 
-    it('creates a getter function for the binding filter and sorter', async () => {
+    it('creates a getter function for the binding filter and comparator', async () => {
       const getter = createViewGetter(server, filterByTag('foo'), (a, b) => {
         return a.key.localeCompare(b.key);
       });

--- a/packages/context/src/context-view.ts
+++ b/packages/context/src/context-view.ts
@@ -44,7 +44,7 @@ export class ContextView<T = unknown> extends EventEmitter
   constructor(
     protected readonly context: Context,
     public readonly filter: BindingFilter,
-    public readonly sorter?: BindingComparator,
+    public readonly comparator?: BindingComparator,
   ) {
     super();
   }
@@ -90,8 +90,8 @@ export class ContextView<T = unknown> extends EventEmitter
   protected findBindings(): Readonly<Binding<T>>[] {
     debug('Finding matching bindings');
     const found = this.context.find(this.filter);
-    if (typeof this.sorter === 'function') {
-      found.sort(this.sorter);
+    if (typeof this.comparator === 'function') {
+      found.sort(this.comparator);
     }
     this._cachedBindings = found;
     return found;

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -441,10 +441,13 @@ export class Context extends EventEmitter {
   /**
    * Create a view of the context chain with the given binding filter
    * @param filter A function to match bindings
-   * @param sorter A function to sort matched bindings
+   * @param comparator A function to sort matched bindings
    */
-  createView<T = unknown>(filter: BindingFilter, sorter?: BindingComparator) {
-    const view = new ContextView<T>(this, filter, sorter);
+  createView<T = unknown>(
+    filter: BindingFilter,
+    comparator?: BindingComparator,
+  ) {
+    const view = new ContextView<T>(this, filter, comparator);
     view.open();
     return view;
   }

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -54,7 +54,7 @@ export interface InjectionMetadata extends ResolutionOptions {
    */
   decorator?: string;
   /**
-   * Optional sorter for matched bindings
+   * Optional comparator for matched bindings
    */
   bindingComparator?: BindingComparator;
   /**
@@ -115,7 +115,7 @@ export function inject(
   }
   const injectionMetadata = Object.assign({decorator: '@inject'}, metadata);
   if (injectionMetadata.bindingComparator && !resolve) {
-    throw new Error('Binding sorter is only allowed with a binding filter');
+    throw new Error('Binding comparator is only allowed with a binding filter');
   }
   return function markParameterOrPropertyAsInjected(
     target: Object,


### PR DESCRIPTION
Use `comparator` instead of `sorter` for parameter names to be consistent.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
