### PR TITLE
test(cli): fix `lerna bootstrap` to link monorepo packages

### DIFF
--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -76,7 +76,14 @@ async function lernaBootstrap(scope) {
     _: [],
     ci: false,
     scope: scope,
-    loglevel: 'silent',
+    // The option "scope" controls both
+    // - which packages to bootstrap
+    // - which monorepo-local dependencies to resolve via symlinks
+    // The option "forceLocal" tells lerna to always symlink local packages.
+    // See https://github.com/lerna/lerna/commit/71174e4709 and
+    // https://github.com/lerna/lerna/pull/2104
+    forceLocal: 'forceLocal',
+    loglevel: 'warn',
     // Disable progress bars
     progress: false,
   });


### PR DESCRIPTION
Lerna v3.10.3 changed the way how `lerna bootstrap --scope` works, breaking our CLI tests when changes are made in dependencies of newly scaffolded projects. (As I discovered while working on https://github.com/strongloop/loopback-next/pull/2928).

This commit fixes the problem by adding `--force-local` option to restore previous behavior, see https://github.com/lerna/lerna/commit/71174e4709. Unfortunately, `--force-local` is broken now, we need to wait until https://github.com/lerna/lerna/pull/2104 is merged and released.

Also to make future troubleshooting easier, I am changing lerna log level used by the test from "silent" to "warn".

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈