### PR TITLE
chore: fix more @param comments in tsdocs

### DIFF
--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -190,7 +190,7 @@ module.exports = class BaseGenerator extends Generator {
 
   /**
    * Override the base prompt to skip prompts with default answers
-   * @param questions One or more questions
+   * @param questions - One or more questions
    */
   async prompt(questions) {
     // Normalize the questions to be an array

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -13,10 +13,10 @@ const PREFIX = 'loopback4:';
 
 /**
  * Parse arguments and run corresponding command
- * @param env Yeoman env
+ * @param env - Yeoman env
  * @param {*} opts Command options
- * @param log Log function
- * @param dryRun flag for dryRun (for testing)
+ * @param log - Log function
+ * @param dryRun - flag for dryRun (for testing)
  */
 function runCommand(env, opts, log, dryRun) {
   const args = opts._;
@@ -113,7 +113,7 @@ function printVersions(log) {
 /**
  * Print a list of available commands
  * @param {*} env Yeoman env
- * @param log Log function
+ * @param log - Log function
  */
 function printCommands(env, log) {
   log('Available commands: ');

--- a/packages/cli/lib/model-discoverer.js
+++ b/packages/cli/lib/model-discoverer.js
@@ -17,9 +17,9 @@ async function discoverModelNames(ds, options) {
 
 /**
  * Returns the schema definition for a model
- * @param ds {Juggler.DataSource}
- * @param modelName {string}
- * @param options {object}
+ * @param ds - {Juggler.DataSource}
+ * @param modelName - {string}
+ * @param options - {object}
  * @returns {Promise<Juggler.SchemaDefinition>}
  */
 async function discoverSingleModel(ds, modelName, options) {
@@ -46,7 +46,7 @@ function loadDataSource(path) {
 
 /**
  * Loads a compiled loopback datasource by name
- * @param name {string}
+ * @param name - {string}
  * @returns {*}
  */
 function loadDataSourceByName(name) {

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -672,7 +672,7 @@ export class Context extends EventEmitter {
    * Find bindings using the tag filter. If the filter matches one of the
    * binding tags, the binding is included.
    *
-   * @param tagFilter  A filter for tags. It can be in one of the following
+   * @param tagFilter - A filter for tags. It can be in one of the following
    * forms:
    * - A regular expression, such as `/controller/`
    * - A wildcard pattern string with optional `*` and `?`, such as `'con*'`

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -44,7 +44,7 @@ export class Application extends Context implements LifeCycleObserver {
   /**
    * Register a controller class with this application.
    *
-   * @param controllerCtor {Function} The controller class
+   * @param controllerCtor - The controller class
    * (constructor function).
    * @param name - Optional controller name, default to the class name
    * @returns The newly created binding, you can use the reference to

--- a/packages/metadata/src/reflect.ts
+++ b/packages/metadata/src/reflect.ts
@@ -12,7 +12,7 @@ import 'reflect-metadata';
  */
 export class NamespacedReflect {
   /**
-   * @param namespace : namespace to bind this reflect context
+   * @param namespace - Namespace to bind this reflect context
    */
   constructor(private namespace?: string) {}
 

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -55,8 +55,8 @@ function isModelClass(
 /**
  * This is a bridge to the legacy DAO class. The function mixes DAO methods
  * into a model class and attach it to a given data source
- * @param modelClass {} Model class
- * @param ds {DataSource} Data source
+ * @param modelClass - Model class
+ * @param ds - Data source
  * @returns {} The new model class with DAO (CRUD) operations
  */
 export function bindModel<T extends juggler.ModelBaseClass>(

--- a/packages/testlab/src/sinon.ts
+++ b/packages/testlab/src/sinon.ts
@@ -27,7 +27,7 @@ export type StubbedInstanceWithSinonAccessor<T> = T & {
  *  - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14811
  *
  * @typeParam TType - Type being stubbed.
- * @param constructor  Object or class to stub.
+ * @param constructor - Object or class to stub.
  * @returns A stubbed version of the constructor, with an extra property `stubs`
  * providing access to stub API for individual methods.
  */


### PR DESCRIPTION
Add `-` for `@param`

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
