### PR TITLE
fix(repository): always copy property definition during juggler model build (#2912)

### DIFF
--- a/packages/repository/src/__tests__/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -190,6 +190,10 @@ describe('DefaultCrudRepository', () => {
         name: 'Role',
         properties: {name: {type: String}},
       });
+
+      // issue 2912: make sure the juggler leaves the original model definition alone
+      expect(User.definition.properties.roles.itemType).to.equal(Role);
+      expect(User.definition.properties.address.type).to.equal(Address);
     });
   });
 

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -140,13 +140,18 @@ export class DefaultCrudRepository<T extends Entity, ID>
     // We need to convert PropertyDefinition into the definition that
     // the juggler understands
     Object.entries(definition.properties).forEach(([key, value]) => {
+      // always clone value so that we do not modify the original model definition
+      // ensures that model definitions can be reused with multiple datasources
       if (value.type === 'array' || value.type === Array) {
         value = Object.assign({}, value, {
           type: [value.itemType && this.resolvePropertyType(value.itemType)],
         });
         delete value.itemType;
+      } else {
+        value = Object.assign({}, value, {
+          type: this.resolvePropertyType(value.type),
+        });
       }
-      value.type = this.resolvePropertyType(value.type);
       properties[key] = Object.assign({}, value);
     });
     const modelClass = dataSource.createModel<juggler.PersistedModelClass>(


### PR DESCRIPTION
Avoids an issue where it modifies the property definition in a way such that
it can't build a second juggler model from the same definition, e.g.  from
attaching the model to a second datasource.

Fixes #2912

## Checklist

:heavy_check_mark: 👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
