### PR TITLE
chore: update @param tsdoc comments to use the official format

### DIFF
--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -300,9 +300,9 @@ To make it easy to support asynchronous event processing, we introduce
 ```ts
 /**
  * Listen on `bind`, `unbind`, or other events
- * @param eventType Context event type
- * @param binding The binding as event source
- * @param context Context object for the binding event
+ * @param eventType - Context event type
+ * @param binding - The binding as event source
+ * @param context - Context object for the binding event
  */
 export type ContextObserverFn = (
   eventType: ContextEventType,
@@ -322,8 +322,8 @@ export interface ContextObserver {
 
   /**
    * Listen on `bind`, `unbind`, or other events
-   * @param eventType Context event type
-   * @param binding The binding as event source
+   * @param eventType - Context event type
+   * @param binding - The binding as event source
    */
   observe: ContextObserverFn;
 }

--- a/docs/site/Extending-request-body-parsing.md
+++ b/docs/site/Extending-request-body-parsing.md
@@ -43,12 +43,12 @@ export interface BodyParser {
   name: string | symbol;
   /**
    * Indicate if the given media type is supported
-   * @param mediaType Media type
+   * @param mediaType - Media type
    */
   supports(mediaType: string): boolean;
   /**
    * Parse the request body
-   * @param request http request
+   * @param request - http request
    */
   parse(request: Request): Promise<RequestBody>;
 }

--- a/docs/site/Interceptors.md
+++ b/docs/site/Interceptors.md
@@ -469,8 +469,8 @@ parameters:
  */
 export interface Interceptor {
   /**
-   * @param context Invocation context
-   * @param next A function to invoke next interceptor or the target method
+   * @param context - Invocation context
+   * @param next - A function to invoke next interceptor or the target method
    * @returns A result as value or promise
    */
   (
@@ -513,11 +513,11 @@ bindings. It extends `Context` with additional properties as follows:
 export class InvocationContext extends Context {
   /**
    * Construct a new instance
-   * @param parent Parent context, such as the RequestContext
-   * @param target Target class (for static methods) or prototype/object
+   * @param parent - Parent context, such as the RequestContext
+   * @param target - Target class (for static methods) or prototype/object
    * (for instance methods)
-   * @param methodName Method name
-   * @param args An array of arguments
+   * @param methodName - Method name
+   * @param args - An array of arguments
    */
   constructor(
     parent: Context,

--- a/docs/site/Routing-requests.md
+++ b/docs/site/Routing-requests.md
@@ -68,13 +68,13 @@ below:
 export interface RestRouter {
   /**
    * Add a route to the router
-   * @param route A route entry
+   * @param route - A route entry
    */
   add(route: RouteEntry): boolean;
 
   /**
    * Find a matching route for the given http request
-   * @param request Http request
+   * @param request - Http request
    * @returns The resolved route, if not found, `undefined` is returned
    */
   find(request: Request): ResolvedRoute | undefined;

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -157,8 +157,8 @@ export class CustomSendProvider implements Provider<Send> {
   /**
    * Use the mimeType given in the request's Accept header to convert
    * the response object!
-   * @param response The response object used to reply to the  client.
-   * @param result The result of the operation carried out by the controller's
+   * @param response - The response object used to reply to the  client.
+   * @param result - The result of the operation carried out by the controller's
    * handling function.
    */
   action(response: Response, result: OperationRetval) {

--- a/examples/greeter-extension/README.md
+++ b/examples/greeter-extension/README.md
@@ -126,7 +126,7 @@ export class GreetingService {
   // ...
   /**
    * Find a greeter that can speak the given language
-   * @param language Language code for the greeting
+   * @param language - Language code for the greeting
    */
   async findGreeter(language: string): Promise<Greeter | undefined> {
     // Get the latest list of greeters
@@ -137,8 +137,8 @@ export class GreetingService {
 
   /**
    * Greet in the given language
-   * @param language Language code
-   * @param name Name
+   * @param language - Language code
+   * @param name - Name
    */
   async greet(language: string, name: string): Promise<string> {
     let greeting: string = '';

--- a/examples/greeter-extension/src/greeting-service.ts
+++ b/examples/greeter-extension/src/greeting-service.ts
@@ -38,7 +38,7 @@ export class GreetingService {
 
   /**
    * Find a greeter that can speak the given language
-   * @param language Language code for the greeting
+   * @param language - Language code for the greeting
    */
   async findGreeter(language: string): Promise<Greeter | undefined> {
     // Get the latest list of greeters
@@ -49,8 +49,8 @@ export class GreetingService {
 
   /**
    * Greet in the given language
-   * @param language Language code
-   * @param name Name
+   * @param language - Language code
+   * @param name - Name
    */
   async greet(language: string, name: string): Promise<string> {
     let greeting: string = '';

--- a/examples/log-extension/README.md
+++ b/examples/log-extension/README.md
@@ -185,7 +185,7 @@ import {LevelMetadata} from '../types';
  * if it is set at or greater than Application LogLevel.
  * LOG_LEVEL.DEBUG < LOG_LEVEL.INFO < LOG_LEVEL.WARN < LOG_LEVEL.ERROR < LOG_LEVEL.OFF
  *
- * @param level The Log Level at or above it should log
+ * @param level - The Log Level at or above it should log
  */
 export function log(level?: number) {
   if (level === undefined) level = LOG_LEVEL.WARN;
@@ -200,8 +200,8 @@ export function log(level?: number) {
 /**
  * Fetch log level stored by `@log` decorator.
  *
- * @param controllerClass Target controller
- * @param methodName Target method
+ * @param controllerClass - Target controller
+ * @param methodName - Target method
  */
 export function getLogMetadata(
   controllerClass: Constructor<{}>,

--- a/examples/log-extension/src/decorators/log.decorator.ts
+++ b/examples/log-extension/src/decorators/log.decorator.ts
@@ -16,7 +16,7 @@ import {LevelMetadata} from '../types';
  * if it is set at or greater than Application LogLevel.
  * LOG_LEVEL.DEBUG < LOG_LEVEL.INFO < LOG_LEVEL.WARN < LOG_LEVEL.ERROR < LOG_LEVEL.OFF
  *
- * @param level The Log Level at or above it should log
+ * @param level - The Log Level at or above it should log
  */
 export function log(level?: number) {
   if (level === undefined) level = LOG_LEVEL.WARN;
@@ -31,8 +31,8 @@ export function log(level?: number) {
 /**
  * Fetch log level stored by `@log` decorator.
  *
- * @param controllerClass Target controller
- * @param methodName Target method
+ * @param controllerClass - Target controller
+ * @param methodName - Target method
  */
 export function getLogMetadata(
   controllerClass: Constructor<{}>,

--- a/examples/log-extension/src/mixins/log.mixin.ts
+++ b/examples/log-extension/src/mixins/log.mixin.ts
@@ -33,7 +33,7 @@ export function LogMixin<T extends Constructor<any>>(superClass: T) {
     /**
      * Set minimum logLevel to be displayed.
      *
-     * @param level The log level to set for @log decorator
+     * @param level - The log level to set for @log decorator
      *
      * @example
      * ```ts

--- a/examples/todo-list/src/__tests__/helpers.ts
+++ b/examples/todo-list/src/__tests__/helpers.ts
@@ -27,7 +27,7 @@ import {Todo, TodoList, TodoListImage} from '../models';
 
 /**
  * Generate a complete Todo object for use with tests.
- * @param todo A partial (or complete) Todo object.
+ * @param todo - A partial (or complete) Todo object.
  */
 export function givenTodo(todo?: Partial<Todo>) {
   const data = Object.assign(
@@ -44,7 +44,7 @@ export function givenTodo(todo?: Partial<Todo>) {
 
 /**
  * Generate a complete TodoList object for use with tests
- * @param todoList A partial (or complete) TodoList object.
+ * @param todoList - A partial (or complete) TodoList object.
  */
 export function givenTodoList(todoList?: Partial<TodoList>) {
   const data = Object.assign(
@@ -58,7 +58,7 @@ export function givenTodoList(todoList?: Partial<TodoList>) {
 
 /**
  * Generate a complete TodoListImage object for use with tests.
- * @param todoListImage A partial (or complete) TodoListImage object.
+ * @param todoListImage - A partial (or complete) TodoListImage object.
  */
 export function givenTodoListImage(todoListImage?: Partial<TodoListImage>) {
   const data = Object.assign(

--- a/examples/todo/src/__tests__/helpers.ts
+++ b/examples/todo/src/__tests__/helpers.ts
@@ -32,7 +32,7 @@ import * as GEO_CODER_CONFIG from '../datasources/geocoder.datasource.json';
 
 /**
  * Generate a complete Todo object for use with tests.
- * @param todo A partial (or complete) Todo object.
+ * @param todo - A partial (or complete) Todo object.
  */
 export function givenTodo(todo?: Partial<Todo>) {
   const data = Object.assign(

--- a/packages/authentication/src/decorators/authenticate.decorator.ts
+++ b/packages/authentication/src/decorators/authenticate.decorator.ts
@@ -21,8 +21,8 @@ export interface AuthenticationMetadata {
 /**
  * Mark a controller method as requiring authenticated user.
  *
- * @param strategyName The name of the authentication strategy to use.
- * @param options Additional options to configure the authentication.
+ * @param strategyName - The name of the authentication strategy to use.
+ * @param options - Additional options to configure the authentication.
  */
 export function authenticate(strategyName: string, options?: Object) {
   return MethodDecoratorFactory.createDecorator<AuthenticationMetadata>(
@@ -37,8 +37,8 @@ export function authenticate(strategyName: string, options?: Object) {
 /**
  * Fetch authentication metadata stored by `@authenticate` decorator.
  *
- * @param controllerClass Target controller
- * @param methodName Target method
+ * @param controllerClass - Target controller
+ * @param methodName - Target method
  */
 export function getAuthenticateMetadata(
   controllerClass: Constructor<{}>,

--- a/packages/authentication/src/providers/auth-action.provider.ts
+++ b/packages/authentication/src/providers/auth-action.provider.ts
@@ -40,7 +40,7 @@ export class AuthenticateActionProvider implements Provider<AuthenticateFn> {
 
   /**
    * The implementation of authenticate() sequence action.
-   * @param request The incoming request provided by the REST layer
+   * @param request - The incoming request provided by the REST layer
    */
   async action(request: Request): Promise<UserProfile | undefined> {
     const strategy = await this.getStrategy();

--- a/packages/authentication/src/services/user.service.ts
+++ b/packages/authentication/src/services/user.service.ts
@@ -84,7 +84,7 @@ export interface UserService<U, C> {
    *   }
    * };
    * ```
-   * @param credentials Credentials for basic auth or configurations for 3rd party.
+   * @param credentials - Credentials for basic auth or configurations for 3rd party.
    *                    Example see the
    */
   verifyCredentials(credentials: C): Promise<U>;
@@ -92,7 +92,7 @@ export interface UserService<U, C> {
   /**
    * Convert the user returned by `verifyCredentials()` to a common
    * user profile that describes a user in your application
-   * @param user The user returned from `verifyCredentials()`
+   * @param user - The user returned from `verifyCredentials()`
    */
   convertToUserProfile(user: U): UserProfile;
 }

--- a/packages/authentication/src/strategy-adapter.ts
+++ b/packages/authentication/src/strategy-adapter.ts
@@ -25,7 +25,7 @@ const passportRequestMixin = require('passport/lib/http/request');
  */
 export class StrategyAdapter {
   /**
-   * @param strategy instance of a class which implements a passport-strategy;
+   * @param strategy - instance of a class which implements a passport-strategy;
    * @description http://passportjs.org/
    */
   constructor(private readonly strategy: Strategy) {}
@@ -35,7 +35,7 @@ export class StrategyAdapter {
    *     1. Create an instance of the strategy
    *     2. add success and failure state handlers
    *     3. authenticate using the strategy
-   * @param request The incoming request.
+   * @param request - The incoming request.
    */
   authenticate(request: Request): Promise<UserProfile> {
     return new Promise<UserProfile>((resolve, reject) => {

--- a/packages/boot/src/boot.component.ts
+++ b/packages/boot/src/boot.component.ts
@@ -35,7 +35,7 @@ export class BootComponent implements Component {
 
   /**
    *
-   * @param app Application instance
+   * @param app - Application instance
    */
   constructor(@inject(CoreBindings.APPLICATION_INSTANCE) app: Application) {
     // Bound as a SINGLETON so it can be cached as it has no state

--- a/packages/boot/src/booters/application-metadata.booter.ts
+++ b/packages/boot/src/booters/application-metadata.booter.ts
@@ -16,8 +16,8 @@ const debug = debugModule('loopback:boot:booter:application-metadata');
  *
  * Configure the application with metadata from `package.json`
  *
- * @param app Application instance
- * @param projectRoot Root of User Project
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project
  */
 export class ApplicationMetadataBooter implements Booter {
   constructor(

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -14,8 +14,8 @@ const debug = debugFactory('loopback:boot:booter-utils');
 /**
  * Returns all files matching the given glob pattern relative to root
  *
- * @param pattern A glob pattern
- * @param root Root folder to start searching for matching files
+ * @param pattern - A glob pattern
+ * @param root - Root folder to start searching for matching files
  * @returns {string[]} Array of discovered files
  */
 export async function discoverFiles(
@@ -28,7 +28,7 @@ export async function discoverFiles(
 /**
  * Given a function, returns true if it is a class, false otherwise.
  *
- * @param target The function to check if it's a class or not.
+ * @param target - The function to check if it's a class or not.
  * @returns {boolean} True if target is a class. False otherwise.
  */
 // tslint:disable-next-line:no-any
@@ -43,8 +43,8 @@ export function isClass(target: any): target is Constructor<any> {
  * identifying the exports from the file by getting the keys of the file
  * and then testing each exported member to see if it's a class or not.
  *
- * @param files An array of string of absolute file paths
- * @param projectRootDir The project root directory
+ * @param files - An array of string of absolute file paths
+ * @param projectRootDir - The project root directory
  * @returns {Constructor<{}>[]} An array of Class constructors from a file
  */
 export function loadClassesFromFiles(

--- a/packages/boot/src/booters/controller.booter.ts
+++ b/packages/boot/src/booters/controller.booter.ts
@@ -15,9 +15,9 @@ import {BootBindings} from '../keys';
  *
  * Supported phases: configure, discover, load
  *
- * @param app Application instance
- * @param projectRoot Root of User Project relative to which all paths are resolved
- * @param [bootConfig] Controller Artifact Options Object
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - Controller Artifact Options Object
  */
 export class ControllerBooter extends BaseArtifactBooter {
   constructor(

--- a/packages/boot/src/booters/datasource.booter.ts
+++ b/packages/boot/src/booters/datasource.booter.ts
@@ -20,9 +20,9 @@ import {BootBindings} from '../keys';
  *
  * Supported phases: configure, discover, load
  *
- * @param app Application instance
- * @param projectRoot Root of User Project relative to which all paths are resolved
- * @param [bootConfig] DataSource Artifact Options Object
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - DataSource Artifact Options Object
  */
 export class DataSourceBooter extends BaseArtifactBooter {
   constructor(

--- a/packages/boot/src/booters/lifecyle-observer.booter.ts
+++ b/packages/boot/src/booters/lifecyle-observer.booter.ts
@@ -24,9 +24,9 @@ type LifeCycleObserverClass = Constructor<LifeCycleObserver>;
  *
  * Supported phases: configure, discover, load
  *
- * @param app Application instance
- * @param projectRoot Root of User Project relative to which all paths are resolved
- * @param [bootConfig] LifeCycleObserver Artifact Options Object
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - LifeCycleObserver Artifact Options Object
  */
 export class LifeCycleObserverBooter extends BaseArtifactBooter {
   observers: LifeCycleObserverClass[];

--- a/packages/boot/src/booters/repository.booter.ts
+++ b/packages/boot/src/booters/repository.booter.ts
@@ -17,9 +17,9 @@ import {ArtifactOptions} from '../interfaces';
  *
  * Supported phases: configure, discover, load
  *
- * @param app Application instance
- * @param projectRoot Root of User Project relative to which all paths are resolved
- * @param [bootConfig] Repository Artifact Options Object
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - Repository Artifact Options Object
  */
 export class RepositoryBooter extends BaseArtifactBooter {
   constructor(

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -18,9 +18,9 @@ type ServiceProviderClass = Constructor<Provider<object>>;
  *
  * Supported phases: configure, discover, load
  *
- * @param app Application instance
- * @param projectRoot Root of User Project relative to which all paths are resolved
- * @param [bootConfig] Service Artifact Options Object
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - Service Artifact Options Object
  */
 export class ServiceBooter extends BaseArtifactBooter {
   serviceProviders: ServiceProviderClass[];

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -25,9 +25,9 @@ const debug = debugModule('loopback:boot:bootstrapper');
  * NOTE: Bootstrapper should be bound as a SINGLETON so it can be cached as
  * it does not maintain any state of it's own.
  *
- * @param app Application instance
- * @param projectRoot The root directory of the project, relative to which all other paths are resolved
- * @param [bootOptions] The BootOptions describing the conventions to be used by various Booters
+ * @param app - Application instance
+ * @param projectRoot - The root directory of the project, relative to which all other paths are resolved
+ * @param bootOptions - The BootOptions describing the conventions to be used by various Booters
  */
 export class Bootstrapper {
   constructor(
@@ -51,7 +51,7 @@ export class Bootstrapper {
    * are bound to the Application instance. Each phase of an instance must
    * complete before the next phase is started.
    *
-   * @param {BootExecutionOptions} execOptions Execution options for boot. These
+   * @param execOptions - Execution options for boot. These
    * determine the phases and booters that are run.
    * @param {Context} [ctx] Optional Context to use to resolve bindings. This is
    * primarily useful when running app.boot() again but with different settings

--- a/packages/boot/src/interfaces.ts
+++ b/packages/boot/src/interfaces.ts
@@ -121,7 +121,7 @@ export interface Bootable {
   boot(): Promise<void>;
   /**
    * Register booters
-   * @param booterClasses A list of booter classes
+   * @param booterClasses - A list of booter classes
    */
   booters(...booterClasses: Constructor<Booter>[]): Binding[];
 }

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -77,7 +77,7 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
      * Given a N number of Booter Classes, this method binds them using the
      * prefix and tag expected by the Bootstrapper.
      *
-     * @param booterCls Booter classes to bind to the Application
+     * @param booterCls - Booter classes to bind to the Application
      *
      * @example
      * ```ts
@@ -93,7 +93,7 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
     /**
      * Override to ensure any Booter's on a Component are also mounted.
      *
-     * @param component The component to add.
+     * @param component - The component to add.
      *
      * @example
      * ```ts
@@ -119,7 +119,7 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
      * booters. This function is intended to be used internally
      * by component()
      *
-     * @param component The component to mount booters of
+     * @param component - The component to mount booters of
      */
     mountComponentBooters(component: Constructor<{}>) {
       const componentKey = `components.${component.name}`;
@@ -136,8 +136,8 @@ export function BootMixin<T extends Constructor<any>>(superClass: T) {
  * Method which binds a given Booter to a given Context with the Prefix and
  * Tags expected by the Bootstrapper
  *
- * @param ctx The Context to bind the Booter Class
- * @param booterCls Booter class to be bound
+ * @param ctx - The Context to bind the Booter Class
+ * @param booterCls - Booter class to be bound
  */
 export function _bindBooter(
   ctx: Context,

--- a/packages/build/test/integration/fixtures/src/index.ts
+++ b/packages/build/test/integration/fixtures/src/index.ts
@@ -19,7 +19,7 @@ export class Hello {
 
   /**
    * Return a greeting
-   * @param msg Message
+   * @param msg - Message
    */
   greet(msg: string) {
     return `Hello, ${this.name}: ${msg}`;

--- a/packages/context/src/__tests__/acceptance/inject-multiple-values.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/inject-multiple-values.acceptance.ts
@@ -152,9 +152,9 @@ describe('@inject.* to receive multiple values matching a filter', async () => {
 
   /**
    * Add a workload monitor to the given context
-   * @param ctx Context object
-   * @param name Name of the monitor
-   * @param workload Current workload
+   * @param ctx - Context object
+   * @param name - Name of the monitor
+   * @param workload - Current workload
    */
   function givenWorkloadMonitor(ctx: Context, name: string, workload: number) {
     return ctx

--- a/packages/context/src/binding-decorator.ts
+++ b/packages/context/src/binding-decorator.ts
@@ -54,7 +54,7 @@ class BindDecoratorFactory extends ClassDecoratorFactory<BindingMetadata> {
  * }
  * ```
  *
- * @param specs A list of binding scope/tags or template functions to
+ * @param specs - A list of binding scope/tags or template functions to
  * configure the binding
  */
 export function bind(...specs: BindingSpec[]): ClassDecorator {

--- a/packages/context/src/binding-filter.ts
+++ b/packages/context/src/binding-filter.ts
@@ -62,7 +62,7 @@ export function isBindingAddress(
 
 /**
  * Create a binding filter for the tag pattern
- * @param tagPattern Binding tag name, regexp, or object
+ * @param tagPattern - Binding tag name, regexp, or object
  */
 export function filterByTag(tagPattern: BindingTag | RegExp): BindingFilter {
   if (typeof tagPattern === 'string' || tagPattern instanceof RegExp) {
@@ -85,7 +85,7 @@ export function filterByTag(tagPattern: BindingTag | RegExp): BindingFilter {
 
 /**
  * Create a binding filter from key pattern
- * @param keyPattern Binding key/wildcard, regexp, or a filter function
+ * @param keyPattern - Binding key/wildcard, regexp, or a filter function
  */
 export function filterByKey(
   keyPattern?: string | RegExp | BindingFilter,
@@ -103,7 +103,7 @@ export function filterByKey(
 
 /**
  * Convert a wildcard pattern to RegExp
- * @param pattern A wildcard string with `*` and `?` as special characters.
+ * @param pattern - A wildcard string with `*` and `?` as special characters.
  * - `*` matches zero or more characters except `.` and `:`
  * - `?` matches exactly one character except `.` and `:`
  */

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -47,7 +47,7 @@ export type BindingSpec = BindingTemplate | BindingScopeAndTags;
 
 /**
  * Check if a class implements `Provider` interface
- * @param cls A class
+ * @param cls - A class
  */
 export function isProviderClass(
   cls: Constructor<unknown>,
@@ -58,7 +58,7 @@ export function isProviderClass(
 /**
  * A factory function to create a template function to bind the target class
  * as a `Provider`.
- * @param target Target provider class
+ * @param target - Target provider class
  */
 export function asProvider(
   target: Constructor<Provider<unknown>>,
@@ -72,7 +72,7 @@ export function asProvider(
 /**
  * A factory function to create a template function to bind the target class
  * as a class or `Provider`.
- * @param target Target class, which can be an implementation of `Provider`
+ * @param target - Target class, which can be an implementation of `Provider`
  */
 export function asClassOrProvider(
   target: Constructor<unknown>,
@@ -89,7 +89,7 @@ export function asClassOrProvider(
 
 /**
  * Convert binding scope and tags as a template function
- * @param scopeAndTags Binding scope and tags
+ * @param scopeAndTags - Binding scope and tags
  */
 export function asBindingTemplate(
   scopeAndTags: BindingScopeAndTags,
@@ -110,7 +110,7 @@ export function asBindingTemplate(
 
 /**
  * Get binding metadata for a class
- * @param target The target class
+ * @param target - The target class
  */
 export function getBindingMetadata(
   target: Function,
@@ -134,7 +134,7 @@ export function removeNameAndKeyTags(binding: Binding<unknown>) {
 /**
  * Get the binding template for a class with binding metadata
  *
- * @param cls A class with optional `@bind`
+ * @param cls - A class with optional `@bind`
  */
 export function bindingTemplateFor<T = unknown>(
   cls: Constructor<T | Provider<T>>,
@@ -208,8 +208,8 @@ export type BindingFromClassOptions = {
  * - `binding.toProvider(cls)`: it `cls` is a value provider class with a
  * prototype method `value()`
  *
- * @param cls A class. It can be either a plain class or  a value provider class
- * @param options Options to customize the binding key
+ * @param cls - A class. It can be either a plain class or  a value provider class
+ * @param options - Options to customize the binding key
  */
 export function createBindingFromClass<T = unknown>(
   cls: Constructor<T | Provider<T>>,
@@ -235,8 +235,8 @@ export function createBindingFromClass<T = unknown>(
 
 /**
  * Find/infer binding key namespace for a type
- * @param type Artifact type, such as `controller`, `datasource`, or `server`
- * @param typeNamespaces An object mapping type names to namespaces
+ * @param type - Artifact type, such as `controller`, `datasource`, or `server`
+ * @param typeNamespaces - An object mapping type names to namespaces
  */
 function getNamespace(type: string, typeNamespaces = DEFAULT_TYPE_NAMESPACES) {
   if (type in typeNamespaces) {
@@ -265,8 +265,8 @@ function getNamespace(type: string, typeNamespaces = DEFAULT_TYPE_NAMESPACES) {
  *     - `name` tag value
  *     - the class name
  *
- * @param cls A class to be bound
- * @param options Options to customize how to build the key
+ * @param cls - A class to be bound
+ * @param options - Options to customize how to build the key
  */
 function buildBindingKey(
   cls: Constructor<unknown>,

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -20,9 +20,9 @@ export class BindingKey<ValueType> {
    * BindingKey.create<number>('config#rest.port');
    * ```
    *
-   * @param key The binding key. When propertyPath is not provided, the key
+   * @param key - The binding key. When propertyPath is not provided, the key
    *   is allowed to contain propertyPath as encoded via `BindingKey#toString()`
-   * @param propertyPath Optional path to a deep property of the bound value.
+   * @param propertyPath - Optional path to a deep property of the bound value.
    */
   public static create<ValueType>(
     key: string,
@@ -54,7 +54,7 @@ export class BindingKey<ValueType> {
    * Get a binding address for retrieving a deep property of the object
    * bound to the current binding key.
    *
-   * @param propertyPath A dot-separated path to a (deep) property, e.g. "server.port".
+   * @param propertyPath - A dot-separated path to a (deep) property, e.g. "server.port".
    */
   deepProperty<PropertyValueType>(propertyPath: string) {
     // TODO(bajtos) allow chaining of propertyPaths, e.g.
@@ -67,7 +67,7 @@ export class BindingKey<ValueType> {
    * Validate the binding key format. Please note that `#` is reserved.
    * Returns a string representation of the binding key.
    *
-   * @param key Binding key, such as `a`, `a.b`, `a:b`, or `a/b`
+   * @param key - Binding key, such as `a`, `a.b`, `a:b`, or `a/b`
    */
   static validate<T>(key: BindingAddress<T>): string {
     if (!key) throw new Error('Binding key must be provided.');
@@ -85,7 +85,7 @@ export class BindingKey<ValueType> {
    * Parse a string containing both the binding key and the path to the deeply
    * nested property to retrieve.
    *
-   * @param keyWithPath The key with an optional path,
+   * @param keyWithPath - The key with an optional path,
    *  e.g. "application.instance" or "config#rest.port".
    */
   static parseKeyWithPath<T>(keyWithPath: BindingAddress<T>): BindingKey<T> {

--- a/packages/context/src/binding-sorter.ts
+++ b/packages/context/src/binding-sorter.ts
@@ -17,8 +17,8 @@ import {Binding} from './binding';
 export interface BindingComparator {
   /**
    * Compare two bindings
-   * @param bindingA First binding
-   * @param bindingB Second binding
+   * @param bindingA - First binding
+   * @param bindingB - Second binding
    * @returns A number to determine order of bindingA and bindingB
    * - 0 leaves bindingA and bindingB unchanged
    * - <0 bindingA comes before bindingB
@@ -46,8 +46,8 @@ export interface BindingComparator {
  * ordered by phase names alphabetically and symbol values come before string
  * values.
  *
- * @param phaseTagName Name of the binding tag for phase
- * @param orderOfPhases An array of phase names as the predefined order
+ * @param phaseTagName - Name of the binding tag for phase
+ * @param orderOfPhases - An array of phase names as the predefined order
  */
 export function compareBindingsByTag(
   phaseTagName: string = 'phase',
@@ -76,9 +76,9 @@ export function compareBindingsByTag(
  *   - symbol values come before string values
  *   - alphabetical order for two symbols or two strings
  *
- * @param a First value
- * @param b Second value
- * @param order An array of values as the predefined order
+ * @param a - First value
+ * @param b - Second value
+ * @param order - An array of values as the predefined order
  */
 export function compareByOrder(
   a: string | symbol | undefined | null,
@@ -109,11 +109,11 @@ export function compareByOrder(
 /**
  * Sort bindings by phase names denoted by a tag and the predefined order
  *
- * @param bindings An array of bindings
- * @param phaseTagName Tag name for phase, for example, we can use the value
+ * @param bindings - An array of bindings
+ * @param phaseTagName - Tag name for phase, for example, we can use the value
  * `'a'` of tag `order` as the phase name for `binding.tag({order: 'a'})`.
  *
- * @param orderOfPhases An array of phase names as the predefined order
+ * @param orderOfPhases - An array of phase names as the predefined order
  */
 export function sortBindingsByPhase(
   bindings: Readonly<Binding<unknown>>[],

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -194,8 +194,8 @@ export class Binding<T = BoundValue> {
 
   /**
    * Cache the resolved value by the binding scope
-   * @param ctx The current context
-   * @param result The calculated value for the binding
+   * @param ctx - The current context
+   * @param result - The calculated value for the binding
    */
   private _cacheValue(
     ctx: Context,
@@ -247,8 +247,8 @@ export class Binding<T = BoundValue> {
    * }
    * ```
    *
-   * @param ctx Context for the resolution
-   * @param session Optional session for binding and dependency resolution
+   * @param ctx - Context for the resolution
+   * @param session - Optional session for binding and dependency resolution
    */
   getValue(ctx: Context, session?: ResolutionSession): ValueOrPromise<T>;
 
@@ -256,8 +256,8 @@ export class Binding<T = BoundValue> {
    * Returns a value or promise for this binding in the given context. The
    * resolved value can be `undefined` if `optional` is set to `true` in
    * `options`.
-   * @param ctx Context for the resolution
-   * @param options Optional options for binding and dependency resolution
+   * @param ctx - Context for the resolution
+   * @param options - Optional options for binding and dependency resolution
    */
   getValue(
     ctx: Context,
@@ -312,7 +312,7 @@ export class Binding<T = BoundValue> {
    * Tag the binding with names or name/value objects. A tag has a name and
    * an optional value. If not supplied, the tag name is used as the value.
    *
-   * @param tags A list of names or name/value objects. Each
+   * @param tags - A list of names or name/value objects. Each
    * parameter can be in one of the following forms:
    * - string: A tag name without value
    * - string[]: An array of tag names
@@ -358,7 +358,7 @@ export class Binding<T = BoundValue> {
 
   /**
    * Set the binding scope
-   * @param scope Binding scope
+   * @param scope - Binding scope
    */
   inScope(scope: BindingScope): this {
     if (this._scope !== scope) this._clearCache();
@@ -369,7 +369,7 @@ export class Binding<T = BoundValue> {
   /**
    * Apply default scope to the binding. It only changes the scope if it's not
    * set yet
-   * @param scope Default binding scope
+   * @param scope - Default binding scope
    */
   applyDefaultScope(scope: BindingScope): this {
     if (!this._scope) {
@@ -380,7 +380,7 @@ export class Binding<T = BoundValue> {
 
   /**
    * Set the `_getValue` function
-   * @param getValue getValue function
+   * @param getValue - getValue function
    */
   private _setValueGetter(getValue: ValueGetter<T>) {
     // Clear the cache
@@ -401,7 +401,7 @@ export class Binding<T = BoundValue> {
    * Bind the key to a constant value. The value must be already available
    * at binding time, it is not allowed to pass a Promise instance.
    *
-   * @param value The bound value.
+   * @param value - The bound value.
    *
    * @example
    *
@@ -443,7 +443,7 @@ export class Binding<T = BoundValue> {
   /**
    * Bind the key to a computed (dynamic) value.
    *
-   * @param factoryFn The factory function creating the value.
+   * @param factoryFn - The factory function creating the value.
    *   Both sync and async functions are supported.
    *
    * @example
@@ -482,7 +482,7 @@ export class Binding<T = BoundValue> {
    * }
    * ```
    *
-   * @param provider The value provider to use.
+   * @param provider - The value provider to use.
    */
   toProvider(providerClass: Constructor<Provider<T>>): this {
     /* istanbul ignore if */
@@ -504,7 +504,7 @@ export class Binding<T = BoundValue> {
   /**
    * Bind the key to an instance of the given class.
    *
-   * @param ctor The class constructor to call. Any constructor
+   * @param ctor - The class constructor to call. Any constructor
    *   arguments must be annotated with `@inject` so that
    *   we can resolve them from the context.
    */
@@ -525,7 +525,7 @@ export class Binding<T = BoundValue> {
 
   /**
    * Bind the key to an alias of another binding
-   * @param keyWithPath Target binding key with optional path,
+   * @param keyWithPath - Target binding key with optional path,
    * such as `servers.RestServer.options#apiExplorer`
    */
   toAlias(keyWithPath: BindingAddress<T>) {
@@ -560,7 +560,7 @@ export class Binding<T = BoundValue> {
    * const serverBinding = new Binding<RestServer>('servers.RestServer1');
    * serverBinding.apply(serverTemplate);
    * ```
-   * @param templateFns One or more functions to configure the binding
+   * @param templateFns - One or more functions to configure the binding
    */
   apply(...templateFns: BindingTemplate<T>[]): this {
     for (const fn of templateFns) {
@@ -587,7 +587,7 @@ export class Binding<T = BoundValue> {
    * A static method to create a binding so that we can do
    * `Binding.bind('foo').to('bar');` as `new Binding('foo').to('bar')` is not
    * easy to read.
-   * @param key Binding key
+   * @param key - Binding key
    */
   static bind<T = unknown>(key: BindingAddress<T>): Binding<T> {
     return new Binding(key.toString());

--- a/packages/context/src/context-observer.ts
+++ b/packages/context/src/context-observer.ts
@@ -16,9 +16,9 @@ export type ContextEventType = 'bind' | 'unbind' | string;
 
 /**
  * Listen on `bind`, `unbind`, or other events
- * @param eventType Context event type
- * @param binding The binding as event source
- * @param context Context object for the binding event
+ * @param eventType - Context event type
+ * @param binding - The binding as event source
+ * @param context - Context object for the binding event
  */
 export type ContextObserverFn = (
   eventType: ContextEventType,
@@ -38,8 +38,8 @@ export interface ContextObserver {
 
   /**
    * Listen on `bind`, `unbind`, or other events
-   * @param eventType Context event type
-   * @param binding The binding as event source
+   * @param eventType - Context event type
+   * @param binding - The binding as event source
    */
   observe: ContextObserverFn;
 }

--- a/packages/context/src/context-view.ts
+++ b/packages/context/src/context-view.ts
@@ -116,7 +116,7 @@ export class ContextView<T = unknown> extends EventEmitter
 
   /**
    * Resolve values for the matching bindings
-   * @param session Resolution session
+   * @param session - Resolution session
    */
   resolve(session?: ResolutionSession): ValueOrPromise<T[]> {
     debug('Resolving values');
@@ -161,9 +161,9 @@ export class ContextView<T = unknown> extends EventEmitter
 
 /**
  * Create a context view as a getter with the given filter
- * @param ctx Context object
- * @param bindingFilter A function to match bindings
- * @param session Resolution session
+ * @param ctx - Context object
+ * @param bindingFilter - A function to match bindings
+ * @param session - Resolution session
  */
 export function createViewGetter<T = unknown>(
   ctx: Context,
@@ -174,10 +174,10 @@ export function createViewGetter<T = unknown>(
 /**
  * Create a context view as a getter with the given filter and sort matched
  * bindings by the comparator.
- * @param ctx Context object
- * @param bindingFilter A function to match bindings
- * @param bindingComparator A function to compare two bindings
- * @param session Resolution session
+ * @param ctx - Context object
+ * @param bindingFilter - A function to match bindings
+ * @param bindingComparator - A function to compare two bindings
+ * @param session - Resolution session
  */
 export function createViewGetter<T = unknown>(
   ctx: Context,
@@ -188,11 +188,11 @@ export function createViewGetter<T = unknown>(
 
 /**
  * Create a context view as a getter
- * @param ctx Context object
- * @param bindingFilter A function to match bindings
- * @param bindingComparatorOrSession A function to sort matched bindings or
+ * @param ctx - Context object
+ * @param bindingFilter - A function to match bindings
+ * @param bindingComparatorOrSession - A function to sort matched bindings or
  * resolution session if the comparator is not needed
- * @param session Resolution session if the comparator is provided
+ * @param session - Resolution session if the comparator is provided
  */
 export function createViewGetter<T = unknown>(
   ctx: Context,

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -115,8 +115,8 @@ export class Context extends EventEmitter {
    * // from `appCtx`
    * const reqCtx = new Context(appCtx, 'request');
    * ```
-   * @param _parent The optional parent context
-   * @param name Name of the context, if not provided, a `uuid` will be
+   * @param _parent - The optional parent context
+   * @param name - Name of the context, if not provided, a `uuid` will be
    * generated as the name
    */
   constructor(_parent?: Context | string, name?: string) {
@@ -132,7 +132,7 @@ export class Context extends EventEmitter {
   /**
    * Wrap the debug statement so that it always print out the context name
    * as the prefix
-   * @param args Arguments for the debug
+   * @param args - Arguments for the debug
    */
   // tslint:disable-next-line:no-any
   private _debug(...args: any[]) {
@@ -173,7 +173,7 @@ export class Context extends EventEmitter {
   /**
    * Add an event listener to its parent context so that this context will
    * be notified of parent events, such as `bind` or `unbind`.
-   * @param event Event name
+   * @param event - Event name
    */
   private addParentEventListener(event: string) {
     if (this._parent == null) return;
@@ -215,7 +215,7 @@ export class Context extends EventEmitter {
 
   /**
    * Handle errors caught during the notification of observers
-   * @param err Error
+   * @param err - Error
    */
   private handleNotificationError(err: unknown) {
     // Bubbling up the error event over the context chain
@@ -281,7 +281,7 @@ export class Context extends EventEmitter {
   /**
    * Listen on given event types and emit `notification` event. This method
    * merge multiple event types into one for notification.
-   * @param eventTypes Context event types
+   * @param eventTypes - Context event types
    */
   private setupNotification(...eventTypes: ContextEventType[]) {
     for (const eventType of eventTypes) {
@@ -320,7 +320,7 @@ export class Context extends EventEmitter {
    * Create a binding with the given key in the context. If a locked binding
    * already exists with the same key, an error will be thrown.
    *
-   * @param key Binding key
+   * @param key - Binding key
    */
   bind<ValueType = BoundValue>(
     key: BindingAddress<ValueType>,
@@ -333,7 +333,7 @@ export class Context extends EventEmitter {
   /**
    * Add a binding to the context. If a locked binding already exists with the
    * same key, an error will be thrown.
-   * @param binding The configured binding to be added
+   * @param binding - The configured binding to be added
    */
   add(binding: Binding<unknown>): this {
     const key = binding.key;
@@ -366,7 +366,7 @@ export class Context extends EventEmitter {
    * return ownerCtx != null && ownerCtx.unbind(key);
    * ```
    *
-   * @param key Binding key
+   * @param key - Binding key
    * @returns true if the binding key is found and removed from this context
    */
   unbind(key: BindingAddress): boolean {
@@ -384,7 +384,7 @@ export class Context extends EventEmitter {
 
   /**
    * Add a context event observer to the context
-   * @param observer Context observer instance or function
+   * @param observer - Context observer instance or function
    */
   subscribe(observer: ContextEventObserver): Subscription {
     this.observers = this.observers || new Set();
@@ -395,7 +395,7 @@ export class Context extends EventEmitter {
 
   /**
    * Remove the context event observer from the context
-   * @param observer Context event observer
+   * @param observer - Context event observer
    */
   unsubscribe(observer: ContextEventObserver): boolean {
     if (!this.observers) return false;
@@ -431,7 +431,7 @@ export class Context extends EventEmitter {
 
   /**
    * Check if an observer is subscribed to this context
-   * @param observer Context observer
+   * @param observer - Context observer
    */
   isSubscribed(observer: ContextObserver) {
     if (!this.observers) return false;
@@ -440,8 +440,8 @@ export class Context extends EventEmitter {
 
   /**
    * Create a view of the context chain with the given binding filter
-   * @param filter A function to match bindings
-   * @param comparator A function to sort matched bindings
+   * @param filter - A function to match bindings
+   * @param comparator - A function to sort matched bindings
    */
   createView<T = unknown>(
     filter: BindingFilter,
@@ -458,10 +458,10 @@ export class Context extends EventEmitter {
    * APIs such as `ctx.bind('key').to(...).tag(...);` and give observers the
    * fully populated binding.
    *
-   * @param eventType Event names: `bind` or `unbind`
-   * @param binding Binding bound or unbound
-   * @param context Owner context
-   * @param observers Current set of context observers
+   * @param eventType - Event names: `bind` or `unbind`
+   * @param binding - Binding bound or unbound
+   * @param context - Owner context
+   * @param observers - Current set of context observers
    */
   protected async notifyObservers(
     eventType: ContextEventType,
@@ -483,7 +483,7 @@ export class Context extends EventEmitter {
   /**
    * Check if a binding exists with the given key in the local context without
    * delegating to the parent context
-   * @param key Binding key
+   * @param key - Binding key
    */
   contains(key: BindingAddress): boolean {
     key = BindingKey.validate(key);
@@ -492,7 +492,7 @@ export class Context extends EventEmitter {
 
   /**
    * Check if a key is bound in the context or its ancestors
-   * @param key Binding key
+   * @param key - Binding key
    */
   isBound(key: BindingAddress): boolean {
     if (this.contains(key)) return true;
@@ -504,7 +504,7 @@ export class Context extends EventEmitter {
 
   /**
    * Get the owning context for a binding key
-   * @param key Binding key
+   * @param key - Binding key
    */
   getOwnerContext(key: BindingAddress): Context | undefined {
     if (this.contains(key)) return this;
@@ -516,7 +516,7 @@ export class Context extends EventEmitter {
 
   /**
    * Find bindings using a key pattern or filter function
-   * @param pattern A filter function, a regexp or a wildcard pattern with
+   * @param pattern - A filter function, a regexp or a wildcard pattern with
    * optional `*` and `?`. Find returns such bindings where the key matches
    * the provided pattern.
    *
@@ -594,9 +594,9 @@ export class Context extends EventEmitter {
    * const a = await ctx.get<number>('data#numbers.a');
    * ```
    *
-   * @param keyWithPath The binding key, optionally suffixed with a path to the
+   * @param keyWithPath - The binding key, optionally suffixed with a path to the
    *   (deeply) nested property to retrieve.
-   * @param session Optional session for resolution (accepted for backward
+   * @param session - Optional session for resolution (accepted for backward
    * compatibility)
    * @returns A promise of the bound value.
    */
@@ -619,9 +619,9 @@ export class Context extends EventEmitter {
    * });
    * ```
    *
-   * @param keyWithPath The binding key, optionally suffixed with a path to the
+   * @param keyWithPath - The binding key, optionally suffixed with a path to the
    *   (deeply) nested property to retrieve.
-   * @param options Options for resolution.
+   * @param options - Options for resolution.
    * @returns A promise of the bound value, or a promise of undefined when
    * the optional binding is not found.
    */
@@ -660,9 +660,9 @@ export class Context extends EventEmitter {
    * const config = await ctx.getSync<RestComponentConfig>('config#rest');
    * ```
    *
-   * @param keyWithPath The binding key, optionally suffixed with a path to the
+   * @param keyWithPath - The binding key, optionally suffixed with a path to the
    *   (deeply) nested property to retrieve.
-   * @param session Session for resolution (accepted for backward compatibility)
+   * @param session - Session for resolution (accepted for backward compatibility)
    * @returns A promise of the bound value.
    */
   getSync<ValueType>(
@@ -688,9 +688,9 @@ export class Context extends EventEmitter {
    * });
    * ```
    *
-   * @param keyWithPath The binding key, optionally suffixed with a path to the
+   * @param keyWithPath - The binding key, optionally suffixed with a path to the
    *   (deeply) nested property to retrieve.
-   * @param options Options for resolution.
+   * @param options - Options for resolution.
    * @returns The bound value, or undefined when an optional binding is not found.
    */
   getSync<ValueType>(
@@ -723,7 +723,7 @@ export class Context extends EventEmitter {
    * Look up a binding by key in the context and its ancestors. If no matching
    * binding is found, an error will be thrown.
    *
-   * @param key Binding key
+   * @param key - Binding key
    */
   getBinding<ValueType = BoundValue>(
     key: BindingAddress<ValueType>,
@@ -734,8 +734,8 @@ export class Context extends EventEmitter {
    * binding is found and `options.optional` is not set to true, an error will
    * be thrown.
    *
-   * @param key Binding key
-   * @param options Options to control if the binding is optional. If
+   * @param key - Binding key
+   * @param options - Options to control if the binding is optional. If
    * `options.optional` is set to true, the method will return `undefined`
    * instead of throwing an error if the binding key is not found.
    */
@@ -766,8 +766,8 @@ export class Context extends EventEmitter {
 
   /**
    * Find or create a binding for the given key
-   * @param key Binding address
-   * @param policy Binding creation policy
+   * @param key - Binding address
+   * @param policy - Binding creation policy
    */
   findOrCreateBinding<T>(
     key: BindingAddress<T>,
@@ -808,9 +808,9 @@ export class Context extends EventEmitter {
    * ctx.getValueOrPromise<number>('data#numbers.a');
    * ```
    *
-   * @param keyWithPath The binding key, optionally suffixed with a path to the
+   * @param keyWithPath - The binding key, optionally suffixed with a path to the
    *   (deeply) nested property to retrieve.
-   * @param optionsOrSession Options for resolution or a session
+   * @param optionsOrSession - Options for resolution or a session
    * @returns The bound value or a promise of the bound value, depending
    *   on how the binding is configured.
    * @internal

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -99,10 +99,10 @@ export interface Injection<ValueType = BoundValue> {
  *
  *  - TODO(bajtos)
  *
- * @param bindingSelector What binding to use in order to resolve the value of the
+ * @param bindingSelector - What binding to use in order to resolve the value of the
  * decorated constructor parameter or property.
- * @param metadata Optional metadata to help the injection
- * @param resolve Optional function to resolve the injection
+ * @param metadata - Optional metadata to help the injection
+ * @param resolve - Optional function to resolve the injection
  *
  */
 export function inject(
@@ -216,7 +216,7 @@ export namespace Getter {
  * ```ts
  * setterFn('my-value');
  * ```
- * @param value The value for the underlying binding
+ * @param value - The value for the underlying binding
  */
 export type Setter<T> = (value: T) => void;
 
@@ -241,9 +241,9 @@ export namespace inject {
    *
    * See also `Getter<T>`.
    *
-   * @param bindingSelector The binding key or filter we want to eventually get
+   * @param bindingSelector - The binding key or filter we want to eventually get
    * value(s) from.
-   * @param metadata Optional metadata to help the injection
+   * @param metadata - Optional metadata to help the injection
    */
   export const getter = function injectGetter(
     bindingSelector: BindingSelector<unknown>,
@@ -269,8 +269,8 @@ export namespace inject {
    *
    * See also `Setter<T>`.
    *
-   * @param bindingKey The key of the value we want to set.
-   * @param metadata Optional metadata to help the injection
+   * @param bindingKey - The key of the value we want to set.
+   * @param metadata - Optional metadata to help the injection
    */
   export const setter = function injectSetter(
     bindingKey: BindingAddress,
@@ -302,8 +302,8 @@ export namespace inject {
    * }
    * ```
    *
-   * @param bindingKey Binding key
-   * @param metadata Metadata for the injection
+   * @param bindingKey - Binding key
+   * @param metadata - Metadata for the injection
    */
   export const binding = function injectBinding(
     bindingKey: BindingAddress,
@@ -324,8 +324,8 @@ export namespace inject {
    *   ) {}
    * }
    * ```
-   * @param bindingTag Tag name, regex or object
-   * @param metadata Optional metadata to help the injection
+   * @param bindingTag - Tag name, regex or object
+   * @param metadata - Optional metadata to help the injection
    */
   export const tag = function injectByTag(
     bindingTag: BindingTag | RegExp,
@@ -348,7 +348,7 @@ export namespace inject {
    *   view: ContextView<string[]>;
    * }
    * ```
-   * @param bindingFilter A binding filter function
+   * @param bindingFilter - A binding filter function
    * @param metadata
    */
   export const view = function injectContextView(
@@ -377,9 +377,9 @@ export namespace inject {
 /**
  * Assert the target type inspected from TypeScript for injection to be the
  * expected type. If the types don't match, an error is thrown.
- * @param injection Injection information
- * @param expectedType Expected type
- * @param expectedTypeName Name of the expected type to be used in the error
+ * @param injection - Injection information
+ * @param expectedType - Expected type
+ * @param expectedTypeName - Name of the expected type to be used in the error
  * @returns The name of the target
  */
 export function assertTargetType(
@@ -471,9 +471,9 @@ function findOrCreateBindingForInjection(
 
 /**
  * Return an array of injection objects for parameters
- * @param target The target class for constructor or static methods,
+ * @param target - The target class for constructor or static methods,
  * or the prototype for instance methods
- * @param method Method name, undefined for constructor
+ * @param method - Method name, undefined for constructor
  */
 export function describeInjectedArguments(
   target: Object,
@@ -504,7 +504,7 @@ export function describeInjectedArguments(
 /**
  * Inspect the target type for the injection to find out the corresponding
  * JavaScript type
- * @param injection Injection information
+ * @param injection - Injection information
  */
 function inspectTargetType(injection: Readonly<Injection>) {
   let type = MetadataInspector.getDesignTypeForProperty(
@@ -527,9 +527,9 @@ function inspectTargetType(injection: Readonly<Injection>) {
 
 /**
  * Resolve an array of bound values matching the filter function for `@inject`.
- * @param ctx Context object
- * @param injection Injection information
- * @param session Resolution session
+ * @param ctx - Context object
+ * @param injection - Injection information
+ * @param session - Resolution session
  */
 function resolveValuesByFilter(
   ctx: Context,
@@ -550,9 +550,9 @@ function resolveValuesByFilter(
  * Resolve to a getter function that returns an array of bound values matching
  * the filter function for `@inject.getter`.
  *
- * @param ctx Context object
- * @param injection Injection information
- * @param session Resolution session
+ * @param ctx - Context object
+ * @param injection - Injection information
+ * @param session - Resolution session
  */
 function resolveAsGetterByFilter(
   ctx: Context,
@@ -572,8 +572,8 @@ function resolveAsGetterByFilter(
 /**
  * Resolve to an instance of `ContextView` by the binding filter function
  * for `@inject.view`
- * @param ctx Context object
- * @param injection Injection information
+ * @param ctx - Context object
+ * @param injection - Injection information
  */
 function resolveAsContextView(ctx: Context, injection: Readonly<Injection>) {
   assertTargetType(injection, ContextView);
@@ -590,7 +590,7 @@ function resolveAsContextView(ctx: Context, injection: Readonly<Injection>) {
 
 /**
  * Return a map of injection objects for properties
- * @param target The target class for static properties or
+ * @param target - The target class for static properties or
  * prototype for instance properties.
  */
 export function describeInjectedProperties(

--- a/packages/context/src/interception-proxy.ts
+++ b/packages/context/src/interception-proxy.ts
@@ -87,8 +87,8 @@ export class InterceptionHandler<T extends object> implements ProxyHandler<T> {
 
 /**
  * Create a proxy that applies interceptors for method invocations
- * @param target Target class or object
- * @param context Context object
+ * @param target - Target class or object
+ * @param context - Context object
  */
 export function createProxyWithInterceptors<T extends object>(
   target: T,

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -53,11 +53,11 @@ type ClassOrPrototype = any;
 export class InvocationContext extends Context {
   /**
    * Construct a new instance of `InvocationContext`
-   * @param parent Parent context, such as the RequestContext
-   * @param target Target class (for static methods) or prototype/object
+   * @param parent - Parent context, such as the RequestContext
+   * @param target - Target class (for static methods) or prototype/object
    * (for instance methods)
-   * @param methodName Method name
-   * @param args An array of arguments
+   * @param methodName - Method name
+   * @param args - An array of arguments
    */
   constructor(
     parent: Context,
@@ -82,7 +82,7 @@ export class InvocationContext extends Context {
 
   /**
    * Sort global interceptor bindings by `globalInterceptorGroup` tags
-   * @param bindings An array of global interceptor bindings
+   * @param bindings - An array of global interceptor bindings
    */
   private sortGlobalInterceptorBindings(
     bindings: Readonly<Binding<Interceptor>>[],
@@ -155,7 +155,7 @@ export class InvocationContext extends Context {
 
   /**
    * Assert the method exists on the target. An error will be thrown if otherwise.
-   * @param context Invocation context
+   * @param context - Invocation context
    */
   assertMethodExists() {
     const targetWithMethods = this.target as Record<string, Function>;
@@ -168,7 +168,7 @@ export class InvocationContext extends Context {
 
   /**
    * Invoke the target method with the given context
-   * @param context Invocation context
+   * @param context - Invocation context
    */
   invokeTargetMethod() {
     const targetWithMethods = this.assertMethodExists();
@@ -197,7 +197,7 @@ export class InvocationContext extends Context {
 /**
  * The `BindingTemplate` function to configure a binding as a global interceptor
  * by tagging it with `ContextTags.INTERCEPTOR`
- * @param binding Binding object
+ * @param binding - Binding object
  */
 export function asGlobalInterceptor(group?: string): BindingTemplate {
   return binding => {
@@ -211,8 +211,8 @@ export function asGlobalInterceptor(group?: string): BindingTemplate {
  */
 export interface Interceptor {
   /**
-   * @param context Invocation context
-   * @param next A function to invoke next interceptor or the target method
+   * @param context - Invocation context
+   * @param next - A function to invoke next interceptor or the target method
    * @returns A result as value or promise
    */
   (
@@ -247,8 +247,8 @@ export const INTERCEPT_METHOD_KEY = MetadataAccessor.create<
  * - [cache, log] + [] => [cache, log]
  * - [log] + [cache] => [log, cache]
  *
- * @param interceptorsFromSpec Interceptors from `@intercept`
- * @param existingInterceptors Interceptors already applied for the method
+ * @param interceptorsFromSpec - Interceptors from `@intercept`
+ * @param existingInterceptors - Interceptors already applied for the method
  */
 export function mergeInterceptors(
   interceptorsFromSpec: InterceptorOrKey[],
@@ -331,7 +331,7 @@ class InterceptMethodDecoratorFactory extends MethodDecoratorFactory<
  * }
  * ```
  *
- * @param interceptorOrKeys One or more interceptors or binding keys that are
+ * @param interceptorOrKeys - One or more interceptors or binding keys that are
  * resolved to be interceptors
  */
 export function intercept(...interceptorOrKeys: InterceptorOrKey[]) {
@@ -367,10 +367,10 @@ export function intercept(...interceptorOrKeys: InterceptorOrKey[]) {
 
 /**
  * Invoke a method with the given context
- * @param context Context object
- * @param target Target class (for static methods) or object (for instance methods)
- * @param methodName Method name
- * @param args An array of argument values
+ * @param context - Context object
+ * @param target - Target class (for static methods) or object (for instance methods)
+ * @param methodName - Method name
+ * @param args - An array of argument values
  */
 export function invokeMethodWithInterceptors(
   context: Context,
@@ -397,8 +397,8 @@ export function invokeMethodWithInterceptors(
 
 /**
  * Invoke the interceptor chain
- * @param context Context object
- * @param interceptors An array of interceptors
+ * @param context - Context object
+ * @param interceptors - An array of interceptors
  */
 function invokeInterceptors(
   context: InvocationContext,
@@ -442,7 +442,7 @@ function invokeInterceptors(
   /**
    * Return the interceptor function or resolve the interceptor function as a
    * binding from the context
-   * @param interceptor Interceptor function or binding key
+   * @param interceptor - Interceptor function or binding key
    */
   function loadInterceptor(interceptor: InterceptorOrKey) {
     if (typeof interceptor === 'function') return interceptor;

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -42,7 +42,7 @@ export type ResolutionElement = BindingElement | InjectionElement;
 
 /**
  * Type guard for binding elements
- * @param element A resolution element
+ * @param element - A resolution element
  */
 function isBinding(
   element: ResolutionElement | undefined,
@@ -52,7 +52,7 @@ function isBinding(
 
 /**
  * Type guard for injection elements
- * @param element A resolution element
+ * @param element - A resolution element
  */
 function isInjection(
   element: ResolutionElement | undefined,
@@ -75,7 +75,7 @@ export class ResolutionSession {
    * Fork the current session so that a new one with the same stack can be used
    * in parallel or future resolutions, such as multiple method arguments,
    * multiple properties, or a getter function
-   * @param session The current session
+   * @param session - The current session
    */
   static fork(session?: ResolutionSession): ResolutionSession | undefined {
     if (session === undefined) return undefined;
@@ -86,8 +86,8 @@ export class ResolutionSession {
 
   /**
    * Start to resolve a binding within the session
-   * @param binding The current binding
-   * @param session The current resolution session
+   * @param binding - The current binding
+   * @param session - The current resolution session
    */
   private static enterBinding(
     binding: Readonly<Binding>,
@@ -100,9 +100,9 @@ export class ResolutionSession {
 
   /**
    * Run the given action with the given binding and session
-   * @param action A function to do some work with the resolution session
-   * @param binding The current binding
-   * @param session The current resolution session
+   * @param action - A function to do some work with the resolution session
+   * @param binding - The current binding
+   * @param session - The current resolution session
    */
   static runWithBinding(
     action: ResolutionAction,
@@ -118,8 +118,8 @@ export class ResolutionSession {
 
   /**
    * Push an injection into the session
-   * @param injection The current injection
-   * @param session The current resolution session
+   * @param injection - The current injection
+   * @param session - The current resolution session
    */
   private static enterInjection(
     injection: Readonly<Injection>,
@@ -132,9 +132,9 @@ export class ResolutionSession {
 
   /**
    * Run the given action with the given injection and session
-   * @param action A function to do some work with the resolution session
-   * @param binding The current injection
-   * @param session The current resolution session
+   * @param action - A function to do some work with the resolution session
+   * @param binding - The current injection
+   * @param session - The current resolution session
    */
   static runWithInjection(
     action: ResolutionAction,
@@ -153,7 +153,7 @@ export class ResolutionSession {
 
   /**
    * Describe the injection for debugging purpose
-   * @param injection Injection object
+   * @param injection - Injection object
    */
   static describeInjection(injection?: Readonly<Injection>) {
     /* istanbul ignore if */
@@ -173,7 +173,7 @@ export class ResolutionSession {
 
   /**
    * Push the injection onto the session
-   * @param injection Injection The current injection
+   * @param injection - Injection The current injection
    */
   pushInjection(injection: Readonly<Injection>) {
     /* istanbul ignore if */
@@ -235,7 +235,7 @@ export class ResolutionSession {
 
   /**
    * Enter the resolution of the given binding. If
-   * @param binding Binding
+   * @param binding - Binding
    */
   pushBinding(binding: Readonly<Binding>) {
     /* istanbul ignore if */
@@ -354,7 +354,7 @@ export type ResolutionOptionsOrSession = ResolutionOptions | ResolutionSession;
 
 /**
  * Normalize ResolutionOptionsOrSession to ResolutionOptions
- * @param optionsOrSession resolution options or session
+ * @param optionsOrSession - resolution options or session
  */
 export function asResolutionOptions(
   optionsOrSession?: ResolutionOptionsOrSession,

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -37,10 +37,10 @@ const getTargetName = DecoratorFactory.getTargetName;
  * The function returns a class when all dependencies were
  * resolved synchronously, or a Promise otherwise.
  *
- * @param ctor The class constructor to call.
- * @param ctx The context containing values for `@inject` resolution
- * @param session Optional session for binding and dependency resolution
- * @param nonInjectedArgs Optional array of args for non-injected parameters
+ * @param ctor - The class constructor to call.
+ * @param ctx - The context containing values for `@inject` resolution
+ * @param session - Optional session for binding and dependency resolution
+ * @param nonInjectedArgs - Optional array of args for non-injected parameters
  */
 export function instantiateClass<T>(
   ctor: Constructor<T>,
@@ -119,9 +119,9 @@ function resolveContext(
 
 /**
  * Resolve the value or promise for a given injection
- * @param ctx Context
- * @param injection Descriptor of the injection
- * @param session Optional session for binding and dependency resolution
+ * @param ctx - Context
+ * @param injection - Descriptor of the injection
+ * @param session - Optional session for binding and dependency resolution
  */
 function resolve<T>(
   ctx: Context,
@@ -170,13 +170,13 @@ function resolve<T>(
  * The function returns an argument array when all dependencies were
  * resolved synchronously, or a Promise otherwise.
  *
- * @param target The class for constructor injection or prototype for method
+ * @param target - The class for constructor injection or prototype for method
  * injection
- * @param method The method name. If set to '', the constructor will
+ * @param method - The method name. If set to '', the constructor will
  * be used.
- * @param ctx The context containing values for `@inject` resolution
- * @param session Optional session for binding and dependency resolution
- * @param nonInjectedArgs Optional array of args for non-injected parameters
+ * @param ctx - The context containing values for `@inject` resolution
+ * @param session - Optional session for binding and dependency resolution
+ * @param nonInjectedArgs - Optional array of args for non-injected parameters
  */
 export function resolveInjectedArguments(
   target: Object,
@@ -250,11 +250,11 @@ export function resolveInjectedArguments(
 
 /**
  * Invoke an instance method with dependency injection
- * @param target Target of the method, it will be the class for a static
+ * @param target - Target of the method, it will be the class for a static
  * method, and instance or class prototype for a prototype method
- * @param method Name of the method
- * @param ctx Context
- * @param nonInjectedArgs Optional array of args for non-injected parameters
+ * @param method - Name of the method
+ * @param ctx - Context
+ * @param nonInjectedArgs - Optional array of args for non-injected parameters
  */
 export function invokeMethod(
   target: Object,
@@ -300,9 +300,9 @@ export function invokeMethod(
  * The function returns an argument array when all dependencies were
  * resolved synchronously, or a Promise otherwise.
  *
- * @param constructor The class for which properties should be resolved.
- * @param ctx The context containing values for `@inject` resolution
- * @param session Optional session for binding and dependency resolution
+ * @param constructor - The class for which properties should be resolved.
+ * @param ctx - The context containing values for `@inject` resolution
+ * @param session - Optional session for binding and dependency resolution
  */
 export function resolveInjectedProperties(
   constructor: Function,

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -35,7 +35,7 @@ export type MapObject<T> = {[name: string]: T};
  * Check whether a value is a Promise-like instance.
  * Recognizes both native promises and third-party promise libraries.
  *
- * @param value The value to check.
+ * @param value - The value to check.
  */
 export function isPromiseLike<T>(
   value: T | PromiseLike<T> | undefined,
@@ -47,8 +47,8 @@ export function isPromiseLike<T>(
 
 /**
  * Get nested properties of an object by path
- * @param value Value of the source object
- * @param path Path to the property
+ * @param value - Value of the source object
+ * @param path - Path to the property
  */
 export function getDeepProperty<OUT = BoundValue, IN = BoundValue>(
   value: IN,
@@ -87,8 +87,8 @@ export function getDeepProperty<OUT = BoundValue, IN = BoundValue>(
  * ```
  * The `result` will be a promise of `{a: 'X', b: 'Y'}`.
  *
- * @param map The original object containing the source entries
- * @param resolver A function resolves an entry to a value or promise. It will
+ * @param map - The original object containing the source entries
+ * @param resolver - A function resolves an entry to a value or promise. It will
  * be invoked with the property value, the property name, and the source object.
  */
 export function resolveMap<T, V>(
@@ -149,8 +149,8 @@ export function resolveMap<T, V>(
  * ```
  * The `result` will be a promise of `['A', 'B']`.
  *
- * @param list The original array containing the source entries
- * @param resolver A function resolves an entry to a value or promise. It will
+ * @param list - The original array containing the source entries
+ * @param resolver - A function resolves an entry to a value or promise. It will
  * be invoked with the property value, the property index, and the source array.
  */
 export function resolveList<T, V>(
@@ -184,8 +184,8 @@ export function resolveList<T, V>(
 
 /**
  * Try to run an action that returns a promise or a value
- * @param action A function that returns a promise or a value
- * @param finalAction A function to be called once the action
+ * @param action - A function that returns a promise or a value
+ * @param finalAction - A function to be called once the action
  * is fulfilled or rejected (synchronously or asynchronously)
  */
 export function tryWithFinally<T>(
@@ -222,9 +222,9 @@ export function tryWithFinally<T>(
 /**
  * Resolve an iterator of source values into a result until the evaluator
  * returns `true`
- * @param source The iterator of source values
- * @param resolver The resolve function that maps the source value to a result
- * @param evaluator The evaluate function that decides when to stop
+ * @param source - The iterator of source values
+ * @param resolver - The resolve function that maps the source value to a result
+ * @param evaluator - The evaluate function that decides when to stop
  */
 export function resolveUntil<T, V>(
   source: Iterator<T>,
@@ -257,8 +257,8 @@ export function resolveUntil<T, V>(
 /**
  * Transform a value or promise with a function that produces a new value or
  * promise
- * @param valueOrPromise The value or promise
- * @param transformer A function that maps the source value to a value or promise
+ * @param valueOrPromise - The value or promise
+ * @param transformer - A function that maps the source value to a value or promise
  */
 export function transformValueOrPromise<T, V>(
   valueOrPromise: ValueOrPromise<T>,

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -181,7 +181,7 @@ export class Application extends Context implements LifeCycleObserver {
    * Add a component to this application and register extensions such as
    * controllers, providers, and servers from the component.
    *
-   * @param componentCtor The component class to add.
+   * @param componentCtor - The component class to add.
    * @param {string=} name Optional component name, default to the class name
    *
    * @example
@@ -221,7 +221,7 @@ export class Application extends Context implements LifeCycleObserver {
    * Set application metadata. `@loopback/boot` calls this method to populate
    * the metadata from `package.json`.
    *
-   * @param metadata Application metadata
+   * @param metadata - Application metadata
    */
   public setMetadata(metadata: ApplicationMetadata) {
     this.bind(CoreBindings.APPLICATION_METADATA).to(metadata);
@@ -229,8 +229,8 @@ export class Application extends Context implements LifeCycleObserver {
 
   /**
    * Register a life cycle observer class
-   * @param ctor A class implements LifeCycleObserver
-   * @param name Optional name for the life cycle observer
+   * @param ctor - A class implements LifeCycleObserver
+   * @param name - Optional name for the life cycle observer
    */
   public lifeCycleObserver<T extends LifeCycleObserver>(
     ctor: Constructor<T>,

--- a/packages/core/src/extension-point.ts
+++ b/packages/core/src/extension-point.ts
@@ -33,7 +33,7 @@ import {CoreTags} from './keys';
  * }
  * ```
  *
- * @param name Name of the extension point
+ * @param name - Name of the extension point
  */
 export function extensionPoint(name: string, ...specs: BindingSpec[]) {
   return bind({tags: {[CoreTags.EXTENSION_POINT]: name}}, ...specs);
@@ -58,7 +58,7 @@ export function extensionPoint(name: string, ...specs: BindingSpec[]) {
  * }
  * ```
  *
- * @param extensionPointName Name of the extension point. If not supplied, we
+ * @param extensionPointName - Name of the extension point. If not supplied, we
  * use the `name` tag from the extension point binding or the class name of the
  * extension point class. If a class needs to inject extensions from multiple
  * extension points, use different `extensionPointName` for different types of
@@ -82,8 +82,8 @@ export function extensions(extensionPointName?: string) {
 
 /**
  * Infer the extension point name from binding tags/class name
- * @param injectionTarget Target class or prototype
- * @param currentBinding Current binding
+ * @param injectionTarget - Target class or prototype
+ * @param currentBinding - Current binding
  */
 function inferExtensionPointName(
   injectionTarget: object,
@@ -111,7 +111,7 @@ function inferExtensionPointName(
 /**
  * A factory function to create binding filter for extensions of a named
  * extension point
- * @param extensionPointName Name of the extension point
+ * @param extensionPointName - Name of the extension point
  */
 export function extensionFilter(extensionPointName: string) {
   return filterByTag({
@@ -122,7 +122,7 @@ export function extensionFilter(extensionPointName: string) {
 /**
  * A factory function to create binding template for extensions of the given
  * extension point
- * @param extensionPointName Name of the extension point
+ * @param extensionPointName - Name of the extension point
  */
 export function extensionFor(extensionPointName: string): BindingTemplate {
   return binding => binding.tag({[CoreTags.EXTENSION_FOR]: extensionPointName});
@@ -130,10 +130,10 @@ export function extensionFor(extensionPointName: string): BindingTemplate {
 
 /**
  * Register an extension for the given extension point to the context
- * @param context Context object
- * @param extensionPointName Name of the extension point
- * @param extensionClass Class or a provider for an extension
- * @param options Options Options for the creation of binding from class
+ * @param context - Context object
+ * @param extensionPointName - Name of the extension point
+ * @param extensionClass - Class or a provider for an extension
+ * @param options - Options Options for the creation of binding from class
  */
 export function addExtension(
   context: Context,

--- a/packages/core/src/lifecycle-registry.ts
+++ b/packages/core/src/lifecycle-registry.ts
@@ -82,7 +82,7 @@ export class LifeCycleObserverRegistry implements LifeCycleObserver {
 
   /**
    * Get the group for a given life cycle observer binding
-   * @param binding Life cycle observer binding
+   * @param binding - Life cycle observer binding
    */
   protected getObserverGroup(
     binding: Readonly<Binding<LifeCycleObserver>>,
@@ -106,7 +106,7 @@ export class LifeCycleObserverRegistry implements LifeCycleObserver {
    * Sort the life cycle observer bindings so that we can start/stop them
    * in the right order. By default, we can start other observers before servers
    * and stop them in the reverse order
-   * @param bindings Life cycle observer bindings
+   * @param bindings - Life cycle observer bindings
    */
   protected sortObserverBindingsByGroup(
     bindings: Readonly<Binding<LifeCycleObserver>>[],
@@ -140,8 +140,8 @@ export class LifeCycleObserverRegistry implements LifeCycleObserver {
 
   /**
    * Notify an observer group of the given event
-   * @param group A group of bindings for life cycle observers
-   * @param event Event name
+   * @param group - A group of bindings for life cycle observers
+   * @param event - Event name
    */
   protected async notifyObservers(
     observers: LifeCycleObserver[],
@@ -172,8 +172,8 @@ export class LifeCycleObserverRegistry implements LifeCycleObserver {
 
   /**
    * Invoke an observer for the given event
-   * @param observer A life cycle observer
-   * @param event Event name
+   * @param observer - A life cycle observer
+   * @param event - Event name
    */
   protected async invokeObserver(
     observer: LifeCycleObserver,
@@ -186,8 +186,8 @@ export class LifeCycleObserverRegistry implements LifeCycleObserver {
 
   /**
    * Emit events to the observer groups
-   * @param events Event names
-   * @param groups Observer groups
+   * @param events - Event names
+   * @param groups - Observer groups
    */
   protected async notifyGroups(
     events: (keyof LifeCycleObserver)[],

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -30,7 +30,7 @@ const lifeCycleMethods: (keyof LifeCycleObserver)[] = ['start', 'stop'];
 
 /**
  * Test if an object implements LifeCycleObserver
- * @param obj An object
+ * @param obj - An object
  */
 export function isLifeCycleObserver(obj: {
   [name: string]: unknown;
@@ -40,7 +40,7 @@ export function isLifeCycleObserver(obj: {
 
 /**
  * Test if a class implements LifeCycleObserver
- * @param ctor A class
+ * @param ctor - A class
  */
 export function isLifeCycleObserverClass(
   ctor: Constructor<unknown>,
@@ -52,7 +52,7 @@ export function isLifeCycleObserverClass(
  * A `BindingTemplate` function to configure the binding as life cycle observer
  * by tagging it with `CoreTags.LIFE_CYCLE_OBSERVER`.
  *
- * @param binding Binding object
+ * @param binding - Binding object
  */
 export function asLifeCycleObserver<T = unknown>(binding: Binding<T>) {
   return binding.tag(CoreTags.LIFE_CYCLE_OBSERVER);
@@ -68,8 +68,8 @@ export function lifeCycleObserverFilter(binding: Readonly<Binding>): boolean {
 
 /**
  * Sugar decorator to mark a class as life cycle observer
- * @param group Optional observer group name
- * @param specs Optional bindings specs
+ * @param group - Optional observer group name
+ * @param specs - Optional bindings specs
  */
 export function lifeCycleObserver(group = '', ...specs: BindingSpec[]) {
   return bind(

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -170,7 +170,7 @@ export class HttpServer {
  *
  * See https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections
  *
- * @param ipcPath Named pipe path
+ * @param ipcPath - Named pipe path
  */
 function checkNamedPipe(ipcPath: string) {
   /* istanbul ignore if */

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -64,9 +64,9 @@ export class DecoratorFactory<
 
   /**
    * Construct a new class decorator factory
-   * @param key Metadata key
-   * @param spec Metadata object from the decorator function
-   * @param options Options for the decorator. Default to
+   * @param key - Metadata key
+   * @param spec - Metadata object from the decorator function
+   * @param options - Options for the decorator. Default to
    * `{allowInheritance: true}` if not provided
    */
   constructor(
@@ -92,7 +92,7 @@ export class DecoratorFactory<
    * metadata into the spec if `allowInheritance` is set to `true`. To customize
    * the behavior, this method can be overridden by sub classes.
    *
-   * @param inheritedMetadata Metadata from base classes for the member
+   * @param inheritedMetadata - Metadata from base classes for the member
    */
   protected inherit(inheritedMetadata: T | undefined | null): T {
     if (!this.allowInheritance()) return this.spec;
@@ -118,9 +118,9 @@ export class DecoratorFactory<
    * MyClass.prototype.myMethod()
    * MyClass.prototype.myMethod[1] // Second parameter of myMethod
    * ```
-   * @param target Class or prototype of a class
-   * @param member Optional property/method name
-   * @param descriptorOrIndex Optional method descriptor or parameter index
+   * @param target - Class or prototype of a class
+   * @param member - Optional property/method name
+   * @param descriptorOrIndex - Optional method descriptor or parameter index
    */
   static getTargetName(
     target: Object,
@@ -152,8 +152,8 @@ export class DecoratorFactory<
 
   /**
    * Get the number of parameters for a given constructor or method
-   * @param target Class or the prototype
-   * @param member Method name
+   * @param target - Class or the prototype
+   * @param member - Method name
    */
   static getNumberOfParameters(target: Object, member?: string) {
     if (target instanceof Function && !member) {
@@ -168,8 +168,8 @@ export class DecoratorFactory<
   /**
    * Set a reference to the target class or prototype for a given spec if
    * it's an object
-   * @param spec Metadata spec
-   * @param target Target of the decoration. It is a class or the prototype of
+   * @param spec - Metadata spec
+   * @param target - Target of the decoration. It is a class or the prototype of
    * a class.
    */
   withTarget(spec: T, target: Object) {
@@ -187,7 +187,7 @@ export class DecoratorFactory<
 
   /**
    * Get the optional decoration target of a given spec
-   * @param spec Metadata spec
+   * @param spec - Metadata spec
    */
   getTarget(spec: T) {
     if (typeof spec === 'object' && spec != null) {
@@ -206,10 +206,10 @@ export class DecoratorFactory<
    *
    * It MUST be overridden by subclasses to process inherited metadata.
    *
-   * @param inheritedMetadata Metadata inherited from the base classes
-   * @param target Decoration target
-   * @param member Optional property or method
-   * @param descriptorOrIndex Optional parameter index or method descriptor
+   * @param inheritedMetadata - Metadata inherited from the base classes
+   * @param target - Decoration target
+   * @param member - Optional property or method
+   * @param descriptorOrIndex - Optional parameter index or method descriptor
    */
   protected mergeWithInherited(
     inheritedMetadata: M,
@@ -228,10 +228,10 @@ export class DecoratorFactory<
    *
    * It MUST be overridden by subclasses to process own metadata.
    *
-   * @param ownMetadata Own Metadata exists locally on the target
-   * @param target Decoration target
-   * @param member Optional property or method
-   * @param descriptorOrIndex Optional parameter index or method descriptor
+   * @param ownMetadata - Own Metadata exists locally on the target
+   * @param target - Decoration target
+   * @param member - Optional property or method
+   * @param descriptorOrIndex - Optional parameter index or method descriptor
    */
   protected mergeWithOwn(
     ownMetadata: M,
@@ -252,9 +252,9 @@ export class DecoratorFactory<
 
   /**
    * Base implementation of the decorator function
-   * @param target Decorator target
-   * @param member Optional property or method
-   * @param descriptorOrIndex Optional method descriptor or parameter index
+   * @param target - Decorator target
+   * @param member - Optional property or method
+   * @param descriptorOrIndex - Optional method descriptor or parameter index
    */
   protected decorate(
     target: Object,
@@ -291,9 +291,9 @@ export class DecoratorFactory<
 
   /**
    * Create a decorator function
-   * @param key Metadata key
-   * @param spec Metadata object from the decorator function
-   * @param options Options for the decorator
+   * @param key - Metadata key
+   * @param spec - Metadata object from the decorator function
+   * @param options - Options for the decorator
    */
   protected static _createDecorator<
     T,
@@ -380,9 +380,9 @@ export class ClassDecoratorFactory<T> extends DecoratorFactory<
 
   /**
    * Create a class decorator function
-   * @param key Metadata key
-   * @param spec Metadata object from the decorator function
-   * @param options Options for the decorator
+   * @param key - Metadata key
+   * @param spec - Metadata object from the decorator function
+   * @param options - Options for the decorator
    */
   static createDecorator<T>(
     key: MetadataKey<T, ClassDecorator>,
@@ -440,9 +440,9 @@ export class PropertyDecoratorFactory<T> extends DecoratorFactory<
 
   /**
    * Create a property decorator function
-   * @param key Metadata key
-   * @param spec Metadata object from the decorator function
-   * @param options Options for the decorator
+   * @param key - Metadata key
+   * @param spec - Metadata object from the decorator function
+   * @param options - Options for the decorator
    */
   static createDecorator<T>(
     key: MetadataKey<T, PropertyDecorator>,
@@ -509,9 +509,9 @@ export class MethodDecoratorFactory<T> extends DecoratorFactory<
 
   /**
    * Create a method decorator function
-   * @param key Metadata key
-   * @param spec Metadata object from the decorator function
-   * @param options Options for the decorator
+   * @param key - Metadata key
+   * @param spec - Metadata object from the decorator function
+   * @param options - Options for the decorator
    */
   static createDecorator<T>(
     key: MetadataKey<T, MethodDecorator>,
@@ -605,9 +605,9 @@ export class ParameterDecoratorFactory<T> extends DecoratorFactory<
 
   /**
    * Create a parameter decorator function
-   * @param key Metadata key
-   * @param spec Metadata object from the decorator function
-   * @param options Options for the decorator
+   * @param key - Metadata key
+   * @param spec - Metadata object from the decorator function
+   * @param options - Options for the decorator
    */
   static createDecorator<T>(
     key: MetadataKey<T, ParameterDecorator>,
@@ -740,9 +740,9 @@ export class MethodParameterDecoratorFactory<T> extends DecoratorFactory<
 
   /**
    * Create a method decorator function
-   * @param key Metadata key
-   * @param spec Metadata object from the decorator function
-   * @param options Options for the decorator
+   * @param key - Metadata key
+   * @param spec - Metadata object from the decorator function
+   * @param options - Options for the decorator
    */
   static createDecorator<T>(
     key: MetadataKey<T, MethodDecorator>,

--- a/packages/metadata/src/inspector.ts
+++ b/packages/metadata/src/inspector.ts
@@ -49,9 +49,9 @@ export class MetadataInspector {
 
   /**
    * Get the metadata associated with the given key for a given class
-   * @param key Metadata key
-   * @param target Class that contains the metadata
-   * @param options Options for inspection
+   * @param key - Metadata key
+   * @param target - Class that contains the metadata
+   * @param options - Options for inspection
    */
   static getClassMetadata<T>(
     key: MetadataKey<T, ClassDecorator>,
@@ -65,10 +65,10 @@ export class MetadataInspector {
 
   /**
    * Define metadata for the given target
-   * @param key Metadata key
-   * @param value Metadata value
-   * @param target Target for the metadata
-   * @param member Optional property or method name
+   * @param key - Metadata key
+   * @param value - Metadata value
+   * @param target - Target for the metadata
+   * @param member - Optional property or method name
    */
   static defineMetadata<T>(
     key: MetadataKey<T, DecoratorType>,
@@ -82,9 +82,9 @@ export class MetadataInspector {
   /**
    * Get the metadata associated with the given key for all methods of the
    * target class or prototype
-   * @param key Metadata key
-   * @param target Class for static methods or prototype for instance methods
-   * @param options Options for inspection
+   * @param key - Metadata key
+   * @param target - Class for static methods or prototype for instance methods
+   * @param options - Options for inspection
    */
   static getAllMethodMetadata<T>(
     key: MetadataKey<T, MethodDecorator>,
@@ -99,11 +99,11 @@ export class MetadataInspector {
   /**
    * Get the metadata associated with the given key for a given method of the
    * target class or prototype
-   * @param key Metadata key
-   * @param target Class for static methods or prototype for instance methods
-   * @param methodName Method name. If not present, default to '' to use
+   * @param key - Metadata key
+   * @param target - Class for static methods or prototype for instance methods
+   * @param methodName - Method name. If not present, default to '' to use
    * the constructor
-   * @param options Options for inspection
+   * @param options - Options for inspection
    */
   static getMethodMetadata<T>(
     key: MetadataKey<T, MethodDecorator>,
@@ -122,9 +122,9 @@ export class MetadataInspector {
   /**
    * Get the metadata associated with the given key for all properties of the
    * target class or prototype
-   * @param key Metadata key
-   * @param target Class for static methods or prototype for instance methods
-   * @param options Options for inspection
+   * @param key - Metadata key
+   * @param target - Class for static methods or prototype for instance methods
+   * @param options - Options for inspection
    */
   static getAllPropertyMetadata<T>(
     key: MetadataKey<T, PropertyDecorator>,
@@ -139,11 +139,11 @@ export class MetadataInspector {
   /**
    * Get the metadata associated with the given key for a given property of the
    * target class or prototype
-   * @param key Metadata key
-   * @param target Class for static properties or prototype for instance
+   * @param key - Metadata key
+   * @param target - Class for static properties or prototype for instance
    * properties
-   * @param propertyName Property name
-   * @param options Options for inspection
+   * @param propertyName - Property name
+   * @param options - Options for inspection
    */
   static getPropertyMetadata<T>(
     key: MetadataKey<T, PropertyDecorator>,
@@ -161,11 +161,11 @@ export class MetadataInspector {
   /**
    * Get the metadata associated with the given key for all parameters of a
    * given method
-   * @param key Metadata key
-   * @param target Class for static methods or prototype for instance methods
-   * @param methodName Method name. If not present, default to '' to use
+   * @param key - Metadata key
+   * @param target - Class for static methods or prototype for instance methods
+   * @param methodName - Method name. If not present, default to '' to use
    * the constructor
-   * @param options Options for inspection
+   * @param options - Options for inspection
    */
   static getAllParameterMetadata<T>(
     key: MetadataKey<T, ParameterDecorator>,
@@ -184,12 +184,12 @@ export class MetadataInspector {
   /**
    * Get the metadata associated with the given key for a parameter of a given
    * method by index
-   * @param key Metadata key
-   * @param target Class for static methods or prototype for instance methods
-   * @param methodName Method name. If not present, default to '' to use
+   * @param key - Metadata key
+   * @param target - Class for static methods or prototype for instance methods
+   * @param methodName - Method name. If not present, default to '' to use
    * the constructor
-   * @param index Index of the parameter, starting with 0
-   * @param options Options for inspection
+   * @param index - Index of the parameter, starting with 0
+   * @param options - Options for inspection
    */
   static getParameterMetadata<T>(
     key: MetadataKey<T, ParameterDecorator>,
@@ -209,8 +209,8 @@ export class MetadataInspector {
 
   /**
    * Get TypeScript design time type for a property
-   * @param target Class or prototype
-   * @param propertyName Property name
+   * @param target - Class or prototype
+   * @param propertyName - Property name
    */
   static getDesignTypeForProperty(
     target: Object,
@@ -221,8 +221,8 @@ export class MetadataInspector {
 
   /**
    * Get TypeScript design time type for a method
-   * @param target Class or prototype
-   * @param methodName Method name
+   * @param target - Class or prototype
+   * @param methodName - Method name
    */
   static getDesignTypeForMethod(
     target: Object,

--- a/packages/metadata/src/reflect.ts
+++ b/packages/metadata/src/reflect.ts
@@ -66,9 +66,9 @@ export class NamespacedReflect {
 
   /**
    * Check if the target has corresponding metadata
-   * @param metadataKey Key
-   * @param target Target
-   * @param propertyKey Optional property key
+   * @param metadataKey - Key
+   * @param target - Target
+   * @param propertyKey - Optional property key
    */
   hasMetadata(
     metadataKey: string,

--- a/packages/metadata/src/types.ts
+++ b/packages/metadata/src/types.ts
@@ -27,7 +27,7 @@ export class MetadataAccessor<T, D extends DecoratorType = DecoratorType> {
 
   /**
    * Create a strongly-typed metadata accessor
-   * @param key The metadata key
+   * @param key - The metadata key
    * @typeparam T Type of the metadata value
    * @typeparam D Type of the decorator
    */

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -17,7 +17,7 @@ import {
 /**
  * Create a new instance of OpenApiSpecBuilder.
  *
- * @param basePath The base path on which the API is served.
+ * @param basePath - The base path on which the API is served.
  */
 export function anOpenApiSpec() {
   return new OpenApiSpecBuilder();
@@ -40,8 +40,8 @@ export class BuilderBase<T extends ISpecificationExtension> {
   /**
    * Add a custom (extension) property to the spec object.
    *
-   * @param key The property name starting with "x-".
-   * @param value The property value.
+   * @param key - The property name starting with "x-".
+   * @param value - The property value.
    */
   withExtension(
     key: string,
@@ -70,7 +70,7 @@ export class BuilderBase<T extends ISpecificationExtension> {
  */
 export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
   /**
-   * @param basePath The base path on which the API is served.
+   * @param basePath - The base path on which the API is served.
    */
   constructor() {
     super(createEmptyApiSpec());
@@ -79,9 +79,9 @@ export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
   /**
    * Define a new OperationObject at the given path and verb (method).
    *
-   * @param verb The HTTP verb.
-   * @param path The path relative to basePath.
-   * @param spec Additional specification of the operation.
+   * @param verb - The HTTP verb.
+   * @param path - The path relative to basePath.
+   * @param spec - Additional specification of the operation.
    */
   withOperation(
     verb: string,
@@ -97,9 +97,9 @@ export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
   /**
    * Define a new operation that returns a string response.
    *
-   * @param verb The HTTP verb.
-   * @param path The path relative to basePath.
-   * @param operationName The name of the controller method implementing
+   * @param verb - The HTTP verb.
+   * @param path - The path relative to basePath.
+   * @param operationName - The name of the controller method implementing
    * this operation (`x-operation-name` field).
    */
   withOperationReturningString(
@@ -126,8 +126,8 @@ export class OperationSpecBuilder extends BuilderBase<OperationObject> {
 
   /**
    * Describe a response for a given HTTP status code.
-   * @param status HTTP status code or string "default"
-   * @param responseSpec Specification of the response
+   * @param status - HTTP status code or string "default"
+   * @param responseSpec - Specification of the response
    */
   withResponse(status: number | 'default', responseSpec: ResponseObject): this {
     // OpenAPI spec uses string indices, i.e. 200 OK uses "200" as the index
@@ -167,7 +167,7 @@ export class OperationSpecBuilder extends BuilderBase<OperationObject> {
   /**
    * Define the operation name (controller method name).
    *
-   * @param name The name of the controller method implementing this operation.
+   * @param name - The name of the controller method implementing this operation.
    */
   withOperationName(name: string): this {
     this.withExtension('x-operation-name', name);
@@ -178,7 +178,7 @@ export class OperationSpecBuilder extends BuilderBase<OperationObject> {
   /**
    * Define the controller name (controller name).
    *
-   * @param name The name of the controller containing this operation.
+   * @param name - The name of the controller containing this operation.
    */
   withControllerName(name: string): this {
     this.withExtension('x-controller-name', name);
@@ -203,7 +203,7 @@ export class OperationSpecBuilder extends BuilderBase<OperationObject> {
 
   /**
    * Define the operationId
-   * @param operationId Operation id
+   * @param operationId - Operation id
    */
   withOperationId(operationId: string): this {
     this._spec.operationId = operationId;

--- a/packages/openapi-v3-types/src/type-guards.ts
+++ b/packages/openapi-v3-types/src/type-guards.ts
@@ -7,7 +7,7 @@ import {SchemaObject, ReferenceObject} from './openapi-v3-spec-types';
 
 /**
  * Type guard for OpenAPI 3.0.0 schema object
- * @param schema An OpenAPI 3.0.0 schema object
+ * @param schema - An OpenAPI 3.0.0 schema object
  */
 
 export function isSchemaObject(

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -60,7 +60,7 @@ type ComponentSchemaMap = {[key: string]: SchemaObject};
 
 /**
  * Build the api spec from class and method level decorations
- * @param constructor Controller class
+ * @param constructor - Controller class
  */
 function resolveControllerSpec(constructor: Function): ControllerSpec {
   debug(`Retrieving OpenAPI specification for controller ${constructor.name}`);
@@ -234,8 +234,8 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
 
 /**
  * Resolve the x-ts-type in the schema object
- * @param spec Controller spec
- * @param schema Schema object
+ * @param spec - Controller spec
+ * @param schema - Schema object
  */
 function processSchemaExtensions(
   spec: ControllerSpec,
@@ -272,8 +272,8 @@ function processSchemaExtensions(
 
 /**
  * Generate json schema for a given x-ts-type
- * @param spec Controller spec
- * @param tsType TS Type
+ * @param spec - Controller spec
+ * @param tsType - TS Type
  */
 function generateOpenAPISchema(spec: ControllerSpec, tsType: Function) {
   if (!spec.components) {
@@ -299,8 +299,8 @@ function generateOpenAPISchema(spec: ControllerSpec, tsType: Function) {
 
 /**
  * Assign related schemas from definitions to the controller spec
- * @param spec Controller spec
- * @param definitions Schema definitions
+ * @param spec - Controller spec
+ * @param definitions - Schema definitions
  */
 function assignRelatedSchemas(
   spec: ControllerSpec,
@@ -330,7 +330,7 @@ function assignRelatedSchemas(
 
 /**
  * Get the controller spec for the given class
- * @param constructor Controller class
+ * @param constructor - Controller class
  */
 export function getControllerSpec(constructor: Function): ControllerSpec {
   let spec = MetadataInspector.getClassMetadata<ControllerSpec>(

--- a/packages/openapi-v3/src/decorators/api.decorator.ts
+++ b/packages/openapi-v3/src/decorators/api.decorator.ts
@@ -19,7 +19,7 @@ import {OAI3Keys} from '../keys';
  * }
  * ```
  *
- * @param spec OpenAPI specification describing the endpoints
+ * @param spec - OpenAPI specification describing the endpoints
  * handled by this controller
  *
  * @decorator

--- a/packages/openapi-v3/src/decorators/operation.decorator.ts
+++ b/packages/openapi-v3/src/decorators/operation.decorator.ts
@@ -12,8 +12,8 @@ import {OAI3Keys} from '../keys';
  * Expose a Controller method as a REST API operation
  * mapped to `GET` request method.
  *
- * @param path The URL path of this operation, e.g. `/product/{id}`
- * @param spec The OpenAPI specification describing parameters and responses
+ * @param path - The URL path of this operation, e.g. `/product/{id}`
+ * @param spec - The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
 export function get(path: string, spec?: OperationObject) {
@@ -24,8 +24,8 @@ export function get(path: string, spec?: OperationObject) {
  * Expose a Controller method as a REST API operation
  * mapped to `POST` request method.
  *
- * @param path The URL path of this operation, e.g. `/product/{id}`
- * @param spec The OpenAPI specification describing parameters and responses
+ * @param path - The URL path of this operation, e.g. `/product/{id}`
+ * @param spec - The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
 export function post(path: string, spec?: OperationObject) {
@@ -36,8 +36,8 @@ export function post(path: string, spec?: OperationObject) {
  * Expose a Controller method as a REST API operation
  * mapped to `PUT` request method.
  *
- * @param path The URL path of this operation, e.g. `/product/{id}`
- * @param spec The OpenAPI specification describing parameters and responses
+ * @param path - The URL path of this operation, e.g. `/product/{id}`
+ * @param spec - The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
 export function put(path: string, spec?: OperationObject) {
@@ -48,8 +48,8 @@ export function put(path: string, spec?: OperationObject) {
  * Expose a Controller method as a REST API operation
  * mapped to `PATCH` request method.
  *
- * @param path The URL path of this operation, e.g. `/product/{id}`
- * @param spec The OpenAPI specification describing parameters and responses
+ * @param path - The URL path of this operation, e.g. `/product/{id}`
+ * @param spec - The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
 export function patch(path: string, spec?: OperationObject) {
@@ -60,8 +60,8 @@ export function patch(path: string, spec?: OperationObject) {
  * Expose a Controller method as a REST API operation
  * mapped to `DELETE` request method.
  *
- * @param path The URL path of this operation, e.g. `/product/{id}`
- * @param spec The OpenAPI specification describing parameters and responses
+ * @param path - The URL path of this operation, e.g. `/product/{id}`
+ * @param spec - The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
 export function del(path: string, spec?: OperationObject) {
@@ -71,9 +71,9 @@ export function del(path: string, spec?: OperationObject) {
 /**
  * Expose a Controller method as a REST API operation.
  *
- * @param verb HTTP verb, e.g. `GET` or `POST`.
- * @param path The URL path of this operation, e.g. `/product/{id}`
- * @param spec The OpenAPI specification describing parameters and responses
+ * @param verb - HTTP verb, e.g. `GET` or `POST`.
+ * @param path - The URL path of this operation, e.g. `/product/{id}`
+ * @param spec - The OpenAPI specification describing parameters and responses
  *   of this operation.
  */
 export function operation(verb: string, path: string, spec?: OperationObject) {

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -28,7 +28,7 @@ import {OAI3Keys} from '../keys';
  * }
  * ```
  *
- * @param paramSpec Parameter specification.
+ * @param paramSpec - Parameter specification.
  */
 export function param(paramSpec: ParameterObject) {
   return function(target: Object, member: string, index: number) {
@@ -116,7 +116,7 @@ const builtinTypes = {
  * }
  * ```
  *
- * @param paramSpec Parameter specification.
+ * @param paramSpec - Parameter specification.
  *
  * Please also see `@param.*` shortcut parameter decorators
  */
@@ -126,84 +126,84 @@ export namespace param {
      * Define a parameter of "integer" type that's read from the query string.
      * Usage: ` @param.query.string('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     string: createParamShortcut('query', builtinTypes.string),
     /**
      * Define a parameter of "number" type that's read from the query string.
      * Usage: ` @param.query.number('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     number: createParamShortcut('query', builtinTypes.number),
     /**
      * Define a parameter of "boolean" type that's read from the query string.
      * Usage: ` @param.query.boolean('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     boolean: createParamShortcut('query', builtinTypes.boolean),
     /**
      * Define a parameter of "integer" type that's read from the query string.
      * Usage: ` @param.query.integer('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     integer: createParamShortcut('query', builtinTypes.integer),
     /**
      * Define a parameter of "long" type that's read from the query string.
      * Usage: ` @param.query.long('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     long: createParamShortcut('query', builtinTypes.long),
     /**
      * Define a parameter of "float" type that's read from the query string.
      * Usage: ` @param.query.float('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     float: createParamShortcut('query', builtinTypes.float),
     /**
      * Define a parameter of "double" type that's read from the query string.
      * Usage: ` @param.query.double('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     double: createParamShortcut('query', builtinTypes.double),
     /**
      * Define a parameter of "byte" type that's read from the query string.
      * Usage: ` @param.query.byte('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     byte: createParamShortcut('query', builtinTypes.byte),
     /**
      * Define a parameter of "binary" type that's read from the query string.
      * Usage: ` @param.query.binary('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     binary: createParamShortcut('query', builtinTypes.binary),
     /**
      * Define a parameter of "date" type that's read from the query string.
      * Usage: ` @param.query.date('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     date: createParamShortcut('query', builtinTypes.date),
     /**
      * Define a parameter of "dateTime" type that's read from the query string.
      * Usage: ` @param.query.dateTime('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     dateTime: createParamShortcut('query', builtinTypes.dateTime),
     /**
      * Define a parameter of "password" type that's read from the query string.
      * Usage: ` @param.query.password('paramName')`
      *
-     * @param name Parameter name.
+     * @param name - Parameter name.
      */
     password: createParamShortcut('query', builtinTypes.password),
 
@@ -212,8 +212,8 @@ export namespace param {
      * - as a JSON string, e.g. `filter={"where":{"id":1}}`); or
      * - in multiple nested keys, e.g. `filter[where][id]=1`
      *
-     * @param name Parameter name
-     * @param schema Optional OpenAPI Schema describing the object value.
+     * @param name - Parameter name
+     * @param schema - Optional OpenAPI Schema describing the object value.
      */
     object: function(
       name: string,
@@ -237,7 +237,7 @@ export namespace param {
      * Define a parameter of "string" type that's read from a request header.
      * Usage: ` @param.header.string('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      * (e.g. `Content-Type`).
      */
     string: createParamShortcut('header', builtinTypes.string),
@@ -245,7 +245,7 @@ export namespace param {
      * Define a parameter of "number" type that's read from a request header.
      * Usage: ` @param.header.number('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      * (e.g. `Content-Length`).
      */
     number: createParamShortcut('header', builtinTypes.number),
@@ -253,7 +253,7 @@ export namespace param {
      * Define a parameter of "boolean" type that's read from a request header.
      * Usage: ` @param.header.boolean('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      * (e.g. `DNT` or `X-Do-Not-Track`).
      */
     boolean: createParamShortcut('header', builtinTypes.boolean),
@@ -261,7 +261,7 @@ export namespace param {
      * Define a parameter of "integer" type that's read from a request header.
      * Usage: ` @param.header.integer('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      * (e.g. `Content-Length`).
      */
     integer: createParamShortcut('header', builtinTypes.integer),
@@ -269,56 +269,56 @@ export namespace param {
      * Define a parameter of "long" type that's read from a request header.
      * Usage: ` @param.header.long('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     long: createParamShortcut('header', builtinTypes.long),
     /**
      * Define a parameter of "float" type that's read from a request header.
      * Usage: ` @param.header.float('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     float: createParamShortcut('header', builtinTypes.float),
     /**
      * Define a parameter of "double" type that's read from a request header.
      * Usage: ` @param.header.double('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     double: createParamShortcut('header', builtinTypes.double),
     /**
      * Define a parameter of "byte" type that's read from a request header.
      * Usage: ` @param.header.byte('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     byte: createParamShortcut('header', builtinTypes.byte),
     /**
      * Define a parameter of "binary" type that's read from a request header.
      * Usage: ` @param.header.binary('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     binary: createParamShortcut('header', builtinTypes.binary),
     /**
      * Define a parameter of "date" type that's read from a request header.
      * Usage: ` @param.header.date('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     date: createParamShortcut('header', builtinTypes.date),
     /**
      * Define a parameter of "dateTime" type that's read from a request header.
      * Usage: ` @param.header.dateTime('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     dateTime: createParamShortcut('header', builtinTypes.dateTime),
     /**
      * Define a parameter of "password" type that's read from a request header.
      * Usage: ` @param.header.password('paramName')`
      *
-     * @param name Parameter name, it must match the header name
+     * @param name - Parameter name, it must match the header name
      */
     password: createParamShortcut('header', builtinTypes.password),
   };
@@ -327,84 +327,84 @@ export namespace param {
      * Define a parameter of "string" type that's read from request path.
      * Usage: ` @param.path.string('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     string: createParamShortcut('path', builtinTypes.string),
     /**
      * Define a parameter of "number" type that's read from request path.
      * Usage: ` @param.path.number('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     number: createParamShortcut('path', builtinTypes.number),
     /**
      * Define a parameter of "boolean" type that's read from request path.
      * Usage: ` @param.path.boolean('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     boolean: createParamShortcut('path', builtinTypes.boolean),
     /**
      * Define a parameter of "integer" type that's read from request path.
      * Usage: ` @param.path.integer('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     integer: createParamShortcut('path', builtinTypes.integer),
     /**
      * Define a parameter of "long" type that's read from request path.
      * Usage: ` @param.path.long('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     long: createParamShortcut('path', builtinTypes.long),
     /**
      * Define a parameter of "float" type that's read from request path.
      * Usage: ` @param.path.float('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     float: createParamShortcut('path', builtinTypes.float),
     /**
      * Define a parameter of "double" type that's read from request path.
      * Usage: ` @param.path.double('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     double: createParamShortcut('path', builtinTypes.double),
     /**
      * Define a parameter of "byte" type that's read from request path.
      * Usage: ` @param.path.byte('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     byte: createParamShortcut('path', builtinTypes.byte),
     /**
      * Define a parameter of "binary" type that's read from request path.
      * Usage: ` @param.path.binary('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     binary: createParamShortcut('path', builtinTypes.binary),
     /**
      * Define a parameter of "date" type that's read from request path.
      * Usage: ` @param.path.date('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     date: createParamShortcut('path', builtinTypes.date),
     /**
      * Define a parameter of "dateTime" type that's read from request path.
      * Usage: ` @param.path.dateTime('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     dateTime: createParamShortcut('path', builtinTypes.dateTime),
     /**
      * Define a parameter of "password" type that's read from request path.
      * Usage: ` @param.path.password('paramName')`
      *
-     * @param name Parameter name matching one of the placeholders in the path
+     * @param name - Parameter name matching one of the placeholders in the path
      */
     password: createParamShortcut('path', builtinTypes.password),
   };
@@ -422,9 +422,9 @@ export namespace param {
    * }
    * ```
    *
-   * @param name Parameter name
-   * @param source Source of the parameter value
-   * @param itemSpec Item type for the array or the full item object
+   * @param name - Parameter name
+   * @param source - Source of the parameter value
+   * @param itemSpec - Item type for the array or the full item object
    */
   export const array = function(
     name: string,

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -73,7 +73,7 @@ export const REQUEST_BODY_INDEX = 'x-parameter-index';
  * }
  * ```
  *
- * @param requestBodySpec The complete requestBody Object or partial of it.
+ * @param requestBodySpec - The complete requestBody Object or partial of it.
  * "partial" for allowing no `content` in spec, for example:
  * ```
  * @requestBody({description: 'a request body'}) user: User
@@ -142,8 +142,8 @@ export namespace requestBody {
    * }
    * ```
    *
-   * @param properties The requestBody properties other than `content`
-   * @param itemSpec the full item object
+   * @param properties - The requestBody properties other than `content`
+   * @param itemSpec - the full item object
    */
   export const array = function(
     itemSpec: SchemaObject | ReferenceObject,

--- a/packages/openapi-v3/src/filter-schema.ts
+++ b/packages/openapi-v3/src/filter-schema.ts
@@ -18,7 +18,7 @@ import {jsonToSchemaObject} from './json-to-schema';
  * Note we don't take the model properties into account yet and return
  * a generic json schema allowing any "where" condition.
  *
- * @param modelCtor The model constructor to build the filter schema for.
+ * @param modelCtor - The model constructor to build the filter schema for.
  */
 export function getFilterSchemaFor(modelCtor: typeof Model): SchemaObject {
   const jsonSchema = getFilterJsonSchemaFor(modelCtor);
@@ -33,7 +33,7 @@ export function getFilterSchemaFor(modelCtor: typeof Model): SchemaObject {
  * Note we don't take the model properties into account yet and return
  * a generic json schema allowing any "where" condition.
  *
- * @param modelCtor The model constructor to build the filter schema for.
+ * @param modelCtor - The model constructor to build the filter schema for.
  */
 export function getWhereSchemaFor(modelCtor: typeof Model): SchemaObject {
   const jsonSchema = getWhereJsonSchemaFor(modelCtor);

--- a/packages/openapi-v3/src/generate-schema.ts
+++ b/packages/openapi-v3/src/generate-schema.ts
@@ -11,8 +11,8 @@ import {SchemaObject} from '@loopback/openapi-v3-types';
  * `type` and `format` will be preserved if provided in `schema`
  *
  * @internal
- * @param type The JavaScript type of a parameter
- * @param schema The schema object provided in an parameter object
+ * @param type - The JavaScript type of a parameter
+ * @param schema - The schema object provided in an parameter object
  */
 export function resolveSchema(
   fn?: Function,

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
 
 /**
  * Converts JSON Schemas into a SchemaObject
- * @param json JSON Schema to convert from
+ * @param json - JSON Schema to convert from
  */
 export function jsonToSchemaObject(json: JsonSchema): SchemaObject {
   const result: SchemaObject = {};
@@ -85,7 +85,7 @@ export function jsonToSchemaObject(json: JsonSchema): SchemaObject {
 /**
  * Helper function used to interpret boolean values as JSON Schemas.
  * See http://json-schema.org/draft-06/json-schema-release-notes.html
- * @param jsonOrBool converts boolean values into their representative JSON Schemas
+ * @param jsonOrBool - converts boolean values into their representative JSON Schemas
  * @returns A JSON Schema document representing the input value.
  */
 export function jsonOrBooleanToJSON(jsonOrBool: boolean | JsonSchema) {

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -21,7 +21,7 @@ export interface JsonSchemaOptions {
 /**
  * Gets the JSON Schema of a TypeScript model/class by seeing if one exists
  * in a cache. If not, one is generated and then cached.
- * @param ctor Contructor of class to get JSON Schema from
+ * @param ctor - Contructor of class to get JSON Schema from
  */
 export function getJsonSchema(
   ctor: Function,
@@ -42,7 +42,7 @@ export function getJsonSchema(
 
 /**
  * Gets the wrapper function of primitives string, number, and boolean
- * @param type Name of type
+ * @param type - Name of type
  */
 export function stringTypeToWrapper(type: string | Function): Function {
   if (typeof type === 'function') {
@@ -88,7 +88,7 @@ export function stringTypeToWrapper(type: string | Function): Function {
 
 /**
  * Determines whether a given string or constructor is array type or not
- * @param type Type as string or wrapper
+ * @param type - Type as string or wrapper
  */
 export function isArrayType(type: string | Function) {
   return type === Array || type === 'array';
@@ -149,7 +149,7 @@ export function metaToJsonProperty(meta: PropertyDefinition): JSONSchema {
 /**
  * Converts a TypeScript class into a JSON Schema using TypeScript's
  * reflection API
- * @param ctor Constructor of class to convert from
+ * @param ctor - Constructor of class to convert from
  */
 export function modelToJsonSchema(
   ctor: Function,

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -18,7 +18,7 @@ const scopeFilter = getFilterJsonSchemaFor(EmptyModel);
  * Note we don't take the model properties into account yet and return
  * a generic json schema allowing any "where" condition.
  *
- * @param modelCtor The model constructor to build the filter schema for.
+ * @param modelCtor - The model constructor to build the filter schema for.
  */
 export function getFilterJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
   const schema: JsonSchema = {
@@ -79,7 +79,7 @@ export function getFilterJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
  * Note we don't take the model properties into account yet and return
  * a generic json schema allowing any "where" condition.
  *
- * @param modelCtor The model constructor to build the filter schema for.
+ * @param modelCtor - The model constructor to build the filter schema for.
  */
 export function getWhereJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
   const schema: JsonSchema = {
@@ -95,7 +95,7 @@ export function getWhereJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
  * Build a JSON schema describing the format of the "fields" object
  * used to include or exclude properties of model instances.
  *
- * @param modelCtor The model constructor to build the filter schema for.
+ * @param modelCtor - The model constructor to build the filter schema for.
  */
 
 export function getFieldsJsonSchemaFor(modelCtor: typeof Model): JsonSchema {

--- a/packages/repository/src/connectors/crud.connector.ts
+++ b/packages/repository/src/connectors/crud.connector.ts
@@ -14,9 +14,9 @@ import {Class, Options, Count} from '../common-types';
 export interface CrudConnector extends Connector {
   /**
    * Create a new entity
-   * @param modelClass The model class
-   * @param entity The entity instance or data
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param entity - The entity instance or data
+   * @param options - Options for the operation
    * @returns A promise of the entity created
    */
   create(
@@ -27,9 +27,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Create multiple entities
-   * @param modelClass The model class
-   * @param entities An array of entity instances or data
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param entities - An array of entity instances or data
+   * @param options - Options for the operation
    * @returns A promise of an array of entities created
    */
   createAll?(
@@ -40,9 +40,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Save an entity
-   * @param modelClass The model class
-   * @param entity The entity instance or data
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param entity - The entity instance or data
+   * @param options - Options for the operation
    * @returns A promise of the entity saved
    */
   save?(
@@ -53,9 +53,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Find matching entities by the filter
-   * @param modelClass The model class
-   * @param filter The query filter
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param filter - The query filter
+   * @param options - Options for the operation
    * @returns A promise of an array of entities found for the filter
    */
   find(
@@ -66,9 +66,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Find an entity by id
-   * @param modelClass The model class
-   * @param id The entity id value
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param id - The entity id value
+   * @param options - Options for the operation
    * @returns A promise of the entity found for the id
    */
   findById?<IdType>(
@@ -79,9 +79,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Update an entity
-   * @param modelClass The model class
-   * @param entity The entity instance or data
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param entity - The entity instance or data
+   * @param options - Options for the operation
    * @returns Promise<true> if an entity is updated, otherwise
    * Promise<false>
    */
@@ -93,9 +93,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Delete an entity
-   * @param modelClass The model class
-   * @param entity The entity instance or data
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param entity - The entity instance or data
+   * @param options - Options for the operation
    * @returns Promise<true> if an entity is deleted, otherwise
    * Promise<false>
    */
@@ -107,10 +107,10 @@ export interface CrudConnector extends Connector {
 
   /**
    * Update matching entities
-   * @param modelClass The model class
-   * @param data The data attributes to be updated
-   * @param where The matching criteria
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param data - The data attributes to be updated
+   * @param where - The matching criteria
+   * @param options - Options for the operation
    * @returns A promise of number of matching entities deleted
    */
   updateAll(
@@ -122,10 +122,10 @@ export interface CrudConnector extends Connector {
 
   /**
    * Update an entity by id
-   * @param modelClass The model class
-   * @param id The entity id value
-   * @param data The data attributes to be updated
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param id - The entity id value
+   * @param data - The data attributes to be updated
+   * @param options - Options for the operation
    * @returns Promise<true> if an entity is updated for the id, otherwise
    * Promise<false>
    */
@@ -138,10 +138,10 @@ export interface CrudConnector extends Connector {
 
   /**
    * Replace an entity by id
-   * @param modelClass The model class
-   * @param id The entity id value
-   * @param data The data attributes to be updated
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param id - The entity id value
+   * @param data - The data attributes to be updated
+   * @param options - Options for the operation
    * @returns Promise<true> if an entity is replaced for the id, otherwise
    * Promise<false>
    */
@@ -154,9 +154,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Delete matching entities
-   * @param modelClass The model class
-   * @param where The matching criteria
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param where - The matching criteria
+   * @param options - Options for the operation
    * @returns A promise of number of matching entities deleted
    */
   deleteAll(
@@ -167,9 +167,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Delete an entity by id
-   * @param modelClass The model class
-   * @param id The entity id value
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param id - The entity id value
+   * @param options - Options for the operation
    * @returns Promise<true> if an entity is deleted for the id, otherwise
    * Promise<false>
    */
@@ -181,9 +181,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Count matching entities
-   * @param modelClass The model class
-   * @param where The matching criteria
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param where - The matching criteria
+   * @param options - Options for the operation
    * @returns A promise of number of matching entities
    */
   count(
@@ -194,9 +194,9 @@ export interface CrudConnector extends Connector {
 
   /**
    * Check if an entity exists for the id
-   * @param modelClass The model class
-   * @param id The entity id value
-   * @param options Options for the operation
+   * @param modelClass - The model class
+   * @param id - The entity id value
+   * @param options - Options for the operation
    * @returns Promise<true> if an entity exists for the id, otherwise
    * Promise<false>
    */

--- a/packages/repository/src/connectors/kv.connector.ts
+++ b/packages/repository/src/connectors/kv.connector.ts
@@ -14,9 +14,9 @@ import {Filter} from '../query';
 export interface KVConnector<T extends Entity> extends Connector {
   /**
    * Delete an entry by key
-   * @param modelClass Model class
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    * @returns Promise<true> if an entry is deleted for the id, otherwise
    * Promise<false>
    */
@@ -28,27 +28,27 @@ export interface KVConnector<T extends Entity> extends Connector {
 
   /**
    * Delete all entries
-   * @param modelClass Model class
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param options - Options for the operation
    * @returns A promise of the number of entries deleted
    */
   deleteAll(modelClass: Class<Entity>, options?: Options): Promise<number>;
 
   /**
    * Get an entry by key
-   * @param modelClass Model class
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    * @returns A promise of the entry found for the key
    */
   get(modelClass: Class<Entity>, key: string, options?: Options): Promise<T>;
 
   /**
    * Set an entry with key/value
-   * @param modelClass Model class
-   * @param key Key for the entry
-   * @param value Value for the entry
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param key - Key for the entry
+   * @param value - Value for the entry
+   * @param options - Options for the operation
    * @returns Promise<true> if an entry is set for the key, otherwise
    * Promise<false>
    */
@@ -61,9 +61,9 @@ export interface KVConnector<T extends Entity> extends Connector {
 
   /**
    * Set up ttl for an entry by key
-   * @param modelClass Model class
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    * @returns Promise<true> if an entry is configured for the key, otherwise
    * Promise<false>
    */
@@ -76,10 +76,10 @@ export interface KVConnector<T extends Entity> extends Connector {
 
   /**
    * Get ttl for an entry by key
-   * @param modelClass Model class
-   * @param key Key for the entry
-   * @param ttl Time to live in millisenconds
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param key - Key for the entry
+   * @param ttl - Time to live in millisenconds
+   * @param options - Options for the operation
    * @returns A promise of the TTL value
    */
   ttl?(
@@ -91,18 +91,18 @@ export interface KVConnector<T extends Entity> extends Connector {
 
   /**
    * Fetch all keys
-   * @param modelClass Model class
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    * @returns A promise of an array of keys for all entries
    */
   keys?(modelClass: Class<Entity>, options?: Options): Promise<string[]>;
 
   /**
    * Get an Iterator for matching keys
-   * @param modelClass Model class
-   * @param filter Matching filter
-   * @param options Options for the operation
+   * @param modelClass - Model class
+   * @param filter - Matching filter
+   * @param options - Options for the operation
    * @returns A promise of an iterator of entries
    */
   iterateKeys?(

--- a/packages/repository/src/decorators/metadata.ts
+++ b/packages/repository/src/decorators/metadata.ts
@@ -16,8 +16,8 @@ export class ModelMetadataHelper {
   /**
    * A utility function to simplify retrieving metadata from a target model and
    * its properties.
-   * @param target The class from which to retrieve metadata.
-   * @param options An options object for the MetadataInspector to customize
+   * @param target - The class from which to retrieve metadata.
+   * @param options - An options object for the MetadataInspector to customize
    * the output of the metadata retrieval functions.
    */
   static getModelMetadata(

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -61,8 +61,8 @@ export function model(definition?: Partial<ModelDefinitionSyntax>) {
 
 /**
  * Build model definition from decorations
- * @param target Target model class
- * @param def Model definition spec
+ * @param target - Target model class
+ * @param def - Model definition spec
  */
 export function buildModelDefinition(
   target: Function & {definition?: ModelDefinition | undefined},
@@ -123,9 +123,9 @@ export namespace property {
 
   /**
    *
-   * @param itemType The type of array items.
+   * @param itemType - The type of array items.
    * Examples: `number`, `Product`, `() => Order`.
-   * @param definition Optional PropertyDefinition object for additional
+   * @param definition - Optional PropertyDefinition object for additional
    * metadata
    */
   export function array(

--- a/packages/repository/src/decorators/repository.decorator.ts
+++ b/packages/repository/src/decorators/repository.decorator.ts
@@ -49,10 +49,10 @@ export class RepositoryMetadata {
   /**
    * Constructor for RepositoryMetadata
    *
-   * @param modelOrRepo Name or class of the model. If the value is a string and
+   * @param modelOrRepo - Name or class of the model. If the value is a string and
    * `dataSource` is not present, it will treated as the name of a predefined
    * repository
-   * @param dataSource Name or instance of the data source
+   * @param dataSource - Name or instance of the data source
    *
    * For example:
    *
@@ -97,7 +97,7 @@ export class RepositoryMetadata {
  * }
  * ```
  *
- * @param repositoryName Name of the repo
+ * @param repositoryName - Name of the repo
  */
 export function repository(
   repositoryName: string | Class<Repository<Model>>,
@@ -127,8 +127,8 @@ export function repository(
  * }
  * ```
  *
- * @param model Name/class of the model
- * @param dataSource Name/instance of the dataSource
+ * @param model - Name/class of the model
+ * @param dataSource - Name/instance of the dataSource
  */
 export function repository(
   model: string | typeof Entity,
@@ -179,7 +179,7 @@ export namespace repository {
    * Decorator used to inject a Getter for a repository
    * Mainly intended for usage with repository injections on relation repository
    * factory
-   * @param nameOrClass The repository class (ProductRepository) or a string name ('ProductRepository').
+   * @param nameOrClass - The repository class (ProductRepository) or a string name ('ProductRepository').
    */
   export function getter(nameOrClass: string | Class<Repository<Model>>) {
     const name =
@@ -190,8 +190,8 @@ export namespace repository {
 
 /**
  * Resolve the @repository injection
- * @param ctx Context
- * @param injection Injection metadata
+ * @param ctx - Context
+ * @param injection - Injection metadata
  */
 async function resolve(ctx: Context, injection: Injection) {
   const meta = injection.metadata as RepositoryMetadata;

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -38,7 +38,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
     /**
      * Add a repository to this application.
      *
-     * @param repoClass The repository to add.
+     * @param repoClass - The repository to add.
      *
      * @example
      * ```ts
@@ -81,7 +81,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
     /**
      * Retrieve the repository instance from the given Repository class
      *
-     * @param repo The repository class to retrieve the instance of
+     * @param repo - The repository class to retrieve the instance of
      */
     // tslint:disable-next-line:no-any
     async getRepository<R extends Repository<any>>(repo: Class<R>): Promise<R> {
@@ -91,8 +91,8 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
     /**
      * Add the dataSource to this application.
      *
-     * @param dataSource The dataSource to add.
-     * @param name The binding name of the datasource; defaults to dataSource.name
+     * @param dataSource - The dataSource to add.
+     * @param name - The binding name of the datasource; defaults to dataSource.name
      *
      * @example
      * ```ts
@@ -138,7 +138,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      * Add a component to this application. Also mounts
      * all the components repositories.
      *
-     * @param component The component to add.
+     * @param component - The component to add.
      *
      * @example
      * ```ts
@@ -165,7 +165,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      * repositories. This function is intended to be used internally
      * by component()
      *
-     * @param component The component to mount repositories of
+     * @param component - The component to mount repositories of
      */
     mountComponentRepositories(component: Class<unknown>) {
       const componentKey = `components.${component.name}`;
@@ -188,7 +188,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      * Please check the documentation for your specific connector(s) for
      * a detailed breakdown of behaviors for automigrate!
      *
-     * @param options Migration options, e.g. whether to update tables
+     * @param options - Migration options, e.g. whether to update tables
      * preserving data or rebuild everything from scratch.
      */
     async migrateSchema(options: SchemaMigrationOptions = {}): Promise<void> {
@@ -258,7 +258,7 @@ export class RepositoryMixinDoc {
   /**
    * Add a repository to this application.
    *
-   * @param repo The repository to add.
+   * @param repo - The repository to add.
    *
    * @example
    * ```ts
@@ -291,7 +291,7 @@ export class RepositoryMixinDoc {
   /**
    * Retrieve the repository instance from the given Repository class
    *
-   * @param repo The repository class to retrieve the instance of
+   * @param repo - The repository class to retrieve the instance of
    */
   // tslint:disable-next-line:no-any
   async getRepository<R extends Repository<any>>(repo: Class<R>): Promise<R> {
@@ -301,8 +301,8 @@ export class RepositoryMixinDoc {
   /**
    * Add the dataSource to this application.
    *
-   * @param dataSource The dataSource to add.
-   * @param name The binding name of the datasource; defaults to dataSource.name
+   * @param dataSource - The dataSource to add.
+   * @param name - The binding name of the datasource; defaults to dataSource.name
    *
    * @example
    * ```ts
@@ -331,7 +331,7 @@ export class RepositoryMixinDoc {
    * Add a component to this application. Also mounts
    * all the components repositories.
    *
-   * @param component The component to add.
+   * @param component - The component to add.
    *
    * @example
    * ```ts
@@ -357,7 +357,7 @@ export class RepositoryMixinDoc {
    * repositories. This function is intended to be used internally
    * by component()
    *
-   * @param component The component to mount repositories of
+   * @param component - The component to mount repositories of
    */
   mountComponentRepository(component: Class<{}>) {}
 
@@ -371,7 +371,7 @@ export class RepositoryMixinDoc {
    * Please check the documentation for your specific connector(s) for
    * a detailed breakdown of behaviors for automigrate!
    *
-   * @param options Migration options, e.g. whether to update tables
+   * @param options - Migration options, e.g. whether to update tables
    * preserving data or rebuild everything from scratch.
    */
   async migrateSchema(options?: SchemaMigrationOptions): Promise<void> {}

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -96,8 +96,8 @@ export class ModelDefinition {
 
   /**
    * Add a property
-   * @param name Property definition or name (string)
-   * @param definitionOrType Definition or property type
+   * @param name - Property definition or name (string)
+   * @param definitionOrType - Definition or property type
    */
   addProperty(
     name: string,
@@ -112,8 +112,8 @@ export class ModelDefinition {
 
   /**
    * Add a setting
-   * @param name Setting name
-   * @param value Setting value
+   * @param name - Setting name
+   * @param value - Setting value
    */
   addSetting(name: string, value: any): this {
     this.settings[name] = value;
@@ -122,7 +122,7 @@ export class ModelDefinition {
 
   /**
    * Define a new relation.
-   * @param definition The definition of the new relation.
+   * @param definition - The definition of the new relation.
    */
   addRelation(definition: RelationMetadata): this {
     this.relations[definition.name] = definition;
@@ -254,7 +254,7 @@ export abstract class Entity extends Model implements Persistable {
   /**
    * Get the identity value for a given entity instance or entity data object.
    *
-   * @param entityOrData The data object for which to determine the identity
+   * @param entityOrData - The data object for which to determine the identity
    * value.
    */
   static getIdOf(entityOrData: AnyObject): any {
@@ -301,7 +301,7 @@ export abstract class Entity extends Model implements Persistable {
 
   /**
    * Build the where object for the given id
-   * @param id The id value
+   * @param id - The id value
    */
   static buildWhereForId(id: any) {
     const where = {} as any;

--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -272,7 +272,7 @@ export class WhereBuilder<MT extends object = AnyObject> {
    * should be considered as `deprecated`.
    *
    * Cast an `and`, `or`, or condition clause to Where
-   * @param clause And/Or/Condition clause
+   * @param clause - And/Or/Condition clause
    */
   cast(clause: AndClause<MT> | OrClause<MT> | Condition<MT>): Where<MT> {
     return clause;
@@ -280,7 +280,7 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add an `and` clause.
-   * @param w One or more where objects
+   * @param w - One or more where objects
    */
   and(...w: (Where<MT> | Where<MT>[])[]): this {
     let clauses: Where<MT>[] = [];
@@ -292,7 +292,7 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add an `or` clause.
-   * @param w One or more where objects
+   * @param w - One or more where objects
    */
   or(...w: (Where<MT> | Where<MT>[])[]): this {
     let clauses: Where<MT>[] = [];
@@ -304,8 +304,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add an `=` condition
-   * @param key Property name
-   * @param val Property value
+   * @param key - Property name
+   * @param val - Property value
    */
   eq<K extends KeyOf<MT>>(key: K, val: MT[K]): this {
     const w: Where<MT> = {};
@@ -315,8 +315,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `!=` condition
-   * @param key Property name
-   * @param val Property value
+   * @param key - Property name
+   * @param val - Property value
    */
   neq<K extends KeyOf<MT>>(key: K, val: MT[K]): this {
     const w: Where<MT> = {};
@@ -326,8 +326,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `>` condition
-   * @param key Property name
-   * @param val Property value
+   * @param key - Property name
+   * @param val - Property value
    */
   gt<K extends KeyOf<MT>>(key: K, val: MT[K]): this {
     const w: Where<MT> = {};
@@ -337,8 +337,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `>=` condition
-   * @param key Property name
-   * @param val Property value
+   * @param key - Property name
+   * @param val - Property value
    */
   gte<K extends KeyOf<MT>>(key: K, val: MT[K]): this {
     const w: Where<MT> = {};
@@ -348,8 +348,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `<` condition
-   * @param key Property name
-   * @param val Property value
+   * @param key - Property name
+   * @param val - Property value
    */
   lt<K extends KeyOf<MT>>(key: K, val: MT[K]): this {
     const w: Where<MT> = {};
@@ -359,8 +359,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `<=` condition
-   * @param key Property name
-   * @param val Property value
+   * @param key - Property name
+   * @param val - Property value
    */
   lte<K extends KeyOf<MT>>(key: K, val: MT[K]): this {
     const w: Where<MT> = {};
@@ -370,8 +370,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `inq` condition
-   * @param key Property name
-   * @param val An array of property values
+   * @param key - Property name
+   * @param val - An array of property values
    */
   inq<K extends KeyOf<MT>>(key: K, val: MT[K][]): this {
     const w: Where<MT> = {};
@@ -381,8 +381,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `nin` condition
-   * @param key Property name
-   * @param val An array of property values
+   * @param key - Property name
+   * @param val - An array of property values
    */
   nin<K extends KeyOf<MT>>(key: K, val: MT[K][]): this {
     const w: Where<MT> = {};
@@ -392,9 +392,9 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `between` condition
-   * @param key Property name
-   * @param val1 Property value lower bound
-   * @param val2 Property value upper bound
+   * @param key - Property name
+   * @param val1 - Property value lower bound
+   * @param val2 - Property value upper bound
    */
   between<K extends KeyOf<MT>>(key: K, val1: MT[K], val2: MT[K]): this {
     const w: Where<MT> = {};
@@ -404,8 +404,8 @@ export class WhereBuilder<MT extends object = AnyObject> {
 
   /**
    * Add a `exists` condition
-   * @param key Property name
-   * @param val Exists or not
+   * @param key - Property name
+   * @param val - Exists or not
    */
   exists<K extends KeyOf<MT>>(key: K, val?: boolean): this {
     const w: Where<MT> = {};
@@ -415,7 +415,7 @@ export class WhereBuilder<MT extends object = AnyObject> {
   /**
    * Add a where object. For conflicting keys with the existing where object,
    * create an `and` clause.
-   * @param where Where filter
+   * @param where - Where filter
    */
   impose(where: Where<MT>): this {
     if (!this.where) {
@@ -459,7 +459,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
   /**
    * Set `limit`
-   * @param limit Maximum number of records to be returned
+   * @param limit - Maximum number of records to be returned
    */
   limit(limit: number): this {
     assert(limit >= 1, `Limit ${limit} must a positive number`);
@@ -469,7 +469,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
   /**
    * Set `offset`
-   * @param offset Offset of the number of records to be returned
+   * @param offset - Offset of the number of records to be returned
    */
   offset(offset: number): this {
     this.filter.offset = offset;
@@ -486,7 +486,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
   /**
    * Describe what fields to be included/excluded
-   * @param f A field name to be included, an array of field names to be
+   * @param f - A field name to be included, an array of field names to be
    * included, or an Fields object for the inclusion/exclusion
    */
   fields(...f: (Fields<MT> | (keyof MT)[] | keyof MT)[]): this {
@@ -512,7 +512,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
   /**
    * Describe the sorting order
-   * @param o A field name with optional direction, an array of field names,
+   * @param o - A field name with optional direction, an array of field names,
    * or an Order object for the field/direction pairs
    */
   order(...o: (string | string[] | Order<MT>)[]): this {
@@ -548,7 +548,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
   /**
    * Declare `include`
-   * @param i A relation name, an array of relation names, or an `Inclusion`
+   * @param i - A relation name, an array of relation names, or an `Inclusion`
    * object for the relation/scope definitions
    */
   include(...i: (string | string[] | Inclusion<MT>)[]): this {
@@ -569,7 +569,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
   /**
    * Declare a where clause
-   * @param w Where object
+   * @param w - Where object
    */
   where(w: Where<MT>): this {
     this.filter.where = w;
@@ -582,7 +582,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
    * properties, throw an error. If it's not a Filter, coerce it to a filter,
    * and carry out the same logic.
    *
-   * @param constraint a constraint object to merge with own filter object
+   * @param constraint - a constraint object to merge with own filter object
    */
   impose(constraint: Filter<MT> | Where<MT>): this {
     if (!this.filter) {
@@ -619,8 +619,8 @@ export class FilterBuilder<MT extends object = AnyObject> {
 
 /**
  * Get nested properties by path
- * @param value Value of an object
- * @param path Path to the property
+ * @param value - Value of an object
+ * @param path - Path to the property
  */
 function getDeepProperty(value: AnyObject, path: string): any {
   const props = path.split('.');

--- a/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
@@ -54,7 +54,7 @@ type BelongsToResolvedDefinition = BelongsToDefinition & {keyTo: string};
  * Resolves given belongsTo metadata if target is specified to be a resolver.
  * Mainly used to infer what the `keyTo` property should be from the target's
  * property id metadata
- * @param relationMeta belongsTo metadata to resolve
+ * @param relationMeta - belongsTo metadata to resolve
  */
 function resolveBelongsToMetadata(relationMeta: BelongsToDefinition) {
   if (!isTypeResolver(relationMeta.target)) {

--- a/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
@@ -11,10 +11,10 @@ import {BelongsToDefinition, RelationType} from '../relation.types';
 
 /**
  * Decorator for belongsTo
- * @param targetResolver A resolver function that returns the target model for
+ * @param targetResolver - A resolver function that returns the target model for
  * a belongsTo relation
- * @param definition Optional metadata for setting up a belongsTo relation
- * @param propertyDefinition Optional metadata for setting up the property
+ * @param definition - Optional metadata for setting up a belongsTo relation
+ * @param propertyDefinition - Optional metadata for setting up the property
  * @returns {(target: Object, key:string)}
  */
 export function belongsTo<T extends Entity>(

--- a/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
@@ -28,8 +28,8 @@ export class DefaultBelongsToRepository<
 > implements BelongsToRepository<TargetEntity> {
   /**
    * Constructor of DefaultBelongsToEntityCrudRepository
-   * @param getTargetRepository the getter of the related target model repository instance
-   * @param constraint the key value pair representing foreign key name to constrain
+   * @param getTargetRepository - the getter of the related target model repository instance
+   * @param constraint - the key value pair representing foreign key name to constrain
    * the target repository instance
    */
   constructor(

--- a/packages/repository/src/relations/has-many/has-many-repository.factory.ts
+++ b/packages/repository/src/relations/has-many/has-many-repository.factory.ts
@@ -28,9 +28,9 @@ export type HasManyRepositoryFactory<Target extends Entity, ForeignKeyType> = (
  * via a HasMany relation, then, the relational repository returned by the
  * factory function would be constrained by a Customer model instance's id(s).
  *
- * @param relationMetadata The relation metadata used to describe the
+ * @param relationMetadata - The relation metadata used to describe the
  * relationship and determine how to apply the constraint.
- * @param targetRepositoryGetter The repository which represents the target model of a
+ * @param targetRepositoryGetter - The repository which represents the target model of a
  * relation attached to a datasource.
  * @returns The factory function which accepts a foreign key value to constrain
  * the given target repository
@@ -62,7 +62,7 @@ type HasManyResolvedDefinition = HasManyDefinition & {keyTo: string};
  * Resolves given hasMany metadata if target is specified to be a resolver.
  * Mainly used to infer what the `keyTo` property should be from the target's
  * belongsTo metadata
- * @param relationMeta hasMany metadata to resolve
+ * @param relationMeta - hasMany metadata to resolve
  */
 function resolveHasManyMetadata(
   relationMeta: HasManyDefinition,

--- a/packages/repository/src/relations/has-many/has-many.decorator.ts
+++ b/packages/repository/src/relations/has-many/has-many.decorator.ts
@@ -11,8 +11,8 @@ import {HasManyDefinition, RelationType} from '../relation.types';
  * Decorator for hasMany
  * Calls property.array decorator underneath the hood and infers foreign key
  * name from target model name unless explicitly specified
- * @param targetResolver Target model for hasMany relation
- * @param definition Optional metadata for setting up hasMany relation
+ * @param targetResolver - Target model for hasMany relation
+ * @param definition - Optional metadata for setting up hasMany relation
  * @returns {(target:any, key:string)}
  */
 export function hasMany<T extends Entity>(

--- a/packages/repository/src/relations/has-many/has-many.repository.ts
+++ b/packages/repository/src/relations/has-many/has-many.repository.ts
@@ -20,8 +20,8 @@ import {EntityCrudRepository} from '../../repositories/repository';
 export interface HasManyRepository<Target extends Entity> {
   /**
    * Create a target model instance
-   * @param targetModelData The target model data
-   * @param options Options for the operation
+   * @param targetModelData - The target model data
+   * @param options - Options for the operation
    * @returns A promise which resolves to the newly created target model instance
    */
   create(
@@ -30,22 +30,22 @@ export interface HasManyRepository<Target extends Entity> {
   ): Promise<Target>;
   /**
    * Find target model instance(s)
-   * @param filter A filter object for where, order, limit, etc.
-   * @param options Options for the operation
+   * @param filter - A filter object for where, order, limit, etc.
+   * @param options - Options for the operation
    * @returns A promise which resolves with the found target instance(s)
    */
   find(filter?: Filter<Target>, options?: Options): Promise<Target[]>;
   /**
    * Delete multiple target model instances
-   * @param where Instances within the where scope are deleted
+   * @param where - Instances within the where scope are deleted
    * @param options
    * @returns A promise which resolves the deleted target model instances
    */
   delete(where?: Where<Target>, options?: Options): Promise<Count>;
   /**
    * Patch multiple target model instances
-   * @param dataObject The fields and their new values to patch
-   * @param where Instances within the where scope are patched
+   * @param dataObject - The fields and their new values to patch
+   * @param where - Instances within the where scope are patched
    * @param options
    * @returns A promise which resolves the patched target model instances
    */
@@ -63,8 +63,8 @@ export class DefaultHasManyRepository<
 > implements HasManyRepository<TargetEntity> {
   /**
    * Constructor of DefaultHasManyEntityCrudRepository
-   * @param getTargetRepository the getter of the related target model repository instance
-   * @param constraint the key value pair representing foreign key name to constrain
+   * @param getTargetRepository - the getter of the related target model repository instance
+   * @param constraint - the key value pair representing foreign key name to constrain
    * the target repository instance
    */
   constructor(

--- a/packages/repository/src/relations/has-one/has-one-repository.factory.ts
+++ b/packages/repository/src/relations/has-one/has-one-repository.factory.ts
@@ -25,9 +25,9 @@ export type HasOneRepositoryFactory<Target extends Entity, ForeignKeyType> = (
  * via a HasOne relation, then, the relational repository returned by the
  * factory function would be constrained by a Customer model instance's id(s).
  *
- * @param relationMetadata The relation metadata used to describe the
+ * @param relationMetadata - The relation metadata used to describe the
  * relationship and determine how to apply the constraint.
- * @param targetRepositoryGetter The repository which represents the target model of a
+ * @param targetRepositoryGetter - The repository which represents the target model of a
  * relation attached to a datasource.
  * @returns The factory function which accepts a foreign key value to constrain
  * the given target repository
@@ -59,7 +59,7 @@ type HasOneResolvedDefinition = HasOneDefinition & {keyTo: string};
  * Resolves given hasOne metadata if target is specified to be a resolver.
  * Mainly used to infer what the `keyTo` property should be from the target's
  * hasOne metadata
- * @param relationMeta hasOne metadata to resolve
+ * @param relationMeta - hasOne metadata to resolve
  */
 function resolveHasOneMetadata(
   relationMeta: HasOneDefinition,

--- a/packages/repository/src/relations/has-one/has-one.decorator.ts
+++ b/packages/repository/src/relations/has-one/has-one.decorator.ts
@@ -10,8 +10,8 @@ import {HasOneDefinition, RelationType} from '../relation.types';
 /*
  * Decorator for hasOne
  * infers foreign key name from target model name unless explicitly specified
- * @param targetResolver Target model for hasOne relation
- * @param definition Optional metadata for setting up hasOne relation
+ * @param targetResolver - Target model for hasOne relation
+ * @param definition - Optional metadata for setting up hasOne relation
  * @returns {(target:any, key:string)}
  */
 export function hasOne<T extends Entity>(

--- a/packages/repository/src/relations/has-one/has-one.repository.ts
+++ b/packages/repository/src/relations/has-one/has-one.repository.ts
@@ -21,8 +21,8 @@ import {
 export interface HasOneRepository<Target extends Entity> {
   /**
    * Create a target model instance
-   * @param targetModelData The target model data
-   * @param options Options for the operation
+   * @param targetModelData - The target model data
+   * @param options - Options for the operation
    * @returns A promise which resolves to the newly created target model instance
    */
   create(
@@ -32,8 +32,8 @@ export interface HasOneRepository<Target extends Entity> {
 
   /**
    * Find the only target model instance that belongs to the declaring model.
-   * @param filter Query filter without a Where condition
-   * @param options Options for the operations
+   * @param filter - Query filter without a Where condition
+   * @param options - Options for the operations
    * @returns A promise of the target object or null if not found.
    */
   get(
@@ -50,7 +50,7 @@ export interface HasOneRepository<Target extends Entity> {
 
   /**
    * Patch the  related target model instance
-   * @param dataObject The target model fields and their new values to patch
+   * @param dataObject - The target model fields and their new values to patch
    * @param options
    * @returns A promise which resolves the patched target model instances
    */
@@ -64,8 +64,8 @@ export class DefaultHasOneRepository<
 > implements HasOneRepository<TargetEntity> {
   /**
    * Constructor of DefaultHasOneEntityCrudRepository
-   * @param getTargetRepository the getter of the related target model repository instance
-   * @param constraint the key value pair representing foreign key name to constrain
+   * @param getTargetRepository - the getter of the related target model repository instance
+   * @param constraint - the key value pair representing foreign key name to constrain
    * the target repository instance
    */
   constructor(

--- a/packages/repository/src/relations/relation.decorator.ts
+++ b/packages/repository/src/relations/relation.decorator.ts
@@ -23,7 +23,7 @@ export function relation(definition?: Object) {
 /**
  * Get metadata of all relations defined on a given model class.
  *
- * @param modelCtor The model class (the constructor function).
+ * @param modelCtor - The model class (the constructor function).
  * @return
  */
 export function getModelRelations(

--- a/packages/repository/src/repositories/constraint-utils.ts
+++ b/packages/repository/src/repositories/constraint-utils.ts
@@ -11,8 +11,8 @@ import {Filter, FilterBuilder, Where, WhereBuilder} from '../query';
 /**
  * A utility function which takes a filter and enforces constraint(s)
  * on it
- * @param originalFilter the filter to apply the constrain(s) to
- * @param constraint the constraint which is to be applied on the filter
+ * @param originalFilter - the filter to apply the constrain(s) to
+ * @param constraint - the constraint which is to be applied on the filter
  * @returns Filter the modified filter with the constraint, otherwise
  * the original filter
  */
@@ -28,8 +28,8 @@ export function constrainFilter<T extends object>(
 /**
  * A utility function which takes a where filter and enforces constraint(s)
  * on it
- * @param originalWhere the where filter to apply the constrain(s) to
- * @param constraint the constraint which is to be applied on the filter
+ * @param originalWhere - the where filter to apply the constrain(s) to
+ * @param constraint - the constraint which is to be applied on the filter
  * @returns Filter the modified filter with the constraint, otherwise
  * the original filter
  */
@@ -44,8 +44,8 @@ export function constrainWhere<T extends object>(
 /**
  * A utility function which takes a model instance data and enforces constraint(s)
  * on it
- * @param originalData the model data to apply the constrain(s) to
- * @param constraint the constraint which is to be applied on the data object
+ * @param originalData - the model data to apply the constrain(s) to
+ * @param constraint - the constraint which is to be applied on the data object
  * @returns the modified data with the constraint, otherwise
  * the original instance data
  */
@@ -68,8 +68,8 @@ export function constrainDataObject<T extends Entity>(
 /**
  * A utility function which takes an array of model instance data and
  * enforces constraint(s) on it
- * @param originalData the array of model data to apply the constrain(s) to
- * @param constraint the constraint which is to be applied on the data objects
+ * @param originalData - the array of model data to apply the constrain(s) to
+ * @param constraint - the constraint which is to be applied on the data objects
  * @returns an array of the modified data with the constraint, otherwise
  * the original instance data array
  */

--- a/packages/repository/src/repositories/kv.repository.bridge.ts
+++ b/packages/repository/src/repositories/kv.repository.bridge.ts
@@ -34,7 +34,7 @@ export class DefaultKeyValueRepository<T extends Entity>
 
   /**
    * Construct a KeyValueRepository with a legacy DataSource
-   * @param ds Legacy DataSource
+   * @param ds - Legacy DataSource
    */
   constructor(
     private entityClass: typeof Entity & {prototype: T},

--- a/packages/repository/src/repositories/kv.repository.ts
+++ b/packages/repository/src/repositories/kv.repository.ts
@@ -26,24 +26,24 @@ export interface KeyValueRepository<T extends Model> extends Repository<T> {
   /**
    * Delete an entry by key
    *
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    */
   delete(key: string, options?: Options): Promise<void>;
 
   /**
    * Delete all entries
    *
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    */
   deleteAll(options?: Options): Promise<void>;
 
   /**
    * Get an entry by key
    *
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    * @returns A promise of the entry
    */
   get(key: string, options?: Options): Promise<T>;
@@ -51,26 +51,26 @@ export interface KeyValueRepository<T extends Model> extends Repository<T> {
   /**
    * Set an entry with key/value
    *
-   * @param key Key for the entry
-   * @param value Value for the entry
-   * @param options Options for the operation
+   * @param key - Key for the entry
+   * @param value - Value for the entry
+   * @param options - Options for the operation
    */
   set(key: string, value: DataObject<T>, options?: Options): Promise<void>;
 
   /**
    * Set up ttl for an entry by key
    *
-   * @param key Key for the entry
-   * @param ttl Ttl for the entry
-   * @param options Options for the operation
+   * @param key - Key for the entry
+   * @param ttl - Ttl for the entry
+   * @param options - Options for the operation
    */
   expire(key: string, ttl: number, options?: Options): Promise<void>;
 
   /**
    * Get ttl for an entry by key
    *
-   * @param key Key for the entry
-   * @param options Options for the operation
+   * @param key - Key for the entry
+   * @param options - Options for the operation
    * @returns A promise of the TTL value
    */
   ttl?(key: string, options?: Options): Promise<number>;
@@ -78,8 +78,8 @@ export interface KeyValueRepository<T extends Model> extends Repository<T> {
   /**
    * Get an Iterator for matching keys
    *
-   * @param filter Filter for keys
-   * @param options Options for the operation
+   * @param filter - Filter for keys
+   * @param options - Options for the operation
    * @returns An async iteratable iterator of keys so that the return value can
    * be used with `for-await-of`.
    */

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -70,7 +70,7 @@ export function bindModel<T extends juggler.ModelBaseClass>(
 
 /**
  * Ensure the value is a promise
- * @param p Promise or void
+ * @param p - Promise or void
  */
 /* tslint:disable-next-line:no-any */
 export function ensurePromise<T>(p: legacy.PromiseOrVoid<T>): Promise<T> {
@@ -94,8 +94,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
 
   /**
    * Constructor of DefaultCrudRepository
-   * @param entityClass Legacy entity class
-   * @param dataSource Legacy data source
+   * @param entityClass - Legacy entity class
+   * @param dataSource - Legacy data source
    */
   constructor(
     // entityClass should have type "typeof T", but that's not supported by TSC
@@ -183,8 +183,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
    *
    * Use `this.createHasManyRepositoryFactoryFor()` instead
    *
-   * @param relationName Name of the relation defined on the source model
-   * @param targetRepo Target repository instance
+   * @param relationName - Name of the relation defined on the source model
+   * @param targetRepo - Target repository instance
    */
   protected _createHasManyRepositoryFactoryFor<
     Target extends Entity,
@@ -224,8 +224,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
    * }
    * ```
    *
-   * @param relationName Name of the relation defined on the source model
-   * @param targetRepo Target repository instance
+   * @param relationName - Name of the relation defined on the source model
+   * @param targetRepo - Target repository instance
    */
   protected createHasManyRepositoryFactoryFor<
     Target extends Entity,
@@ -248,8 +248,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
    *
    * Use `this.createBelongsToAccessorFor()` instead
    *
-   * @param relationName Name of the relation defined on the source model
-   * @param targetRepo Target repository instance
+   * @param relationName - Name of the relation defined on the source model
+   * @param targetRepo - Target repository instance
    */
   protected _createBelongsToAccessorFor<Target extends Entity, TargetId>(
     relationName: string,
@@ -261,8 +261,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
   /**
    * Function to create a belongs to accessor
    *
-   * @param relationName Name of the relation defined on the source model
-   * @param targetRepo Target repository instance
+   * @param relationName - Name of the relation defined on the source model
+   * @param targetRepo - Target repository instance
    */
   protected createBelongsToAccessorFor<Target extends Entity, TargetId>(
     relationName: string,
@@ -280,8 +280,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
    * @deprecated
    * Function to create a constrained hasOne relation repository factory
    *
-   * @param relationName Name of the relation defined on the source model
-   * @param targetRepo Target repository instance
+   * @param relationName - Name of the relation defined on the source model
+   * @param targetRepo - Target repository instance
    */
   protected _createHasOneRepositoryFactoryFor<
     Target extends Entity,
@@ -300,8 +300,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
   /**
    * Function to create a constrained hasOne relation repository factory
    *
-   * @param relationName Name of the relation defined on the source model
-   * @param targetRepo Target repository instance
+   * @param relationName - Name of the relation defined on the source model
+   * @param targetRepo - Target repository instance
    */
   protected createHasOneRepositoryFactoryFor<
     Target extends Entity,

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -25,10 +25,10 @@ export interface Repository<T extends Model> {}
 export interface ExecutableRepository<T extends Model> extends Repository<T> {
   /**
    * Execute a query with the given parameter object or an array of parameters
-   * @param command The query string or command object
-   * @param parameters The object with name/value pairs or an array of parameter
+   * @param command - The query string or command object
+   * @param parameters - The object with name/value pairs or an array of parameter
    * values
-   * @param options Options
+   * @param options - Options
    */
   execute(
     command: Command,
@@ -44,33 +44,33 @@ export interface CrudRepository<T extends ValueObject | Entity>
   extends Repository<T> {
   /**
    * Create a new record
-   * @param dataObject The data to be created
-   * @param options Options for the operations
+   * @param dataObject - The data to be created
+   * @param options - Options for the operations
    * @returns A promise of record created
    */
   create(dataObject: DataObject<T>, options?: Options): Promise<T>;
 
   /**
    * Create all records
-   * @param dataObjects An array of data to be created
-   * @param options Options for the operations
+   * @param dataObjects - An array of data to be created
+   * @param options - Options for the operations
    * @returns A promise of an array of records created
    */
   createAll(dataObjects: DataObject<T>[], options?: Options): Promise<T[]>;
 
   /**
    * Find matching records
-   * @param filter Query filter
-   * @param options Options for the operations
+   * @param filter - Query filter
+   * @param options - Options for the operations
    * @returns A promise of an array of records found
    */
   find(filter?: Filter<T>, options?: Options): Promise<T[]>;
 
   /**
    * Updating matching records with attributes from the data object
-   * @param dataObject The data to be updated
-   * @param where Matching criteria
-   * @param options Options for the operations
+   * @param dataObject - The data to be updated
+   * @param where - Matching criteria
+   * @param options - Options for the operations
    * @returns A promise of number of records updated
    */
   updateAll(
@@ -81,16 +81,16 @@ export interface CrudRepository<T extends ValueObject | Entity>
 
   /**
    * Delete matching records
-   * @param where Matching criteria
-   * @param options Options for the operations
+   * @param where - Matching criteria
+   * @param options - Options for the operations
    * @returns A promise of number of records deleted
    */
   deleteAll(where?: Where<T>, options?: Options): Promise<Count>;
 
   /**
    * Count matching records
-   * @param where Matching criteria
-   * @param options Options for the operations
+   * @param where - Matching criteria
+   * @param options - Options for the operations
    * @returns A promise of number of records matched
    */
   count(where?: Where<T>, options?: Options): Promise<Count>;
@@ -113,8 +113,8 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Save an entity. If no id is present, create a new entity
-   * @param entity Entity to be saved
-   * @param options Options for the operations
+   * @param entity - Entity to be saved
+   * @param options - Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.
    */
@@ -122,8 +122,8 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Update an entity
-   * @param entity Entity to be updated
-   * @param options Options for the operations
+   * @param entity - Entity to be updated
+   * @param options - Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.
    */
@@ -131,8 +131,8 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Delete an entity
-   * @param entity Entity to be deleted
-   * @param options Options for the operations
+   * @param entity - Entity to be deleted
+   * @param options - Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.
    */
@@ -140,19 +140,19 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Find an entity by id, return a rejected promise if not found.
-   * @param id Value for the entity id
-   * @param filter Additional query options. E.g. `filter.include` configures
+   * @param id - Value for the entity id
+   * @param filter - Additional query options. E.g. `filter.include` configures
    * which related models to fetch as part of the database query (or queries).
-   * @param options Options for the operations
+   * @param options - Options for the operations
    * @returns A promise of an entity found for the id
    */
   findById(id: ID, filter?: Filter<T>, options?: Options): Promise<T>;
 
   /**
    * Update an entity by id with property/value pairs in the data object
-   * @param id Value for the entity id
-   * @param data Data attributes to be updated
-   * @param options Options for the operations
+   * @param id - Value for the entity id
+   * @param data - Data attributes to be updated
+   * @param options - Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.
    */
@@ -160,9 +160,9 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Replace an entity by id
-   * @param id Value for the entity id
-   * @param data Data attributes to be replaced
-   * @param options Options for the operations
+   * @param id - Value for the entity id
+   * @param data - Data attributes to be replaced
+   * @param options - Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.
    */
@@ -170,8 +170,8 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Delete an entity by id
-   * @param id Value for the entity id
-   * @param options Options for the operations
+   * @param id - Value for the entity id
+   * @param options - Options for the operations
    * @returns A promise that will be resolve if the operation succeeded or will
    * be rejected if the entity was not found.
    */
@@ -179,8 +179,8 @@ export interface EntityCrudRepository<T extends Entity, ID>
 
   /**
    * Check if an entity exists for the given id
-   * @param id Value for the entity id
-   * @param options Options for the operations
+   * @param id - Value for the entity id
+   * @param options - Options for the operations
    * @returns Promise<true> if an entity exists for the id, otherwise
    * Promise<false>
    */

--- a/packages/repository/src/type-resolver.ts
+++ b/packages/repository/src/type-resolver.ts
@@ -31,7 +31,7 @@ export type TypeResolver<
 
 /**
  * A function that checks whether a function is a TypeResolver or not.
- * @param fn The value to check.
+ * @param fn - The value to check.
  */
 export function isTypeResolver<T extends Object>(
   // tslint:disable-next-line:no-any
@@ -74,7 +74,7 @@ export function isBuiltinType(fn: Function): boolean {
 
 /**
  * Resolve a type value that may have been provided via TypeResolver.
- * @param fn A type class or a type provider.
+ * @param fn - A type class or a type provider.
  * @returns The resolved type.
  */
 export function resolveType<T extends Object>(

--- a/packages/repository/src/types/type.ts
+++ b/packages/repository/src/types/type.ts
@@ -18,7 +18,7 @@ export interface Type<T> {
 
   /**
    * Test if the given value is an instance of this type
-   * @param value The value
+   * @param value - The value
    */
   isInstance(value: any): boolean;
 
@@ -29,23 +29,23 @@ export interface Type<T> {
 
   /**
    * Check if the given value can be coerced into this type
-   * @param value The value to to be coerced
+   * @param value - The value to to be coerced
    * @returns {boolean}
    */
   isCoercible(value: any, options?: Options): boolean;
 
   /**
    * Coerce the value into this type
-   * @param value The value to be coerced
-   * @param options Options for coercion
+   * @param value - The value to be coerced
+   * @param options - Options for coercion
    * @returns Coerced value of this type
    */
   coerce(value: any, options?: Options): T | null | undefined;
 
   /**
    * Serialize a value into json
-   * @param value The value of this type
-   * @param options Options for serialization
+   * @param value - The value of this type
+   * @param options - Options for serialization
    */
   serialize(value: T | null | undefined, options?: Options): any;
 }

--- a/packages/rest/src/__tests__/helpers.ts
+++ b/packages/rest/src/__tests__/helpers.ts
@@ -12,9 +12,9 @@ import {RestServerConfig, RestServerResolvedConfig} from '../rest.server';
 
 /**
  * Create an OpenAPI request body spec with the given content
- * @param schema The schema object
- * @param options Other attributes for the spec
- * @param mediaType Optional media type, default to `application/json`
+ * @param schema - The schema object
+ * @param options - Other attributes for the spec
+ * @param mediaType - Optional media type, default to `application/json`
  */
 export function aBodySpec(
   schema: SchemaObject | ReferenceObject,

--- a/packages/rest/src/body-parsers/body-parser.helpers.ts
+++ b/packages/rest/src/body-parsers/body-parser.helpers.ts
@@ -17,7 +17,7 @@ const debug = debugModule('loopback:rest:body-parser');
 
 /**
  * Get the content-type header value from the request
- * @param req Http request
+ * @param req - Http request
  */
 export function getContentType(req: Request): string | undefined {
   return req.get('content-type');
@@ -48,8 +48,8 @@ export function normalizeParsingError(err: HttpError) {
 
 /**
  * Parse the request body asynchronously
- * @param handle The express middleware handler
- * @param request Http request
+ * @param handle - The express middleware handler
+ * @param request - Http request
  */
 export function invokeBodyParserMiddleware(
   handle: BodyParserMiddleware,
@@ -73,7 +73,7 @@ export const DEFAULT_LIMIT = '1mb';
 
 /**
  * Extract parser options based on the parser type
- * @param type json|urlencoded|text
+ * @param type - json|urlencoded|text
  * @param options
  */
 export function getParserOptions(

--- a/packages/rest/src/body-parsers/body-parser.ts
+++ b/packages/rest/src/body-parsers/body-parser.ts
@@ -131,7 +131,7 @@ export class RequestBodyParser {
 
   /**
    * Find a body parser that supports the media type
-   * @param matchedMediaType Media type
+   * @param matchedMediaType - Media type
    */
   private _findParser(matchedMediaType: string) {
     for (const parser of this.parsers) {
@@ -150,8 +150,8 @@ export class RequestBodyParser {
 
   /**
    * Resolve and invoke a custom parser
-   * @param customParser The parser name, class or function
-   * @param request Http request
+   * @param customParser - The parser name, class or function
+   * @param request - Http request
    */
   private async _invokeCustomParser(
     customParser: string | Constructor<BodyParser> | BodyParserFunction,

--- a/packages/rest/src/body-parsers/types.ts
+++ b/packages/rest/src/body-parsers/types.ts
@@ -39,12 +39,12 @@ export interface BodyParser {
   name: string | symbol;
   /**
    * Indicate if the given media type is supported
-   * @param mediaType Media type
+   * @param mediaType - Media type
    */
   supports(mediaType: string): boolean;
   /**
    * Parse the request body
-   * @param request http request
+   * @param request - http request
    */
   parse(request: Request): Promise<RequestBody>;
 }

--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -25,8 +25,8 @@ const debug = debugModule('loopback:rest:coercion');
  * Coerce the http raw data to a JavaScript type data of a parameter
  * according to its OpenAPI schema specification.
  *
- * @param data The raw data get from http request
- * @param schema The parameter's schema defined in OpenAPI specification
+ * @param data - The raw data get from http request
+ * @param schema - The parameter's schema defined in OpenAPI specification
  */
 export function coerceParameter(
   data: string | undefined | object,

--- a/packages/rest/src/coercion/utils.ts
+++ b/packages/rest/src/coercion/utils.ts
@@ -28,7 +28,7 @@ export function isEmpty(data: string) {
 /**
  * A set of truthy values. A data in this set will be coerced to `true`.
  *
- * @param data The raw data get from http request
+ * @param data - The raw data get from http request
  * @returns The corresponding coerced boolean type
  */
 export function isTrue(data: string): boolean {
@@ -37,7 +37,7 @@ export function isTrue(data: string): boolean {
 
 /**
  * A set of falsy values. A data in this set will be coerced to `false`.
- * @param data The raw data get from http request
+ * @param data - The raw data get from http request
  * @returns The corresponding coerced boolean type
  */
 export function isFalse(data: string): boolean {
@@ -56,7 +56,7 @@ const REGEX_RFC3339_DATE = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]
 /**
  * Return true when a date follows the RFC3339 standard
  *
- * @param date The date to verify
+ * @param date - The date to verify
  */
 export function matchDateFormat(date: string) {
   const pattern = new RegExp(REGEX_RFC3339_DATE);
@@ -68,8 +68,8 @@ export function matchDateFormat(date: string) {
 /**
  * Return the corresponding OpenAPI data type given an OpenAPI schema
  *
- * @param type The type in an OpenAPI schema specification
- * @param format The format in an OpenAPI schema specification
+ * @param type - The type in an OpenAPI schema specification
+ * @param format - The format in an OpenAPI schema specification
  */
 export function getOAIPrimitiveType(type?: string, format?: string) {
   if (type === 'object' || type === 'array') return type;

--- a/packages/rest/src/coercion/validator.ts
+++ b/packages/rest/src/coercion/validator.ts
@@ -31,9 +31,9 @@ export class Validator {
    * The validation executed before type coercion. Like
    * checking absence.
    *
-   * @param type A parameter's type.
-   * @param value A parameter's raw value from http request.
-   * @param opts options
+   * @param type - A parameter's type.
+   * @param value - A parameter's raw value from http request.
+   * @param opts - options
    */
   validateParamBeforeCoercion(
     value: string | object | undefined,

--- a/packages/rest/src/parse-json.ts
+++ b/packages/rest/src/parse-json.ts
@@ -15,7 +15,7 @@
 
 /**
  * Factory to create a reviver function for `JSON.parse` to sanitize keys
- * @param reviver Reviver function
+ * @param reviver - Reviver function
  */
 export function sanitizeJsonParse(reviver?: (key: any, value: any) => any) {
   return (key: string, value: any) => {
@@ -31,8 +31,8 @@ export function sanitizeJsonParse(reviver?: (key: any, value: any) => any) {
 
 /**
  *
- * @param text JSON string
- * @param reviver Optional reviver function for `JSON.parse`
+ * @param text - JSON string
+ * @param reviver - Optional reviver function for `JSON.parse`
  */
 export function parseJson(
   text: string,

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -23,8 +23,8 @@ const debug = debugFactory('loopback:rest:parser');
  * Parses the request to derive arguments to be passed in for the Application
  * controller method
  *
- * @param request Incoming HTTP request
- * @param route Resolved Route
+ * @param request - Incoming HTTP request
+ * @param route - Resolved Route
  */
 export async function parseOperationArgs(
   request: Request,

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -61,8 +61,8 @@ export class RestApplication extends Application implements HttpServerLike {
    * server.listen(3000);
    * ```
    *
-   * @param req The request.
-   * @param res The response.
+   * @param req - The request.
+   * @param res - The response.
    */
   get requestHandler(): HttpRequestListener {
     return this.restServer.requestHandler;
@@ -91,11 +91,11 @@ export class RestApplication extends Application implements HttpServerLike {
   /**
    * Mount static assets to the REST server.
    * See https://expressjs.com/en/4x/api.html#express.static
-   * @param path The path(s) to serve the asset.
+   * @param path - The path(s) to serve the asset.
    * See examples at https://expressjs.com/en/4x/api.html#path-examples
    * To avoid performance penalty, `/` is not allowed for now.
-   * @param rootDir The root directory from which to serve static assets
-   * @param options Options for serve-static
+   * @param rootDir - The root directory from which to serve static assets
+   * @param options - Options for serve-static
    */
   static(path: PathParams, rootDir: string, options?: ServeStaticOptions) {
     this.restServer.static(path, rootDir, options);
@@ -103,8 +103,8 @@ export class RestApplication extends Application implements HttpServerLike {
 
   /**
    * Bind a body parser to the server context
-   * @param parserClass Body parser class
-   * @param address Optional binding address
+   * @param parserClass - Body parser class
+   * @param address - Optional binding address
    */
   bodyParser(
     bodyParserClass: Constructor<BodyParser>,
@@ -115,7 +115,7 @@ export class RestApplication extends Application implements HttpServerLike {
 
   /**
    * Configure the `basePath` for the rest server
-   * @param path Base path
+   * @param path - Base path
    */
   basePath(path: string = '') {
     this.restServer.basePath(path);
@@ -134,12 +134,12 @@ export class RestApplication extends Application implements HttpServerLike {
    * app.route('get', '/greet', operationSpec, MyController, 'greet');
    * ```
    *
-   * @param verb HTTP verb of the endpoint
-   * @param path URL path of the endpoint
-   * @param spec The OpenAPI spec describing the endpoint (operation)
-   * @param controllerCtor Controller constructor
-   * @param controllerFactory A factory function to create controller instance
-   * @param methodName The name of the controller method
+   * @param verb - HTTP verb of the endpoint
+   * @param path - URL path of the endpoint
+   * @param spec - The OpenAPI spec describing the endpoint (operation)
+   * @param controllerCtor - Controller constructor
+   * @param controllerFactory - A factory function to create controller instance
+   * @param methodName - The name of the controller method
    */
   route<T>(
     verb: string,
@@ -161,10 +161,10 @@ export class RestApplication extends Application implements HttpServerLike {
    * app.route('get', '/', operationSpec, greet);
    * ```
    *
-   * @param verb HTTP verb of the endpoint
-   * @param path URL path of the endpoint
-   * @param spec The OpenAPI spec describing the endpoint (operation)
-   * @param handler The function to invoke with the request parameters
+   * @param verb - HTTP verb of the endpoint
+   * @param path - URL path of the endpoint
+   * @param spec - The OpenAPI spec describing the endpoint (operation)
+   * @param handler - The function to invoke with the request parameters
    * described in the spec.
    */
   route(
@@ -186,7 +186,7 @@ export class RestApplication extends Application implements HttpServerLike {
    * app.route(route);
    * ```
    *
-   * @param route The route to add.
+   * @param route - The route to add.
    */
   route(route: RouteEntry): Binding;
 
@@ -246,11 +246,11 @@ export class RestApplication extends Application implements HttpServerLike {
    * app.redirect('/explorer', '/explorer/');
    * ```
    *
-   * @param fromPath URL path of the redirect endpoint
-   * @param toPathOrUrl Location (URL path or full URL) where to redirect to.
+   * @param fromPath - URL path of the redirect endpoint
+   * @param toPathOrUrl - Location (URL path or full URL) where to redirect to.
    * If your server is configured with a custom `basePath`, then the base path
    * is prepended to the target location.
-   * @param statusCode HTTP status code to respond with,
+   * @param statusCode - HTTP status code to respond with,
    *   defaults to 303 (See Other).
    */
   redirect(
@@ -269,7 +269,7 @@ export class RestApplication extends Application implements HttpServerLike {
    * Note that this will override any routes defined via decorators at the
    * controller level (this function takes precedent).
    *
-   * @param {OpenApiSpec} spec The OpenAPI specification, as an object.
+   * @param spec - The OpenAPI specification, as an object.
    * @returns {Binding}
    */
   api(spec: OpenApiSpec): Binding {
@@ -280,9 +280,9 @@ export class RestApplication extends Application implements HttpServerLike {
    * Mount an Express router to expose additional REST endpoints handled
    * via legacy Express-based stack.
    *
-   * @param basePath Path where to mount the router at, e.g. `/` or `/api`.
-   * @param router The Express router to handle the requests.
-   * @param spec A partial OpenAPI spec describing endpoints provided by the
+   * @param basePath - Path where to mount the router at, e.g. `/` or `/api`.
+   * @param router - The Express router to handle the requests.
+   * @param spec - A partial OpenAPI spec describing endpoints provided by the
    * router. LoopBack will prepend `basePath` to all endpoints automatically.
    * This argument is optional. You can leave it out if you don't want to
    * document the routes.

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -123,8 +123,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * httpServer.listen(3000);
    * ```
    *
-   * @param req The request.
-   * @param res The response.
+   * @param req - The request.
+   * @param res - The response.
    */
 
   protected _requestHandler: HttpRequestListener;
@@ -175,7 +175,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    *
    * Creates an instance of RestServer.
    *
-   * @param {Application} app The application instance (injected via
+   * @param app - The application instance (injected via
    * CoreBindings.APPLICATION_INSTANCE).
    * @param {RestServerConfig=} config The configuration options (injected via
    * RestBindings.CONFIG).
@@ -454,7 +454,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Register a controller class with this server.
    *
-   * @param {Constructor} controllerCtor The controller class
+   * @param controllerCtor - The controller class
    * (constructor function).
    * @returns {Binding} The newly created binding, you can use the reference to
    * further modify the binding, e.g. lock the value to prevent further
@@ -487,12 +487,12 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * app.route('get', '/greet', operationSpec, MyController, 'greet');
    * ```
    *
-   * @param verb HTTP verb of the endpoint
-   * @param path URL path of the endpoint
-   * @param spec The OpenAPI spec describing the endpoint (operation)
-   * @param controllerCtor Controller constructor
-   * @param controllerFactory A factory function to create controller instance
-   * @param methodName The name of the controller method
+   * @param verb - HTTP verb of the endpoint
+   * @param path - URL path of the endpoint
+   * @param spec - The OpenAPI spec describing the endpoint (operation)
+   * @param controllerCtor - Controller constructor
+   * @param controllerFactory - A factory function to create controller instance
+   * @param methodName - The name of the controller method
    */
   route<I>(
     verb: string,
@@ -514,10 +514,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * app.route('get', '/', operationSpec, greet);
    * ```
    *
-   * @param verb HTTP verb of the endpoint
-   * @param path URL path of the endpoint
-   * @param spec The OpenAPI spec describing the endpoint (operation)
-   * @param handler The function to invoke with the request parameters
+   * @param verb - HTTP verb of the endpoint
+   * @param path - URL path of the endpoint
+   * @param spec - The OpenAPI spec describing the endpoint (operation)
+   * @param handler - The function to invoke with the request parameters
    * described in the spec.
    */
   route(
@@ -539,7 +539,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * app.route(route);
    * ```
    *
-   * @param route The route to add.
+   * @param route - The route to add.
    */
   route(route: RouteEntry): Binding;
 
@@ -615,11 +615,11 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * server.redirect('/explorer', '/explorer/');
    * ```
    *
-   * @param fromPath URL path of the redirect endpoint
-   * @param toPathOrUrl Location (URL path or full URL) where to redirect to.
+   * @param fromPath - URL path of the redirect endpoint
+   * @param toPathOrUrl - Location (URL path or full URL) where to redirect to.
    * If your server is configured with a custom `basePath`, then the base path
    * is prepended to the target location.
-   * @param statusCode HTTP status code to respond with,
+   * @param statusCode - HTTP status code to respond with,
    *   defaults to 303 (See Other).
    */
   redirect(
@@ -640,10 +640,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Mount static assets to the REST server.
    * See https://expressjs.com/en/4x/api.html#express.static
-   * @param path The path(s) to serve the asset.
+   * @param path - The path(s) to serve the asset.
    * See examples at https://expressjs.com/en/4x/api.html#path-examples
-   * @param rootDir The root directory from which to serve static assets
-   * @param options Options for serve-static
+   * @param rootDir - The root directory from which to serve static assets
+   * @param options - Options for serve-static
    */
   static(path: PathParams, rootDir: string, options?: ServeStaticOptions) {
     this._externalRoutes.registerAssets(path, rootDir, options);
@@ -657,7 +657,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * Note that this will override any routes defined via decorators at the
    * controller level (this function takes precedent).
    *
-   * @param {OpenApiSpec} spec The OpenAPI specification, as an object.
+   * @param spec - The OpenAPI specification, as an object.
    * @returns {Binding}
    *
    */
@@ -707,7 +707,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * }
    * ```
    *
-   * @param value The sequence to invoke for each incoming request.
+   * @param value - The sequence to invoke for each incoming request.
    */
   public sequence(value: Constructor<SequenceHandler>) {
     this.bind(RestBindings.SEQUENCE).toClass(value);
@@ -723,7 +723,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * });
    * ```
    *
-   * @param handlerFn The handler to invoke for each incoming request.
+   * @param handlerFn - The handler to invoke for each incoming request.
    */
   public handler(handlerFn: SequenceFunction) {
     class SequenceFromFunction extends DefaultSequence {
@@ -750,8 +750,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
   /**
    * Bind a body parser to the server context
-   * @param parserClass Body parser class
-   * @param address Optional binding address
+   * @param parserClass - Body parser class
+   * @param address - Optional binding address
    */
   bodyParser(
     bodyParserClass: Constructor<BodyParser>,
@@ -764,7 +764,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
   /**
    * Configure the `basePath` for the rest server
-   * @param path Base path
+   * @param path - Base path
    */
   basePath(path: string = '') {
     if (this._requestHandler) {
@@ -841,9 +841,9 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * Mount an Express router to expose additional REST endpoints handled
    * via legacy Express-based stack.
    *
-   * @param basePath Path where to mount the router at, e.g. `/` or `/api`.
-   * @param router The Express router to handle the requests.
-   * @param spec A partial OpenAPI spec describing endpoints provided by the
+   * @param basePath - Path where to mount the router at, e.g. `/` or `/api`.
+   * @param router - The Express router to handle the requests.
+   * @param spec - A partial OpenAPI spec describing endpoints provided by the
    * router. LoopBack will prepend `basePath` to all endpoints automatically.
    * This argument is optional. You can leave it out if you don't want to
    * document the routes.
@@ -859,8 +859,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
 /**
  * Create a binding for the given body parser class
- * @param parserClass Body parser class
- * @param key Optional binding address
+ * @param parserClass - Body parser class
+ * @param key - Optional binding address
  */
 export function createBodyParserBinding(
   parserClass: Constructor<BodyParser>,

--- a/packages/rest/src/router/base-route.ts
+++ b/packages/rest/src/router/base-route.ts
@@ -16,9 +16,9 @@ export abstract class BaseRoute implements RouteEntry {
 
   /**
    * Construct a new route
-   * @param verb http verb
-   * @param path http request path pattern
-   * @param spec OpenAPI operation spec
+   * @param verb - http verb
+   * @param path - http request path pattern
+   * @param spec - OpenAPI operation spec
    */
   constructor(
     verb: string,

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -47,12 +47,12 @@ export class ControllerRoute<T> extends BaseRoute {
 
   /**
    * Construct a controller based route
-   * @param verb http verb
-   * @param path http request path
-   * @param spec OpenAPI operation spec
-   * @param controllerCtor Controller class
-   * @param controllerFactory A factory function to create a controller instance
-   * @param methodName Controller method name, default to `x-operation-name`
+   * @param verb - http verb
+   * @param path - http request path
+   * @param spec - OpenAPI operation spec
+   * @param controllerCtor - Controller class
+   * @param controllerFactory - A factory function to create a controller instance
+   * @param methodName - Controller method name, default to `x-operation-name`
    */
   constructor(
     verb: string,
@@ -147,7 +147,7 @@ export class ControllerRoute<T> extends BaseRoute {
 
 /**
  * Create a controller factory function for a given binding key
- * @param key Binding key
+ * @param key - Binding key
  */
 export function createControllerFactoryForBinding<T>(
   key: string,
@@ -157,7 +157,7 @@ export function createControllerFactoryForBinding<T>(
 
 /**
  * Create a controller factory function for a given class
- * @param controllerCtor Controller class
+ * @param controllerCtor - Controller class
  */
 export function createControllerFactoryForClass<T>(
   controllerCtor: ControllerClass<T>,
@@ -177,7 +177,7 @@ export function createControllerFactoryForClass<T>(
 
 /**
  * Create a controller factory function for a given instance
- * @param controllerCtor Controller instance
+ * @param controllerCtor - Controller instance
  */
 export function createControllerFactoryForInstance<T>(
   controllerInst: T,

--- a/packages/rest/src/router/openapi-path.ts
+++ b/packages/rest/src/router/openapi-path.ts
@@ -63,7 +63,7 @@ export function getPathVariables(path: string) {
 
 /**
  * Convert an OpenAPI path to Express (path-to-regexp) style
- * @param path OpenAPI path with optional variables as `{var}`
+ * @param path - OpenAPI path with optional variables as `{var}`
  */
 export function toExpressPath(path: string) {
   // Convert `.` to `\\.` so that path-to-regexp will treat it as the plain

--- a/packages/rest/src/router/rest-router.ts
+++ b/packages/rest/src/router/rest-router.ts
@@ -13,13 +13,13 @@ import {ResolvedRoute, RouteEntry} from './route-entry';
 export interface RestRouter {
   /**
    * Add a route to the router
-   * @param route A route entry
+   * @param route - A route entry
    */
   add(route: RouteEntry): void;
 
   /**
    * Find a matching route for the given http request
-   * @param request Http request
+   * @param request - Http request
    * @returns The resolved route, if not found, `undefined` is returned
    */
   find(request: Request): ResolvedRoute | undefined;

--- a/packages/rest/src/router/route-sort.ts
+++ b/packages/rest/src/router/route-sort.ts
@@ -21,8 +21,8 @@ const HTTP_VERBS: {[name: string]: number} = {
 
 /**
  * Compare two routes by verb/path for sorting
- * @param route1 First route entry
- * @param route2 Second route entry
+ * @param route1 - First route entry
+ * @param route2 - Second route entry
  */
 export function compareRoute(
   route1: Pick<RouteEntry, 'verb' | 'path'>,
@@ -57,7 +57,7 @@ export function compareRoute(
 
 /**
  *
- * @param path Parse a path template into tokens
+ * @param path - Parse a path template into tokens
  */
 function parse(path: string) {
   const tokens: pathToRegExp.Token[] = [];

--- a/packages/rest/src/router/router-base.ts
+++ b/packages/rest/src/router/router-base.ts
@@ -72,8 +72,8 @@ export abstract class BaseRouter implements RestRouter {
 
   /**
    * Build a key for verb+path as `/<verb>/<path>`
-   * @param verb HTTP verb/method
-   * @param path URL path
+   * @param verb - HTTP verb/method
+   * @param path - URL path
    */
   protected getKey(verb: string, path: string) {
     verb = normalizeVerb(verb);
@@ -84,13 +84,13 @@ export abstract class BaseRouter implements RestRouter {
   // The following abstract methods need to be implemented by its subclasses
   /**
    * Add a route with path variables
-   * @param route Route
+   * @param route - Route
    */
   protected abstract addRouteWithPathVars(route: RouteEntry): void;
 
   /**
    * Find a route with path variables for a given request
-   * @param request Http request
+   * @param request - Http request
    */
   protected abstract findRouteWithPathVars(
     verb: string,
@@ -105,7 +105,7 @@ export abstract class BaseRouter implements RestRouter {
 
 /**
  * Normalize http verb to lowercase
- * @param verb Http verb
+ * @param verb - Http verb
  */
 function normalizeVerb(verb: string) {
   // Use lower case, default to `get`
@@ -114,7 +114,7 @@ function normalizeVerb(verb: string) {
 
 /**
  * Normalize path to make sure it starts with `/`
- * @param path Path
+ * @param path - Path
  */
 function normalizePath(path: string) {
   // Prepend `/` if needed

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -85,7 +85,7 @@ export class RoutingTable {
 
   /**
    * Register a route
-   * @param route A route entry
+   * @param route - A route entry
    */
   registerRoute(route: RouteEntry) {
     // TODO(bajtos) handle the case where opSpec.parameters contains $ref

--- a/packages/rest/src/router/trie.ts
+++ b/packages/rest/src/router/trie.ts
@@ -51,8 +51,8 @@ export class Trie<T> {
 
   /**
    * Create a node for a given path template
-   * @param pathTemplate The path template,
-   * @param value Value of the route
+   * @param pathTemplate - The path template,
+   * @param value - Value of the route
    */
   create(routeTemplate: string, value: T) {
     const keys = routeTemplate.split('/').filter(Boolean);
@@ -61,7 +61,7 @@ export class Trie<T> {
 
   /**
    * Match a route path against the trie
-   * @param path The route path, such as `/customers/c01`
+   * @param path - The route path, such as `/customers/c01`
    */
   match(
     path: string,
@@ -94,8 +94,8 @@ function isNodeWithValue<T>(node: Node<T>): node is NodeWithValue<T> {
 
 /**
  * Use depth-first preorder traversal to list all nodes with values
- * @param root Root node
- * @param visitor A function to process nodes with values
+ * @param root - Root node
+ * @param visitor - A function to process nodes with values
  */
 function traverse<T>(root: Node<T>, visitor: (node: NodeWithValue<T>) => void) {
   if (isNodeWithValue(root)) visitor(root);
@@ -106,8 +106,8 @@ function traverse<T>(root: Node<T>, visitor: (node: NodeWithValue<T>) => void) {
 
 /**
  * Match the given key to one or more children of the parent node
- * @param key Key
- * @param parent Parent node
+ * @param key - Key
+ * @param parent - Parent node
  */
 function matchChildren<T>(key: string, parent: Node<T>): ResolvedNode<T>[] {
   const resolvedNodes: ResolvedNode<T>[] = [];
@@ -140,10 +140,10 @@ function matchChildren<T>(key: string, parent: Node<T>): ResolvedNode<T>[] {
 
 /**
  * Search a sub list of keys against the parent node
- * @param keys An array of keys
- * @param index Starting index of the key list
- * @param params An object to receive resolved parameter values
- * @param parent Parent node
+ * @param keys - An array of keys
+ * @param index - Starting index of the key list
+ * @param params - An object to receive resolved parameter values
+ * @param parent - Parent node
  */
 function search<T>(
   keys: string[],
@@ -172,10 +172,10 @@ function search<T>(
 
 /**
  * Create a node for a sub list of keys against the parent node
- * @param keys An array of keys
- * @param index Starting index of the key list
- * @param value Value of the node
- * @param parent Parent node
+ * @param keys - An array of keys
+ * @param index - Starting index of the key list
+ * @param value - Value of the node
+ * @param parent - Parent node
  */
 function createNode<T>(
   keys: string[],

--- a/packages/rest/src/sequence.ts
+++ b/packages/rest/src/sequence.ts
@@ -28,7 +28,7 @@ export interface SequenceHandler {
   /**
    * Handle the request by running the configured sequence of actions.
    *
-   * @param context The request context: HTTP request and response objects,
+   * @param context - The request context: HTTP request and response objects,
    * per-request IoC container and more.
    */
   handle(context: RequestContext): Promise<void>;
@@ -57,15 +57,15 @@ export class DefaultSequence implements SequenceHandler {
    * Constructor: Injects findRoute, invokeMethod & logError
    * methods as promises.
    *
-   * @param {FindRoute} findRoute Finds the appropriate controller method,
+   * @param findRoute - Finds the appropriate controller method,
    *  spec and args for invocation (injected via SequenceActions.FIND_ROUTE).
-   * @param {ParseParams} parseParams The parameter parsing function (injected
+   * @param parseParams - The parameter parsing function (injected
    * via SequenceActions.PARSE_PARAMS).
-   * @param {InvokeMethod} invoke Invokes the method specified by the route
+   * @param invoke - Invokes the method specified by the route
    * (injected via SequenceActions.INVOKE_METHOD).
-   * @param {Send} send The action to merge the invoke result with the response
+   * @param send - The action to merge the invoke result with the response
    * (injected via SequenceActions.SEND)
-   * @param {Reject} reject The action to take if the invoke returns a rejected
+   * @param reject - The action to take if the invoke returns a rejected
    * promise result (injected via SequenceActions.REJECT).
    */
   constructor(
@@ -89,7 +89,7 @@ export class DefaultSequence implements SequenceHandler {
    *  - Error is caught and logged using 'logError' if any of the above steps
    *    in the sequence fails with an error.
    *
-   * @param context The request context: HTTP request and response objects,
+   * @param context - The request context: HTTP request and response objects,
    * per-request IoC container and more.
    */
   async handle(context: RequestContext): Promise<void> {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -41,10 +41,10 @@ export type ParseParams = (
 /**
  * Invokes a method defined in the Application Controller
  *
- * @param controller Name of end-user's application controller
+ * @param controller - Name of end-user's application controller
  *  class which defines the methods.
- * @param method Method name in application controller class
- * @param args Operation arguments for the method
+ * @param method - Method name in application controller class
+ * @param args - Operation arguments for the method
  * @returns OperationRetval Result from method invocation
  */
 export type InvokeMethod = (
@@ -55,26 +55,26 @@ export type InvokeMethod = (
 /**
  * Send the operation response back to the client.
  *
- * @param response The response the response to send to.
- * @param result The operation result to send.
+ * @param response - The response the response to send to.
+ * @param result - The operation result to send.
  */
 export type Send = (response: Response, result: OperationRetval) => void;
 
 /**
  * Reject the request with an error.
  *
- * @param handlerContext The context object holding HTTP request, response
+ * @param handlerContext - The context object holding HTTP request, response
  * and other data  needed to handle an incoming HTTP request.
- * @param err The error.
+ * @param err - The error.
  */
 export type Reject = (handlerContext: HandlerContext, err: Error) => void;
 
 /**
  * Log information about a failed request.
  *
- * @param err The error reported by request handling code.
- * @param statusCode Status code of the HTTP response
- * @param request The request that failed.
+ * @param err - The error reported by request handling code.
+ * @param statusCode - Status code of the HTTP response
+ * @param request - The request that failed.
  */
 export type LogError = (
   err: Error,

--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -25,9 +25,9 @@ export type RequestBodyValidationOptions = AJV.Options;
  * The JSON schema is generated from the OpenAPI schema which is typically defined
  * by `@requestBody()`.
  * The validation leverages AJV schema validator.
- * @param body The request body parsed from an HTTP request.
- * @param requestBodySpec The OpenAPI requestBody specification defined in `@requestBody()`.
- * @param globalSchemas The referenced schemas generated from `OpenAPISpec.components.schemas`.
+ * @param body - The request body parsed from an HTTP request.
+ * @param requestBodySpec - The OpenAPI requestBody specification defined in `@requestBody()`.
+ * @param globalSchemas - The referenced schemas generated from `OpenAPISpec.components.schemas`.
  */
 export function validateRequestBody(
   body: RequestBody,
@@ -61,7 +61,7 @@ export function validateRequestBody(
 
 /**
  * Convert an OpenAPI schema to the corresponding JSON schema.
- * @param openapiSchema The OpenAPI schema to convert.
+ * @param openapiSchema - The OpenAPI schema to convert.
  */
 function convertToJsonSchema(openapiSchema: SchemaObject) {
   const jsonSchema = toJsonSchema(openapiSchema);
@@ -78,9 +78,9 @@ function convertToJsonSchema(openapiSchema: SchemaObject) {
 
 /**
  * Validate the request body data against JSON schema.
- * @param body The request body data.
- * @param schema The JSON schema used to perform the validation.
- * @param globalSchemas Schema references.
+ * @param body - The request body data.
+ * @param schema - The JSON schema used to perform the validation.
+ * @param globalSchemas - Schema references.
  */
 
 const compiledSchemaCache = new WeakMap();

--- a/packages/rest/src/writer.ts
+++ b/packages/rest/src/writer.ts
@@ -10,8 +10,8 @@ import {Readable} from 'stream';
  * Writes the result from Application controller method
  * into the HTTP response
  *
- * @param response HTTP Response
- * @param result Result from the API to write into HTTP Response
+ * @param response - HTTP Response
+ * @param result - Result from the API to write into HTTP Response
  */
 export function writeResultToResponse(
   // not needed and responsibility should be in the sequence.send

--- a/packages/service-proxy/src/decorators/service.decorator.ts
+++ b/packages/service-proxy/src/decorators/service.decorator.ts
@@ -54,8 +54,8 @@ export function serviceProxy(dataSource: string | juggler.DataSource) {
 
 /**
  * Resolve the @repository injection
- * @param ctx Context
- * @param injection Injection metadata
+ * @param ctx - Context
+ * @param injection - Injection metadata
  */
 async function resolve(ctx: Context, injection: Injection) {
   const meta = injection.metadata as ServiceProxyMetadata;

--- a/packages/service-proxy/src/legacy-juggler-bridge.ts
+++ b/packages/service-proxy/src/legacy-juggler-bridge.ts
@@ -21,7 +21,7 @@ export interface GenericService {
  * Get a service proxy from a LoopBack 3.x data source backed by
  * service-oriented connectors such as `rest`, `soap`, and `grpc`.
  *
- * @param ds A legacy data source
+ * @param ds - A legacy data source
  * @typeparam T The generic type of service interface
  */
 export async function getService<T = GenericService>(

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -41,7 +41,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
     /**
      * Add a service to this application.
      *
-     * @param provider The service provider to register.
+     * @param provider - The service provider to register.
      *
      * @example
      * ```ts
@@ -81,7 +81,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      * Add a component to this application. Also mounts
      * all the components services.
      *
-     * @param component The component to add.
+     * @param component - The component to add.
      *
      * @example
      * ```ts
@@ -108,7 +108,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      * services. This function is intended to be used internally
      * by component()
      *
-     * @param component The component to mount services of
+     * @param component - The component to mount services of
      */
     mountComponentServices(component: Class<unknown>) {
       const componentKey = `components.${component.name}`;
@@ -151,7 +151,7 @@ export class ServiceMixinDoc {
   /**
    * Add a service to this application.
    *
-   * @param provider The service provider to register.
+   * @param provider - The service provider to register.
    *
    * @example
    * ```ts
@@ -181,7 +181,7 @@ export class ServiceMixinDoc {
    * Add a component to this application. Also mounts
    * all the components services.
    *
-   * @param component The component to add.
+   * @param component - The component to add.
    *
    * @example
    * ```ts
@@ -207,7 +207,7 @@ export class ServiceMixinDoc {
    * services. This function is intended to be used internally
    * by component()
    *
-   * @param component The component to mount services of
+   * @param component - The component to mount services of
    */
   mountComponentServices(component: Class<unknown>) {}
 }

--- a/packages/testlab/src/client.ts
+++ b/packages/testlab/src/client.ts
@@ -30,7 +30,7 @@ export function createClientForHandler(
  * Create a SuperTest client for a running RestApplication instance.
  * It is the responsibility of the caller to ensure that the app
  * is running and to stop the application after all tests are done.
- * @param app A running (listening) instance of a RestApplication.
+ * @param app - A running (listening) instance of a RestApplication.
  */
 export function createRestAppClient(app: RestApplicationLike) {
   const url = app.restServer.rootUrl || app.restServer.url;

--- a/packages/testlab/src/http-error-logger.ts
+++ b/packages/testlab/src/http-error-logger.ts
@@ -9,7 +9,7 @@ import {IncomingMessage} from 'http';
 /**
  * Creates a Logger that logs an Error if the HTTP status code is not expected
  *
- * @param expectedStatusCode HTTP status code that is expected
+ * @param expectedStatusCode - HTTP status code that is expected
  */
 export function createUnexpectedHttpErrorLogger(
   expectedStatusCode?: number,

--- a/packages/testlab/src/http-server-config.ts
+++ b/packages/testlab/src/http-server-config.ts
@@ -25,7 +25,7 @@ export type ConfigRetval<T extends object> = T & {
  *    environments like Travis-CI.
  *  - Provide default TLS key & cert when `protocol` is set to `https`.
  *
- * @param customConfig Additional configuration options to apply.
+ * @param customConfig - Additional configuration options to apply.
  */
 export function givenHttpServerConfig<T extends object>(
   customConfig?: T & {protocol?: string},

--- a/packages/testlab/src/shot.ts
+++ b/packages/testlab/src/shot.ts
@@ -138,7 +138,7 @@ export function stubExpressContext(
 
 /**
  * Use `express.query` to parse the query string into `request.query` object
- * @param request Express http request object
+ * @param request - Express http request object
  */
 function parseQuery(request: express.Request) {
   // Use `express.query` to parse the query string

--- a/packages/testlab/src/test-sandbox.ts
+++ b/packages/testlab/src/test-sandbox.ts
@@ -35,7 +35,7 @@ export class TestSandbox {
    * Will create a directory if it doesn't already exist. If it exists, you
    * still get an instance of the TestSandbox.
    *
-   * @param path Path of the TestSandbox. If relative (it will be resolved relative to cwd()).
+   * @param path - Path of the TestSandbox. If relative (it will be resolved relative to cwd()).
    */
   constructor(path: string) {
     // resolve ensures path is absolute / makes it absolute (relative to cwd())
@@ -77,7 +77,7 @@ export class TestSandbox {
   /**
    * Makes a directory in the TestSandbox
    *
-   * @param dir Name of directory to create (relative to TestSandbox path)
+   * @param dir - Name of directory to create (relative to TestSandbox path)
    */
   async mkdir(dir: string): Promise<void> {
     await ensureDir(resolve(this.path, dir));
@@ -89,8 +89,8 @@ export class TestSandbox {
    * will have its sourceMappingURL updated to point to the original file as
    * an absolute path so you don't need to copy the map file.
    *
-   * @param src Absolute path of file to be copied to the TestSandbox
-   * @param [dest] Optional. Destination filename of the copy operation
+   * @param src - Absolute path of file to be copied to the TestSandbox
+   * @param dest - Optional. Destination filename of the copy operation
    * (relative to TestSandbox). Original filename used if not specified.
    */
   async copyFile(src: string, dest?: string): Promise<void> {


### PR DESCRIPTION
Normalize `@param name description` to be `@param name - description`
See https://github.com/microsoft/tsdoc/issues/128

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
