### PR TITLE
chore: configure prettier to ignore generated apidocs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 packages/cli/generators/*/templates
 packages/tsdocs/fixtures/monorepo/docs
 packages/tsdocs/fixtures/monorepo/**/dist
+packages/tsdocs/fixtures/monorepo/**/docs
 **/.sandbox
 packages/*/dist
 examples/*/dist


### PR DESCRIPTION
Sometimes when I run `npm t` after `git rebase`, I receive the following error:
```
> node packages/build/bin/run-prettier "**/*.ts" "**/*.js" "**/*.md" "-l"

packages/tsdocs/fixtures/monorepo/packages/pkg1/docs/apidocs/reports-temp/pkg1.api.md
packages/tsdocs/fixtures/monorepo/packages/pkg1/docs/apidocs/reports/pkg1.api.md
```

This pull request fixes the problem by adding `packages/tsdocs/fixtures/monorepo/**/docs` to `.prettierignore` list.

See also the similar `.gitignore` entries:

https://github.com/strongloop/loopback-next/blob/a18adf654f8a865c62ac21f08e3773f1ea419cef/.gitignore#L14-L15

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈