### PR TITLE
fix(tsdocs): escape constructor name to avoid Jekyll site generation issue

### DIFF
--- a/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
+++ b/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs-extra';
 import pEvent from 'p-event';
 import * as path from 'path';
 import {runExtractorForMonorepo, updateApiDocs} from '../..';
+import {fixConstructorName} from '../../update-api-md-docs';
 
 const runCLI = require('@loopback/build').runCLI;
 
@@ -79,7 +80,10 @@ describe('tsdocs', function() {
     });
 
     const files = await fs.readdir(SITE_APIDOCS_ROOT);
-    expect(files.sort()).to.eql(['index.md', ...API_MD_FILES]);
+    expect(files.sort()).to.eql([
+      'index.md',
+      ...API_MD_FILES.map(fixConstructorName),
+    ]);
 
     for (const f of files) {
       const md = await fs.readFile(path.join(SITE_APIDOCS_ROOT, f), 'utf-8');
@@ -104,5 +108,11 @@ permalink: /doc/en/lb4/apidocs.index.html
 - [pkg2](pkg2.md)
 
 `);
+
+    const constructorDoc = await fs.readFile(
+      path.join(SITE_APIDOCS_ROOT, 'pkg1.pet._constructor_.md'),
+      'utf-8',
+    );
+    expect(constructorDoc).to.not.match(/\.\(constructor\)/);
   });
 });

--- a/packages/tsdocs/src/update-api-md-docs.ts
+++ b/packages/tsdocs/src/update-api-md-docs.ts
@@ -119,6 +119,7 @@ async function addJekyllMetadata(
     }
 
     const docFile = path.join(apiDocsRoot, f);
+    const targetDocFile = path.join(apiDocsRoot, fixConstructorName(f));
     let doc = await fs.readFile(docFile, 'utf-8');
 
     if (isPackage && options.generateDefaultPackageDoc) {
@@ -158,8 +159,20 @@ permalink: /doc/en/lb4/apidocs.${name}.html
 
 ${doc}
 `;
+
+    // Fix `*.(constructor)`
+    doc = fixConstructorName(doc);
+
     if (!options.dryRun) {
-      await fs.writeFile(docFile, doc, 'utf-8');
+      await fs.writeFile(targetDocFile, doc, 'utf-8');
+      if (targetDocFile !== docFile) {
+        await fs.remove(docFile);
+      }
     }
   }
+}
+
+// Fix `*.(constructor)`
+export function fixConstructorName(name: string) {
+  return name.replace(/\.\(constructor\)/g, '._constructor_');
 }


### PR DESCRIPTION
In https://loopback.io/doc/en/lb4/apidocs.context.binding.html, it references https://loopback.io/doc/en/lb4/context.binding.(constructor).md.

Please note api-extractor/api-documenter uses `.(constructor).md` for file names. Jekyll has trouble converting such files.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
