### PR TITLE
refactor(repository): simplify `ensurePromise` helper

### DIFF
--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter, isPromiseLike} from '@loopback/context';
+import {Getter} from '@loopback/context';
 import * as assert from 'assert';
 import * as legacy from 'loopback-datasource-juggler';
 import {
@@ -74,11 +74,8 @@ export function bindModel<T extends juggler.ModelBaseClass>(
  * @param p - Promise or void
  */
 export function ensurePromise<T>(p: legacy.PromiseOrVoid<T>): Promise<T> {
-  if (p && isPromiseLike(p)) {
-    // Juggler uses promise-like Bluebird instead of native Promise
-    // implementation. We need to convert the promise returned by juggler
-    // methods to proper native Promise instance.
-    return Promise.resolve(p);
+  if (p && p instanceof Promise) {
+    return p;
   } else {
     return Promise.reject(new Error('The value should be a Promise: ' + p));
   }


### PR DESCRIPTION
loopback-datasource-juggler is always using native Promises, no need to wrap the promises returned by juggler APIs into another Promise instance.

This is a follow-up for https://github.com/strongloop/loopback-datasource-juggler/pull/1749 and older https://github.com/strongloop/loopback-datasource-juggler/pull/1631.

I discovered this improvement opportunity while experimenting with optimizing dependencies of `@loopback/repository` (loosely related to https://github.com/strongloop/loopback-next/issues/3126).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈