### PR TITLE
docs: change link to authentication tutorial

### DIFF
--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -651,6 +651,6 @@ export class MyApplication extends BootMixin(
   }
 ```
 
-You can find a working example of a LoopBack 4 shopping cart application with
-JWT authentication
-[here](https://github.com/strongloop/loopback4-example-shopping).
+You can find a **completed example** and **tutorial** of a LoopBack 4 shopping
+cart application with JWT authentication
+[here](./tutorials/authentication/Authentication-Tutorial.md).


### PR DESCRIPTION
Change link from shopping cart example github link
to authentication tutorial link.

Related to : https://github.com/strongloop/loopback-next/issues/2940

Changing the github link at the bottom to the authentication tutorial link instead (the tutorial itself has the link to the github shopping cart example link, as well as the tutorial steps.)

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
