### PR TITLE
test: remove unnecessary async functions

### DIFF
--- a/packages/context/src/__tests__/acceptance/inject-multiple-values.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/inject-multiple-values.acceptance.ts
@@ -16,7 +16,7 @@ import {
 let app: Context;
 let server: Context;
 
-describe('@inject.* to receive multiple values matching a filter', async () => {
+describe('@inject.* to receive multiple values matching a filter', () => {
   const workloadMonitorFilter = filterByTag('workloadMonitor');
   beforeEach(givenWorkloadMonitors);
 

--- a/packages/context/src/__tests__/integration/inject-view.integration.ts
+++ b/packages/context/src/__tests__/integration/inject-view.integration.ts
@@ -7,14 +7,14 @@ import {expect} from '@loopback/testlab';
 import {
   Binding,
   BindingScope,
-  filterByTag,
   Context,
   ContextView,
+  filterByTag,
   Getter,
   inject,
 } from '../..';
 
-describe('@inject.view', async () => {
+describe('@inject.view', () => {
   let ctx: Context;
   beforeEach(() => {
     ctx = givenContext();

--- a/packages/context/src/__tests__/integration/inject.integration.ts
+++ b/packages/context/src/__tests__/integration/inject.integration.ts
@@ -14,7 +14,7 @@ import {
   inject,
 } from '../..';
 
-describe('@inject.* to receive multiple values matching a filter', async () => {
+describe('@inject.* to receive multiple values matching a filter', () => {
   let ctx: Context;
   beforeEach(() => {
     ctx = givenContext();

--- a/packages/context/src/__tests__/unit/binding.unit.ts
+++ b/packages/context/src/__tests__/unit/binding.unit.ts
@@ -191,7 +191,7 @@ describe('Binding', () => {
     });
   });
 
-  describe('toAlias(bindingKeyWithPath)', async () => {
+  describe('toAlias(bindingKeyWithPath)', () => {
     it('binds to another binding with sync value', () => {
       ctx.bind('parent.options').to({child: {disabled: true}});
       ctx.bind('child.options').toAlias('parent.options#child');


### PR DESCRIPTION
Convert `describe` functions from async to sync.

I noticed this problem while experimenting with Jest, which does not support async describe blocks.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
