### PR TITLE
feat(example-todo-list): add navigational properties to todo-list example

### DIFF
--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -38,6 +38,89 @@ Controller TodoList was created in src/controllers/
 
 And voilà! We now have a set of basic APIs for todo-lists, just like that!
 
+#### Inclusion of Related Models
+
+In order to get our related `Todo`s for each `TodoList`, let's update the
+`schema`.
+
+In `src/models/todo-list.controller.ts`, first import `getModelSchemaRef` from
+`@loopback/rest`.
+
+Then update the following `schema`s in `responses`'s `content`:
+
+{% include code-caption.html content="src/models/todo-list.controller.ts" %}
+
+```ts
+@get('/todo-lists', {
+  responses: {
+    '200': {
+      description: 'Array of TodoList model instances',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: getModelSchemaRef(TodoList, {includeRelations: true}),
+          },
+        },
+      },
+    },
+  },
+})
+async find(/*...*/) {/*...*/}
+
+@get('/todo-lists/{id}', {
+  responses: {
+    '200': {
+      description: 'TodoList model instance',
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(TodoList, {includeRelations: true}),
+        },
+      },
+    },
+  },
+})
+async findById(/*...*/) {/*...*/}
+```
+
+Let's also update it in the `TodoController`:
+
+{% include code-caption.html content="src/models/todo.controller.ts" %}
+
+```ts
+@get('/todos', {
+  responses: {
+    '200': {
+      description: 'Array of Todo model instances',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: getModelSchemaRef(Todo, {includeRelations: true}),
+          },
+        },
+      },
+    },
+  },
+})
+})
+async findTodos(/*...*/) {/*...*/}
+
+@get('/todos/{id}', {
+  responses: {
+    '200': {
+      description: 'Todo model instance',
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Todo, {includeRelations: true}),
+        },
+      },
+    },
+  },
+})
+async findTodoById(/*...*/) {/*...*/}
+```
+
 ### Create TodoList's Todo controller
 
 For the controller handling `Todos` of a `TodoList`, we'll start with an empty
@@ -196,8 +279,8 @@ export class TodoListTodoController {
 }
 ```
 
-Check out our todo-list example to see the full source code generated for
-TodoListTodo controller:
+Check out our `TodoList` example to see the full source code generated for the
+`TodoListTodo` controller:
 [src/controllers/todo-list-todo.controller.ts](https://github.com/strongloop/loopback-next/blob/master/examples/todo-list/src/controllers/todo-list-todo.controller.ts)
 
 ### Try it out

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
@@ -71,7 +71,8 @@ Model TodoList was created in src/models/
 ```
 
 Now that we have our new model, we need to define its relation with the `Todo`
-model. Add the following import statements and property to the `TodoList` model:
+model. Add the following import statements and property to the `TodoList` model
+and update the `TodoListRelations` interface to include `todos`:
 
 {% include code-caption.html content="src/models/todo-list.model.ts" %}
 
@@ -101,7 +102,8 @@ suggests, `@hasMany()` informs LoopBack 4 that a todo list can have many todo
 items.
 
 To complement `TodoList`'s relationship to `Todo`, we'll add in the `todoListId`
-property on the `Todo` model to define the relation on both ends:
+property on the `Todo` model to define the relation on both ends, along with
+updating the `TodoRelations` interface to include `todoList`:
 
 {% include code-caption.html content="src/models/todo.model.ts" %}
 

--- a/examples/todo-list/data/db.json
+++ b/examples/todo-list/data/db.json
@@ -12,7 +12,7 @@
     },
     "TodoList": {
       "1": "{\"title\":\"Sith lord's check list\",\"lastModified\":\"a long time ago\",\"id\":1}",
-      "2": "{\"title\":\"My daily chores\",,\"lastModified\":\"2018-07-13\",\"id\":2}"
+      "2": "{\"title\":\"My daily chores\",\"lastModified\":\"2018-07-13\",\"id\":2}"
     }
   }
 }

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -50,6 +50,7 @@
     "@loopback/build": "^2.0.1",
     "@loopback/eslint-config": "^1.1.2",
     "@loopback/http-caching-proxy": "^1.1.3",
+    "@loopback/repository": "^1.8.0",
     "@loopback/testlab": "^1.6.1",
     "@types/lodash": "^4.14.134",
     "@types/node": "^10.14.9",

--- a/examples/todo-list/src/__tests__/integration/todo-list-image.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo-list-image.repository.integration.ts
@@ -1,0 +1,66 @@
+import {expect, toJSON} from '@loopback/testlab';
+import {
+  TodoListImageRepository,
+  TodoListRepository,
+  TodoRepository,
+} from '../../repositories';
+import {
+  givenEmptyDatabase,
+  givenTodoListImageInstance,
+  givenTodoListInstance,
+  testdb,
+} from '../helpers';
+
+describe('TodoListImageRepository', () => {
+  let todoListImageRepo: TodoListImageRepository;
+  let todoListRepo: TodoListRepository;
+  let todoRepo: TodoRepository;
+
+  before(async () => {
+    todoListRepo = new TodoListRepository(
+      testdb,
+      async () => todoRepo,
+      async () => todoListImageRepo,
+    );
+    todoListImageRepo = new TodoListImageRepository(
+      testdb,
+      async () => todoListRepo,
+    );
+  });
+
+  beforeEach(givenEmptyDatabase);
+
+  it('includes TodoList in find method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const image = await givenTodoListImageInstance(todoListImageRepo, {
+      todoListId: list.id,
+    });
+
+    const response = await todoListImageRepo.find({
+      include: [{relation: 'todoList'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual([
+      {
+        ...toJSON(image),
+        todoList: toJSON(list),
+      },
+    ]);
+  });
+
+  it('includes TodoList in findById result', async () => {
+    const list = await givenTodoListInstance(todoListRepo, {});
+    const image = await givenTodoListImageInstance(todoListImageRepo, {
+      todoListId: list.id,
+    });
+
+    const response = await todoListImageRepo.findById(image.id, {
+      include: [{relation: 'todoList'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(image),
+      todoList: toJSON(list),
+    });
+  });
+});

--- a/examples/todo-list/src/__tests__/integration/todo-list.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo-list.repository.integration.ts
@@ -1,0 +1,59 @@
+import {expect, toJSON} from '@loopback/testlab';
+import {
+  TodoListImageRepository,
+  TodoListRepository,
+  TodoRepository,
+} from '../../repositories';
+import {
+  givenEmptyDatabase,
+  givenTodoInstance,
+  givenTodoListInstance,
+  testdb,
+} from '../helpers';
+
+describe('TodoListRepository', () => {
+  let todoListImageRepo: TodoListImageRepository;
+  let todoListRepo: TodoListRepository;
+  let todoRepo: TodoRepository;
+
+  before(async () => {
+    todoListRepo = new TodoListRepository(
+      testdb,
+      async () => todoRepo,
+      async () => todoListImageRepo,
+    );
+    todoRepo = new TodoRepository(testdb, async () => todoListRepo);
+  });
+
+  beforeEach(givenEmptyDatabase);
+
+  it('includes Todos in find method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
+
+    const response = await todoListRepo.find({
+      include: [{relation: 'todos'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual([
+      {
+        ...toJSON(list),
+        todos: [toJSON(todo)],
+      },
+    ]);
+  });
+
+  it('includes Todos in findById result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
+
+    const response = await todoListRepo.findById(list.id, {
+      include: [{relation: 'todos'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(list),
+      todos: [toJSON(todo)],
+    });
+  });
+});

--- a/examples/todo-list/src/__tests__/integration/todo.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo.repository.integration.ts
@@ -1,0 +1,59 @@
+import {expect, toJSON} from '@loopback/testlab';
+import {
+  TodoListImageRepository,
+  TodoListRepository,
+  TodoRepository,
+} from '../../repositories';
+import {
+  givenEmptyDatabase,
+  givenTodoInstance,
+  givenTodoListInstance,
+  testdb,
+} from '../helpers';
+
+describe('TodoRepository', () => {
+  let todoListImageRepo: TodoListImageRepository;
+  let todoListRepo: TodoListRepository;
+  let todoRepo: TodoRepository;
+
+  before(async () => {
+    todoListRepo = new TodoListRepository(
+      testdb,
+      async () => todoRepo,
+      async () => todoListImageRepo,
+    );
+    todoRepo = new TodoRepository(testdb, async () => todoListRepo);
+  });
+
+  beforeEach(givenEmptyDatabase);
+
+  it('includes TodoList in find method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
+
+    const response = await todoRepo.find({
+      include: [{relation: 'todoList'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual([
+      {
+        ...toJSON(todo),
+        todoList: toJSON(list),
+      },
+    ]);
+  });
+
+  it('includes TodoList in findById result', async () => {
+    const list = await givenTodoListInstance(todoListRepo, {});
+    const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
+
+    const response = await todoRepo.findById(todo.id, {
+      include: [{relation: 'todoList'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(todo),
+      todoList: toJSON(list),
+    });
+  });
+});

--- a/examples/todo-list/src/controllers/todo-list-image.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-image.controller.ts
@@ -3,10 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {TodoListRepository} from '../repositories';
 import {repository} from '@loopback/repository';
-import {param, post, requestBody, get} from '@loopback/rest';
+import {get, getModelSchemaRef, param, post, requestBody} from '@loopback/rest';
 import {TodoListImage} from '../models';
+import {TodoListRepository} from '../repositories';
 
 export class TodoListImageController {
   constructor(
@@ -32,7 +32,11 @@ export class TodoListImageController {
     responses: {
       '200': {
         description: 'The image belonging to the TodoList',
-        content: {'application/json': {schema: {'x-ts-type': TodoListImage}}},
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(TodoListImage, {includeRelations: true}),
+          },
+        },
       },
     },
   })

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -14,6 +14,7 @@ import {
   del,
   get,
   getFilterSchemaFor,
+  getModelSchemaRef,
   getWhereSchemaFor,
   param,
   patch,
@@ -60,7 +61,14 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'Array of TodoList model instances',
-        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(TodoList, {includeRelations: true}),
+            },
+          },
+        },
       },
     },
   })
@@ -91,12 +99,20 @@ export class TodoListController {
     responses: {
       '200': {
         description: 'TodoList model instance',
-        content: {'application/json': {schema: {'x-ts-type': TodoList}}},
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(TodoList, {includeRelations: true}),
+          },
+        },
       },
     },
   })
-  async findById(@param.path.number('id') id: number): Promise<TodoList> {
-    return await this.todoListRepository.findById(id);
+  async findById(
+    @param.path.number('id') id: number,
+    @param.query.object('filter', getFilterSchemaFor(TodoList))
+    filter?: Filter<TodoList>,
+  ): Promise<TodoList> {
+    return await this.todoListRepository.findById(id, filter);
   }
 
   @patch('/todo-lists/{id}', {

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -8,6 +8,7 @@ import {
   del,
   get,
   getFilterSchemaFor,
+  getModelSchemaRef,
   param,
   patch,
   post,
@@ -36,15 +37,20 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {schema: {'x-ts-type': Todo}}},
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Todo, {includeRelations: true}),
+          },
+        },
       },
     },
   })
   async findTodoById(
     @param.path.number('id') id: number,
-    @param.query.boolean('items') items?: boolean,
+    @param.query.object('filter', getFilterSchemaFor(Todo))
+    filter?: Filter<Todo>,
   ): Promise<Todo> {
-    return await this.todoRepo.findById(id);
+    return await this.todoRepo.findById(id, filter);
   }
 
   @get('/todos', {
@@ -53,7 +59,10 @@ export class TodoController {
         description: 'Array of Todo model instances',
         content: {
           'application/json': {
-            schema: {type: 'array', items: {'x-ts-type': Todo}},
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(Todo, {includeRelations: true}),
+            },
           },
         },
       },

--- a/examples/todo-list/src/models/todo.model.ts
+++ b/examples/todo-list/src/models/todo.model.ts
@@ -43,7 +43,7 @@ export class Todo extends Entity {
 }
 
 export interface TodoRelations {
-  todoList?: TodoListWithRelations[];
+  todoList?: TodoListWithRelations;
 }
 
 export type TodoWithRelations = Todo & TodoRelations;

--- a/examples/todo-list/src/repositories/todo-list-image.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list-image.repository.ts
@@ -7,10 +7,17 @@ import {Getter, inject} from '@loopback/core';
 import {
   BelongsToAccessor,
   DefaultCrudRepository,
+  Filter,
+  Options,
   repository,
 } from '@loopback/repository';
 import {DbDataSource} from '../datasources';
-import {TodoList, TodoListImage, TodoListImageRelations} from '../models';
+import {
+  TodoList,
+  TodoListImage,
+  TodoListImageRelations,
+  TodoListImageWithRelations,
+} from '../models';
 import {TodoListRepository} from './todo-list.repository';
 
 export class TodoListImageRepository extends DefaultCrudRepository<
@@ -28,9 +35,58 @@ export class TodoListImageRepository extends DefaultCrudRepository<
     protected todoListRepositoryGetter: Getter<TodoListRepository>,
   ) {
     super(TodoListImage, dataSource);
-    this.todoList = this._createBelongsToAccessorFor(
+    this.todoList = this.createBelongsToAccessorFor(
       'todoList',
       todoListRepositoryGetter,
     );
+  }
+
+  async find(
+    filter?: Filter<TodoListImage>,
+    options?: Options,
+  ): Promise<TodoListImageWithRelations[]> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = {...filter, include: undefined};
+
+    const result = await super.find(filter, options);
+
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todo-lists in fewer DB queries
+    // this is a temporary implementation, please see
+    // https://github.com/strongloop/loopback-next/issues/3195
+    if (include && include.length && include[0].relation === 'todoList') {
+      await Promise.all(
+        result.map(async r => {
+          r.todoList = await this.todoList(r.id);
+        }),
+      );
+    }
+
+    return result;
+  }
+
+  async findById(
+    id: typeof TodoListImage.prototype.id,
+    filter?: Filter<TodoListImage>,
+    options?: Options,
+  ): Promise<TodoListImageWithRelations> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = {...filter, include: undefined};
+
+    const result = await super.findById(id, filter, options);
+
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todo-lists in fewer DB queries
+    // this is a temporary implementation, please see
+    // https://github.com/strongloop/loopback-next/issues/3195
+    if (include && include.length && include[0].relation === 'todoList') {
+      result.todoList = await this.todoList(result.id);
+    }
+
+    return result;
   }
 }

--- a/examples/todo-list/src/repositories/todo-list.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list.repository.ts
@@ -6,12 +6,20 @@
 import {Getter, inject} from '@loopback/core';
 import {
   DefaultCrudRepository,
+  Filter,
   HasManyRepositoryFactory,
   HasOneRepositoryFactory,
   juggler,
+  Options,
   repository,
 } from '@loopback/repository';
-import {Todo, TodoList, TodoListImage, TodoListRelations} from '../models';
+import {
+  Todo,
+  TodoList,
+  TodoListImage,
+  TodoListRelations,
+  TodoListWithRelations,
+} from '../models';
 import {TodoListImageRepository} from './todo-list-image.repository';
 import {TodoRepository} from './todo.repository';
 
@@ -49,5 +57,53 @@ export class TodoListRepository extends DefaultCrudRepository<
 
   public findByTitle(title: string) {
     return this.findOne({where: {title}});
+  }
+
+  async find(
+    filter?: Filter<TodoList>,
+    options?: Options,
+  ): Promise<TodoListWithRelations[]> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = {...filter, include: undefined};
+    const result = await super.find(filter, options);
+
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todos in fewer DB queries
+    // this is a temporary implementation, please see
+    // https://github.com/strongloop/loopback-next/issues/3195
+    if (include && include.length && include[0].relation === 'todos') {
+      await Promise.all(
+        result.map(async r => {
+          r.todos = await this.todos(r.id).find();
+        }),
+      );
+    }
+
+    return result;
+  }
+
+  async findById(
+    id: typeof TodoList.prototype.id,
+    filter?: Filter<TodoList>,
+    options?: Options,
+  ): Promise<TodoListWithRelations> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = {...filter, include: undefined};
+
+    const result = await super.findById(id, filter, options);
+
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todos in fewer DB queries
+    // this is a temporary implementation, please see
+    // https://github.com/strongloop/loopback-next/issues/3195
+    if (include && include.length && include[0].relation === 'todos') {
+      result.todos = await this.todos(result.id).find();
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/2633.

- Overwrote `find` and `findById` functions in `TodoRepository`, `TodoListRepository`, `TodoListImage` to include a hard-coded retrieval of related models.
  - https://github.com/strongloop/loopback-next/issues/3195 is for improvement of this
- Updated response schemas for controller methods `find` and `findById` to leverage `getModelSchemaRef` and `includeRelations`
- Updated `TodoList` tutorial

Note: since `HasOneRepository<T>` doesn't have a `find` function, the `image` property wasn't included in the `TodoList` instances as part of this PR.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
