### PR TITLE
feat(repository): include navigation properties in JSON

### DIFF
--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -206,12 +206,24 @@ export abstract class Model {
       return this.toObject({ignoreUnknownProperties: false});
     }
 
+    const copyPropertyAsJson = (key: string) => {
+      json[key] = asJSON((this as AnyObject)[key]);
+    };
+
     const json: AnyObject = {};
     for (const p in def.properties) {
       if (p in this) {
-        json[p] = asJSON((this as AnyObject)[p]);
+        copyPropertyAsJson(p);
       }
     }
+
+    for (const r in def.relations) {
+      const relName = def.relations[r].name;
+      if (relName in this) {
+        copyPropertyAsJson(relName);
+      }
+    }
+
     return json;
   }
 


### PR DESCRIPTION
Modify the code converting Model instances to JSON data to include navigational properties for the defined model relations.

See https://github.com/strongloop/loopback-next/pull/3171 and https://github.com/strongloop/loopback-next/issues/2633

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈