### PR TITLE
fix(cli): remove no-any warning from model template

### DIFF
--- a/packages/cli/generators/model/templates/model.ts.ejs
+++ b/packages/cli/generators/model/templates/model.ts.ejs
@@ -26,6 +26,7 @@ export class <%= className %> extends <%= modelBaseClass %> {
   // Define well-known properties here
 
   // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [prop: string]: any;
 <% } -%>
 

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -198,6 +198,10 @@ describe('lb4 model integration', () => {
         expectedModelFile,
         /export class Test extends Entity {/,
       );
+      assert.fileContent(
+        expectedModelFile,
+        /eslint-disable-next-line \@typescript-eslint\/no-explicit-any/,
+      );
       assert.fileContent(expectedModelFile, /\[prop: string\]: any;/);
     });
 


### PR DESCRIPTION
Disabling the no-any warning that happens when a model allows additional properties

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
