### PR TITLE
fix(docs): remove note about not supporting partial updates

### DIFF
--- a/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
+++ b/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
@@ -50,14 +50,6 @@ Here are some requests you can try:
 - `PATCH /todos/{id}`, using the same ID, with a body of
   `{ "desc": "need milk for cereal" }`
 
-{% include note.html content="
-In the meantime, use
-`{ \"title\": \"get the milk\", \"desc\": \"need milk for cereal\" }` as the
-body for `PATCH/todos/{id}`, as LoopBack 4 doesn't support partial updates yet.
-For more information, see
-[GitHub issue 1722](https://github.com/strongloop/loopback-next/issues/1722).
-" %}
-
 That's it! You've just created your first LoopBack 4 application!
 
 ### Where to go from here


### PR DESCRIPTION
Now that partial updates are [supported](https://github.com/strongloop/loopback-next/pull/3199) for this example, this note is no longer relevant.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
