### PR TITLE
fix: use symlinked docs package

### DIFF
--- a/bin/build-docs-site.sh
+++ b/bin/build-docs-site.sh
@@ -31,7 +31,7 @@ rm -rf sandbox/loopback.io/
 git clone --depth 1 https://github.com/strongloop/loopback.io.git sandbox/loopback.io
 
 # Bootstrap the `loopback.io` package
-lerna bootstrap --scope loopback.io-workflow-scripts
+lerna bootstrap --scope loopback.io-workflow-scripts --scope @loopback/docs
 
 pushd $REPO_ROOT/sandbox/loopback.io/ >/dev/null
 


### PR DESCRIPTION
Add `@loopback/docs` as a filter option when running `lerna bootstrap` for `loopback.io` in order to see changes in local docs package live after running `npm run build:site`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
