### PR TITLE
fix(cli): clean up template for life cycle observers

### DIFF
--- a/packages/cli/generators/observer/templates/observer-template.ts.ejs
+++ b/packages/cli/generators/observer/templates/observer-template.ts.ejs
@@ -1,7 +1,6 @@
 import {
   /* inject, Application, CoreBindings, */
   lifeCycleObserver, // The decorator
-  CoreTags,
   LifeCycleObserver, // The interface
 } from '@loopback/core';
 
@@ -28,6 +27,6 @@ export class <%= className %> implements LifeCycleObserver {
    * This method will be invoked when the application stops
    */
   async stop(): Promise<void> {
-    // Add your logic for start
+    // Add your logic for stop
   }
 }

--- a/packages/cli/test/integration/generators/observer.integration.js
+++ b/packages/cli/test/integration/generators/observer.integration.js
@@ -81,6 +81,8 @@ function verifyGeneratedScript(group = '') {
   );
   assert.fileContent(expectedFile, `@lifeCycleObserver('${group}')`);
   assert.fileContent(expectedFile, /async start\(\): Promise\<void\> {/);
+  assert.fileContent(expectedFile, /\/\/ Add your logic for start/);
+  assert.fileContent(expectedFile, /\/\/ Add your logic for stop/);
   assert.fileContent(expectedFile, /async stop\(\): Promise\<void\> {/);
   assert.file(INDEX_FILE);
   assert.fileContent(INDEX_FILE, /export \* from '.\/my-observer.observer';/);


### PR DESCRIPTION
Fix typo/unused import in template for life cycle observers.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
