### PR TITLE
feat(testlab): improve typings for `toJSON()` helper

### DIFF
--- a/packages/testlab/src/__tests__/unit/to-json.test.ts
+++ b/packages/testlab/src/__tests__/unit/to-json.test.ts
@@ -62,6 +62,42 @@ describe('toJSON', () => {
     expectUndefined(value);
   });
 
+  it('handles `object | null`', () => {
+    const input = createValueOfUnionType<object | null>({});
+    const output = toJSON(input);
+    expectComplexType<object | null>(output, input);
+  });
+
+  it('handles `object | undefined`', () => {
+    const input = createValueOfUnionType<object | undefined>({});
+    const output = toJSON(input);
+    expectComplexType<object | undefined>(output, input);
+  });
+
+  it('handles `object | null | undefined`', () => {
+    const input = createValueOfUnionType<object | null | undefined>({});
+    const output = toJSON(input);
+    expectComplexType<object | null | undefined>(output, input);
+  });
+
+  it('handles `unknown[] | null`', () => {
+    const input = createValueOfUnionType<unknown[] | null>([]);
+    const output = toJSON(input);
+    expectComplexType<unknown[] | null>(output, input);
+  });
+
+  it('handles `unknown[] | undefined`', () => {
+    const input = createValueOfUnionType<unknown[] | undefined>([]);
+    const output = toJSON(input);
+    expectComplexType<unknown[] | undefined>(output, input);
+  });
+
+  it('handles `unknown[] | null | undefined`', () => {
+    const input = createValueOfUnionType<unknown[] | null | undefined>([]);
+    const output = toJSON(input);
+    expectComplexType<unknown[] | null | undefined>(output, input);
+  });
+
   it('handles classes with custom toJSON', () => {
     class Customer {
       private __data: object;
@@ -155,4 +191,14 @@ function expectNull(actual: null) {
 
 function expectUndefined(actual: undefined) {
   expect(actual).to.be.undefined();
+}
+
+function expectComplexType<T>(actual: T, expected: T) {
+  expect(actual).to.deepEqual(expected);
+}
+
+// A helper to force TypeScript to treat the given value as of a union type,
+// e.g. treat `{}` as `object | undefined | null`.
+function createValueOfUnionType<T>(value: T): T {
+  return value;
 }

--- a/packages/testlab/src/to-json.ts
+++ b/packages/testlab/src/to-json.ts
@@ -32,6 +32,21 @@ export function toJSON(value: number): number;
 export function toJSON(value: boolean): boolean;
 export function toJSON(value: string): string;
 
+// The following overloads are required to allow TypesScript handle
+// commonly used union types.
+
+export function toJSON(value: unknown[] | null): unknown[] | null;
+export function toJSON(value: unknown[] | undefined): unknown[] | undefined;
+export function toJSON(
+  value: unknown[] | null | undefined,
+): unknown[] | null | undefined;
+
+export function toJSON(value: object | null): object | null;
+export function toJSON(value: object | undefined): object | undefined;
+export function toJSON(
+  value: object | null | undefined,
+): object | null | undefined;
+
 export function toJSON<T>(value: T) {
   return JSON.parse(JSON.stringify({value})).value;
 }


### PR DESCRIPTION
While working on https://github.com/strongloop/loopback-next/issues/2634, I discovered that `findOne` returns `T | null` and this type cannot be passed to `toJSON` helper, because there is no overload accepting such type.

This pull requests improves the type definitions to let the compiler understand toJSON's behavior for commonly used union types like `object | null` or `unknown[] | null`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈