### PR TITLE
docs(build): fix formatting in CHANGELOG

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -35,36 +35,29 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 specify it explicitly. It is no longer possible to specify compilation target
 via non-option argument like `lb-tsc es2017`.
 
-Migration guide:
+    Migration guide:
 
-- Modify your `tsconfig.json` file and configure `dist` via `compilerOptions.outDir`
+    - Modify your `tsconfig.json` file and configure `dist` via `compilerOptions.outDir`
 
-- If you are using target different from `es2017`, then configure it via
+    - If you are using target different from `es2017`, then configure it via
   `compilerOptions.target`.
 
-- Remove `es2017` and `--outDir dist` from lb-tsc arguments.
+    - Remove `es2017` and `--outDir dist` from lb-tsc arguments.
 
-- Ensure that the output directory is listed in `lb-clean` arguments,
-  e.g. call `lb-clean dist`.
+    - Ensure that the output directory is listed in `lb-clean` arguments,
+      e.g. call `lb-clean dist`.
 
-- When calling `lb-mocha`, replace `DIST` with the actual outDir value,
-  typically `dist`.
+    - When calling `lb-mocha`, replace `DIST` with the actual outDir value,
+      typically `dist`.
 
-Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>
 * **build:** `lb-apidocs` helper is no longer available. Please switch
 to Microsoft api-extractor and api-documenter.
 * **build:** `lb-tslint` helper is no longer available. Please
 install `tslint` directly as a dependency and invoke `tslint` instead
 of `lb-tslint`.
 
-Alternatively, you can migrate from tslint to eslint and use the
-recently introduced helper `lb-eslint`.
-
-Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>
-
-
-
-
+    Alternatively, you can migrate from tslint to eslint and use the
+    recently introduced helper `lb-eslint`.
 
 ## [1.7.1](https://github.com/strongloop/loopback-next/compare/@loopback/build@1.7.0...@loopback/build@1.7.1) (2019-06-06)
 


### PR DESCRIPTION
While describing Build 2.0 changes for our next Milestone blog post, I noticed that Breaking changes in our changelog are incorrectly formatted. This pull request fixes the formatting.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
