### PR TITLE
chore: import eslint rules from eslint-config-loopback

### DIFF
--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -36,7 +36,7 @@ module.exports = function(projGenerator, props, projectType) {
 
     describe('_setupGenerator', () => {
       describe('args validation', () => {
-        it('errors out if validation fails', () => {
+        it('errors out if validation fails for an argument value', () => {
           const result = testUtils
             .executeGenerator(projGenerator)
             .withArguments(['fooBar']);
@@ -45,7 +45,7 @@ module.exports = function(projGenerator, props, projectType) {
           );
         });
 
-        it('errors out if validation fails', () => {
+        it('errors out if validation fails for an option value', () => {
           const result = testUtils
             .executeGenerator(projGenerator)
             .withOptions({name: 'fooBar'})

--- a/packages/cli/test/unit/utils.unit.js
+++ b/packages/cli/test/unit/utils.unit.js
@@ -364,7 +364,7 @@ describe('Utils', () => {
       );
     });
 
-    it('returns string for an array check with a number', () => {
+    it('returns string for an array check with an object', () => {
       expect(utils.validateStringObject('array')({})).to.be.eql(
         'The value must be a stringified array',
       );
@@ -374,7 +374,7 @@ describe('Utils', () => {
       expect(utils.validateStringObject('object')('{}')).to.be.True();
     });
 
-    it('returns string for an array check with an object', () => {
+    it('returns string for an array check with an object-like string', () => {
       expect(utils.validateStringObject('array')('{}')).to.be.eql(
         'The value must be a stringified array',
       );

--- a/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
@@ -637,7 +637,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.locations).to.eql(['San Francisco', 'San Jose']);
   });
 
-  it('injects values by tag asynchronously', async () => {
+  it('reports correct resolution path when injecting values by tag', async () => {
     class Store {
       constructor(@inject.tag('store:location') public locations: string[]) {}
     }

--- a/packages/context/src/__tests__/unit/binding-sorter.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-sorter.unit.ts
@@ -53,7 +53,7 @@ describe('BindingComparator', () => {
     assertOrder('validator1', 'validator2', 'metrics', 'logger1');
   });
 
-  it('sorts by binding order without phase tags', () => {
+  it('sorts by binding order without phase tags (for symbol tags)', () => {
     /**
      * Phases
      * - '': validator1 // not part of ['log', 'auth']

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -152,7 +152,7 @@ describe('Application', () => {
       expect(binding.tagNames).to.containEql('foo');
     });
 
-    it('binds providers from a component', () => {
+    it('honors tags when binding providers from a component', () => {
       @bind({tags: ['foo']})
       class MyProvider implements Provider<string> {
         value() {

--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -57,6 +57,15 @@ module.exports = {
     'no-redeclare': 'off',
 
     /**
+     * Rules imported from eslint-config-loopback
+     */
+    'mocha/handle-done-callback': 'error',
+    'mocha/no-exclusive-tests': 'error',
+    'mocha/no-identical-title': 'error',
+    'mocha/no-nested-tests': 'error',
+    'no-array-constructor': 'error',
+
+    /**
      * TypeScript specific rules
      * See https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules
      */

--- a/packages/rest/src/__tests__/unit/rest.component.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.component.unit.ts
@@ -25,9 +25,20 @@ import {aRestServerConfig} from '../helpers';
 const SequenceActions = RestBindings.SequenceActions;
 describe('RestComponent', () => {
   describe('Providers', () => {
-    describe('Default implementations are bound', () => {
+    describe('Default implementation', () => {
       let app: Application;
       let comp: Component;
+
+      const EXPECTED_KEYS = [
+        RestBindings.SequenceActions.LOG_ERROR.key,
+        RestBindings.SequenceActions.FIND_ROUTE.key,
+        RestBindings.SequenceActions.INVOKE_METHOD.key,
+        RestBindings.SequenceActions.REJECT.key,
+        RestBindings.BIND_ELEMENT.key,
+        RestBindings.GET_FROM_CONTEXT.key,
+        RestBindings.SequenceActions.PARSE_PARAMS.key,
+        RestBindings.SequenceActions.SEND.key,
+      ];
 
       before(async () => {
         app = new Application();
@@ -42,16 +53,15 @@ describe('RestComponent', () => {
         comp = await app.get<Component>('components.RestComponent');
       });
 
-      it('', async () => {
-        for (const key in comp.providers || {}) {
-          it(key, async () => {
-            const result = await app.get(key);
-            const expected: Provider<BoundValue> = new comp.providers![key]();
-            expect(result).to.deepEqual(expected.value());
-          });
-        }
-      });
+      for (const key of EXPECTED_KEYS) {
+        it(`binds ${key}`, async () => {
+          const result = await app.get(key);
+          const expected: Provider<BoundValue> = new comp.providers![key]();
+          expect(result).to.deepEqual(expected.value());
+        });
+      }
     });
+
     describe('LOG_ERROR', () => {
       it('matches expected argument signature', async () => {
         const app = new Application();


### PR DESCRIPTION
This pull request adds rules from eslint-config-loopback (see https://github.com/strongloop/eslint-config-loopback/blob/master/eslint.json) and fixes violations of these new rules (mostly mocha/no-identical-title).

This is a follow-up for #2492 which switched loopback-next from tslint to eslint.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈