### PR TITLE
Make invocation context parent public and fix optional binding resolution

### DIFF
--- a/packages/context/src/__tests__/unit/binding.unit.ts
+++ b/packages/context/src/__tests__/unit/binding.unit.ts
@@ -229,6 +229,13 @@ describe('Binding', () => {
       );
     });
 
+    it('allows optional if binding does not have a value getter', () => {
+      // This can happen for `@inject.binding`
+      ctx.bind('child.options');
+      const childOptions = ctx.getSync('child.options', {optional: true});
+      expect(childOptions).to.be.undefined();
+    });
+
     it('allows optional if alias binding cannot be resolved', () => {
       ctx.bind('child.options').toAlias('parent.options#child');
       const childOptions = ctx.getSync('child.options', {optional: true});

--- a/packages/context/src/__tests__/unit/invocation-context.unit.ts
+++ b/packages/context/src/__tests__/unit/invocation-context.unit.ts
@@ -43,6 +43,10 @@ describe('InvocationContext', () => {
     );
   });
 
+  it('has public access to parent context', () => {
+    expect(invocationCtxForGreet.parent).to.equal(ctx);
+  });
+
   it('throws error if method does not exist', () => {
     expect(() => invalidInvocationCtx.assertMethodExists()).to.throw(
       'Method MyController.prototype.invalid-method not found',

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -299,6 +299,8 @@ export class Binding<T = BoundValue> {
       );
       return this._cacheValue(ctx, result);
     }
+    // `@inject.binding` adds a binding without _getValue
+    if (options.optional) return undefined;
     return Promise.reject(
       new Error(`No value was configured for binding ${this.key}.`),
     );

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -60,7 +60,9 @@ export class InvocationContext extends Context {
    * @param args - An array of arguments
    */
   constructor(
-    parent: Context,
+    // Make `parent` public so that the interceptor can add bindings to
+    // the request context, for example, tracing id
+    public readonly parent: Context,
     public readonly target: object,
     public readonly methodName: string,
     public readonly args: InvocationArgs,


### PR DESCRIPTION
1. InvocationContext.parent (public readonly)
2. Allow `optional` for binding without a value getter

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
