### PR TITLE
Helpers for building JSON/OpenAPI schema referencing shared definitions

### DIFF
--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -3,15 +3,41 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {
+  ReferenceObject,
+  SchemaObject,
+  SchemasObject,
+} from '@loopback/openapi-v3-types';
 import {JsonSchema} from '@loopback/repository-json-schema';
-import {SchemaObject} from '@loopback/openapi-v3-types';
 import * as _ from 'lodash';
+
+/**
+ * Custom LoopBack extension: a reference to Schema object that's bundled
+ * inside `definitions` property.
+ *
+ * @example
+ *
+ * ```ts
+ * const spec: SchemaRef = {
+ *   $ref: '/components/schemas/Product',
+ *   definitions: {
+ *     Product: {
+ *       title: 'Product',
+ *       properties: {
+ *         // etc.
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type SchemaRef = ReferenceObject & {definitions: SchemasObject};
 
 /**
  * Converts JSON Schemas into a SchemaObject
  * @param json - JSON Schema to convert from
  */
-export function jsonToSchemaObject(json: JsonSchema): SchemaObject {
+export function jsonToSchemaObject(json: JsonSchema): SchemaObject | SchemaRef {
   const result: SchemaObject = {};
   const propsToIgnore = [
     'anyOf',

--- a/packages/repository-json-schema/src/__tests__/helpers/expect-valid-json-schema.ts
+++ b/packages/repository-json-schema/src/__tests__/helpers/expect-valid-json-schema.ts
@@ -1,0 +1,20 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository-json-schema
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import * as Ajv from 'ajv';
+import {JsonSchema} from '../..';
+
+export function expectValidJsonSchema(schema: JsonSchema) {
+  const ajv = new Ajv();
+  const validate = ajv.compile(
+    require('ajv/lib/refs/json-schema-draft-06.json'),
+  );
+  const isValid = validate(schema);
+  const result = isValid
+    ? 'JSON Schema is valid'
+    : ajv.errorsText(validate.errors!);
+  expect(result).to.equal('JSON Schema is valid');
+}

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -12,13 +12,13 @@ import {
   property,
 } from '@loopback/repository';
 import {expect} from '@loopback/testlab';
-import * as Ajv from 'ajv';
 import {
   getJsonSchema,
   JsonSchema,
   JSON_SCHEMA_KEY,
   modelToJsonSchema,
 } from '../..';
+import {expectValidJsonSchema} from '../helpers/expect-valid-json-schema';
 
 describe('build-schema', () => {
   describe('modelToJsonSchema', () => {
@@ -629,21 +629,9 @@ describe('build-schema', () => {
         expect(schema).to.deepEqual(expectedSchema);
       });
     });
-
-    function expectValidJsonSchema(schema: JsonSchema) {
-      const ajv = new Ajv();
-      const validate = ajv.compile(
-        require('ajv/lib/refs/json-schema-draft-06.json'),
-      );
-      const isValid = validate(schema);
-      const result = isValid
-        ? 'JSON Schema is valid'
-        : ajv.errorsText(validate.errors!);
-      expect(result).to.equal('JSON Schema is valid');
-    }
   });
 
-  describe('getjsonSchema', () => {
+  describe('getJsonSchema', () => {
     it('gets cached JSON schema if one exists', () => {
       @model()
       class TestModel {

--- a/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: @loopback/repository-json-schema
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {model, property} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import {getJsonSchemaRef} from '../..';
+
+describe('getJsonSchemaRef', () => {
+  it('creates spec referencing shared model schema', () => {
+    @model()
+    class MyModel {
+      @property()
+      name: string;
+    }
+
+    const spec = getJsonSchemaRef(MyModel);
+
+    expect(spec).to.deepEqual({
+      $ref: '#/definitions/MyModel',
+      definitions: {
+        MyModel: {
+          title: 'MyModel',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -41,6 +41,50 @@ export function getJsonSchema(
 }
 
 /**
+ * Describe the provided Model as a reference to a definition shared by multiple
+ * endpoints. The definition is included in the returned schema.
+ *
+ * @example
+ *
+ * ```ts
+ * const schema = {
+ *   $ref: '/definitions/Product',
+ *   definitions: {
+ *     Product: {
+ *       title: 'Product',
+ *       properties: {
+ *         // etc.
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param modelCtor - The model constructor (e.g. `Product`)
+ * @param options - Additional options
+ */
+export function getJsonSchemaRef(
+  modelCtor: Function,
+  options?: JsonSchemaOptions,
+): JSONSchema {
+  const schemaWithDefinitions = getJsonSchema(modelCtor, options);
+  const key = schemaWithDefinitions.title;
+
+  // ctor is not a model
+  if (!key) return schemaWithDefinitions;
+
+  const definitions = Object.assign({}, schemaWithDefinitions.definitions);
+  const schema = Object.assign({}, schemaWithDefinitions);
+  delete schema.definitions;
+  definitions[key] = schema;
+
+  return {
+    $ref: `#/definitions/${key}`,
+    definitions,
+  };
+}
+
+/**
  * Gets the wrapper function of primitives string, number, and boolean
  * @param type - Name of type
  */

--- a/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
@@ -17,6 +17,7 @@ import {
   post,
   requestBody,
   RestApplication,
+  SchemaObject,
 } from '../../..';
 import {aBodySpec} from '../../helpers';
 
@@ -45,7 +46,7 @@ describe('Validation at REST level', () => {
   // Add a schema that requires `description`
   const PRODUCT_SPEC_WITH_DESCRIPTION = jsonToSchemaObject(
     getJsonSchema(Product),
-  );
+  ) as SchemaObject;
   PRODUCT_SPEC_WITH_DESCRIPTION.required!.push('description');
 
   // This is the standard use case that most LB4 applications should use.


### PR DESCRIPTION
Introduce the following helpers:

- `getModelSchemaRef` returning OpenAPI spec
- `getJsonSchemaRef` returning JSON Schema

Example usage in controllers:

```ts
class MyController {
  @get('/my', {
    responses: {
      '200': {
        description: 'Array of MyModel model instances',
        content: {
          'application/json': {
            schema: getModelSchemaRef(MyModel),
          },
        },
      },
    },
  })
  async find(): Promise<MyModel[]> {
    // etc.
  }
}
```

Resolve #2631.

See also #1352, #2652 and #2653.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈