### PR TITLE
docs: point to new authentication component doc link

### DIFF
--- a/docs/site/decorators/Decorators_authenticate.md
+++ b/docs/site/decorators/Decorators_authenticate.md
@@ -41,4 +41,4 @@ export class WhoAmIController {
 ```
 
 For more information on authentication with LoopBack, visit
-[here](https://github.com/strongloop/loopback-next/blob/master/packages/authentication/README.md).
+[here](../Loopback-component-authentication.md).


### PR DESCRIPTION
Point to new Authentication component document

Related to https://github.com/strongloop/loopback-next/issues/2940 

Instead of pointing to @loopback/authentication/README.MD, point to 
new authentication component document.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
