### PR TITLE
docs: update "Query string parameters" section

### DIFF
--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -215,16 +215,16 @@ is called, it will make use of your function instead! You can use this approach
 to override any of the actions listed under the `RestBindings.SequenceActions`
 namespace.
 
-### Query string parameters
+### Query string parameters and path parameters
 
 OAI 3.0.x describes the data from a request’s header, query and path in an
 operation specification’s parameters property. In a Controller method, such an
 argument is typically decorated by @param(). We've made multiple shortcuts
 available to the `@param()` decorator in the form of
-`@param.<http_source>.<OAI_primitive_type>`. Using this notation, query string
-parameters can be described as `@param.query.string`. Here is an example of a
+`@param.<http_source>.<OAI_primitive_type>`. Using this notation, path
+parameters can be described as `@param.path.string`. Here is an example of a
 controller method which retrieves a Note model instance by obtaining the `id`
-from the query string object.
+from the path object.
 
 ```ts
 @get('/notes/{id}', {
@@ -235,7 +235,7 @@ from the query string object.
     },
   },
 })
-async findById(@param.query.string('id') id: string): Promise<Note> {
+async findById(@param.path.string('id') id: string): Promise<Note> {
   return await this.noteRepository.findById(id);
 }
 ```


### PR DESCRIPTION
In "Query string parameters" section's example, `id` should be obtained from `path` instead of `query`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
