### PR TITLE
`find*` methods include navigational properties

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -67,6 +67,12 @@ export class Order extends Entity {
     super(data);
   }
 }
+
+export interface OrderRelations {
+  // describe navigational properties here
+}
+
+export type OrderWithRelations = Order & OrderRelations;
 ```
 
 The definition of the `belongsTo` relation is inferred by using the `@belongsTo`
@@ -82,6 +88,10 @@ class Order extends Entity {
   // constructor, properties, etc.
   @belongsTo(() => Customer, {keyTo: 'pk'})
   customerId: number;
+}
+
+export interface OrderRelations {
+  customer?: CustomerWithRelations;
 }
 ```
 
@@ -120,12 +130,13 @@ import {
   juggler,
   repository,
 } from '@loopback/repository';
-import {Customer, Order} from '../models';
+import {Customer, Order, OrderRelations} from '../models';
 import {CustomerRepository} from '../repositories';
 
 export class OrderRepository extends DefaultCrudRepository<
   Order,
-  typeof Order.prototype.id
+  typeof Order.prototype.id,
+  OrderRelations
 > {
   public readonly customer: BelongsToAccessor<
     Customer,
@@ -212,6 +223,13 @@ export class Category extends Entity {
     super(data);
   }
 }
+
+export interface CategoryRelations {
+  categories?: CategoryWithRelations[];
+  parent?: CategoryWithRelations;
+}
+
+export type CategoryWithRelations = Category & CategoryRelations;
 ```
 
 The `CategoryRepository` must be declared like below
@@ -219,7 +237,8 @@ The `CategoryRepository` must be declared like below
 ```ts
 export class CategoryRepository extends DefaultCrudRepository<
   Category,
-  typeof Category.prototype.id
+  typeof Category.prototype.id,
+  CategoryRelations
 > {
   public readonly parent: BelongsToAccessor<
     Category,

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -131,6 +131,12 @@ export class Order extends Entity {
     super(data);
   }
 }
+
+export interface OrderRelations {
+  // describe navigational properties here
+}
+
+export type OrderWithRelations = Order & OrderRelations;
 ```
 
 The foreign key property (`customerId`) in the target model can be added via a
@@ -140,7 +146,7 @@ corresponding [belongsTo](BelongsTo-relation.md) relation, too.
 
 ```ts
 import {Entity, model, property, belongsTo} from '@loopback/repository';
-import {Customer} from './customer.model';
+import {Customer, CustomerWithRelations} from './customer.model';
 
 @model()
 export class Order extends Entity {
@@ -164,6 +170,12 @@ export class Order extends Entity {
     super(data);
   }
 }
+
+export interface OrderRelations {
+  customer?: CustomerWithRelations;
+}
+
+export type OrderWithRelations = Order & OrderRelations;
 ```
 
 ## Configuring a hasMany relation
@@ -195,7 +207,7 @@ The following code snippet shows how it would look like:
 content="/src/repositories/customer.repository.ts" %}
 
 ```ts
-import {Order, Customer} from '../models';
+import {Order, Customer, CustomerRelations} from '../models';
 import {OrderRepository} from './order.repository';
 import {
   DefaultCrudRepository,
@@ -207,7 +219,8 @@ import {inject, Getter} from '@loopback/core';
 
 export class CustomerRepository extends DefaultCrudRepository<
   Customer,
-  typeof Customer.prototype.id
+  typeof Customer.prototype.id,
+  CustomerRelations
 > {
   public readonly orders: HasManyRepositoryFactory<
     Order,

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -162,13 +162,14 @@ TypeScript version:
 
 ```ts
 import {DefaultCrudRepository, juggler} from '@loopback/repository';
-import {Account} from '../models';
+import {Account, AccountRelations} from '../models';
 import {DbDataSource} from '../datasources';
 import {inject} from '@loopback/context';
 
 export class AccountRepository extends DefaultCrudRepository<
   Account,
-  typeof Account.prototype.id
+  typeof Account.prototype.id,
+  AccountRelations
 > {
   constructor(@inject('datasources.db') dataSource: DbDataSource) {
     super(Account, dataSource);

--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -57,7 +57,7 @@ defined on a source model `Supplier` in the example below:
 {% include code-caption.html content="/src/models/supplier.model.ts" %}
 
 ```ts
-import {Account} from './account.model';
+import {Account, AccountWithRelations} from './account.model';
 import {Entity, property, hasOne} from '@loopback/repository';
 
 export class Supplier extends Entity {
@@ -80,13 +80,19 @@ export class Supplier extends Entity {
     super(data);
   }
 }
+
+export interface SupplierRelations {
+  account?: AccountWithRelations;
+}
+
+export type SupplierWithRelations = Supplier & SupplierRelations;
 ```
 
 On the other side of the relation, we'd need to declare a `belongsTo` relation
 since every `Account` has to belong to exactly one `Supplier`:
 
 ```ts
-import {Supplier} from './supplier.model';
+import {Supplier, SupplierWithRelations} from './supplier.model';
 import {Entity, property, belongsTo} from '@loopback/repository';
 
 export class Account extends Entity {
@@ -108,6 +114,12 @@ export class Account extends Entity {
     super(data);
   }
 }
+
+export interface AccountRelations {
+  supplier?: SupplierWithRelations;
+}
+
+export type AccountWithRelations = Account & AccountRelations;
 ```
 
 The definition of the `hasOne` relation is inferred by using the `@hasOne`
@@ -190,7 +202,7 @@ The following code snippet shows how it would look like:
 content="/src/repositories/supplier.repository.ts" %}
 
 ```ts
-import {Account, Supplier} from '../models';
+import {Account, Supplier, SupplierRelations} from '../models';
 import {AccountRepository} from './account.repository';
 import {
   DefaultCrudRepository,
@@ -202,7 +214,8 @@ import {inject, Getter} from '@loopback/core';
 
 export class SupplierRepository extends DefaultCrudRepository<
   Supplier,
-  typeof Supplier.prototype.id
+  typeof Supplier.prototype.id,
+  SupplierRelations
 > {
   public readonly account: HasOneRepositoryFactory<
     Account,

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
@@ -76,7 +76,7 @@ model. Add the following import statements and property to the `TodoList` model:
 
 ```ts
 import {hasMany} from '@loopback/repository';
-import {Todo} from './todo.model';
+import {Todo, TodoWithRelations} from './todo.model';
 
 @model()
 export class TodoList extends Entity {
@@ -87,6 +87,12 @@ export class TodoList extends Entity {
 
   // ...constructor def...
 }
+
+export interface TodoListRelations {
+  todos?: TodoWithRelations[];
+}
+
+export type TodoListWithRelations = TodoList & TodoListRelations;
 ```
 
 The `@hasMany()` decorator defines this property. As the decorator's name
@@ -108,6 +114,12 @@ export class Todo extends Entity {
 
   // ...constructor def...
 }
+
+export interface TodoRelations {
+  todoList?: TodoListWithRelations;
+}
+
+export type TodoWithRelations = Todo & TodoRelations;
 ```
 
 Once the models have been completely configured, it's time to move on to adding

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
@@ -58,12 +58,13 @@ import {
   juggler,
   repository,
 } from '@loopback/repository';
-import {Todo, TodoList} from '../models';
+import {Todo, TodoList, TodoListRelations} from '../models';
 import {TodoRepository} from './todo.repository';
 
 export class TodoListRepository extends DefaultCrudRepository<
   TodoList,
-  typeof TodoList.prototype.id
+  typeof TodoList.prototype.id,
+  TodoListRelations
 > {
   public readonly todos: HasManyRepositoryFactory<
     Todo,

--- a/examples/express-composition/src/models/note.model.ts
+++ b/examples/express-composition/src/models/note.model.ts
@@ -28,3 +28,9 @@ export class Note extends Entity {
     super(data);
   }
 }
+
+export interface NoteRelations {
+  // describe navigational properties here
+}
+
+export type NoteWithRelations = Note & NoteRelations;

--- a/examples/express-composition/src/repositories/note.repository.ts
+++ b/examples/express-composition/src/repositories/note.repository.ts
@@ -3,14 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {DefaultCrudRepository} from '@loopback/repository';
-import {Note} from '../models';
-import {DsDataSource} from '../datasources';
 import {inject} from '@loopback/core';
+import {DefaultCrudRepository} from '@loopback/repository';
+import {DsDataSource} from '../datasources';
+import {Note, NoteRelations} from '../models';
 
 export class NoteRepository extends DefaultCrudRepository<
   Note,
-  typeof Note.prototype.id
+  typeof Note.prototype.id,
+  NoteRelations
 > {
   constructor(@inject('datasources.ds') dataSource: DsDataSource) {
     super(Note, dataSource);

--- a/examples/todo-list/src/models/todo-list-image.model.ts
+++ b/examples/todo-list/src/models/todo-list-image.model.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property, belongsTo} from '@loopback/repository';
-import {TodoList} from './todo-list.model';
+import {belongsTo, Entity, model, property} from '@loopback/repository';
+import {TodoList, TodoListWithRelations} from './todo-list.model';
 
 @model()
 export class TodoListImage extends Entity {
@@ -29,3 +29,9 @@ export class TodoListImage extends Entity {
     super(data);
   }
 }
+
+export interface TodoListImageRelations {
+  todoList?: TodoListWithRelations;
+}
+
+export type TodoListImageWithRelations = TodoListImage & TodoListImageRelations;

--- a/examples/todo-list/src/models/todo-list.model.ts
+++ b/examples/todo-list/src/models/todo-list.model.ts
@@ -3,9 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property, hasMany, hasOne} from '@loopback/repository';
-import {Todo} from './todo.model';
-import {TodoListImage} from './todo-list-image.model';
+import {Entity, hasMany, hasOne, model, property} from '@loopback/repository';
+import {
+  TodoListImage,
+  TodoListImageWithRelations,
+} from './todo-list-image.model';
+import {Todo, TodoWithRelations} from './todo.model';
 
 @model()
 export class TodoList extends Entity {
@@ -36,3 +39,10 @@ export class TodoList extends Entity {
     super(data);
   }
 }
+
+export interface TodoListRelations {
+  todos?: TodoWithRelations[];
+  image?: TodoListImageWithRelations;
+}
+
+export type TodoListWithRelations = TodoList & TodoListRelations;

--- a/examples/todo-list/src/models/todo.model.ts
+++ b/examples/todo-list/src/models/todo.model.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, property, model, belongsTo} from '@loopback/repository';
-import {TodoList} from './todo-list.model';
+import {belongsTo, Entity, model, property} from '@loopback/repository';
+import {TodoList, TodoListWithRelations} from './todo-list.model';
 
 @model()
 export class Todo extends Entity {
@@ -41,3 +41,9 @@ export class Todo extends Entity {
     super(data);
   }
 }
+
+export interface TodoRelations {
+  todoList?: TodoListWithRelations[];
+}
+
+export type TodoWithRelations = Todo & TodoRelations;

--- a/examples/todo-list/src/repositories/todo-list-image.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list-image.repository.ts
@@ -1,21 +1,22 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo-list
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Getter, inject} from '@loopback/core';
 import {
+  BelongsToAccessor,
   DefaultCrudRepository,
   repository,
-  BelongsToAccessor,
 } from '@loopback/repository';
-import {TodoListImage, TodoList} from '../models';
 import {DbDataSource} from '../datasources';
-import {inject, Getter} from '@loopback/core';
+import {TodoList, TodoListImage, TodoListImageRelations} from '../models';
 import {TodoListRepository} from './todo-list.repository';
 
 export class TodoListImageRepository extends DefaultCrudRepository<
   TodoListImage,
-  typeof TodoListImage.prototype.id
+  typeof TodoListImage.prototype.id,
+  TodoListImageRelations
 > {
   public readonly todoList: BelongsToAccessor<
     TodoList,

--- a/examples/todo-list/src/repositories/todo-list.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list.repository.ts
@@ -7,17 +7,18 @@ import {Getter, inject} from '@loopback/core';
 import {
   DefaultCrudRepository,
   HasManyRepositoryFactory,
+  HasOneRepositoryFactory,
   juggler,
   repository,
-  HasOneRepositoryFactory,
 } from '@loopback/repository';
-import {Todo, TodoList, TodoListImage} from '../models';
-import {TodoRepository} from './todo.repository';
+import {Todo, TodoList, TodoListImage, TodoListRelations} from '../models';
 import {TodoListImageRepository} from './todo-list-image.repository';
+import {TodoRepository} from './todo.repository';
 
 export class TodoListRepository extends DefaultCrudRepository<
   TodoList,
-  typeof TodoList.prototype.id
+  typeof TodoList.prototype.id,
+  TodoListRelations
 > {
   public readonly todos: HasManyRepositoryFactory<
     Todo,

--- a/examples/todo-list/src/repositories/todo.repository.ts
+++ b/examples/todo-list/src/repositories/todo.repository.ts
@@ -10,12 +10,13 @@ import {
   juggler,
   repository,
 } from '@loopback/repository';
-import {Todo, TodoList} from '../models';
+import {Todo, TodoList, TodoRelations} from '../models';
 import {TodoListRepository} from './todo-list.repository';
 
 export class TodoRepository extends DefaultCrudRepository<
   Todo,
-  typeof Todo.prototype.id
+  typeof Todo.prototype.id,
+  TodoRelations
 > {
   public readonly todoList: BelongsToAccessor<
     TodoList,

--- a/examples/todo/src/models/todo.model.ts
+++ b/examples/todo/src/models/todo.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
@@ -44,3 +44,9 @@ export class Todo extends Entity {
     super(data);
   }
 }
+
+export interface TodoRelations {
+  // describe navigational properties here
+}
+
+export type TodoWithRelations = Todo & TodoRelations;

--- a/examples/todo/src/repositories/todo.repository.ts
+++ b/examples/todo/src/repositories/todo.repository.ts
@@ -1,15 +1,16 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
 // Node module: @loopback/example-todo
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {DefaultCrudRepository, juggler} from '@loopback/repository';
-import {Todo} from '../models';
 import {inject} from '@loopback/core';
+import {DefaultCrudRepository, juggler} from '@loopback/repository';
+import {Todo, TodoRelations} from '../models';
 
 export class TodoRepository extends DefaultCrudRepository<
   Todo,
-  typeof Todo.prototype.id
+  typeof Todo.prototype.id,
+  TodoRelations
 > {
   constructor(@inject('datasources.db') dataSource: juggler.DataSource) {
     super(Todo, dataSource);

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -219,7 +219,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       modelDefinition.isModelBaseBuiltin = true;
       modelDefinition.modelBaseClass = 'Entity';
       modelDefinition.className = utils.pascalCase(modelDefinition.name);
-      // These last two are so that the template doesn't error out of they aren't there
+      // These last two are so that the template doesn't error out if they aren't there
       modelDefinition.allowAdditionalProperties = true;
       // modelDefinition.modelSettings = modelDefinition.settings || {};
       modelDefinition.modelSettings = utils.stringifyModelSettings(

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -71,7 +71,6 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
     this.artifactInfo.properties = {};
     this.artifactInfo.modelSettings = {};
-    this.propCounter = 0;
 
     this.artifactInfo.modelDir = path.resolve(
       this.artifactInfo.rootDir,

--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -33,3 +33,9 @@ export class <%= className %> extends <%= modelBaseClass %> {
     super(data);
   }
 }
+
+export interface <%= className %>Relations {
+  // describe navigational properties here
+}
+
+export type <%= className %>WithRelations = <%= className %> & <%= className %>Relations;

--- a/packages/cli/generators/repository/templates/src/repositories/repository-crud-default-template.ts.ejs
+++ b/packages/cli/generators/repository/templates/src/repositories/repository-crud-default-template.ts.ejs
@@ -1,7 +1,7 @@
 <%if (isRepositoryBaseBuiltin) {  -%>
 import {<%= repositoryTypeClass %>} from '@loopback/repository';
 <% } -%>
-import {<%= modelName %>} from '../models';
+import {<%= modelName %>, <%= modelName %>Relations} from '../models';
 import {<%= dataSourceClassName %>} from '../datasources';
 import {inject} from '@loopback/core';
 <%if ( !isRepositoryBaseBuiltin ) { -%>
@@ -10,7 +10,8 @@ import {<%=repositoryBaseClass %>} from './<%=repositoryBaseFile %>';
 
 export class <%= className %>Repository extends <%= repositoryBaseClass %><
   <%= modelName %>,
-  typeof <%= modelName %>.prototype.<%= idProperty %>
+  typeof <%= modelName %>.prototype.<%= idProperty %>,
+  <%= modelName %>Relations
 > {
   constructor(
     @inject('datasources.<%= dataSourceName %>') dataSource: <%= dataSourceClassName %>,

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -201,6 +201,34 @@ describe('lb4 model integration', () => {
       assert.fileContent(expectedModelFile, /\[prop: string\]: any;/);
     });
 
+    it('scaffolds empty model relation interface and relation type', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withPrompts({
+          name: 'test',
+          propName: null,
+          modelBaseClass: 'Entity',
+          allowAdditionalProperties: false,
+        });
+
+      assert.file(expectedModelFile);
+      assert.file(expectedIndexFile);
+
+      assert.fileContent(
+        expectedModelFile,
+        /import {Entity, model, property} from '@loopback\/repository';/,
+      );
+      assert.fileContent(
+        expectedModelFile,
+        /export type TestWithRelations = Test & TestRelations;/,
+      );
+      assert.fileContent(
+        expectedModelFile,
+        /export interface TestRelations {\n  \/\/ describe navigational properties here\n}/,
+      );
+    });
+
     it('scaffolds correct files with args', async () => {
       await testUtils
         .executeGenerator(generator)

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -282,6 +282,7 @@ describe('lb4 repository', function() {
         /export class DefaultModelRepository extends DefaultCrudRepository\</,
       );
       assert.fileContent(expectedFile, /typeof DefaultModel.prototype.id/);
+      assert.fileContent(expectedFile, /DefaultModelRelations/);
       assert.file(INDEX_FILE);
       assert.fileContent(
         INDEX_FILE,

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -52,6 +52,12 @@ export class Note extends Entity {
   @property()
   content: string;
 }
+
+export interface NoteRelations {
+  // describe navigational properties here
+}
+
+export type NoteWithRelations = Note & NoteRelations;
 ```
 
 **NOTE**: There is no declarative support for data source and model yet in
@@ -66,12 +72,13 @@ dependency injection to resolve the datasource.
 ```ts
 // src/repositories/note.repository.ts
 import {DefaultCrudRepository, DataSourceType} from '@loopback/repository';
-import {Note} from '../models';
+import {Note, NoteRelations} from '../models';
 import {inject} from '@loopback/core';
 
 export class NoteRepository extends DefaultCrudRepository<
   Note,
-  typeof Note.prototype.id
+  typeof Note.prototype.id,
+  NoteRelations
 > {
   constructor(@inject('datasources.db') protected dataSource: DataSourceType) {
     super(Note, dataSource);

--- a/packages/repository/src/__tests__/acceptance/has-many-without-di.relation.acceptance.ts
+++ b/packages/repository/src/__tests__/acceptance/has-many-without-di.relation.acceptance.ts
@@ -8,12 +8,12 @@ import {
   DefaultCrudRepository,
   Entity,
   EntityCrudRepository,
+  Getter,
   hasMany,
   HasManyRepositoryFactory,
   juggler,
   model,
   property,
-  Getter,
 } from '../..';
 
 describe('HasMany relation', () => {

--- a/packages/repository/src/__tests__/fixtures/models/address.model.ts
+++ b/packages/repository/src/__tests__/fixtures/models/address.model.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property, belongsTo} from '../../..';
-import {Customer} from './customer.model';
+import {belongsTo, Entity, model, property} from '../../..';
+import {Customer, CustomerWithRelations} from './customer.model';
 
 @model()
 export class Address extends Entity {
@@ -29,3 +29,9 @@ export class Address extends Entity {
   @belongsTo(() => Customer)
   customerId: number;
 }
+
+export interface AddressRelations {
+  customer?: CustomerWithRelations;
+}
+
+export type AddressWithRelations = Address & AddressRelations;

--- a/packages/repository/src/__tests__/fixtures/models/customer.model.ts
+++ b/packages/repository/src/__tests__/fixtures/models/customer.model.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, hasMany, model, property, hasOne, belongsTo} from '../../..';
+import {belongsTo, Entity, hasMany, hasOne, model, property} from '../../..';
+import {Address, AddressWithRelations} from './address.model';
 import {Order} from './order.model';
-import {Address} from './address.model';
 
 @model()
 export class Customer extends Entity {
@@ -32,3 +32,11 @@ export class Customer extends Entity {
   @belongsTo(() => Customer)
   parentId?: number;
 }
+
+export interface CustomerRelations {
+  address?: AddressWithRelations;
+  customers?: CustomerWithRelations[];
+  parentCustomer?: CustomerWithRelations;
+}
+
+export type CustomerWithRelations = Customer & CustomerRelations;

--- a/packages/repository/src/__tests__/fixtures/models/order.model.ts
+++ b/packages/repository/src/__tests__/fixtures/models/order.model.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {belongsTo, Entity, model, property} from '../../..';
-import {Customer} from './customer.model';
+import {Customer, CustomerWithRelations} from './customer.model';
 
 @model()
 export class Order extends Entity {
@@ -29,3 +29,9 @@ export class Order extends Entity {
   @belongsTo(() => Customer)
   customerId: number;
 }
+
+export interface OrderRelations {
+  customer?: CustomerWithRelations;
+}
+
+export type OrderWithRelations = Order & OrderRelations;

--- a/packages/repository/src/__tests__/fixtures/models/product.model.ts
+++ b/packages/repository/src/__tests__/fixtures/models/product.model.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {model, property, Entity} from '../../..';
+import {Entity, model, property} from '../../..';
 
 @model()
 export class Product extends Entity {
@@ -24,3 +24,9 @@ export class Product extends Entity {
     super(data);
   }
 }
+
+export interface ProductRelations {
+  // describe navigational properties here
+}
+
+export type ProductWithRelations = Product & ProductRelations;

--- a/packages/repository/src/__tests__/fixtures/repositories/address.repository.ts
+++ b/packages/repository/src/__tests__/fixtures/repositories/address.repository.ts
@@ -10,12 +10,13 @@ import {
   juggler,
   repository,
 } from '../../..';
-import {Customer, Address} from '../models';
+import {Address, AddressRelations, Customer} from '../models';
 import {CustomerRepository} from '../repositories';
 
 export class AddressRepository extends DefaultCrudRepository<
   Address,
-  typeof Address.prototype.zipcode
+  typeof Address.prototype.zipcode,
+  AddressRelations
 > {
   public readonly customer: BelongsToAccessor<
     Customer,

--- a/packages/repository/src/__tests__/fixtures/repositories/customer.repository.ts
+++ b/packages/repository/src/__tests__/fixtures/repositories/customer.repository.ts
@@ -5,20 +5,21 @@
 
 import {Getter, inject} from '@loopback/context';
 import {
+  BelongsToAccessor,
   DefaultCrudRepository,
   HasManyRepositoryFactory,
   juggler,
   repository,
-  BelongsToAccessor,
 } from '../../..';
-import {Customer, Order, Address} from '../models';
-import {OrderRepository} from './order.repository';
 import {HasOneRepositoryFactory} from '../../../';
+import {Address, Customer, CustomerRelations, Order} from '../models';
 import {AddressRepository} from './address.repository';
+import {OrderRepository} from './order.repository';
 
 export class CustomerRepository extends DefaultCrudRepository<
   Customer,
-  typeof Customer.prototype.id
+  typeof Customer.prototype.id,
+  CustomerRelations
 > {
   public readonly orders: HasManyRepositoryFactory<
     Order,

--- a/packages/repository/src/__tests__/fixtures/repositories/order.repository.ts
+++ b/packages/repository/src/__tests__/fixtures/repositories/order.repository.ts
@@ -10,12 +10,13 @@ import {
   juggler,
   repository,
 } from '../../..';
-import {Customer, Order} from '../models';
+import {Customer, Order, OrderRelations} from '../models';
 import {CustomerRepository} from '../repositories';
 
 export class OrderRepository extends DefaultCrudRepository<
   Order,
-  typeof Order.prototype.id
+  typeof Order.prototype.id,
+  OrderRelations
 > {
   public readonly customer: BelongsToAccessor<
     Customer,

--- a/packages/repository/src/__tests__/fixtures/repositories/product.repository.ts
+++ b/packages/repository/src/__tests__/fixtures/repositories/product.repository.ts
@@ -4,12 +4,13 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {DefaultCrudRepository, juggler} from '../../..';
-import {Product} from '../models/product.model';
+import {Product, ProductRelations} from '../models/product.model';
 export {Product};
 
 export class ProductRepository extends DefaultCrudRepository<
   Product,
-  typeof Product.prototype.id
+  typeof Product.prototype.id,
+  ProductRelations
 > {
   constructor(dataSource: juggler.DataSource) {
     super(Product, dataSource);

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -88,8 +88,11 @@ export function ensurePromise<T>(p: legacy.PromiseOrVoid<T>): Promise<T> {
  * Default implementation of CRUD repository using legacy juggler model
  * and data source
  */
-export class DefaultCrudRepository<T extends Entity, ID>
-  implements EntityCrudRepository<T, ID> {
+export class DefaultCrudRepository<
+  T extends Entity,
+  ID,
+  Relations extends object = {}
+> implements EntityCrudRepository<T, ID, Relations> {
   modelClass: juggler.PersistedModelClass;
 
   /**
@@ -207,7 +210,8 @@ export class DefaultCrudRepository<T extends Entity, ID>
    * ```ts
    * class CustomerRepository extends DefaultCrudRepository<
    *   Customer,
-   *   typeof Customer.prototype.id
+   *   typeof Customer.prototype.id,
+   *   CustomerRelations
    * > {
    *   public readonly orders: HasManyRepositoryFactory<Order, typeof Customer.prototype.id>;
    *
@@ -340,7 +344,10 @@ export class DefaultCrudRepository<T extends Entity, ID>
     }
   }
 
-  async find(filter?: Filter<T>, options?: Options): Promise<T[]> {
+  async find(
+    filter?: Filter<T>,
+    options?: Options,
+  ): Promise<(T & Relations)[]> {
     const models = await ensurePromise(
       this.modelClass.find(filter as legacy.Filter, options),
     );
@@ -355,14 +362,18 @@ export class DefaultCrudRepository<T extends Entity, ID>
     return this.toEntity(model);
   }
 
-  async findById(id: ID, filter?: Filter<T>, options?: Options): Promise<T> {
+  async findById(
+    id: ID,
+    filter?: Filter<T>,
+    options?: Options,
+  ): Promise<T & Relations> {
     const model = await ensurePromise(
       this.modelClass.findById(id, filter as legacy.Filter, options),
     );
     if (!model) {
       throw new EntityNotFoundError(this.entityClass, id);
     }
-    return this.toEntity(model);
+    return this.toEntity<T & Relations>(model);
   }
 
   update(entity: T, options?: Options): Promise<void> {
@@ -445,11 +456,11 @@ export class DefaultCrudRepository<T extends Entity, ID>
     return ensurePromise(this.dataSource.execute(command, parameters, options));
   }
 
-  protected toEntity(model: juggler.PersistedModel): T {
-    return new this.entityClass(model.toObject()) as T;
+  protected toEntity<R extends T>(model: juggler.PersistedModel): R {
+    return new this.entityClass(model.toObject()) as R;
   }
 
-  protected toEntities(models: juggler.PersistedModel[]): T[] {
-    return models.map(m => this.toEntity(m));
+  protected toEntities<R extends T>(models: juggler.PersistedModel[]): R[] {
+    return models.map(m => this.toEntity<R>(m));
   }
 }

--- a/packages/repository/src/repositories/repository.ts
+++ b/packages/repository/src/repositories/repository.ts
@@ -40,8 +40,10 @@ export interface ExecutableRepository<T extends Model> extends Repository<T> {
 /**
  * Basic CRUD operations for ValueObject and Entity. No ID is required.
  */
-export interface CrudRepository<T extends ValueObject | Entity>
-  extends Repository<T> {
+export interface CrudRepository<
+  T extends ValueObject | Entity,
+  Relations extends object = {}
+> extends Repository<T> {
   /**
    * Create a new record
    * @param dataObject - The data to be created
@@ -64,7 +66,7 @@ export interface CrudRepository<T extends ValueObject | Entity>
    * @param options - Options for the operations
    * @returns A promise of an array of records found
    */
-  find(filter?: Filter<T>, options?: Options): Promise<T[]>;
+  find(filter?: Filter<T>, options?: Options): Promise<(T & Relations)[]>;
 
   /**
    * Updating matching records with attributes from the data object
@@ -105,9 +107,11 @@ export interface EntityRepository<T extends Entity, ID>
 /**
  * CRUD operations for a repository of entities
  */
-export interface EntityCrudRepository<T extends Entity, ID>
-  extends EntityRepository<T, ID>,
-    CrudRepository<T> {
+export interface EntityCrudRepository<
+  T extends Entity,
+  ID,
+  Relations extends object = {}
+> extends EntityRepository<T, ID>, CrudRepository<T, Relations> {
   // entityClass should have type "typeof T", but that's not supported by TSC
   entityClass: typeof Entity & {prototype: T};
 
@@ -146,7 +150,11 @@ export interface EntityCrudRepository<T extends Entity, ID>
    * @param options - Options for the operations
    * @returns A promise of an entity found for the id
    */
-  findById(id: ID, filter?: Filter<T>, options?: Options): Promise<T>;
+  findById(
+    id: ID,
+    filter?: Filter<T>,
+    options?: Options,
+  ): Promise<T & Relations>;
 
   /**
    * Update an entity by id with property/value pairs in the data object


### PR DESCRIPTION
Resolves https://github.com/strongloop/loopback-next/issues/2632.

- `find` and `findById` now use `T & Relations` instead of `T`
- New prompt for `lb4 model` that asks for relations in order to create the relation interface (e.g. `export interface TodoRelations {}`). It leaves it empty if there are no current relations.
- Newly scaffolded models from `lb4 model` include `{modelName}WithRelations` type (e.g. `export type TodoWithRelations = Todo & TodoRelations;`)
- Generic parameter `Relations` added to `DefaultCrudRepository`
- When scaffolding a repository with `lb4 repository`, it now includes `{modelName}Relations` (e.g. 
```ts
export class TodoListRepository extends DefaultCrudRepository<
  TodoList,
  typeof TodoList.prototype.id
  TodoListRelations
> 
```
)

**Question**: should all models include a relations interface? If so, I'll update the examples/docs.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
