### PR TITLE
ci: remove Node.js 8 and 10 on MacOS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 
 os:
   - linux
-  - osx
 
 script:
   - npm run postinstall
@@ -22,6 +21,10 @@ after_success:
 
 matrix:
   include:
+    - node_js: "12"
+      os: osx
+      # using the default script to build & run the tests
+
     - node_js: "8"
       os: linux
       env: TASK=code-lint


### PR DESCRIPTION
As discussed on Slack:  We don't have any platform specific code, I think it's enough to pick a single Node.js version to test on MacOS. We test different Node.js versions on Linux.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈