### PR TITLE
build: fixes bin/build-docs-site.sh

### DIFF
--- a/bin/build-docs-site.sh
+++ b/bin/build-docs-site.sh
@@ -21,15 +21,15 @@ DIR=`dirname $0`
 REPO_ROOT=$DIR/..
 pushd $REPO_ROOT >/dev/null
 
-# Update apidocs
-lerna bootstrap
-lerna run --scope @loopback/docs prepack
-
 # Clean up sandbox/loopback.io directory
 rm -rf sandbox/loopback.io/
 
 # Shadow clone the `strongloop/loopback.io` github repo
 git clone --depth 1 https://github.com/strongloop/loopback.io.git sandbox/loopback.io
+
+# Update apidocs
+lerna bootstrap --scope @loopback/tsdocs
+lerna run --scope @loopback/docs prepack
 
 # Add loopback.io-workflow-scripts with @loopback/docs linked
 lerna bootstrap --scope @loopback/docs --scope loopback.io-workflow-scripts


### PR DESCRIPTION
fixes bin/build-docs-site.sh

When performing:

```sh
npm run build:site
cd sandbox
cd loopback.io
npm start
```

to generate documentation and have it run in a local server on your laptop, the
latest change made to a document in `docs/site` don't appear in the generated HTML.





<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
