### PR TITLE
fix(cli): fix app default project name. untildify the project path

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -4,14 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
+
 const BaseGenerator = require('./base-generator');
 const utils = require('./utils');
 const chalk = require('chalk');
-<<<<<<< HEAD
 const cliVersion = require('../package.json').version;
-=======
 const path = require('path');
->>>>>>> af20999f... fix(cli): fix app default project name. relevant test added
 
 module.exports = class ProjectGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -7,7 +7,11 @@
 const BaseGenerator = require('./base-generator');
 const utils = require('./utils');
 const chalk = require('chalk');
+<<<<<<< HEAD
 const cliVersion = require('../package.json').version;
+=======
+const path = require('path');
+>>>>>>> af20999f... fix(cli): fix app default project name. relevant test added
 
 module.exports = class ProjectGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.
@@ -132,7 +136,8 @@ module.exports = class ProjectGenerator extends BaseGenerator {
         name: 'name',
         message: 'Project name:',
         when: this.projectInfo.name == null,
-        default: this.options.name || this.appname,
+        default:
+          this.options.name || utils.toFileName(path.basename(process.cwd())),
         validate: utils.validate,
       },
       {

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -26,6 +26,8 @@ const connectors = require('../generators/datasource/connectors.json');
 const stringifyObject = require('stringify-object');
 const camelCase = _.camelCase;
 const kebabCase = _.kebabCase;
+const untildify = require('untildify');
+const tildify = require('tildify');
 const readdirAsync = promisify(fs.readdir);
 const toFileName = name => {
   return kebabCase(name).replace(/\-(\d+)$/g, '$1');
@@ -127,6 +129,8 @@ exports.camelCase = camelCase;
 exports.toVarName = toVarName;
 exports.pluralize = pluralize;
 exports.urlSlug = urlSlug;
+exports.untildify = untildify;
+exports.tildify = tildify;
 
 exports.validate = function(name) {
   const isValid = validate(name).validForNewPackages;

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -4684,6 +4684,11 @@
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
+				},
+				"untildify": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+					"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
 				}
 			}
 		},
@@ -4914,6 +4919,11 @@
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
 			}
+		},
+		"tildify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+			"integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
 		},
 		"timed-out": {
 			"version": "4.0.1",
@@ -5150,9 +5160,9 @@
 			}
 		},
 		"untildify": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
 		},
 		"unzip-response": {
 			"version": "2.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,8 @@
     "unicode-10.0.0": "^0.7.5",
     "update-notifier": "^3.0.1",
     "url-slug": "^2.1.1",
+    "untildify": "^4.0.0",
+    "tildify": "^2.0.0",
     "validate-npm-package-name": "^3.0.0",
     "yeoman-generator": "^4.0.1"
   },

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -6,12 +6,18 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const {promisify} = require('util');
 const path = require('path');
+const tildify = require('tildify');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const generator = path.join(__dirname, '../../../generators/app');
+<<<<<<< HEAD
 const cliVersion = require('../../../package.json').version;
+=======
+const build = require('@loopback/build');
+>>>>>>> af20999f... fix(cli): fix app default project name. relevant test added
 const props = {
   name: 'my-app',
   description: 'My app for LoopBack 4',
@@ -210,3 +216,38 @@ function testFormat() {
 process.env.CI && !process.env.DEBUG
   ? describe.skip
   : describe('app-generator with --format', testFormat);
+
+/** For testing if the generator handles default values properly */
+describe('app-generator with default values', () => {
+  const rootDir = path.join(__dirname, '../../../..');
+  const defaultValProjPath = path.join(rootDir, 'sandbox/default-value-app');
+  const sandbox = path.join(rootDir, 'sandbox');
+  const pathToDefValApp = path.join(defaultValProjPath, 'default-value-app');
+  const defaultValProps = {
+    name: '',
+    description: 'An app to test out default values',
+    outdir: '',
+  };
+
+  before(async () => {
+    // default-value-app should not exist at this point
+    assert.equal(fs.existsSync(defaultValProjPath), false);
+    assert.equal(fs.existsSync(pathToDefValApp), false);
+    return (
+      helpers
+        .run(generator)
+        .inDir(defaultValProjPath)
+        // Mark it private to prevent accidental npm publication
+        .withOptions({private: true})
+        .withPrompts(defaultValProps)
+    );
+  });
+  it('scaffold a new app for default-value-app', async () => {
+    // default-value-app should be created at this point
+    assert.equal(fs.existsSync(pathToDefValApp), true);
+  });
+  after(() => {
+    process.chdir(sandbox);
+    build.clean(['node', 'run-clean', defaultValProjPath]);
+  });
+});


### PR DESCRIPTION
## Description 
In the [issue 2092](https://github.com/strongloop/loopback-next/issues/2092), the **default project name** could be generated incorrectly if the cwd folder name has hyphens, fixed. The **input app name** has no such issue.

The user also suggested that `lb4` should allow the project to be generated in the CWD. However, that could be messy and confusing. The other issue is that `lb4` allows user to use any project path as they want. This could be problematic: 
```javascript
(CWD: User/lb4-app)
? Project name: pathFromRoot
? Project root directory:  ~/try/pathFromRoot
...
Application pathFromRoot was created in ~/try/pathFromRoot

lb4-app$ ls
~
lb4-app$ cd ~
[goes to the root folder]
```
The change here is to untildify the input path to make sure that it always uses absolute path.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
resolves https://github.com/strongloop/loopback-next/issues/2092

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
