### PR TITLE
Remove usages of "@loopback/openapi-v3-types" and deprecate the package

### DIFF
--- a/docs/site/Defining-the-API-using-design-first-approach.shelved.md
+++ b/docs/site/Defining-the-API-using-design-first-approach.shelved.md
@@ -341,13 +341,15 @@ import * as _ from 'lodash';
 
 // Import API fragments here
 
-export let spec = OpenApiSpec.createEmptyApiSpec();
-spec.info = {
-  title: 'Your API',
-  version: '1.0',
+export const spec: OpenApiSpec = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Your API',
+    version: '1.0',
+  },
+  paths: {},
+  servers: [{url: '/'}],
 };
-spec.swagger = '2.0';
-spec.basePath = '/';
 
 _.merge(spec, ProductAPI);
 _.merge(spec, DealAPI);

--- a/docs/site/Routes.md
+++ b/docs/site/Routes.md
@@ -60,8 +60,7 @@ be confused with `x-operation-name`, which is a string for the Controller method
 name.
 
 ```ts
-import {RestApplication} from '@loopback/rest';
-import {OpenApiSpec} from '@loopback/openapi-v3-types';
+import {OpenApiSpec, RestApplication} from '@loopback/rest';
 
 function greet(name: string) {
   return `hello ${name}`;
@@ -107,8 +106,7 @@ which is defined using `spec`. The route is then attached to a valid server
 context running underneath the application.
 
 ```ts
-import {RestApplication, Route} from '@loopback/rest';
-import {OperationObject} from '@loopback/openapi-v3-types';
+import {OperationObject, RestApplication, Route} from '@loopback/rest';
 
 const spec: OperationObject = {
   parameters: [{name: 'name', in: 'query', schema: {type: 'string'}}],

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -47,7 +47,7 @@ building sequences, you use LoopBack Elements to respond to a request:
   docs link
 - [`OperationRetVal`](https://loopback.io/doc/en/lb4/apidocs.rest.operationretval.html)
 - [`ParseParams`](https://loopback.io/doc/en/lb4/apidocs.rest.parseparams.html)
-- [`OpenAPISpec`](https://loopback.io/doc/en/lb4/apidocs.openapi-v3-types.openapispec.html)
+- [`OpenAPISpec`](https://loopback.io/doc/en/lb4/apidocs.openapi-v3.openapispec.html)
 
 ## Actions
 

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -39,7 +39,6 @@
     "@loopback/context": "^1.20.1",
     "@loopback/core": "^1.8.4",
     "@loopback/openapi-v3": "^1.6.4",
-    "@loopback/openapi-v3-types": "^1.1.4",
     "@loopback/repository": "^1.8.1",
     "@loopback/rest": "^1.16.2",
     "@loopback/rest-explorer": "^1.2.4",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -39,7 +39,6 @@
     "@loopback/context": "^1.20.1",
     "@loopback/core": "^1.8.4",
     "@loopback/openapi-v3": "^1.6.4",
-    "@loopback/openapi-v3-types": "^1.1.4",
     "@loopback/repository": "^1.8.1",
     "@loopback/rest": "^1.16.2",
     "@loopback/rest-explorer": "^1.2.4",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -394,7 +394,6 @@ Run the following command to install the CLI.
       - @loopback/core: ^1.1.7
       - @loopback/metadata: ^1.0.7
       - @loopback/openapi-spec-builder: ^1.0.7
-      - @loopback/openapi-v3-types: ^1.0.7
       - @loopback/openapi-v3: ^1.2.3
       - @loopback/repository-json-schema: ^1.3.3
       - @loopback/repository: ^1.1.7

--- a/packages/openapi-spec-builder/package-lock.json
+++ b/packages/openapi-spec-builder/package-lock.json
@@ -9,6 +9,11 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
 			"integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q==",
 			"dev": true
+		},
+		"openapi3-ts": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-1.3.0.tgz",
+			"integrity": "sha512-Xk3hsB0PzB4dzr/r/FdmK+VfQbZH7lQQ2iipMS1/1eoz1wUvh5R7rmOakYvw0bQJJE6PYrOLx8UHsYmzgTr+YQ=="
 		}
 	}
 }

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -23,7 +23,7 @@
     "Testing"
   ],
   "dependencies": {
-    "@loopback/openapi-v3-types": "^1.1.4"
+    "openapi3-ts": "^1.3.0"
   },
   "devDependencies": {
     "@loopback/build": "^2.0.2",

--- a/packages/openapi-spec-builder/src/__tests__/unit/openapi-spec-builder.unit.ts
+++ b/packages/openapi-spec-builder/src/__tests__/unit/openapi-spec-builder.unit.ts
@@ -3,15 +3,23 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {createEmptyApiSpec, ParameterObject} from '@loopback/openapi-v3-types';
 import {expect} from '@loopback/testlab';
+import {ParameterObject} from 'openapi3-ts';
 import {anOpenApiSpec, anOperationSpec} from '../../openapi-spec-builder';
 
 describe('OpenAPI Spec Builder', () => {
   describe('anOpenApiSpec', () => {
     it('creates an empty spec', () => {
       const spec = anOpenApiSpec().build();
-      expect(spec).to.eql(createEmptyApiSpec());
+      expect(spec).to.eql({
+        openapi: '3.0.0',
+        info: {
+          title: 'LoopBack Application',
+          version: '1.0.0',
+        },
+        paths: {},
+        servers: [{url: '/'}],
+      });
     });
 
     it('adds an extension', () => {

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -3,16 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import * as assert from 'assert';
 import {
-  createEmptyApiSpec,
   ISpecificationExtension,
-  OpenApiSpec,
+  OpenAPIObject,
   OperationObject,
   ParameterObject,
   RequestBodyObject,
   ResponseObject,
-} from '@loopback/openapi-v3-types';
-import * as assert from 'assert';
+} from 'openapi3-ts';
 
 /**
  * Create a new instance of OpenApiSpecBuilder.
@@ -71,12 +70,20 @@ export class BuilderBase<T extends ISpecificationExtension> {
 /**
  * A builder for creating OpenApiSpec documents.
  */
-export class OpenApiSpecBuilder extends BuilderBase<OpenApiSpec> {
+export class OpenApiSpecBuilder extends BuilderBase<OpenAPIObject> {
   /**
    * @param basePath - The base path on which the API is served.
    */
   constructor() {
-    super(createEmptyApiSpec());
+    super({
+      openapi: '3.0.0',
+      info: {
+        title: 'LoopBack Application',
+        version: '1.0.0',
+      },
+      paths: {},
+      servers: [{url: '/'}],
+    });
   }
 
   /**

--- a/packages/openapi-v3-types/README.md
+++ b/packages/openapi-v3-types/README.md
@@ -7,6 +7,11 @@ TypeScript type definitions for OpenAPI Spec/Swagger documents.
 TypeScript definitions describing the schema of OpenAPI/Swagger documents,
 including LoopBack-specific extensions.
 
+**This package is deprecated, use
+[openapi3-ts](https://www.npmjs.com/package/openapi3-ts) or
+[@loopback/openapi-v3](https://www.npmjs.com/package/@loopback/openapi-v3)
+instead.**
+
 ## Installation
 
 ```sh

--- a/packages/openapi-v3-types/package.json
+++ b/packages/openapi-v3-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loopback/openapi-v3-types",
   "version": "1.1.4",
-  "description": "TypeScript type definitions for OpenAPI Specifications.",
+  "description": "[DEPRECATED] TypeScript type definitions for OpenAPI Specifications.",
   "engines": {
     "node": ">=8.9"
   },

--- a/packages/openapi-v3/package-lock.json
+++ b/packages/openapi-v3/package-lock.json
@@ -39,6 +39,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"openapi3-ts": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-1.3.0.tgz",
+			"integrity": "sha512-Xk3hsB0PzB4dzr/r/FdmK+VfQbZH7lQQ2iipMS1/1eoz1wUvh5R7rmOakYvw0bQJJE6PYrOLx8UHsYmzgTr+YQ=="
 		}
 	}
 }

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -5,6 +5,13 @@
   "engines": {
     "node": ">=8.9"
   },
+  "dependencies": {
+    "@loopback/context": "^1.20.1",
+    "openapi3-ts": "^1.3.0",
+    "@loopback/repository-json-schema": "^1.7.2",
+    "debug": "^4.1.1",
+    "lodash": "^4.17.11"
+  },
   "devDependencies": {
     "@loopback/build": "^2.0.2",
     "@loopback/eslint-config": "^1.1.2",
@@ -46,12 +53,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git"
-  },
-  "dependencies": {
-    "@loopback/context": "^1.20.1",
-    "@loopback/openapi-v3-types": "^1.1.4",
-    "@loopback/repository-json-schema": "^1.7.2",
-    "debug": "^4.1.1",
-    "lodash": "^4.17.11"
   }
 }

--- a/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
@@ -3,11 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  OperationObject,
-  ParameterObject,
-  SchemaObject,
-} from '@loopback/openapi-v3-types';
 import {Entity, model, property} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
 import {
@@ -15,10 +10,13 @@ import {
   ControllerSpec,
   get,
   getControllerSpec,
+  getModelSchemaRef,
+  OperationObject,
   param,
+  ParameterObject,
   post,
   requestBody,
-  getModelSchemaRef,
+  SchemaObject,
 } from '../..';
 
 describe('controller spec', () => {

--- a/packages/openapi-v3/src/__tests__/unit/create-empty-spec.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/create-empty-spec.unit.ts
@@ -1,0 +1,28 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {createEmptyApiSpec} from '../../types';
+
+describe('createEmptyApiSpec', () => {
+  it('sets version 3', () => {
+    expect(createEmptyApiSpec().openapi).to.equal('3.0.0');
+  });
+
+  it('sets the spec info object', () => {
+    expect(createEmptyApiSpec().info).to.deepEqual({
+      title: 'LoopBack Application',
+      version: '1.0.0',
+    });
+  });
+
+  it('creates an empty paths object', () => {
+    expect(createEmptyApiSpec().paths).to.deepEqual({});
+  });
+
+  it('creates a default servers array', () => {
+    expect(createEmptyApiSpec().servers).to.deepEqual([{url: '/'}]);
+  });
+});

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
@@ -3,9 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
-import {ParameterObject} from '@loopback/openapi-v3-types';
+import {get, getControllerSpec, param, ParameterObject} from '../../../..';
 
 describe('Routing metadata for parameters', () => {
   describe('@param.query.string', () => {

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param.decorator.unit.ts
@@ -4,13 +4,17 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
-import {
-  OperationObject,
-  ParameterObject,
-  ResponsesObject,
-} from '@loopback/openapi-v3-types';
 import {expect} from '@loopback/testlab';
-import {get, getControllerSpec, operation, param, patch} from '../../../../';
+import {
+  get,
+  getControllerSpec,
+  operation,
+  OperationObject,
+  param,
+  ParameterObject,
+  patch,
+  ResponsesObject,
+} from '../../../../';
 
 describe('Routing metadata for parameters', () => {
   describe('@param', () => {

--- a/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-primitives.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-primitives.decorator.unit.ts
@@ -3,15 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  ControllerSpec,
-  post,
-  requestBody,
-  getControllerSpec,
-} from '../../../../';
-import {ContentObject, SchemaObject} from '@loopback/openapi-v3-types';
 import {Class} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
+import {
+  ContentObject,
+  ControllerSpec,
+  getControllerSpec,
+  post,
+  requestBody,
+  SchemaObject,
+} from '../../../../';
 
 describe('requestBody decorator', () => {
   context('for a primitive type', () => {

--- a/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
@@ -3,11 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
-
-import {SchemaObject} from '@loopback/openapi-v3-types';
-import {jsonToSchemaObject, jsonOrBooleanToJSON} from '../..';
 import {JsonSchema} from '@loopback/repository-json-schema';
+import {expect} from '@loopback/testlab';
+import {jsonOrBooleanToJSON, jsonToSchemaObject, SchemaObject} from '../..';
 
 describe('jsonToSchemaObject', () => {
   it('does nothing when given an empty object', () => {

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -5,6 +5,15 @@
 
 import {DecoratorFactory, MetadataInspector} from '@loopback/context';
 import {
+  getJsonSchema,
+  getJsonSchemaRef,
+  JsonSchemaOptions,
+} from '@loopback/repository-json-schema';
+import * as _ from 'lodash';
+import {resolveSchema} from './generate-schema';
+import {jsonToSchemaObject, SchemaRef} from './json-to-schema';
+import {OAI3Keys} from './keys';
+import {
   ComponentsObject,
   ISpecificationExtension,
   isReferenceObject,
@@ -16,16 +25,7 @@ import {
   ResponseObject,
   SchemaObject,
   SchemasObject,
-} from '@loopback/openapi-v3-types';
-import {
-  getJsonSchema,
-  getJsonSchemaRef,
-  JsonSchemaOptions,
-} from '@loopback/repository-json-schema';
-import * as _ from 'lodash';
-import {resolveSchema} from './generate-schema';
-import {jsonToSchemaObject, SchemaRef} from './json-to-schema';
-import {OAI3Keys} from './keys';
+} from './types';
 
 const debug = require('debug')('loopback:openapi3:metadata:controller-spec');
 

--- a/packages/openapi-v3/src/decorators/operation.decorator.ts
+++ b/packages/openapi-v3/src/decorators/operation.decorator.ts
@@ -3,10 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {OperationObject} from '@loopback/openapi-v3-types';
 import {MethodDecoratorFactory} from '@loopback/context';
 import {RestEndpoint} from '../controller-spec';
 import {OAI3Keys} from '../keys';
+import {OperationObject} from '../types';
 
 /**
  * Expose a Controller method as a REST API operation

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  isSchemaObject,
-  ParameterObject,
-  ParameterLocation,
-  ReferenceObject,
-  SchemaObject,
-} from '@loopback/openapi-v3-types';
 import {MetadataInspector, ParameterDecoratorFactory} from '@loopback/context';
 import {resolveSchema} from '../generate-schema';
 import {OAI3Keys} from '../keys';
+import {
+  isSchemaObject,
+  ParameterLocation,
+  ParameterObject,
+  ReferenceObject,
+  SchemaObject,
+} from '../types';
 
 /**
  * Describe an input parameter of a Controller method.

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -4,15 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {MetadataInspector, ParameterDecoratorFactory} from '@loopback/context';
-import {
-  ReferenceObject,
-  RequestBodyObject,
-  SchemaObject,
-} from '@loopback/openapi-v3-types';
 import * as _ from 'lodash';
 import {inspect} from 'util';
 import {resolveSchema} from '../generate-schema';
 import {OAI3Keys} from '../keys';
+import {ReferenceObject, RequestBodyObject, SchemaObject} from '../types';
 
 const debug = require('debug')('loopback:openapi3:metadata:requestbody');
 export const REQUEST_BODY_INDEX = 'x-parameter-index';

--- a/packages/openapi-v3/src/filter-schema.ts
+++ b/packages/openapi-v3/src/filter-schema.ts
@@ -3,13 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {SchemaObject} from '@loopback/openapi-v3-types';
 import {
   getFilterJsonSchemaFor,
   getWhereJsonSchemaFor,
   Model,
 } from '@loopback/repository-json-schema';
 import {jsonToSchemaObject} from './json-to-schema';
+import {SchemaObject} from './types';
 
 /**
  * Build an OpenAPI schema describing the format of the "filter" object

--- a/packages/openapi-v3/src/generate-schema.ts
+++ b/packages/openapi-v3/src/generate-schema.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {SchemaObject} from '@loopback/openapi-v3-types';
+import {SchemaObject} from './types';
 
 /**
  * Generate the `type` and `format` property in a Schema Object according to a

--- a/packages/openapi-v3/src/index.ts
+++ b/packages/openapi-v3/src/index.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './decorators';
-export * from './controller-spec';
-export * from './json-to-schema';
-export * from './filter-schema';
-
 export * from '@loopback/repository-json-schema';
+export * from './controller-spec';
+export * from './decorators';
+export * from './filter-schema';
+export * from './json-to-schema';
+export * from './types';

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -3,13 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  ReferenceObject,
-  SchemaObject,
-  SchemasObject,
-} from '@loopback/openapi-v3-types';
 import {JsonSchema} from '@loopback/repository-json-schema';
 import * as _ from 'lodash';
+import {ReferenceObject, SchemaObject, SchemasObject} from './types';
 
 /**
  * Custom LoopBack extension: a reference to Schema object that's bundled

--- a/packages/openapi-v3/src/keys.ts
+++ b/packages/openapi-v3/src/keys.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {MetadataAccessor} from '@loopback/context';
-import {RestEndpoint, ControllerSpec} from '.';
-import {ParameterObject, RequestBodyObject} from '@loopback/openapi-v3-types';
+import {ControllerSpec, RestEndpoint} from './controller-spec';
+import {ParameterObject, RequestBodyObject} from './types';
 
 // Copyright IBM Corp. 2018. All Rights Reserved.
 // Node module: @loopback/openapi-v3

--- a/packages/openapi-v3/src/types.ts
+++ b/packages/openapi-v3/src/types.ts
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {OpenAPIObject} from 'openapi3-ts';
+/*
+ * OpenApiSpec - A typescript representation of OpenApi 3.0.0
+ */
+export type OpenApiSpec = OpenAPIObject;
+
+// Export also all spec interfaces
+export * from 'openapi3-ts';
+
+/**
+ * Create an empty OpenApiSpec object that's still a valid openapi document.
+ *
+ * @deprecated Use `OpenApiBuilder` from `openapi3-ts` instead.
+ */
+export function createEmptyApiSpec(): OpenApiSpec {
+  return {
+    openapi: '3.0.0',
+    info: {
+      title: 'LoopBack Application',
+      version: '1.0.0',
+    },
+    paths: {},
+    servers: [{url: '/'}],
+  };
+}

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -23,7 +23,6 @@
     "@loopback/core": "^1.8.4",
     "@loopback/http-server": "^1.4.3",
     "@loopback/openapi-v3": "^1.6.4",
-    "@loopback/openapi-v3-types": "^1.1.4",
     "@types/body-parser": "^1.17.0",
     "@types/cors": "^2.8.5",
     "@types/express": "^4.17.0",

--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -6,12 +6,16 @@
 import {BindingScope, Constructor, Context, inject} from '@loopback/context';
 import {Application, CoreBindings} from '@loopback/core';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
-import {api, get, param, post, requestBody} from '@loopback/openapi-v3';
 import {
+  api,
+  get,
   OperationObject,
+  param,
   ParameterObject,
+  post,
+  requestBody,
   ResponseObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import {
   Client,
   createClientForHandler,

--- a/packages/rest/src/__tests__/helpers.ts
+++ b/packages/rest/src/__tests__/helpers.ts
@@ -7,7 +7,7 @@ import {
   ReferenceObject,
   RequestBodyObject,
   SchemaObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import {RestServerConfig, RestServerResolvedConfig} from '../rest.server';
 
 /**

--- a/packages/rest/src/__tests__/integration/http-handler.integration.ts
+++ b/packages/rest/src/__tests__/integration/http-handler.integration.ts
@@ -5,8 +5,12 @@
 
 import {Context} from '@loopback/context';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
-import {ControllerSpec, get} from '@loopback/openapi-v3';
-import {ParameterObject, RequestBodyObject} from '@loopback/openapi-v3-types';
+import {
+  ControllerSpec,
+  get,
+  ParameterObject,
+  RequestBodyObject,
+} from '@loopback/openapi-v3';
 import {
   Client,
   createClientForHandler,

--- a/packages/rest/src/__tests__/unit/body-parser.unit.ts
+++ b/packages/rest/src/__tests__/unit/body-parser.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from '@loopback/core';
-import {OperationObject, RequestBodyObject} from '@loopback/openapi-v3-types';
+import {OperationObject, RequestBodyObject} from '@loopback/openapi-v3';
 import {
   expect,
   ShotRequestOptions,

--- a/packages/rest/src/__tests__/unit/coercion/invalid-spec.unit.test.ts
+++ b/packages/rest/src/__tests__/unit/coercion/invalid-spec.unit.test.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {test} from './utils';
+import {ParameterLocation} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../../';
-import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {test} from './utils';
 
 const INVALID_PARAM = {
   in: <ParameterLocation>'unknown',

--- a/packages/rest/src/__tests__/unit/coercion/paramObject.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramObject.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ParameterObject} from '@loopback/openapi-v3-types';
+import {ParameterObject} from '@loopback/openapi-v3';
 import * as qs from 'qs';
 import {RestHttpErrors} from '../../..';
 import {test} from './utils';

--- a/packages/rest/src/__tests__/unit/coercion/paramStringToBoolean.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramStringToBoolean.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {test} from './utils';
+import {ParameterLocation} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../../';
-import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {test} from './utils';
 
 const BOOLEAN_PARAM = {
   in: <ParameterLocation>'path',

--- a/packages/rest/src/__tests__/unit/coercion/paramStringToBuffer.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramStringToBuffer.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {test} from './utils';
-import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {ParameterLocation} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../..';
+import {test} from './utils';
 
 const BUFFER_PARAM = {
   in: <ParameterLocation>'path',

--- a/packages/rest/src/__tests__/unit/coercion/paramStringToDate.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramStringToDate.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {test} from './utils';
-import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {ParameterLocation} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../../';
+import {test} from './utils';
 
 const DATE_PARAM = {
   in: <ParameterLocation>'path',

--- a/packages/rest/src/__tests__/unit/coercion/paramStringToInteger.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramStringToInteger.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {test} from './utils';
+import {ParameterLocation} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../../';
-import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {test} from './utils';
 
 const INT32_PARAM = {
   in: <ParameterLocation>'path',

--- a/packages/rest/src/__tests__/unit/coercion/paramStringToNumber.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramStringToNumber.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {test} from './utils';
-import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {ParameterLocation} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../../';
+import {test} from './utils';
 
 const NUMBER_PARAM = {
   in: <ParameterLocation>'path',

--- a/packages/rest/src/__tests__/unit/coercion/paramStringToString.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramStringToString.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ParameterObject} from '@loopback/openapi-v3-types';
+import {ParameterObject} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../..';
 import {test} from './utils';
 

--- a/packages/rest/src/__tests__/unit/coercion/parseStringToDatetime.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/parseStringToDatetime.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {test} from './utils';
+import {ParameterLocation} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../../../';
-import {ParameterLocation} from '@loopback/openapi-v3-types';
+import {test} from './utils';
 
 const DATETIME_PARAM = {
   in: <ParameterLocation>'path',

--- a/packages/rest/src/__tests__/unit/coercion/utils.ts
+++ b/packages/rest/src/__tests__/unit/coercion/utils.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {OperationObject, ParameterObject} from '@loopback/openapi-v3-types';
+import {OperationObject, ParameterObject} from '@loopback/openapi-v3';
 import {
   expect,
   ShotRequestOptions,

--- a/packages/rest/src/__tests__/unit/parser.unit.ts
+++ b/packages/rest/src/__tests__/unit/parser.unit.ts
@@ -9,7 +9,7 @@ import {
   ParameterObject,
   RequestBodyObject,
   SchemaObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import {
   expect,
   ShotRequestOptions,

--- a/packages/rest/src/__tests__/unit/request-body.validator.test.ts
+++ b/packages/rest/src/__tests__/unit/request-body.validator.test.ts
@@ -7,7 +7,7 @@ import {
   ReferenceObject,
   SchemaObject,
   SchemasObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import {expect} from '@loopback/testlab';
 import {RestHttpErrors, validateRequestBody} from '../../';
 import {aBodySpec} from '../helpers';

--- a/packages/rest/src/body-parsers/body-parser.ts
+++ b/packages/rest/src/body-parsers/body-parser.ts
@@ -11,7 +11,7 @@ import {
   inject,
   instantiateClass,
 } from '@loopback/context';
-import {isReferenceObject, OperationObject} from '@loopback/openapi-v3-types';
+import {isReferenceObject, OperationObject} from '@loopback/openapi-v3';
 import * as debugModule from 'debug';
 import {is} from 'type-is';
 import {RestHttpErrors} from '../rest-http-error';

--- a/packages/rest/src/body-parsers/types.ts
+++ b/packages/rest/src/body-parsers/types.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ReferenceObject, SchemaObject} from '@loopback/openapi-v3-types';
+import {ReferenceObject, SchemaObject} from '@loopback/openapi-v3';
 import {Request} from '../types';
 /**
  * Request body with metadata

--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {isReferenceObject, ParameterObject} from '@loopback/openapi-v3-types';
+import {isReferenceObject, ParameterObject} from '@loopback/openapi-v3';
 import * as debugModule from 'debug';
 import {RestHttpErrors} from '../';
 import {parseJson} from '../parse-json';

--- a/packages/rest/src/coercion/validator.ts
+++ b/packages/rest/src/coercion/validator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ParameterObject, SchemaObject} from '@loopback/openapi-v3-types';
+import {ParameterObject, SchemaObject} from '@loopback/openapi-v3';
 import {RestHttpErrors} from '../';
 
 /**

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -4,22 +4,19 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from '@loopback/context';
-import {PathObject, SchemasObject} from '@loopback/openapi-v3-types';
-import {ControllerSpec} from '@loopback/openapi-v3';
-
-import {SequenceHandler} from './sequence';
-import {
-  RoutingTable,
-  ResolvedRoute,
-  RouteEntry,
-  ControllerClass,
-  ControllerFactory,
-} from './router';
-import {Request, Response} from './types';
-
+import {ControllerSpec, PathObject, SchemasObject} from '@loopback/openapi-v3';
 import {RestBindings} from './keys';
 import {RequestContext} from './request-context';
 import {RestServerResolvedConfig} from './rest.server';
+import {
+  ControllerClass,
+  ControllerFactory,
+  ResolvedRoute,
+  RouteEntry,
+  RoutingTable,
+} from './router';
+import {SequenceHandler} from './sequence';
+import {Request, Response} from './types';
 
 export class HttpHandler {
   protected _apiDefinitions: SchemasObject;

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -27,4 +27,3 @@ import * as HttpErrors from 'http-errors';
 export {HttpErrors};
 
 export * from '@loopback/openapi-v3';
-export * from '@loopback/openapi-v3-types';

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -6,7 +6,7 @@
 import {BindingKey, Context} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {HttpProtocol} from '@loopback/http-server';
-import {OpenApiSpec} from '@loopback/openapi-v3-types';
+import {OpenApiSpec} from '@loopback/openapi-v3';
 import * as https from 'https';
 import {ErrorWriterOptions} from 'strong-error-handler';
 import {BodyParser, RequestBodyParser} from './body-parsers';

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -3,13 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {REQUEST_BODY_INDEX} from '@loopback/openapi-v3';
 import {
   isReferenceObject,
   OperationObject,
   ParameterObject,
+  REQUEST_BODY_INDEX,
   SchemasObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import * as debugFactory from 'debug';
 import {RequestBody, RequestBodyParser} from './body-parsers';
 import {coerceParameter} from './coercion/coerce-parameter';

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -5,7 +5,7 @@
 
 import {Binding, BindingAddress, Constructor} from '@loopback/context';
 import {Application, ApplicationConfig, Server} from '@loopback/core';
-import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3-types';
+import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3';
 import {PathParams} from 'express-serve-static-core';
 import {ServeStaticOptions} from 'serve-static';
 import {format} from 'util';

--- a/packages/rest/src/rest.component.ts
+++ b/packages/rest/src/rest.component.ts
@@ -11,7 +11,7 @@ import {
   ProviderMap,
   Server,
 } from '@loopback/core';
-import {createEmptyApiSpec} from '@loopback/openapi-v3-types';
+import {createEmptyApiSpec} from '@loopback/openapi-v3';
 import {
   JsonBodyParser,
   RequestBodyParser,

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -13,12 +13,12 @@ import {
 } from '@loopback/context';
 import {Application, CoreBindings, Server} from '@loopback/core';
 import {HttpServer, HttpServerOptions} from '@loopback/http-server';
-import {getControllerSpec} from '@loopback/openapi-v3';
 import {
+  getControllerSpec,
   OpenApiSpec,
   OperationObject,
   ServerObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import {AssertionError} from 'assert';
 import * as cors from 'cors';
 import * as debugFactory from 'debug';

--- a/packages/rest/src/router/base-route.ts
+++ b/packages/rest/src/router/base-route.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from '@loopback/context';
-import {OperationObject} from '@loopback/openapi-v3-types';
+import {OperationObject} from '@loopback/openapi-v3';
 import {OperationArgs, OperationRetval} from '../types';
 import {RouteEntry} from './route-entry';
 

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -4,15 +4,15 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  BindingScope,
   Constructor,
   Context,
   instantiateClass,
   invokeMethod,
   ValueOrPromise,
-  BindingScope,
 } from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
-import {OperationObject} from '@loopback/openapi-v3-types';
+import {OperationObject} from '@loopback/openapi-v3';
 import * as HttpErrors from 'http-errors';
 import {OperationArgs, OperationRetval} from '../types';
 import {BaseRoute} from './base-route';

--- a/packages/rest/src/router/external-express-routes.ts
+++ b/packages/rest/src/router/external-express-routes.ts
@@ -8,7 +8,7 @@ import {
   OpenApiSpec,
   OperationObject,
   SchemasObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import * as express from 'express';
 import {RequestHandler} from 'express';
 import {PathParams} from 'express-serve-static-core';

--- a/packages/rest/src/router/handler-route.ts
+++ b/packages/rest/src/router/handler-route.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context, invokeMethodWithInterceptors} from '@loopback/context';
-import {OperationObject} from '@loopback/openapi-v3-types';
+import {OperationObject} from '@loopback/openapi-v3';
 import {OperationArgs, OperationRetval} from '../types';
 import {BaseRoute} from './base-route';
 

--- a/packages/rest/src/router/redirect-route.ts
+++ b/packages/rest/src/router/redirect-route.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {RouteEntry, ResolvedRoute} from '.';
+import {OperationObject, SchemasObject} from '@loopback/openapi-v3';
+import {ResolvedRoute, RouteEntry} from '.';
 import {RequestContext} from '../request-context';
-import {OperationObject, SchemasObject} from '@loopback/openapi-v3-types';
 import {OperationArgs, OperationRetval, PathParameterValues} from '../types';
 
 export class RedirectRoute implements RouteEntry, ResolvedRoute {

--- a/packages/rest/src/router/route-entry.ts
+++ b/packages/rest/src/router/route-entry.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from '@loopback/context';
-import {OperationObject, SchemasObject} from '@loopback/openapi-v3-types';
+import {OperationObject, SchemasObject} from '@loopback/openapi-v3';
 import {OperationArgs, OperationRetval, PathParameterValues} from '../types';
 
 /**

--- a/packages/rest/src/router/router-spec.ts
+++ b/packages/rest/src/router/router-spec.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {OpenApiSpec} from '@loopback/openapi-v3-types';
+import {OpenApiSpec} from '@loopback/openapi-v3';
 
 export type RouterSpec = Pick<OpenApiSpec, 'paths' | 'components' | 'tags'>;
 

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -3,12 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ControllerSpec} from '@loopback/openapi-v3';
 import {
+  ControllerSpec,
   OperationObject,
   ParameterObject,
   PathObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import * as assert from 'assert';
 import * as debugFactory from 'debug';
 import * as HttpErrors from 'http-errors';

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Binding, BoundValue} from '@loopback/context';
-import {ReferenceObject, SchemaObject} from '@loopback/openapi-v3-types';
+import {ReferenceObject, SchemaObject} from '@loopback/openapi-v3';
 import * as ajv from 'ajv';
 import {
   Options,

--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -8,7 +8,7 @@ import {
   RequestBodyObject,
   SchemaObject,
   SchemasObject,
-} from '@loopback/openapi-v3-types';
+} from '@loopback/openapi-v3';
 import * as AJV from 'ajv';
 import * as debugModule from 'debug';
 import * as _ from 'lodash';


### PR DESCRIPTION
Remove remaining usage of `@loopback/openapi-v3-types` and deprecate the package.

See https://github.com/strongloop/loopback-next/issues/301

> try to upstream `createEmptyApiSpec`, e.g. to src/dsl/OpenApiBuilder.ts

I decided against upstreaming this helper. The builder in openapi3-ts is adding more empty objects to the spec, I am concerned that by reworking `createEmptyApiSpec` to leverate their builder, we could break existing tests depending on less fields being set in an empty spec.

See https://github.com/metadevpro/openapi3-ts/blob/e55fef88e6b9188678528bdf33fee0072033a720/src/dsl/OpenApiBuilder.ts#L14-L35

> then move the rest to our openapi-v3 package (createEmptyApiSpec should go to openapi--spec-builder package)

I decided to move `createEmptyApiSpec` to `openapi-v3` to preserve backwards compatibility for users of our `openapi-v3` and `rest` packages.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈