### PR TITLE
feat(testlab): add generic helper `skipOnTravis`

### DIFF
--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -8,7 +8,7 @@ import {
   givenHttpServerConfig,
   httpGetAsync,
   httpsGetAsync,
-  itSkippedOnTravis,
+  skipOnTravis,
   supertest,
 } from '@loopback/testlab';
 import * as fs from 'fs';
@@ -22,7 +22,7 @@ describe('HttpServer (integration)', () => {
 
   afterEach(stopServer);
 
-  itSkippedOnTravis('formats IPv6 url correctly', async () => {
+  skipOnTravis(it, 'formats IPv6 url correctly', async () => {
     server = new HttpServer(dummyRequestHandler, {
       host: '::1',
     } as HttpOptions);
@@ -164,7 +164,7 @@ describe('HttpServer (integration)', () => {
     expect(response.statusCode).to.equal(200);
   });
 
-  itSkippedOnTravis('supports HTTP over IPv6', async () => {
+  skipOnTravis(it, 'supports HTTP over IPv6', async () => {
     server = new HttpServer(dummyRequestHandler, {host: '::1'});
     await server.start();
     expect(getAddressFamily(server)).to.equal('IPv6');
@@ -190,7 +190,7 @@ describe('HttpServer (integration)', () => {
     expect(response.statusCode).to.equal(200);
   });
 
-  itSkippedOnTravis('handles IPv6 loopback address in HTTPS', async () => {
+  skipOnTravis(it, 'handles IPv6 loopback address in HTTPS', async () => {
     const httpsServer: HttpServer = givenHttpsServer({
       host: '::1',
     });

--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -10,7 +10,7 @@ import {
   expect,
   givenHttpServerConfig,
   httpsGetAsync,
-  itSkippedOnTravis,
+  skipOnTravis,
   supertest,
 } from '@loopback/testlab';
 import * as fs from 'fs';
@@ -705,7 +705,7 @@ paths:
     await server.stop();
   });
 
-  itSkippedOnTravis('handles IPv6 loopback address in HTTPS', async () => {
+  skipOnTravis(it, 'handles IPv6 loopback address in HTTPS', async () => {
     const keyPath = path.join(FIXTURES, 'key.pem');
     const certPath = path.join(FIXTURES, 'cert.pem');
     const server = await givenAServer({
@@ -726,7 +726,7 @@ paths:
   });
 
   // https://github.com/strongloop/loopback-next/issues/1623
-  itSkippedOnTravis('handles IPv6 address for API Explorer UI', async () => {
+  skipOnTravis(it, 'handles IPv6 address for API Explorer UI', async () => {
     const keyPath = path.join(FIXTURES, 'key.pem');
     const certPath = path.join(FIXTURES, 'cert.pem');
     const server = await givenAServer({

--- a/packages/testlab/README.md
+++ b/packages/testlab/README.md
@@ -47,7 +47,7 @@ Table of contents:
 - [sinon](#sinon) - Mocks, stubs and more.
 - [shot](#shot) - HTTP Request/Response stubs.
 - [validateApiSpec](#validateapispec) - Open API Spec validator.
-- [itSkippedOnTravis](#itskippedontravis) - Skip tests on Travis env.
+- [skipOnTravis](#skipontravis) - Skip tests on Travis env.
 - [createRestAppClient](#createrestappclient) - Create a supertest client
   connected to a running RestApplication.
 - [givenHttpServerConfig](#givenhttpserverconfig) - Generate HTTP server config.
@@ -82,10 +82,21 @@ by Shot in your unit tests:
 - Code modifying core HTTP Response, including full request/response handlers
 - Code parsing Express HTTP Request or modifying Express HTTP Response
 
-### `itSkippedOnTravis`
+### `skipOnTravis`
 
 Helper function for skipping tests on Travis environment. If you need to skip
-testing on Travis for any reason, use this instead of Mocha's `it`.
+testing on Travis for any reason, use this helper together with `it` or
+`describe`.
+
+```ts
+skipOnTravis(it, 'does something when some condition', async () => {
+  // the test code
+});
+```
+
+Under the hood, `skipOnTravis` invokes the provided test verb by default (e.g.
+`it`). When the helper detects Travis CI environment variables, then it calls
+`.skip` instead (e.g. `it.skip`).
 
 ### `createRestAppClient`
 


### PR DESCRIPTION
Introduce a generic helper `skipOnTravis` that supports arbitrary BDD verbs (`it`, `describe`, etc.) in a test-framework-agnostic way. Rework `itSkippedOnTravis` to leverage the new helper and deprecate it (in tsdocs only).

This is a follow-up for #3013.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
