### PR TITLE
fix: run acceptance tests for free-form properties for MongoDB

### DIFF
--- a/acceptance/repository-mongodb/src/__tests__/mongodb.datasource.ts
+++ b/acceptance/repository-mongodb/src/__tests__/mongodb.datasource.ts
@@ -17,7 +17,6 @@ export const MONGODB_CONFIG: DataSourceOptions = {
   database: process.env.MONGODB_DATABASE || 'repository-tests',
 };
 
-export const MONGODB_FEATURES: CrudConnectorFeatures = {
+export const MONGODB_FEATURES: Partial<CrudConnectorFeatures> = {
   idType: 'string',
-  freeFormProperties: false,
 };

--- a/acceptance/repository-mysql/src/__tests__/mysql.datasource.ts
+++ b/acceptance/repository-mysql/src/__tests__/mysql.datasource.ts
@@ -20,7 +20,7 @@ export const MYSQL_CONFIG: DataSourceOptions = {
   createDatabase: true,
 };
 
-export const MYSQL_FEATURES: CrudConnectorFeatures = {
+export const MYSQL_FEATURES: Partial<CrudConnectorFeatures> = {
   idType: 'number',
   freeFormProperties: false,
 };


### PR DESCRIPTION
I noticed that the acceptance tests for MongoDB are skipping tests for free-form properties (strict mode turned off). This pull request is fixing the problem.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
