### PR TITLE
fix(rest): correctly handle basePath set via basePath() API

### DIFF
--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -854,6 +854,14 @@ paths:
       expect(response.body.servers).to.containEql({url: '/api'});
     });
 
+    it('controls server urls even when set via server.basePath() API', async () => {
+      server.basePath('/v2');
+      const response = await createClientForHandler(server.requestHandler).get(
+        '/openapi.json',
+      );
+      expect(response.body.servers).to.containEql({url: '/v2'});
+    });
+
     it('controls redirect locations', async () => {
       server.controller(DummyController);
       server.redirect('/page/html', '/html');

--- a/packages/rest/src/request-context.ts
+++ b/packages/rest/src/request-context.ts
@@ -38,7 +38,12 @@ export class RequestContext extends Context implements HandlerContext {
     const request = this.request;
     let basePath = this.serverConfig.basePath || '';
     if (request.baseUrl && request.baseUrl !== '/') {
-      basePath = request.baseUrl + basePath;
+      if (!basePath || request.baseUrl.endsWith(basePath)) {
+        // Express has already applied basePath to baseUrl
+        basePath = request.baseUrl;
+      } else {
+        basePath = request.baseUrl + basePath;
+      }
     }
     return basePath;
   }

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -776,6 +776,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
     path = path.replace(/(^\/)|(\/$)/, '');
     if (path) path = '/' + path;
     this._basePath = path;
+    this.config.basePath = path;
   }
 
   /**


### PR DESCRIPTION
- Fix `server.basePath()` method to update `basePath` in the config object too.
- This fixes the server url in openapi.json to include basePath again.
- Add more test to verify the changes and prevent future regressions

See https://github.com/strongloop/loopback-next/issues/914
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
