### PR TITLE
fix(cli): add eslint related dev dependencies to generated package.json

### DIFF
--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -96,10 +96,15 @@
   "devDependencies": {
     "@loopback/build": "<%= project.dependencies['@loopback/build'] -%>",
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
-    "@loopback/eslint-config": "<%= project.dependencies['@loopback/eslint-config'] -%>",
     "@types/node": "<%= project.dependencies['@types/node'] -%>",
     <% if (project.eslint) { -%>
+    "@typescript-eslint/parser": "<%= project.dependencies['@typescript-eslint/parser'] -%>",
+    "@typescript-eslint/eslint-plugin": "<%= project.dependencies['@typescript-eslint/eslint-plugin'] -%>",
+    "@loopback/eslint-config": "<%= project.dependencies['@loopback/eslint-config'] -%>",
     "eslint": "<%= project.dependencies['eslint'] -%>",
+    "eslint-config-prettier": "<%= project.dependencies['eslint-config-prettier'] -%>",
+    "eslint-plugin-eslint-plugin": "<%= project.dependencies['eslint-plugin-eslint-plugin'] -%>",
+    "eslint-plugin-mocha": "<%= project.dependencies['eslint-plugin-mocha'] -%>",
     <% } -%>
     "typescript": "<%= project.dependencies['typescript'] -%>"
   }

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -101,9 +101,14 @@
     "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
 <% } -%>
 <% if (project.eslint) { -%>
-    "eslint": "<%= project.dependencies['eslint'] -%>",
+    "@typescript-eslint/parser": "<%= project.dependencies['@typescript-eslint/parser'] -%>",
+    "@typescript-eslint/eslint-plugin": "<%= project.dependencies['@typescript-eslint/eslint-plugin'] -%>",
     "@loopback/eslint-config": "<%= project.dependencies['@loopback/eslint-config'] -%>",
-<% } -%>
+    "eslint": "<%= project.dependencies['eslint'] -%>",
+    "eslint-config-prettier": "<%= project.dependencies['eslint-config-prettier'] -%>",
+    "eslint-plugin-eslint-plugin": "<%= project.dependencies['eslint-plugin-eslint-plugin'] -%>",
+    "eslint-plugin-mocha": "<%= project.dependencies['eslint-plugin-mocha'] -%>",
+  <% } -%>
     "typescript": "<%= project.dependencies['typescript'] -%>"
   }
 }

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -252,6 +252,11 @@ module.exports = function(projGenerator, props, projectType) {
           ['package.json', '@loopback/build'],
           ['package.json', '"typescript"'],
           ['package.json', '"eslint"'],
+          ['package.json', 'eslint-config-prettier'],
+          ['package.json', 'eslint-plugin-eslint-plugin'],
+          ['package.json', 'eslint-plugin-mocha'],
+          ['package.json', '@typescript-eslint/eslint-plugin'],
+          ['package.json', '@loopback/eslint-config'],
           ['.eslintrc.js', '@loopback/eslint-config'],
           ['tsconfig.json', '@loopback/build'],
         ]);
@@ -339,6 +344,11 @@ module.exports = function(projGenerator, props, projectType) {
           ['package.json', '"clean": "rimraf dist"'],
           ['package.json', '"typescript"'],
           ['package.json', '"eslint"'],
+          ['package.json', 'eslint-config-prettier'],
+          ['package.json', 'eslint-plugin-eslint-plugin'],
+          ['package.json', 'eslint-plugin-mocha'],
+          ['package.json', '@typescript-eslint/eslint-plugin'],
+          ['package.json', '@loopback/eslint-config'],
           ['package.json', '"prettier"'],
           ['.eslintrc.js', "extends: '@loopback/eslint-config'"],
           ['tsconfig.json', '"compilerOptions"'],
@@ -391,7 +401,15 @@ module.exports = function(projGenerator, props, projectType) {
       });
 
       it('creates files', () => {
-        assert.noFile(['.eslintrc.js', 'eslint.build.json']);
+        assert.noFile(
+          ['.eslintrc.js', 'eslint.build.json'],
+          ['package.json', '"eslint"'],
+          ['package.json', 'eslint-config-prettier'],
+          ['package.json', 'eslint-plugin-eslint-plugin'],
+          ['package.json', 'eslint-plugin-mocha'],
+          ['package.json', '@typescript-eslint/eslint-plugin'],
+          ['package.json', '@loopback/eslint-config'],
+        );
         assert.jsonFileContent('package.json', props);
       });
     });
@@ -422,6 +440,11 @@ module.exports = function(projGenerator, props, projectType) {
         assert.noFileContent([
           ['package.json', '@loopback/build'],
           ['package.json', '"eslint"'],
+          ['package.json', 'eslint-config-prettier'],
+          ['package.json', 'eslint-plugin-eslint-plugin'],
+          ['package.json', 'eslint-plugin-mocha'],
+          ['package.json', '@typescript-eslint/eslint-plugin'],
+          ['package.json', '@loopback/eslint-config'],
           ['tsconfig.json', '@loopback/build'],
         ]);
         assert.fileContent([


### PR DESCRIPTION
Some of eslint related dev dependencies are missing from generated project package.json files and it fails `npm test`.

The issue was not caught by our acceptance test as such deps happen to be available at `loopback-next` level and our generated app is in `loopback-next/sandbox`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
