### PR TITLE
chore: use 1.0.0 instead of prereleases

### DIFF
--- a/examples/greeting-app/package-lock.json
+++ b/examples/greeting-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@loopback/example-greeting-app",
-	"version": "1.0.0-3",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/example-greeting-app",
-  "version": "1.0.0-3",
+  "version": "1.0.0",
   "description": "An example greeting application for LoopBack 4",
   "main": "index.js",
   "engines": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -14,7 +14,7 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "@loopback/eslint-config": "^1.0.0-3",
+    "@loopback/eslint-config": "^1.0.0",
     "@loopback/tslint-config": "^2.0.4",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.11.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -122,10 +122,10 @@
       "@loopback/example-greeter-extension": "^1.2.7",
       "@loopback/booter-lb3app": "^1.1.6",
       "@loopback/example-lb3-application": "^1.0.3",
-      "@loopback/eslint-config": "^1.0.0-3",
+      "@loopback/eslint-config": "^1.0.0",
       "eslint": "^5.16.0",
       "eslint-plugin-mocha": "^5.3.0",
-      "@loopback/example-greeting-app": "^1.0.0-3",
+      "@loopback/example-greeting-app": "^1.0.0",
       "@loopback/example-context": "^1.1.0"
     }
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopback/eslint-config",
-  "version": "1.0.0-3",
+  "version": "1.0.0",
   "description": "Shared configuration for ESLint",
   "engines": {
     "node": ">=8.9"


### PR DESCRIPTION
Please note that lerna promotes 1.0.0-1 to 1.0.0-2 instead of 1.0.0.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
