### PR TITLE
chore: fix generic type param comments in tsdocs

### DIFF
--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -132,7 +132,7 @@ export class Application extends Context implements LifeCycleObserver {
   /**
    * Retrieve the singleton instance for a bound server.
    *
-   * @typeparam T
+   * @typeParam T - Server type
    * @param ctor - The constructor that was used to make the
    * binding.
    * @returns A Promise of server instance

--- a/packages/metadata/src/types.ts
+++ b/packages/metadata/src/types.ts
@@ -14,8 +14,8 @@ export type DecoratorType =
 
 /**
  * A strongly-typed metadata accessor via reflection
- * @typeparam T Type of the metadata value
- * @typeparam D Type of the decorator
+ * @typeParam T - Type of the metadata value
+ * @typeParam D - Type of the decorator
  */
 // tslint:disable-next-line:no-unused
 export class MetadataAccessor<T, D extends DecoratorType = DecoratorType> {
@@ -28,8 +28,8 @@ export class MetadataAccessor<T, D extends DecoratorType = DecoratorType> {
   /**
    * Create a strongly-typed metadata accessor
    * @param key - The metadata key
-   * @typeparam T Type of the metadata value
-   * @typeparam D Type of the decorator
+   * @typeParam T - Type of the metadata value
+   * @typeParam D - Type of the decorator
    */
   static create<T, D extends DecoratorType>(key: string) {
     return new MetadataAccessor<T, D>(key);
@@ -38,8 +38,8 @@ export class MetadataAccessor<T, D extends DecoratorType = DecoratorType> {
 
 /**
  * Key for metadata access via reflection
- * @typeparam T Type of the metadata value
- * @typeparam D Type of the decorator
+ * @typeParam T - Type of the metadata value
+ * @typeParam D - Type of the decorator
  */
 export type MetadataKey<T, D extends DecoratorType> =
   | MetadataAccessor<T, D>

--- a/packages/repository/src/type-resolver.ts
+++ b/packages/repository/src/type-resolver.ts
@@ -14,10 +14,10 @@ import {Class} from './common-types';
  * the actual reference to the class itself until later, when both sides
  * of the relation are created as JavaScript classes.
  *
- * @typeparam Type The type we are resolving, for example `Entity` or `Product`.
+ * @typeParam Type - The type we are resolving, for example `Entity` or `Product`.
  * This parameter is required.
  *
- * @typeparam StaticMembers The static properties available on the
+ * @typeParam StaticMembers - The static properties available on the
  * type class. For example, all models have static `modelName` property.
  * When `StaticMembers` are not provided, we default to static properties of
  * a `Function` - `name`, `length`, `apply`, `call`, etc.

--- a/packages/service-proxy/src/legacy-juggler-bridge.ts
+++ b/packages/service-proxy/src/legacy-juggler-bridge.ts
@@ -22,7 +22,7 @@ export interface GenericService {
  * service-oriented connectors such as `rest`, `soap`, and `grpc`.
  *
  * @param ds - A legacy data source
- * @typeparam T The generic type of service interface
+ * @typeParam T - The generic type of service interface
  */
 export async function getService<T = GenericService>(
   ds: legacy.DataSource,

--- a/packages/testlab/src/sinon.ts
+++ b/packages/testlab/src/sinon.ts
@@ -26,7 +26,7 @@ export type StubbedInstanceWithSinonAccessor<T> = T & {
  *  - https://github.com/Microsoft/TypeScript/issues/13543
  *  - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14811
  *
- * @typeparam TType Type being stubbed.
+ * @typeParam TType - Type being stubbed.
  * @param constructor  Object or class to stub.
  * @returns A stubbed version of the constructor, with an extra property `stubs`
  * providing access to stub API for individual methods.


### PR DESCRIPTION
Use `@typeParam T - description` format.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
