### PR TITLE
refactor(repository-json-schema): unify code building schema title and cache key

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -229,7 +229,7 @@ describe('build-schema', () => {
 
     it('returns "partial" when a single option "partial" is set', () => {
       const key = buildModelCacheKey({partial: true});
-      expect(key).to.equal('partial');
+      expect(key).to.equal('modelPartial');
     });
 
     it('returns concatenated option names otherwise', () => {
@@ -238,7 +238,7 @@ describe('build-schema', () => {
         partial: true,
         includeRelations: true,
       });
-      expect(key).to.equal('includeRelations+partial');
+      expect(key).to.equal('modelPartialWithRelations');
     });
   });
 });


### PR DESCRIPTION
- Extract the code building schema title suffix (e.g. `WithRelations`) into a new function `getTitleSuffix`
- Rework the function `buildModelCacheKey` to leverage `getTitleSuffix` under the hood

This change simplifies the process of adding a new schema option, as there is only a single place to modify (`getTitleSuffix`) now.

See #3199

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈