### PR TITLE
fix(booter-lb3app): stringify and parse lb3 spec before converting it

### DIFF
--- a/packages/booter-lb3app/fixtures/lb3app/common/models/coffee-shop.json
+++ b/packages/booter-lb3app/fixtures/lb3app/common/models/coffee-shop.json
@@ -16,7 +16,17 @@
      }
   },
   "validations":[],
-  "relations":{},
+  "relations": {
+     "coffee": {
+        "type": "embedsMany",
+        "model": "Coffee",
+        "property": "coffees",
+        "options": {
+           "validate": true,
+           "forceId": false
+         }
+      }
+  },
   "acls":[
    {
       "accessType":"EXECUTE",

--- a/packages/booter-lb3app/fixtures/lb3app/common/models/coffee.js
+++ b/packages/booter-lb3app/fixtures/lb3app/common/models/coffee.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = function(Coffee) {};

--- a/packages/booter-lb3app/fixtures/lb3app/common/models/coffee.json
+++ b/packages/booter-lb3app/fixtures/lb3app/common/models/coffee.json
@@ -1,0 +1,22 @@
+{
+  "name": "Coffee",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "blend": {
+      "type": "string",
+      "required": true
+     },
+     "size": {
+       "type": "string",
+       "required": true
+     }
+  },
+  "validations": [],
+  "relations": {},
+  "acls": [],
+  "methods": {}
+}

--- a/packages/booter-lb3app/fixtures/lb3app/server/model-config.json
+++ b/packages/booter-lb3app/fixtures/lb3app/server/model-config.json
@@ -38,5 +38,9 @@
   "CoffeeShop": {
      "dataSource": "db",
      "public": true
+  },
+  "Coffee": {
+   "dataSource": "db",
+   "public": true
   }
 }

--- a/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
+++ b/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
@@ -49,6 +49,28 @@ describe('booter-lb3app', () => {
           // id is excluded, it is not allowed in CREATE requests
           name: {type: 'string'},
           city: {type: 'string'},
+          coffees: {
+            type: 'array',
+            items: {$ref: '#/components/schemas/Coffee'},
+          },
+        });
+    });
+
+    it('includes the target model as a property of the source model in a relation', () => {
+      const spec = app.restServer.getApiSpec();
+      const schemas = (spec.components || {}).schemas || {};
+
+      expect(schemas.CoffeeShop)
+        .to.have.property('properties')
+        .eql({
+          name: {type: 'string'},
+          city: {type: 'string'},
+          id: {type: 'number', format: 'double'},
+          coffees: {
+            // default is excluded
+            type: 'array',
+            items: {$ref: '#/components/schemas/Coffee'},
+          },
         });
     });
   });

--- a/packages/booter-lb3app/src/lb3app.booter.ts
+++ b/packages/booter-lb3app/src/lb3app.booter.ts
@@ -92,9 +92,15 @@ export class Lb3AppBooter implements Booter {
     const swaggerSpec = generateSwaggerSpec(lb3App, {
       generateOperationScopedModels: true,
     });
-    const result = await swagger2openapi.convertObj(swaggerSpec, {
+
+    // remove any properties that have values that are functions before
+    // converting, as `convertObj` can't handle function values
+    const fixedSwaggerSpec = JSON.parse(JSON.stringify(swaggerSpec));
+
+    const result = await swagger2openapi.convertObj(fixedSwaggerSpec, {
       // swagger2openapi options
     });
+
     return result.openapi as OpenApiSpec;
   }
 


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/3163.

Stringify the LB3 app's spec before converting it so it removes `default` values that are functions. These `default` values are included automatically as part of any `embedsMany` or `referencesMany` relation as part of the source model's target model property.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
