### PR TITLE
feat(boot): Add a booter to bind classes with `@bind`

### DIFF
--- a/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {bind, BindingScope, Provider} from '@loopback/core';
+
+@bind({
+  tags: {namespace: 'bindables'},
+  scope: BindingScope.SINGLETON,
+})
+export class GreetingService {
+  greet(whom: string = 'world') {
+    return Promise.resolve(`Hello ${whom}`);
+  }
+}
+
+@bind({tags: {namespace: 'bindables', name: 'CurrentDate'}})
+export class DateProvider implements Provider<Date> {
+  value(): Promise<Date> {
+    return Promise.resolve(new Date());
+  }
+}
+
+export class NotBindableGreetingService {
+  greet(whom: string = 'world') {
+    return Promise.resolve(`Hello ${whom}`);
+  }
+}
+
+export class NotBindableDateProvider implements Provider<Date> {
+  value(): Promise<Date> {
+    return Promise.resolve(new Date());
+  }
+}

--- a/packages/boot/src/__tests__/integration/bindable-classes.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/bindable-classes.booter.integration.ts
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, TestSandbox} from '@loopback/testlab';
+import {resolve} from 'path';
+import {BooterApp} from '../fixtures/application';
+
+describe('bindable class booter integration tests', () => {
+  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
+  const sandbox = new TestSandbox(SANDBOX_PATH);
+
+  const NAMESPACE = 'bindables';
+
+  let app: BooterApp;
+
+  beforeEach('reset sandbox', () => sandbox.reset());
+  beforeEach(getApp);
+
+  it('boots bindable classes when app.boot() is called', async () => {
+    const expectedBindings = [
+      `${NAMESPACE}.CurrentDate`,
+      `${NAMESPACE}.GreetingService`,
+    ];
+
+    await app.boot();
+
+    const bindings = app.findByTag({namespace: 'bindables'}).map(b => b.key);
+    expect(bindings.sort()).to.eql(expectedBindings.sort());
+  });
+
+  async function getApp() {
+    await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
+    await sandbox.copyFile(
+      resolve(__dirname, '../fixtures/bindable-classes.artifact.js'),
+      'bindables/bindable-classes.js',
+    );
+
+    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    app = new MyApp();
+  }
+});

--- a/packages/boot/src/boot.component.ts
+++ b/packages/boot/src/boot.component.ts
@@ -7,6 +7,7 @@ import {BindingScope, inject} from '@loopback/context';
 import {Application, Component, CoreBindings} from '@loopback/core';
 import {
   ApplicationMetadataBooter,
+  BindableClassBooter,
   ControllerBooter,
   DataSourceBooter,
   InterceptorProviderBooter,
@@ -33,6 +34,7 @@ export class BootComponent implements Component {
     DataSourceBooter,
     LifeCycleObserverBooter,
     InterceptorProviderBooter,
+    BindableClassBooter,
   ];
 
   /**

--- a/packages/boot/src/booters/bindable-class.booter.ts
+++ b/packages/boot/src/booters/bindable-class.booter.ts
@@ -1,0 +1,68 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  BINDING_METADATA_KEY,
+  createBindingFromClass,
+  inject,
+  MetadataInspector,
+} from '@loopback/context';
+import {Application, CoreBindings} from '@loopback/core';
+import * as debugFactory from 'debug';
+import {ArtifactOptions} from '../interfaces';
+import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
+
+const debug = debugFactory('loopback:boot:class-booter');
+
+/**
+ * A class that extends BaseArtifactBooter to boot the generic Class or Provider
+ * artifact type that is decorated with `@bind`.
+ *
+ * Supported phases: configure, discover, load
+ *
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - Artifact Options Object
+ */
+export class BindableClassBooter extends BaseArtifactBooter {
+  constructor(
+    @inject(CoreBindings.APPLICATION_INSTANCE)
+    public app: Application,
+    @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
+    @inject(`${BootBindings.BOOT_OPTIONS}#bindables`)
+    public classConfig: ArtifactOptions = {},
+  ) {
+    super(projectRoot, Object.assign({}, BindableClassDefaults, classConfig));
+  }
+
+  /**
+   * Uses super method to get a list of Artifact classes. Boot each file by
+   * creating a DataSourceConstructor and binding it to the application class.
+   */
+  async load() {
+    await super.load();
+
+    for (const cls of this.classes) {
+      if (!MetadataInspector.getClassMetadata(BINDING_METADATA_KEY, cls)) {
+        debug('Skip class not decorated with @bind: %s', cls.name);
+        return;
+      }
+      debug('Bind class: %s', cls.name);
+      const binding = createBindingFromClass(cls);
+      this.app.add(binding);
+      debug('Binding created for class: %j', binding);
+    }
+  }
+}
+
+/**
+ * Default ArtifactOptions for BindableClassBooter.
+ */
+export const BindableClassDefaults: ArtifactOptions = {
+  dirs: ['bindables'],
+  extensions: ['.js'],
+  nested: true,
+};

--- a/packages/boot/src/booters/index.ts
+++ b/packages/boot/src/booters/index.ts
@@ -6,6 +6,7 @@
 export * from './application-metadata.booter';
 export * from './base-artifact.booter';
 export * from './booter-utils';
+export * from './bindable-class.booter';
 export * from './controller.booter';
 export * from './datasource.booter';
 export * from './interceptor.booter';

--- a/packages/boot/src/booters/interceptor.booter.ts
+++ b/packages/boot/src/booters/interceptor.booter.ts
@@ -26,9 +26,9 @@ type InterceptorProviderClass = Constructor<Provider<Interceptor>>;
  *
  * Supported phases: configure, discover, load
  *
- * @param app Application instance
- * @param projectRoot Root of User Project relative to which all paths are resolved
- * @param [bootConfig] InterceptorProvider Artifact Options Object
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - InterceptorProvider Artifact Options Object
  */
 export class InterceptorProviderBooter extends BaseArtifactBooter {
   interceptors: InterceptorProviderClass[];
@@ -67,7 +67,7 @@ export class InterceptorProviderBooter extends BaseArtifactBooter {
 }
 
 /**
- * Default ArtifactOptions for DataSourceBooter.
+ * Default ArtifactOptions for InterceptorProviderBooter.
  */
 export const InterceptorProviderDefaults: ArtifactOptions = {
   dirs: ['interceptors'],

--- a/packages/cli/generators/app/templates/src/bindables/README.md
+++ b/packages/cli/generators/app/templates/src/bindables/README.md
@@ -1,0 +1,4 @@
+# Bindable Classes
+
+This directory contains classes decorated with `@bind` that can be bound to the
+application context.


### PR DESCRIPTION
Implements https://github.com/strongloop/loopback-next/issues/3260#issuecomment-506438362

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
