### PR TITLE
chore: fix block tags for tsdoc comments

### DIFF
--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -29,13 +29,13 @@ export interface JsonSchemaOptions {
   partial?: boolean;
 
   /**
-   * @private
+   * @internal
    */
   visited?: {[key: string]: JSONSchema};
 }
 
 /**
- * @private
+ * @internal
  */
 export function buildModelCacheKey(options: JsonSchemaOptions = {}): string {
   // Backwards compatibility: preserve cache key "modelOnly"

--- a/packages/repository-tests/src/helpers.repository-tests.ts
+++ b/packages/repository-tests/src/helpers.repository-tests.ts
@@ -17,7 +17,7 @@ export function getCrudContext(context: Mocha.Context) {
 /**
  * Convert a function accepting context in the first argument into a regular
  * Mocha function.
- * @param fn A Mocha function (describe/it/before/after callback) accepting
+ * @param fn - A Mocha function (describe/it/before/after callback) accepting
  * `CrudTestContext` as the regular argument.
  */
 export function withCrudCtx(


### PR DESCRIPTION
Fixes invalid block tags in tsdoc comments.

Maybe we should add a travis task to run apidocs generation to catch such errors.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
