### PR TITLE
chore: remove tsconfig.build.tsbuildinfo with npm run clean

### DIFF
--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -11,7 +11,7 @@
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-context*.tgz dist package",
+    "clean": "lb-clean *example-context*.tgz dist tsconfig.build.tsbuildinfo package",
     "verify": "npm pack && tar xf *example-context*.tgz && tree package && npm run clean",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-greeter-extension-*.tgz dist package",
+    "clean": "lb-clean *example-greeter-extension-*.tgz dist tsconfig.build.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-greeting-app-*.tgz dist package",
+    "clean": "lb-clean *example-greeting-app-*.tgz dist tsconfig.build.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -11,7 +11,7 @@
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-hello-world*.tgz dist package",
+    "clean": "lb-clean *example-hello-world*.tgz dist tsconfig.build.tsbuildinfo package",
     "verify": "npm pack && tar xf *example-hello-world*.tgz && tree package && npm run clean",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-lb3-application*.tgz dist package",
+    "clean": "lb-clean *example-lb3-application*.tgz dist tsconfig.build.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-log-extension-*.tgz dist package",
+    "clean": "lb-clean *example-log-extension-*.tgz dist tsconfig.build.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-soap*.tgz dist package api-docs dist",
+    "clean": "lb-clean *example-soap*.tgz dist package api-docs dist tsconfig.build.tsbuildinfo",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-todo-list*.tgz dist package",
+    "clean": "lb-clean *example-todo-list*.tgz dist tsconfig.build.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-todo*.tgz dist package",
+    "clean": "lb-clean *example-todo*.tgz dist tsconfig.build.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-authentication*.tgz dist package",
+    "clean": "lb-clean loopback-authentication*.tgz dist tsconfig.build.tsbuildinfo package",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-boot*.tgz dist package",
+    "clean": "lb-clean loopback-boot*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-booter-lb3app*.tgz dist package",
+    "clean": "lb-clean loopback-booter-lb3app*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-booter-lb3app*.tgz && tree package && npm run clean"

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean dist",
+    "clean": "lb-clean dist tsconfig.build.tsbuildinfo",
 <% if (project.prettier && project.eslint) { -%>
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-context*.tgz dist package",
+    "clean": "lb-clean loopback-context*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-core*.tgz dist package",
+    "clean": "lb-clean loopback-core*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-caching-proxy*.tgz dist package",
+    "clean": "lb-clean loopback-caching-proxy*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-caching-proxy*.tgz && tree package && npm run clean"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-http-server*.tgz dist package",
+    "clean": "lb-clean loopback-http-server*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-http-server*.tgz && tree package && npm run clean"

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-metadata*.tgz dist package",
+    "clean": "lb-clean loopback-metadata*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-openapi-spec-builder*.tgz dist package",
+    "clean": "lb-clean loopback-openapi-spec-builder*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-openapi-spec-builder*.tgz && tree package && npm run clean"

--- a/packages/openapi-v3-types/package.json
+++ b/packages/openapi-v3-types/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-openapi-v3-types*.tgz dist package",
+    "clean": "lb-clean loopback-openapi-v3-types*.tgz dist tsconfig.build.tsbuildinfo package",
     "verify": "npm pack && tar xf loopback-openapi-v3-types*.tgz && tree package && npm run clean",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-openapi-v3*.tgz dist package",
+    "clean": "lb-clean loopback-openapi-v3*.tgz dist tsconfig.build.tsbuildinfo package",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-json-schema*.tgz dist package",
+    "clean": "lb-clean loopback-json-schema*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-json-schema*.tgz && tree package && npm run clean"

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-repository*.tgz dist package",
+    "clean": "lb-clean loopback-repository*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-repository*.tgz && tree package && npm run clean"

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-explorer*.tgz dist package",
+    "clean": "lb-clean loopback-explorer*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-explorer*.tgz && tree package && npm run clean"

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-rest*.tgz dist package",
+    "clean": "lb-clean loopback-rest*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-service-proxy*.tgz dist package",
+    "clean": "lb-clean loopback-service-proxy*.tgz dist tsconfig.build.tsbuildinfo package",
     "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-testlab*.tgz dist package",
+    "clean": "lb-clean loopback-testlab*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-testlab*.tgz && tree package && npm run clean"

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -12,7 +12,7 @@
     "document-apidocs": "api-documenter markdown -i ../../docs/apidocs/models -o ../../docs/site/apidocs",
     "update-apidocs": "node bin/update-apidocs",
     "build": "lb-tsc",
-    "clean": "lb-clean loopback-tsdocs*.tgz dist package",
+    "clean": "lb-clean loopback-tsdocs*.tgz dist tsconfig.build.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "verify": "npm pack && tar xf loopback-tsdocs*.tgz && tree package && npm run clean"


### PR DESCRIPTION
During `npm run clean`, if `tsconfig.build.tsbuildinfo` is not removed but `dist` is removed, `tsc` won't regenerate JS code into `dist`.

The issue can be reproduced as follows:

```
cd loopback-next/packages/context
npm run clean
npm test
```

=>

```
Error: No test files found: "dist/__tests__/**/*.js"
npm ERR! Test failed.  See above for more details.
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
