### PR TITLE
feat(cli): enable source map for npm start script

### DIFF
--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -52,7 +52,7 @@
   <% } -%>
     "migrate": "node ./dist/migrate",
     "prestart": "npm run build",
-    "start": "node .",
+    "start": "node -r source-map-support/register .",
 <% } -%>
     "prepublishOnly": "npm run test"
   },
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@loopback/build": "<%= project.dependencies['@loopback/build'] -%>",
+    "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
     "@types/node": "<%= project.dependencies['@types/node'] -%>",
     <% if (project.eslint) { -%>

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -51,7 +51,7 @@
     "docker:run": "docker run -p 3000:3000 -d <%= project.name -%>",
   <% } -%>
     "migrate": "node ./dist/migrate",
-    "start": "npm run build && node .",
+    "start": "npm run build && node -r source-map-support/register .",
 <% } -%>
     "prepare": "npm run build"
   },
@@ -86,6 +86,7 @@
   },
   "devDependencies": {
     "rimraf": "<%= project.dependencies['rimraf'] -%>",
+    "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
 <% if (project.mocha) { -%>
     "@types/mocha": "<%= project.dependencies['@types/mocha'] -%>",

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -257,6 +257,7 @@ module.exports = function(projGenerator, props, projectType) {
           ['package.json', 'eslint-plugin-mocha'],
           ['package.json', '@typescript-eslint/eslint-plugin'],
           ['package.json', '@loopback/eslint-config'],
+          ['package.json', 'source-map-support'],
           ['.eslintrc.js', '@loopback/eslint-config'],
           ['tsconfig.json', '@loopback/build'],
         ]);
@@ -282,7 +283,7 @@ module.exports = function(projGenerator, props, projectType) {
           assert.jsonFileContent('package.json', {
             scripts: {
               prestart: 'npm run build',
-              start: 'node .',
+              start: 'node -r source-map-support/register .',
             },
           });
         }


### PR DESCRIPTION
Implements https://github.com/strongloop/loopback-next/issues/3223

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
