### PR TITLE
Use @config to inject options

### DIFF
--- a/examples/greeter-extension/README.md
+++ b/examples/greeter-extension/README.md
@@ -169,7 +169,7 @@ knowing much about one another.
 
 ```ts
 import {Greeter, asGreeter} from '../types';
-import {bind, inject} from '@loopback/context';
+import {bind, inject, config} from '@loopback/context';
 
 /**
  * Options for the Chinese greeter
@@ -190,7 +190,7 @@ export class ChineseGreeter implements Greeter {
     /**
      * Inject the configuration for ChineseGreeter
      */
-    @inject('greeters.ChineseGreeter.options', {optional: true})
+    @config()
     private options: ChineseGreeterOptions = {nameFirst: true},
   ) {}
 

--- a/packages/boot/src/booters/controller.booter.ts
+++ b/packages/boot/src/booters/controller.booter.ts
@@ -3,11 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {CoreBindings, Application} from '@loopback/core';
-import {inject} from '@loopback/context';
+import {bind, config, inject} from '@loopback/context';
+import {Application, CoreBindings} from '@loopback/core';
 import {ArtifactOptions} from '../interfaces';
-import {BaseArtifactBooter} from './base-artifact.booter';
 import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
  * A class that extends BaseArtifactBooter to boot the 'Controller' artifact type.
@@ -19,11 +19,12 @@ import {BootBindings} from '../keys';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Controller Artifact Options Object
  */
+@bind({tags: {configPath: 'controllers'}})
 export class ControllerBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) public app: Application,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#controllers`)
+    @config()
     public controllerConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/datasource.booter.ts
+++ b/packages/boot/src/booters/datasource.booter.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {bind, config, inject} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {
   ApplicationWithRepositories,
-  juggler,
   Class,
+  juggler,
 } from '@loopback/repository';
-import {inject} from '@loopback/context';
 import {ArtifactOptions} from '../interfaces';
-import {BaseArtifactBooter} from './base-artifact.booter';
 import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
  * A class that extends BaseArtifactBooter to boot the 'DataSource' artifact type.
@@ -24,12 +24,13 @@ import {BootBindings} from '../keys';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - DataSource Artifact Options Object
  */
+@bind({tags: {configPath: 'datasources'}})
 export class DataSourceBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: ApplicationWithRepositories,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#datasources`)
+    @config()
     public datasourceConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/interceptor.booter.ts
+++ b/packages/boot/src/booters/interceptor.booter.ts
@@ -4,7 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  bind,
   BindingScope,
+  config,
   Constructor,
   createBindingFromClass,
   inject,
@@ -30,6 +32,7 @@ type InterceptorProviderClass = Constructor<Provider<Interceptor>>;
  * @param projectRoot Root of User Project relative to which all paths are resolved
  * @param [bootConfig] InterceptorProvider Artifact Options Object
  */
+@bind({tags: {configPath: 'interceptors'}})
 export class InterceptorProviderBooter extends BaseArtifactBooter {
   interceptors: InterceptorProviderClass[];
 
@@ -37,7 +40,7 @@ export class InterceptorProviderBooter extends BaseArtifactBooter {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: Application,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#interceptors`)
+    @config()
     public interceptorConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/lifecyle-observer.booter.ts
+++ b/packages/boot/src/booters/lifecyle-observer.booter.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor, inject} from '@loopback/context';
+import {bind, config, Constructor, inject} from '@loopback/context';
 import {
   Application,
   CoreBindings,
@@ -28,6 +28,7 @@ type LifeCycleObserverClass = Constructor<LifeCycleObserver>;
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - LifeCycleObserver Artifact Options Object
  */
+@bind({tags: {configPath: 'observers'}})
 export class LifeCycleObserverBooter extends BaseArtifactBooter {
   observers: LifeCycleObserverClass[];
 
@@ -35,7 +36,7 @@ export class LifeCycleObserverBooter extends BaseArtifactBooter {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: Application,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#observers`)
+    @config()
     public observerConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/repository.booter.ts
+++ b/packages/boot/src/booters/repository.booter.ts
@@ -3,12 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {bind, config, inject} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
-import {inject} from '@loopback/context';
 import {ApplicationWithRepositories} from '@loopback/repository';
-import {BaseArtifactBooter} from './base-artifact.booter';
-import {BootBindings} from '../keys';
 import {ArtifactOptions} from '../interfaces';
+import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
  * A class that extends BaseArtifactBooter to boot the 'Repository' artifact type.
@@ -21,12 +21,13 @@ import {ArtifactOptions} from '../interfaces';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Repository Artifact Options Object
  */
+@bind({tags: {configPath: 'repositories'}})
 export class RepositoryBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: ApplicationWithRepositories,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#repositories`)
+    @config()
     public repositoryOptions: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -3,12 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {bind, Constructor, inject, Provider, config} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {ApplicationWithServices} from '@loopback/service-proxy';
-import {inject, Provider, Constructor} from '@loopback/context';
 import {ArtifactOptions} from '../interfaces';
-import {BaseArtifactBooter} from './base-artifact.booter';
 import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
 
 type ServiceProviderClass = Constructor<Provider<object>>;
 
@@ -22,6 +22,7 @@ type ServiceProviderClass = Constructor<Provider<object>>;
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Service Artifact Options Object
  */
+@bind({tags: {configPath: 'services'}})
 export class ServiceBooter extends BaseArtifactBooter {
   serviceProviders: ServiceProviderClass[];
 
@@ -29,7 +30,7 @@ export class ServiceBooter extends BaseArtifactBooter {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: ApplicationWithServices,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#services`)
+    @config()
     public serviceConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -5,10 +5,10 @@
 
 import {
   Binding,
+  BindingScope,
   Constructor,
   Context,
   createBindingFromClass,
-  BindingScope,
 } from '@loopback/context';
 import {BootComponent} from '../boot.component';
 import {Bootstrapper} from '../bootstrapper';
@@ -145,9 +145,17 @@ export function _bindBooter(
 ): Binding {
   const binding = createBindingFromClass(booterCls, {
     namespace: BootBindings.BOOTER_PREFIX,
-  })
-    .tag(BootBindings.BOOTER_TAG)
-    .inScope(BindingScope.SINGLETON);
+    defaultScope: BindingScope.SINGLETON,
+  }).tag(BootBindings.BOOTER_TAG);
   ctx.add(binding);
+  /**
+   * Set up configuration binding as alias to `BootBindings.BOOT_OPTIONS`
+   * so that the booter can use `@config`.
+   */
+  if (binding.tagMap.configPath) {
+    ctx
+      .configure(binding.key)
+      .toAlias(`${BootBindings.BOOT_OPTIONS.key}#${binding.tagMap.configPath}`);
+  }
   return binding;
 }

--- a/packages/rest-explorer/README.md
+++ b/packages/rest-explorer/README.md
@@ -31,6 +31,14 @@ By default, API Explorer is mounted at `/explorer`. This path can be customized
 via RestExplorer configuration as follows:
 
 ```ts
+this.configure(RestExplorerBindings.COMPONENT).to({
+  path: '/openapi/ui',
+});
+```
+
+Or:
+
+```ts
 this.bind(RestExplorerBindings.CONFIG).to({
   path: '/openapi/ui',
 });

--- a/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.acceptance.ts
+++ b/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.acceptance.ts
@@ -107,7 +107,7 @@ describe('API Explorer (acceptance)', () => {
       config: RestExplorerConfig,
     ) {
       app = givenRestApplication();
-      app.bind(RestExplorerBindings.CONFIG).to(config);
+      app.configure(RestExplorerBindings.COMPONENT).to(config);
       app.component(RestExplorerComponent);
       await app.start();
       request = createRestAppClient(app);

--- a/packages/rest-explorer/src/rest-explorer.component.ts
+++ b/packages/rest-explorer/src/rest-explorer.component.ts
@@ -3,26 +3,28 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import {bind, config, ContextTags, inject} from '@loopback/context';
 import {Component, CoreBindings} from '@loopback/core';
-import {RestApplication, createControllerFactoryForClass} from '@loopback/rest';
+import {createControllerFactoryForClass, RestApplication} from '@loopback/rest';
+import {ExplorerController} from './rest-explorer.controller';
 import {RestExplorerBindings} from './rest-explorer.keys';
 import {RestExplorerConfig} from './rest-explorer.types';
-import {ExplorerController} from './rest-explorer.controller';
 
 const swaggerUI = require('swagger-ui-dist');
 
 /**
  * A component providing a self-hosted API Explorer.
  */
+@bind({tags: {[ContextTags.KEY]: RestExplorerBindings.COMPONENT.key}})
 export class RestExplorerComponent implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     private application: RestApplication,
-    @inject(RestExplorerBindings.CONFIG, {optional: true})
-    config: RestExplorerConfig = {},
+    @config()
+    restExplorerConfig: RestExplorerConfig = {},
   ) {
-    const explorerPath = config.path || '/explorer';
+    const explorerPath = restExplorerConfig.path || '/explorer';
 
     this.registerControllerRoute('get', explorerPath, 'indexRedirect');
     this.registerControllerRoute('get', explorerPath + '/', 'index');

--- a/packages/rest-explorer/src/rest-explorer.keys.ts
+++ b/packages/rest-explorer/src/rest-explorer.keys.ts
@@ -4,13 +4,17 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingKey} from '@loopback/context';
+import {RestExplorerComponent} from './rest-explorer.component';
 import {RestExplorerConfig} from './rest-explorer.types';
 
 /**
  * Binding keys used by this component.
  */
 export namespace RestExplorerBindings {
-  export const CONFIG = BindingKey.create<RestExplorerConfig>(
-    'rest-explorer.config',
+  export const COMPONENT = BindingKey.create<RestExplorerComponent>(
+    'components.RestExplorerComponent',
+  );
+  export const CONFIG = BindingKey.buildKeyForConfig<RestExplorerConfig>(
+    COMPONENT,
   );
 }


### PR DESCRIPTION
This PR contains a list of commits to use `@config` for injection of options. We use `toAlias` to keep backward compatibility. 

For example:

```ts
ctx.configure(bindingKey).toAlias(`${optionsBindingKey}#${configPath}`);
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
