### PR TITLE
feat(eslint-config): enable "no-floating-promises" rule

### DIFF
--- a/bin/run-lerna.js
+++ b/bin/run-lerna.js
@@ -25,4 +25,9 @@ async function run(argv, options) {
 }
 
 module.exports = run;
-if (require.main === module) run(process.argv);
+if (require.main === module) {
+  run(process.argv).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/bin/sync-dev-deps.js
+++ b/bin/sync-dev-deps.js
@@ -87,7 +87,12 @@ function updatePackageJson(pkgFile, masterDeps) {
   return true;
 }
 
-if (require.main === module) syncDevDeps();
+if (require.main === module) {
+  syncDevDeps().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
 
 function readPackageJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8'));

--- a/bin/update-template-deps.js
+++ b/bin/update-template-deps.js
@@ -63,4 +63,9 @@ async function updateTemplateDeps() {
   }
 }
 
-if (require.main === module) updateTemplateDeps();
+if (require.main === module) {
+  updateTemplateDeps().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/binding-types.ts
+++ b/examples/context/src/binding-types.ts
@@ -96,4 +96,9 @@ export async function main() {
   console.log(greeter.hello());
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/configuration-injection.ts
+++ b/examples/context/src/configuration-injection.ts
@@ -46,4 +46,9 @@ export async function main() {
   console.log(greeter.greet('Ray'));
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/context-chain.ts
+++ b/examples/context/src/context-chain.ts
@@ -44,4 +44,9 @@ export async function main() {
   console.log(greeter.greet('John'));
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/context-observation.ts
+++ b/examples/context/src/context-observation.ts
@@ -88,4 +88,9 @@ export async function main() {
   await requestCtx.waitUntilObserversNotified();
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/custom-configuration-resolver.ts
+++ b/examples/context/src/custom-configuration-resolver.ts
@@ -77,4 +77,9 @@ export async function main() {
   console.log(barConfig);
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/custom-inject-decorator.ts
+++ b/examples/context/src/custom-inject-decorator.ts
@@ -33,4 +33,9 @@ export async function main() {
   console.log(greeter.hello());
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/custom-inject-resolve.ts
+++ b/examples/context/src/custom-inject-resolve.ts
@@ -52,4 +52,9 @@ export async function main() {
   console.log(greeter.hello());
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/dependency-injection.ts
+++ b/examples/context/src/dependency-injection.ts
@@ -138,4 +138,9 @@ export async function main() {
   console.log(greeting);
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/find-bindings.ts
+++ b/examples/context/src/find-bindings.ts
@@ -75,4 +75,9 @@ export async function main() {
   console.log(view.bindings.map(b => b.key));
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/index.ts
+++ b/examples/context/src/index.ts
@@ -27,5 +27,8 @@ export async function main() {
 if (require.main === module) {
   process.env.FOO = JSON.stringify({bar: 'xyz'});
 
-  main();
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/examples/context/src/injection-without-binding.ts
+++ b/examples/context/src/injection-without-binding.ts
@@ -36,4 +36,9 @@ export async function main() {
   await sayHello(ctx);
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/interceptor-proxy.ts
+++ b/examples/context/src/interceptor-proxy.ts
@@ -109,4 +109,9 @@ export async function main() {
   console.log(await greeter!.greet('John'));
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/parameterized-decoration.ts
+++ b/examples/context/src/parameterized-decoration.ts
@@ -63,4 +63,9 @@ export async function main() {
   console.log('2: %s', greeting2.hello());
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/sync-async.ts
+++ b/examples/context/src/sync-async.ts
@@ -76,4 +76,9 @@ export async function main() {
   await greetWithAsyncUser(ctx);
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/src/value-promise.ts
+++ b/examples/context/src/value-promise.ts
@@ -121,4 +121,9 @@ async function greetFromAll(greetersView: ContextView<Greeter>) {
   await transformValueOrPromise(greetingsByLanguage, console.log);
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/greeter-extension/index.js
+++ b/examples/greeter-extension/index.js
@@ -7,5 +7,8 @@ module.exports = require('./dist');
 
 if (require.main === module) {
   const app = new module.exports.GreetingApplication();
-  app.main();
+  app.main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/packages/cli/bin/download-connector-list.js
+++ b/packages/cli/bin/download-connector-list.js
@@ -51,4 +51,7 @@ async function download() {
   await writeFileAsync(DEST, JSON.stringify(out, null, 2));
 }
 
-download();
+download().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/context/src/__tests__/unit/resolver.unit.ts
+++ b/packages/context/src/__tests__/unit/resolver.unit.ts
@@ -56,6 +56,7 @@ describe('constructor injection', () => {
     }
 
     expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       instantiateClass(TestClass, ctx);
     }).to.throw(/Cannot resolve injected arguments/);
   });
@@ -383,6 +384,7 @@ describe('property injection', () => {
     }
 
     expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       instantiateClass(TestClass, ctx);
     }).to.throw(/Cannot resolve injected property/);
   });

--- a/packages/context/src/__tests__/unit/value-promise.unit.ts
+++ b/packages/context/src/__tests__/unit/value-promise.unit.ts
@@ -26,6 +26,7 @@ describe('tryWithFinally', () => {
     let finalActionInvoked = false;
     const action = () => 1;
     const finalAction = () => (finalActionInvoked = true);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     tryWithFinally(action, finalAction);
     expect(finalActionInvoked).to.be.true();
   });

--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -134,9 +134,7 @@ module.exports = {
 
     // Rules mapped from `@loopback/tslint-config/tslint.build.json
     '@typescript-eslint/await-thenable': 'error', // tslint:await-promise: [true, 'PromiseLike', 'RequestPromise'],
-
-    // See https://github.com/typescript-eslint/typescript-eslint/issues/464
-    // tslint:no-floating-promises: [true, 'PromiseLike', 'RequestPromise'],
+    '@typescript-eslint/no-floating-promises': 'error',
 
     'no-void': 'error', // tslint:no-void-expression: [true, 'ignore-arrow-function-shorthand'],
   },

--- a/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
@@ -51,6 +51,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "where" as an object', () => {
     const filter = {where: 'invalid-where'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors || []).to.containDeep([
       {
@@ -63,6 +64,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "fields" as an object', () => {
     const filter = {fields: 'invalid-fields'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors || []).to.containDeep([
       {
@@ -75,6 +77,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "include" as an array for models with relations', () => {
     const filter = {include: 'invalid-include'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors || []).to.containDeep([
       {
@@ -92,6 +95,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "offset" as an integer', () => {
     const filter = {offset: 'invalid-offset'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors || []).to.containDeep([
       {
@@ -104,6 +108,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "limit" as an integer', () => {
     const filter = {limit: 'invalid-limit'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors || []).to.containDeep([
       {
@@ -116,6 +121,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "skip" as an integer', () => {
     const filter = {skip: 'invalid-skip'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors || []).to.containDeep([
       {
@@ -128,6 +134,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "order" as an array', () => {
     const filter = {order: 'invalid-order'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors || []).to.containDeep([
       {

--- a/packages/rest/src/__tests__/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/sequence/sequence.acceptance.ts
@@ -38,7 +38,7 @@ describe('Sequence', () => {
   let server: RestServer;
   beforeEach(givenAppWithController);
   it('provides a default sequence', async () => {
-    whenIRequest()
+    await whenIRequest()
       .get('/name')
       .expect('SequenceApp');
   });
@@ -52,7 +52,7 @@ describe('Sequence', () => {
       .expect('hello world');
   });
 
-  it('allows users to define a custom sequence as a class', () => {
+  it('allows users to define a custom sequence as a class', async () => {
     class MySequence implements SequenceHandler {
       constructor(@inject(SequenceActions.SEND) private send: Send) {}
 
@@ -63,7 +63,7 @@ describe('Sequence', () => {
     // bind user defined sequence
     server.sequence(MySequence);
 
-    whenIRequest()
+    await whenIRequest()
       .get('/')
       .expect('hello world');
   });

--- a/packages/tsdocs/bin/extract-apis.js
+++ b/packages/tsdocs/bin/extract-apis.js
@@ -27,4 +27,7 @@ async function main() {
   await runExtractorForMonorepo({silent, dryRun, apiReportEnabled});
 }
 
-main();
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/tsdocs/bin/update-apidocs.js
+++ b/packages/tsdocs/bin/update-apidocs.js
@@ -15,4 +15,7 @@ async function main() {
   await updateApiDocs({silent, dryRun});
 }
 
-main();
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
See https://github.com/typescript-eslint/typescript-eslint/pull/495 that re-implemented the rule in typescript-eslint.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈