### PR TITLE
fix(cli): make sure tsbuildinfo is removed by the clean script

### DIFF
--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean dist tsconfig.build.tsbuildinfo",
+    "clean": "lb-clean dist *.tsbuildinfo",
 <% if (project.prettier && project.eslint) { -%>
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist *.tsbuildinfo",
 <% if (project.prettier && project.eslint) { -%>
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -112,6 +112,13 @@ describe('app-generator specific files', () => {
     assert.fileContent('package.json', /"docker:run": "docker run/);
   });
 
+  it('creates npm script "clean"', () => {
+    assert.fileContent(
+      'package.json',
+      '"clean": "lb-clean dist *.tsbuildinfo"',
+    );
+  });
+
   it('creates npm script "migrate-db"', async () => {
     const pkg = JSON.parse(await readFile('package.json'));
     expect(pkg.scripts).to.have.property('migrate', 'node ./dist/migrate');

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -341,7 +341,7 @@ module.exports = function(projGenerator, props, projectType) {
           ['tsconfig.json', '@loopback/build'],
         ]);
         assert.fileContent([
-          ['package.json', '"clean": "rimraf dist"'],
+          ['package.json', '"clean": "rimraf dist *.tsbuildinfo"'],
           ['package.json', '"typescript"'],
           ['package.json', '"eslint"'],
           ['package.json', 'eslint-config-prettier'],


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/3197

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
