### PR TITLE
fix: specify the type for handler

### DIFF
--- a/packages/rest/src/router/external-express-routes.ts
+++ b/packages/rest/src/router/external-express-routes.ts
@@ -10,7 +10,7 @@ import {
   SchemasObject,
 } from '@loopback/openapi-v3-types';
 import * as express from 'express';
-import {RequestHandler} from 'express';
+import {RequestHandler, Application} from 'express';
 import {PathParams} from 'express-serve-static-core';
 import * as HttpErrors from 'http-errors';
 import * as onFinished from 'on-finished';
@@ -50,7 +50,10 @@ export class ExternalExpressRoutes {
     rootDir: string,
     options?: ServeStaticOptions,
   ) {
-    this._staticRoutes.use(path, express.static(rootDir, options));
+    this._staticRoutes.use(path, express.static(
+      rootDir,
+      options,
+    ) as Application);
   }
 
   public mountRouter(


### PR DESCRIPTION
Fixes the following build error on my local:

```
packages/rest/src/router/external-express-routes.ts(53,34): error TS2345: Argument of type 'Handler' is not assignable to parameter of type 'Application'.
  Type 'Handler' is missing the following properties from type 'Application': init, defaultConfiguration, engine, set, and 61 more.
npm ERR! Darwin 17.7.0
npm ERR! argv "/Users/jannyhou/.nvm/versions/node/v10.15.3/bin/node" "/Users/jannyhou/node_modules/.bin/npm" "run" "build"
npm ERR! node v10.15.3
npm ERR! npm  v3.10.6
npm ERR! code ELIFECYCLE
npm ERR! @loopback/benchmark@1.2.6 build: `lb-tsc es2017 --outDir dist`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the @loopback/benchmark@1.2.6 build script 'lb-tsc es2017 --outDir dist'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the @loopback/benchmark package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     lb-tsc es2017 --outDir dist
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs @loopback/benchmark
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls @loopback/benchmark
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /Users/jannyhou/2019/passport-strategy/loopback-next/benchmark/npm-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! loopback-next@0.1.0 build: `node bin/run-lerna run build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the loopback-next@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jannyhou/.strong-registry/official.cache/_logs/2019-05-27T02_24_01_852Z-debug.log
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

