### PR TITLE
chore: upgrade to TypeScript 3.5

### DIFF
--- a/examples/express-composition/package-lock.json
+++ b/examples/express-composition/package-lock.json
@@ -730,9 +730,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "unpipe": {

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -61,6 +61,6 @@
     "@types/express": "^4.16.1",
     "@types/node": "^10.11.2",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   }
 }

--- a/examples/express-composition/src/controllers/note.controller.ts
+++ b/examples/express-composition/src/controllers/note.controller.ts
@@ -11,14 +11,14 @@ import {
   Where,
 } from '@loopback/repository';
 import {
-  post,
-  param,
+  del,
   get,
   getFilterSchemaFor,
   getWhereSchemaFor,
+  param,
   patch,
+  post,
   put,
-  del,
   requestBody,
 } from '@loopback/rest';
 import {Note} from '../models';
@@ -51,7 +51,7 @@ export class NoteController {
     },
   })
   async count(
-    @param.query.object('where', getWhereSchemaFor(Note)) where?: Where,
+    @param.query.object('where', getWhereSchemaFor(Note)) where?: Where<Note>,
   ): Promise<Count> {
     return await this.noteRepository.count(where);
   }
@@ -69,7 +69,8 @@ export class NoteController {
     },
   })
   async find(
-    @param.query.object('filter', getFilterSchemaFor(Note)) filter?: Filter,
+    @param.query.object('filter', getFilterSchemaFor(Note))
+    filter?: Filter<Note>,
   ): Promise<Note[]> {
     return await this.noteRepository.find(filter);
   }
@@ -84,7 +85,7 @@ export class NoteController {
   })
   async updateAll(
     @requestBody() note: Note,
-    @param.query.object('where', getWhereSchemaFor(Note)) where?: Where,
+    @param.query.object('where', getWhereSchemaFor(Note)) where?: Where<Note>,
   ): Promise<Count> {
     return await this.noteRepository.updateAll(note, where);
   }

--- a/examples/greeter-extension/package-lock.json
+++ b/examples/greeter-extension/package-lock.json
@@ -314,9 +314,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-			"integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+			"integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
 			"dev": true
 		},
 		"wrappy": {

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -49,7 +49,7 @@
     "@types/debug": "4.1.4",
     "@types/node": "^10.11.2",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "dependencies": {
     "@loopback/context": "^1.16.0",

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -302,9 +302,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "wrappy": {

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -46,7 +46,7 @@
     "@loopback/tslint-config": "^2.0.4",
     "@types/node": "^10.11.2",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "keywords": [
     "loopback",

--- a/examples/lb3-application/package-lock.json
+++ b/examples/lb3-application/package-lock.json
@@ -2210,9 +2210,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-			"integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+			"integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
 			"dev": true
 		},
 		"uid2": {

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^10.11.2",
     "lodash": "^4.17.11",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "keywords": [
     "loopback",

--- a/examples/log-extension/package-lock.json
+++ b/examples/log-extension/package-lock.json
@@ -314,9 +314,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "wrappy": {

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -48,7 +48,7 @@
     "@types/debug": "^4.1.4",
     "@types/node": "^10.11.2",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "dependencies": {
     "@loopback/context": "^1.16.0",

--- a/examples/rpc-server/package-lock.json
+++ b/examples/rpc-server/package-lock.json
@@ -730,9 +730,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "unpipe": {

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -50,6 +50,6 @@
     "@types/express": "^4.11.1",
     "@types/node": "^10.11.2",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   }
 }

--- a/examples/soap-calculator/package-lock.json
+++ b/examples/soap-calculator/package-lock.json
@@ -1437,9 +1437,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "underscore": {

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -60,6 +60,6 @@
     "mocha": "^6.1.3",
     "source-map-support": "^0.5.5",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   }
 }

--- a/examples/todo-list/package-lock.json
+++ b/examples/todo-list/package-lock.json
@@ -906,9 +906,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "uri-js": {

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -56,7 +56,7 @@
     "@types/node": "^10.11.2",
     "lodash": "^4.17.10",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "keywords": [
     "loopback",

--- a/examples/todo-list/src/__tests__/unit/controllers/todo-list-todo.controller.unit.ts
+++ b/examples/todo-list/src/__tests__/unit/controllers/todo-list-todo.controller.unit.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  Count,
   DefaultHasManyRepository,
   HasManyRepository,
 } from '@loopback/repository';
@@ -32,7 +33,8 @@ describe('TodoController', () => {
   in our tests themselves.
   =============================================================================
    */
-  let todos: sinon.SinonStub;
+  // tslint:disable:no-any
+  let todos: sinon.SinonStub<any[], Todo[]>;
 
   /*
   =============================================================================
@@ -42,10 +44,11 @@ describe('TodoController', () => {
   in our tests themselves.
   =============================================================================
    */
-  let create: sinon.SinonStub;
-  let find: sinon.SinonStub;
-  let patch: sinon.SinonStub;
-  let del: sinon.SinonStub;
+  let create: sinon.SinonStub<any[], Promise<Todo>>;
+  let find: sinon.SinonStub<any[], Promise<Todo[]>>;
+  let patch: sinon.SinonStub<any[], Promise<Count>>;
+  let del: sinon.SinonStub<any[], Promise<Count>>;
+  // tslint:enable:no-any
 
   /*
   =============================================================================
@@ -98,22 +101,22 @@ describe('TodoController', () => {
 
   describe('patch()', () => {
     it('returns a number of todos updated', async () => {
-      patch.resolves([aChangedTodo].length);
+      patch.resolves({count: [aChangedTodo].length});
       const where = {title: aTodoWithId.title};
       expect(
         await controller.patch(aTodoListWithId.id!, aTodoToPatchTo, where),
-      ).to.eql(1);
+      ).to.eql({count: 1});
       sinon.assert.calledWith(todos, aTodoListWithId.id!);
       sinon.assert.calledWith(patch, aTodoToPatchTo, where);
     });
   });
 
   describe('deleteAll()', () => {
-    it('successfully deletes existing items', async () => {
-      del.resolves(aListOfTodos.length);
-      expect(await controller.delete(aTodoListWithId.id!)).to.eql(
-        aListOfTodos.length,
-      );
+    it('returns a number of todos deleted', async () => {
+      del.resolves({count: aListOfTodos.length});
+      expect(await controller.delete(aTodoListWithId.id!)).to.eql({
+        count: aListOfTodos.length,
+      });
       sinon.assert.calledWith(todos, aTodoListWithId.id!);
       sinon.assert.called(del);
     });
@@ -155,7 +158,8 @@ describe('TodoController', () => {
     (todoListRepo as any).todos = todos;
 
     // Setup CRUD fakes
-    ({create, find, patch, delete: del} = constrainedTodoRepo.stubs);
+    // tslint:disable-next-line:no-any
+    ({create, find, patch, delete: del} = constrainedTodoRepo.stubs as any);
 
     controller = new TodoListTodoController(todoListRepo);
   }

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -56,7 +56,7 @@ export class TodoListTodoController {
   })
   async find(
     @param.path.number('id') id: number,
-    @param.query.object('filter') filter?: Filter,
+    @param.query.object('filter') filter?: Filter<Todo>,
   ): Promise<Todo[]> {
     return await this.todoListRepo.todos(id).find(filter);
   }
@@ -72,7 +72,7 @@ export class TodoListTodoController {
   async patch(
     @param.path.number('id') id: number,
     @requestBody() todo: Partial<Todo>,
-    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
+    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
     return await this.todoListRepo.todos(id).patch(todo, where);
   }
@@ -87,7 +87,7 @@ export class TodoListTodoController {
   })
   async delete(
     @param.path.number('id') id: number,
-    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where,
+    @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
     return await this.todoListRepo.todos(id).delete(where);
   }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -50,7 +50,8 @@ export class TodoListController {
     },
   })
   async count(
-    @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
+    @param.query.object('where', getWhereSchemaFor(TodoList))
+    where?: Where<TodoList>,
   ): Promise<Count> {
     return await this.todoListRepository.count(where);
   }
@@ -64,7 +65,8 @@ export class TodoListController {
     },
   })
   async find(
-    @param.query.object('filter', getFilterSchemaFor(TodoList)) filter?: Filter,
+    @param.query.object('filter', getFilterSchemaFor(TodoList))
+    filter?: Filter<TodoList>,
   ): Promise<TodoList[]> {
     return await this.todoListRepository.find(filter);
   }
@@ -79,7 +81,8 @@ export class TodoListController {
   })
   async updateAll(
     @requestBody() obj: Partial<TodoList>,
-    @param.query.object('where', getWhereSchemaFor(TodoList)) where?: Where,
+    @param.query.object('where', getWhereSchemaFor(TodoList))
+    where?: Where<TodoList>,
   ): Promise<Count> {
     return await this.todoListRepository.updateAll(obj, where);
   }

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -60,7 +60,8 @@ export class TodoController {
     },
   })
   async findTodos(
-    @param.query.object('filter', getFilterSchemaFor(Todo)) filter?: Filter,
+    @param.query.object('filter', getFilterSchemaFor(Todo))
+    filter?: Filter<Todo>,
   ): Promise<Todo[]> {
     return await this.todoRepo.find(filter);
   }

--- a/examples/todo/package-lock.json
+++ b/examples/todo/package-lock.json
@@ -906,9 +906,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "uri-js": {

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -56,7 +56,7 @@
     "@types/node": "^10.11.2",
     "lodash": "^4.17.10",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "keywords": [
     "loopback",

--- a/examples/todo/src/__tests__/unit/controllers/todo.controller.unit.ts
+++ b/examples/todo/src/__tests__/unit/controllers/todo.controller.unit.ts
@@ -100,7 +100,7 @@ describe('TodoController', () => {
 
     it('uses the provided filter', async () => {
       const find = todoRepo.stubs.find;
-      const filter: Filter = {where: {isCompleted: false}};
+      const filter: Filter<Todo> = {where: {isComplete: false}};
 
       find.resolves(aListOfTodos);
       await controller.findTodos(filter);

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -73,7 +73,8 @@ export class TodoController {
     },
   })
   async findTodos(
-    @param.query.object('filter', getFilterSchemaFor(Todo)) filter?: Filter,
+    @param.query.object('filter', getFilterSchemaFor(Todo))
+    filter?: Filter<Todo>,
   ): Promise<Todo[]> {
     return await this.todoRepo.find(filter);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7266,9 +7266,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-eslint-plugin": "^2.0.1",
     "eslint-plugin-mocha": "^5.3.0",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "scripts": {
     "postinstall": "lerna bootstrap",

--- a/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
@@ -22,7 +22,8 @@ describe('datasource booter unit tests', () => {
   class AppWithRepo extends RepositoryMixin(Application) {}
 
   let app: AppWithRepo;
-  let stub: sinon.SinonStub;
+  // tslint:disable-next-line:no-any
+  let stub: sinon.SinonStub<[any?, ...any[]], void>;
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);

--- a/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
@@ -22,7 +22,8 @@ describe('repository booter unit tests', () => {
   class RepoApp extends RepositoryMixin(Application) {}
 
   let app: RepoApp;
-  let stub: sinon.SinonStub;
+  // tslint:disable-next-line:no-any
+  let stub: sinon.SinonStub<[any?, ...any[]], void>;
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);

--- a/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
@@ -19,7 +19,8 @@ describe('service booter unit tests', () => {
   class AppWithRepo extends ServiceMixin(Application) {}
 
   let app: AppWithRepo;
-  let stub: sinon.SinonStub;
+  // tslint:disable-next-line:no-any
+  let stub: sinon.SinonStub<[any?, ...any[]], void>;
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -2649,9 +2649,9 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -31,7 +31,7 @@
     "source-map-support": "^0.5.12",
     "strong-docs": "^4.2.0",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.5.1"
   },
   "bin": {
     "lb-tsc": "./bin/compile-package.js",

--- a/packages/context/src/__tests__/acceptance/method-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/method-level-bindings.acceptance.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, inject, invokeMethod} from '../..';
 import * as debugModule from 'debug';
+import {Context, inject, invokeMethod, BindingKey} from '../..';
 const debug = debugModule('loopback:context:test');
 
 class InfoController {
@@ -37,7 +37,7 @@ class InfoController {
   }
 }
 
-const INFO_CONTROLLER = 'controllers.info';
+const INFO_CONTROLLER = BindingKey.create<InfoController>('controllers.info');
 
 describe('Context bindings - Injecting dependencies of method', () => {
   let ctx: Context;

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -32,10 +32,9 @@ const lifeCycleMethods: (keyof LifeCycleObserver)[] = ['start', 'stop'];
  * Test if an object implements LifeCycleObserver
  * @param obj - An object
  */
-export function isLifeCycleObserver(obj: {
-  [name: string]: unknown;
-}): obj is LifeCycleObserver {
-  return lifeCycleMethods.some(m => typeof obj[m] === 'function');
+export function isLifeCycleObserver(obj: object): obj is LifeCycleObserver {
+  const candidate = obj as Partial<LifeCycleObserver>;
+  return lifeCycleMethods.some(m => typeof candidate[m] === 'function');
 }
 
 /**

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as assert from 'assert';
 import {
+  createEmptyApiSpec,
+  ISpecificationExtension,
   OpenApiSpec,
   OperationObject,
-  ResponseObject,
   ParameterObject,
-  createEmptyApiSpec,
   RequestBodyObject,
-  ISpecificationExtension,
+  ResponseObject,
 } from '@loopback/openapi-v3-types';
+import * as assert from 'assert';
 
 /**
  * Create a new instance of OpenApiSpecBuilder.
@@ -53,7 +53,10 @@ export class BuilderBase<T extends ISpecificationExtension> {
       `Invalid extension ${key}, extension keys must be prefixed with "x-"`,
     );
 
-    this._spec[key] = value;
+    // `this._spec[key] = value;` is broken in TypeScript 3.5
+    // See https://github.com/microsoft/TypeScript/issues/31661
+    // tslint:disable-next-line:no-any
+    (this._spec as Record<string, any>)[key] = value;
     return this;
   }
 


### PR DESCRIPTION
Upgrade to TypeScript 3.5

I have to address a few breaking changes:

1. https://github.com/microsoft/TypeScript/issues/31661
2. Generic type is default to `unknown` instead of `{}` now.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
