### PR TITLE
feat(testlab): rework itSkippedOnTravis to support Jest framework

### DIFF
--- a/packages/testlab/src/skip-travis.ts
+++ b/packages/testlab/src/skip-travis.ts
@@ -3,8 +3,21 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// tslint:disable-next-line:no-any
-export type TestCallbackRetval = void | PromiseLike<any>;
+// Simplified test function type from Mocha
+export interface TestFn {
+  (this: TestContext): PromiseLike<unknown>;
+  (this: TestContext, done: Function): void;
+}
+
+// Type of "this" object provided by Mocha to test functions
+export interface TestContext {
+  skip(): this;
+  timeout(ms: number | string): this;
+  retries(n: number): this;
+  slow(ms: number): this;
+  // tslint:disable-next-line:no-any
+  [index: string]: any;
+}
 
 /**
  * Helper function for skipping tests on Travis env
@@ -13,10 +26,7 @@ export type TestCallbackRetval = void | PromiseLike<any>;
  */
 export function itSkippedOnTravis(
   expectation: string,
-  callback?: (
-    this: Mocha.ITestCallbackContext,
-    done: MochaDone,
-  ) => TestCallbackRetval,
+  callback?: TestFn,
 ): void {
   if (process.env.TRAVIS) {
     it.skip(`[SKIPPED ON TRAVIS] ${expectation}`, callback);


### PR DESCRIPTION
Describe referenced Mocha types directly in testlab to avoid compile-time dependency on Mocha types, some of which are not compatible with Jest -- fix https://github.com/strongloop/loopback-next/issues/2452

Contents of `packages/testlab/dist/skip-travis.d.ts`:

**BEFORE**

```ts
/// <reference types="mocha" />
export declare type TestCallbackRetval = void | PromiseLike<any>;
/**
 * Helper function for skipping tests on Travis env
 * @param expectation
 * @param callback
 */
export declare function itSkippedOnTravis(expectation: string, callback?: (this: Mocha.ITestCallbackContext, done: MochaDone) => TestCallbackRetval): void;
```

Notice `/// <reference types="mocha" />` which is the root cause of the problem reported in #2452

**AFTER**

```ts
export interface TestFn {
    (this: TestContext): PromiseLike<unknown>;
    (this: TestContext, done: Function): void;
}
export interface TestContext {
    skip(): this;
    timeout(ms: number | string): this;
    retries(n: number): this;
    slow(ms: number): this;
    [index: string]: any;
}
/**
 * Helper function for skipping tests on Travis env
 * @param expectation
 * @param callback
 */
export declare function itSkippedOnTravis(expectation: string, callback?: TestFn): void;
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈