### PR TITLE
chore: fix formatting in PR & ISSUE templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,5 +11,4 @@ HELP US HELP YOU, PLEASE
 - Consider using a more suitable venue for questions such as Stack Overflow, Gitter, etc.
 -->
 
-_See [Reporting Issues](http://loopback.io/doc/en/contrib/Reporting-issues.html)
-for more tips on writing good issues_
+_See [Reporting Issues](http://loopback.io/doc/en/contrib/Reporting-issues.html) for more tips on writing good issues_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,19 +10,14 @@ See also #23
 
 ## Checklist
 
-👉
-[Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next)
-👈
+👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈
 
 - [ ] `npm test` passes on your machine
 - [ ] New tests added or existing tests modified to cover all changes
-- [ ] Code conforms with the
-      [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
+- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
 - [ ] API Documentation in code was updated
 - [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
 - [ ] Affected artifact templates in `packages/cli` were updated
 - [ ] Affected example projects in `examples/*` were updated
 
-👉
-[Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html)
-👈
+👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.github/
 /coverage
 /docs/apidocs
 /docs/site/apidocs


### PR DESCRIPTION
GitHub preserves newline characters in the rendered HTML output, see how the Checklist below is rendered now, before the changes in this PR are applied. We must not add extra newlines even if it means that the markdown files have lines longer than 80 characters.

This commit reverts changes in `.github` made by 72cb8aafad3 (https://github.com/strongloop/loopback-next/pull/3130

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉
[Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next)
👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the
      [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉
[Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html)
👈