### PR TITLE
fix(build): remove `lb-tslint` from README

### DIFF
--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -95,51 +95,6 @@ Now you run the scripts, such as:
     | ------------------ | ------------------------------------------------------------------------------------------------- |
     | `--copy-resources` | Copy all non-typescript files from `src` and `test` to `outDir`, preserving their relative paths. |
 
-- lb-tslint
-
-  By default, `lb-tslint` searches your project's root directory for
-  `tslint.build.json` then `tslint.json`. If neither of them exists, it falls
-  back to `./node_modules/@loopback/build/config/tslint.common.json`.
-
-  `lb-tslint` also depends on `tsconfig.build.json` or `tsconfig.json` to
-  reference the project.
-
-  **NOTE:** Our recommended configuration of tslint rules is maintained inside
-  the package `@loopback/tslint-config`. We strongly recommend users to create
-  their own tslint configuration files inheriting from `@loopback/tslint-config`
-  instead of relying on the defaults provided by `@loopback/build`.
-
-  To customize the configuration:
-
-  - Create `tslint.build.json` in your project's root directory, for example:
-
-    ```json
-    {
-      "$schema": "http://json.schemastore.org/tslint",
-      "extends": ["@loopback/eslint-config/tslint.build.json"],
-      // This configuration files enabled rules which require type checking
-      // and therefore cannot be run by Visual Studio Code TSLint extension
-      // See https://github.com/Microsoft/vscode-tslint/issues/70
-      "rules": {
-        // These rules find errors related to TypeScript features.
-        // These rules catch common errors in JS programming or otherwise
-        // confusing constructs that are prone to producing bugs.
-
-        "await-promise": true,
-        "no-floating-promises": true,
-        "no-void-expression": [true, "ignore-arrow-function-shorthand"]
-      }
-    }
-    ```
-
-- Set options explicitly for the script
-
-  ```sh
-  lb-tslint -c tslint.json -p tsconfig.json
-  ```
-
-  For more information, see <https://palantir.github.io/tslint/usage/cli/>.
-
 4.  Run builds
 
 ```sh


### PR DESCRIPTION
This is a follow-up for https://github.com/strongloop/loopback-next/pull/3063 which removed `lb-tslint` implementation. Let's update the docs too!


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈