### PR TITLE
fix(rest): honor options for AJV validator caching

### DIFF
--- a/packages/rest/src/__tests__/unit/request-body.validator.test.ts
+++ b/packages/rest/src/__tests__/unit/request-body.validator.test.ts
@@ -58,6 +58,44 @@ describe('validateRequestBody', () => {
     );
   });
 
+  // Test for https://github.com/strongloop/loopback-next/issues/3234
+  it('honors options for AJV validator caching', () => {
+    // 1. Trigger a validation with `{coerceTypes: false}`
+    validateRequestBody(
+      {
+        value: {city: 'San Jose', unit: 123, isOwner: true},
+        schema: ADDRESS_SCHEMA,
+      },
+      aBodySpec(ADDRESS_SCHEMA),
+      {},
+      {coerceTypes: false},
+    );
+
+    // 2. Trigger a validation with `{coerceTypes: true}`
+    validateRequestBody(
+      {
+        value: {city: 'San Jose', unit: '123', isOwner: 'true'},
+        schema: ADDRESS_SCHEMA,
+      },
+      aBodySpec(ADDRESS_SCHEMA),
+      {},
+      {coerceTypes: true},
+    );
+
+    // 3. Trigger a validation with `{coerceTypes: false}` with invalid data
+    expect(() =>
+      validateRequestBody(
+        {
+          value: {city: 'San Jose', unit: '123', isOwner: true},
+          schema: ADDRESS_SCHEMA,
+        },
+        aBodySpec(ADDRESS_SCHEMA),
+        {},
+        {coerceTypes: false},
+      ),
+    ).to.throw(/The request body is invalid/);
+  });
+
   it('rejects data missing a required property', () => {
     const details: RestHttpErrors.ValidationErrorDetails[] = [
       {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -85,6 +85,14 @@ export type LogError = (
 ) => void;
 
 /**
+ * Cache for AJV schema validators
+ */
+export type SchemaValidatorCache = WeakMap<
+  SchemaObject | ReferenceObject, // First keyed by schema object
+  Map<string, ajv.ValidateFunction> // Second level keyed by stringified AJV options
+>;
+
+/**
  * Options for request body validation using AJV
  */
 export interface RequestBodyValidationOptions extends ajv.Options {
@@ -92,10 +100,7 @@ export interface RequestBodyValidationOptions extends ajv.Options {
    * Custom cache for compiled schemas by AJV. This setting makes it possible
    * to skip the default cache.
    */
-  compiledSchemaCache?: WeakMap<
-    SchemaObject | ReferenceObject,
-    ajv.ValidateFunction
-  >;
+  compiledSchemaCache?: SchemaValidatorCache;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
This PR improves the AJV validator caching by honoring `options` as different `options` leads to different validate functions.

Fixes https://github.com/strongloop/loopback-next/issues/3234

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
