### PR TITLE
feat(build): enable incremental compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ packages/tsdocs/fixtures/monorepo/docs
 /docs/site/readmes
 /docs/apidocs/reports-temp
 /docs/apidocs/models
+*.tsbuildinfo
 
 # TBD: Exclude api reports from git for now
 /docs/apidocs/reports

--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -10,6 +10,8 @@
     // FIXME(bajtos) LB4 is not compatible with this setting yet
     "strictPropertyInitialization": false,
 
+    "incremental": true,
+
     "lib": ["es2018", "esnext.asynciterable"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/packages/cli/generators/project/templates/_.gitignore
+++ b/packages/cli/generators/project/templates/_.gitignore
@@ -62,3 +62,6 @@ api-docs/
 
 # Transpiled JavaScript files from Typescript
 /dist
+
+# Cache used by TypeScript's incremental build
+*.tsbuildinfo

--- a/packages/cli/generators/project/templates/tsconfig.json.ejs
+++ b/packages/cli/generators/project/templates/tsconfig.json.ejs
@@ -17,6 +17,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
 
+    "incremental": true,
+
     "lib": ["es2018", "esnext.asynciterable"],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -116,6 +116,10 @@ describe('app-generator specific files', () => {
     const pkg = JSON.parse(await readFile('package.json'));
     expect(pkg.scripts).to.have.property('migrate', 'node ./dist/migrate');
   });
+
+  it('creates .gitignore', () => {
+    assert.fileContent('.gitignore', /^\*\.tsbuildinfo$/m);
+  });
 });
 
 describe('app-generator with docker disabled', () => {


### PR DESCRIPTION
Enable incremental compilation to speed up our builds. Note: this improvement will apply to projects consuming LoopBack too, once they upgrade to the latest version of `@loopback/build`.

**BEFORE**

```
$ time npm run build
  real  0m35.229s
  user  3m51.223s
  sys   0m14.384s
```

**AFTER**

The first build to populate tsbuildinfo file:

```
$ time npm run build
  real  0m35.692s
  user  3m55.728s
  sys   0m13.828s
```

Subsequent builds (in my case, there were no code changes from the last build):

```
$ time npm run build
  real  0m19.510s
  user  2m3.894s
  sys   0m9.581s
```

I am expecting the build times to improve even more when TypeScript 3.5 is released, see https://devblogs.microsoft.com/typescript/announcing-typescript-3-5-rc/

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈