### PR TITLE
docs: removes unnecessary 'npm install @types/passport' command

### DIFF
--- a/docs/site/Using-components.md
+++ b/docs/site/Using-components.md
@@ -18,7 +18,6 @@ Install the following dependencies:
 
 ```sh
 npm install --save @loopback/authentication
-npm install @types/passport
 ```
 
 Load the component in your application:


### PR DESCRIPTION
Removes unnecessary 'npm install @types/passport' command
after the 'npm install --save @loopback/authentication' command.
The authentication component no longer has a dependency
on the passport-based modules.

Related to : https://github.com/strongloop/loopback-next/issues/2940
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
