### PR TITLE
chore: configure RenovateBot to group api-extractor packages

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -35,6 +35,14 @@
   "separateMajorMinor": true,
   "separateMinorPatch": false,
 
+  "packageRules": [{
+    "packageNames": [
+      "@microsoft/api-extractor",
+      "@microsoft/api-documenter"
+    ],
+    "groupName": "api-extractor packages"
+  }],
+
   "masterIssue": true,
   "masterIssueApproval": false,
   "masterIssueAutoclose": true


### PR DESCRIPTION
Configure RenovateBot to group updates of the following packages into
a single pull request:

- `@microsoft/api-extractor`
- `@microsoft/api-documenter`

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
