### PR TITLE
fix(authentication): fix the options type in decorator

### DIFF
--- a/packages/authentication/src/decorators/authenticate.decorator.ts
+++ b/packages/authentication/src/decorators/authenticate.decorator.ts
@@ -24,7 +24,7 @@ export interface AuthenticationMetadata {
  * @param strategyName - The name of the authentication strategy to use.
  * @param options - Additional options to configure the authentication.
  */
-export function authenticate(strategyName: string, options?: Object) {
+export function authenticate(strategyName: string, options?: object) {
   return MethodDecoratorFactory.createDecorator<AuthenticationMetadata>(
     AUTHENTICATION_METADATA_KEY,
     {


### PR DESCRIPTION
See discussion in https://github.com/strongloop/strongloop.com/pull/198#discussion_r287506418

Fix the type of `options` in the auth decorator. It should be `object` not `Object`. I didn't add a test case because when providing other types the code will have the red line warning in editor, before compiling.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
