### PR TITLE
fix: modelSettings is stringified properly #2915

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -219,9 +219,12 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       modelDefinition.isModelBaseBuiltin = true;
       modelDefinition.modelBaseClass = 'Entity';
       modelDefinition.className = utils.pascalCase(modelDefinition.name);
-      // These last two are so that the templat doesn't error out of they aren't there
+      // These last two are so that the template doesn't error out of they aren't there
       modelDefinition.allowAdditionalProperties = true;
-      modelDefinition.modelSettings = modelDefinition.settings || {};
+      // modelDefinition.modelSettings = modelDefinition.settings || {};
+      modelDefinition.modelSettings = utils.stringifyModelSettings(
+        modelDefinition.settings || {},
+      );
       debug(`Generating: ${modelDefinition.name}`);
 
       const fullPath = path.resolve(

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -14,7 +14,6 @@ const inspect = require('util').inspect;
 const utils = require('../../lib/utils');
 const chalk = require('chalk');
 const path = require('path');
-const stringifyObject = require('stringify-object');
 
 const PROMPT_BASE_MODEL_CLASS = 'Please select the model base class';
 const ERROR_NO_MODELS_FOUND = 'Model was not found in';
@@ -515,13 +514,8 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
     });
 
     if (this.artifactInfo.modelSettings) {
-      this.artifactInfo.modelSettings = stringifyObject(
-        {settings: this.artifactInfo.modelSettings},
-        {
-          indent: '  ', // two spaces
-          singleQuotes: true,
-          inlineCharacterLimit: 80,
-        },
+      this.artifactInfo.modelSettings = utils.stringifyModelSettings(
+        this.artifactInfo.modelSettings,
       );
     }
 

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -23,6 +23,7 @@ const urlSlug = require('url-slug');
 const validate = require('validate-npm-package-name');
 const Conflicter = require('yeoman-generator/lib/util/conflicter');
 const connectors = require('../generators/datasource/connectors.json');
+const stringifyObject = require('stringify-object');
 
 const readdirAsync = promisify(fs.readdir);
 
@@ -515,6 +516,17 @@ exports.getDataSourceName = function(datasourcesDir, dataSourceClass) {
 exports.dataSourceToJSONFileName = function(dataSourceClass) {
   return path.join(
     _.kebabCase(dataSourceClass.replace('Datasource', '')) + '.datasource.json',
+  );
+};
+
+exports.stringifyModelSettings = function(modelSettings) {
+  return stringifyObject(
+    {settings: modelSettings},
+    {
+      indent: '  ', // two spaces
+      singleQuotes: true,
+      inlineCharacterLimit: 80,
+    },
   );
 };
 


### PR DESCRIPTION
modelSettings is stringified ahead of time to prevent `@settings([object object])`

Fixes #2915, see also #2953

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
