### PR TITLE
fix(cli): discover prompt exits after generating

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -242,6 +242,8 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         dir: this.options.outDir || this.artifactInfo.outDir,
         file: utils.getModelFileName(modelDefinition.name),
       });
+
+      await this.artifactInfo.dataSource.disconnect();
     }
 
     // This part at the end is just for the ArtifactGenerator

--- a/packages/cli/test/fixtures/discover/mem.datasource.js.txt
+++ b/packages/cli/test/fixtures/discover/mem.datasource.js.txt
@@ -80,6 +80,10 @@ class DiscoverOnly extends DataSource {
     this.connected = true;
   }
 
+  disconnect() {
+    this.connected = false;
+  }
+
   async discoverModelDefinitions(options = {views: true}) {
     let models = modelList;
     if (!options.views) {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
resolves https://github.com/strongloop/loopback-next/issues/2952
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
