### PR TITLE
discover uses owner instead of schema key

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -194,7 +194,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         await modelMaker.discoverSingleModel(
           this.artifactInfo.dataSource,
           modelInfo.name,
-          {schema: modelInfo.schema},
+          {schema: modelInfo.owner},
         ),
       );
       debug(`Discovered: ${modelInfo.name}`);


### PR DESCRIPTION
DiscoverModelNames used to return an array of {'table': 'foo', 'schema': 'bar'}, now the 'schema' key has been changed to 'owner'.  This broke a part of the discover feature, this one-liner fixes it.

Fixes #3074

Looking at the refactors across the board, it seems the term "schema" has been changed to "owner" in this context.  Should I do a follow-up PR which addresses this in the discover module?

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
