### PR TITLE
fix(metadata): don't rely on `instanceof` checks

### DIFF
--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -157,12 +157,13 @@ export class DecoratorFactory<
    * @param member - Method name
    */
   static getNumberOfParameters(target: Object, member?: string) {
-    if (target instanceof Function && !member) {
+    if (typeof target === 'function' && !member) {
       // constructor
       return target.length;
     } else {
       // target[member] is a function
-      return (<{[methodName: string]: Function}>target)[member!].length;
+      const method = (<{[methodName: string]: Function}>target)[member!];
+      return method.length;
     }
   }
 


### PR DESCRIPTION
The testing framework [Jest](https://jestjs.io) creates a new V8 VM for each test file and as a result, it's not possible to rely on `instanceof Function` checks to work - there may be multiple `Function` constructors present.

This commit reworks `instanceof Function` check to use `typeof` instead.

See also https://github.com/strongloop/loopback-next/issues/3159

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈