### PR TITLE
chore: add the package lock for tsconfig

### DIFF
--- a/packages/tslint-config/package-lock.json
+++ b/packages/tslint-config/package-lock.json
@@ -1,0 +1,77 @@
+{
+	"name": "@loopback/tslint-config",
+	"version": "2.1.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@fimbul/bifrost": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@fimbul/bifrost/-/bifrost-0.17.0.tgz",
+			"integrity": "sha512-gVTkJAOef5HtN6LPmrtt5fAUmBywwlgmObsU3FBhPoNeXPLaIl2zywXkJEtvvVLQnaFmtff3x+wIj5lHRCDE3Q==",
+			"requires": {
+				"@fimbul/ymir": "^0.17.0",
+				"get-caller-file": "^2.0.0",
+				"tslib": "^1.8.1",
+				"tsutils": "^3.5.0"
+			},
+			"dependencies": {
+				"tsutils": {
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
+					"integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
+					"requires": {
+						"tslib": "^1.8.1"
+					}
+				}
+			}
+		},
+		"@fimbul/ymir": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@fimbul/ymir/-/ymir-0.17.0.tgz",
+			"integrity": "sha512-xMXM9KTXRLHLVS6dnX1JhHNEkmWHcAVCQ/4+DA1KKwC/AFnGHzu/7QfQttEPgw3xplT+ILf9e3i64jrFwB3JtA==",
+			"requires": {
+				"inversify": "^5.0.0",
+				"reflect-metadata": "^0.1.12",
+				"tslib": "^1.8.1"
+			}
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+		},
+		"inversify": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.1.tgz",
+			"integrity": "sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ=="
+		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
+		"tslib": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+		},
+		"tslint-consistent-codestyle": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.15.1.tgz",
+			"integrity": "sha512-38Y3Dz4zcABe/PlPAQSGNEWPGVq0OzcIQR7SEU6dNujp/SgvhxhJOhIhI9gY4r0I3/TNtvVQwARWor9O9LPZWg==",
+			"requires": {
+				"@fimbul/bifrost": "^0.17.0",
+				"tslib": "^1.7.1",
+				"tsutils": "^2.29.0"
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"requires": {
+				"tslib": "^1.8.1"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes the CI failure caused by missing package-lock.json file in tslint-config:
See error log in https://travis-ci.org/strongloop/loopback-next/jobs/545396234

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
