### PR TITLE
feat(boot): use @config to inject options for booters

### DIFF
--- a/packages/boot/src/booters/application-metadata.booter.ts
+++ b/packages/boot/src/booters/application-metadata.booter.ts
@@ -6,7 +6,7 @@
 import {CoreBindings, Application} from '@loopback/core';
 import {inject} from '@loopback/context';
 import {BootBindings} from '../keys';
-import {Booter} from '../interfaces';
+import {Booter} from '../types';
 import path = require('path');
 
 import * as debugModule from 'debug';

--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -6,7 +6,7 @@
 import {Constructor} from '@loopback/context';
 import * as debugFactory from 'debug';
 import * as path from 'path';
-import {ArtifactOptions, Booter} from '../interfaces';
+import {ArtifactOptions, Booter} from '../types';
 import {discoverFiles, loadClassesFromFiles} from './booter-utils';
 
 const debug = debugFactory('loopback:boot:base-artifact-booter');

--- a/packages/boot/src/booters/controller.booter.ts
+++ b/packages/boot/src/booters/controller.booter.ts
@@ -3,10 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, config, inject} from '@loopback/context';
+import {config, inject} from '@loopback/context';
 import {Application, CoreBindings} from '@loopback/core';
-import {ArtifactOptions} from '../interfaces';
 import {BootBindings} from '../keys';
+import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
@@ -19,7 +19,7 @@ import {BaseArtifactBooter} from './base-artifact.booter';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Controller Artifact Options Object
  */
-@bind({tags: {configPath: 'controllers'}})
+@booter('controllers')
 export class ControllerBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) public app: Application,

--- a/packages/boot/src/booters/controller.booter.ts
+++ b/packages/boot/src/booters/controller.booter.ts
@@ -3,11 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {CoreBindings, Application} from '@loopback/core';
-import {inject} from '@loopback/context';
+import {bind, config, inject} from '@loopback/context';
+import {Application, CoreBindings} from '@loopback/core';
 import {ArtifactOptions} from '../interfaces';
-import {BaseArtifactBooter} from './base-artifact.booter';
 import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
  * A class that extends BaseArtifactBooter to boot the 'Controller' artifact type.
@@ -19,11 +19,12 @@ import {BootBindings} from '../keys';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Controller Artifact Options Object
  */
+@bind({tags: {configPath: 'controllers'}})
 export class ControllerBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE) public app: Application,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#controllers`)
+    @config()
     public controllerConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/datasource.booter.ts
+++ b/packages/boot/src/booters/datasource.booter.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {bind, config, inject} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {
   ApplicationWithRepositories,
-  juggler,
   Class,
+  juggler,
 } from '@loopback/repository';
-import {inject} from '@loopback/context';
 import {ArtifactOptions} from '../interfaces';
-import {BaseArtifactBooter} from './base-artifact.booter';
 import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
  * A class that extends BaseArtifactBooter to boot the 'DataSource' artifact type.
@@ -24,12 +24,13 @@ import {BootBindings} from '../keys';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - DataSource Artifact Options Object
  */
+@bind({tags: {configPath: 'datasources'}})
 export class DataSourceBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: ApplicationWithRepositories,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#datasources`)
+    @config()
     public datasourceConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/datasource.booter.ts
+++ b/packages/boot/src/booters/datasource.booter.ts
@@ -3,15 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, config, inject} from '@loopback/context';
+import {config, inject} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {
   ApplicationWithRepositories,
   Class,
   juggler,
 } from '@loopback/repository';
-import {ArtifactOptions} from '../interfaces';
 import {BootBindings} from '../keys';
+import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
@@ -24,7 +24,7 @@ import {BaseArtifactBooter} from './base-artifact.booter';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - DataSource Artifact Options Object
  */
-@bind({tags: {configPath: 'datasources'}})
+@booter('datasources')
 export class DataSourceBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/packages/boot/src/booters/interceptor.booter.ts
+++ b/packages/boot/src/booters/interceptor.booter.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingScope,
   config,
   Constructor,
@@ -15,8 +14,8 @@ import {
 } from '@loopback/context';
 import {Application, CoreBindings} from '@loopback/core';
 import * as debugFactory from 'debug';
-import {ArtifactOptions} from '../interfaces';
 import {BootBindings} from '../keys';
+import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';
 
 const debug = debugFactory('loopback:boot:interceptor-booter');
@@ -32,7 +31,7 @@ type InterceptorProviderClass = Constructor<Provider<Interceptor>>;
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - InterceptorProvider Artifact Options Object
  */
-@bind({tags: {configPath: 'interceptors'}})
+@booter('interceptors')
 export class InterceptorProviderBooter extends BaseArtifactBooter {
   interceptors: InterceptorProviderClass[];
 

--- a/packages/boot/src/booters/interceptor.booter.ts
+++ b/packages/boot/src/booters/interceptor.booter.ts
@@ -4,7 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  bind,
   BindingScope,
+  config,
   Constructor,
   createBindingFromClass,
   inject,
@@ -30,6 +32,7 @@ type InterceptorProviderClass = Constructor<Provider<Interceptor>>;
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - InterceptorProvider Artifact Options Object
  */
+@bind({tags: {configPath: 'interceptors'}})
 export class InterceptorProviderBooter extends BaseArtifactBooter {
   interceptors: InterceptorProviderClass[];
 
@@ -37,7 +40,7 @@ export class InterceptorProviderBooter extends BaseArtifactBooter {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: Application,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#interceptors`)
+    @config()
     public interceptorConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/lifecyle-observer.booter.ts
+++ b/packages/boot/src/booters/lifecyle-observer.booter.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor, inject} from '@loopback/context';
+import {bind, config, Constructor, inject} from '@loopback/context';
 import {
   Application,
   CoreBindings,
@@ -28,6 +28,7 @@ type LifeCycleObserverClass = Constructor<LifeCycleObserver>;
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - LifeCycleObserver Artifact Options Object
  */
+@bind({tags: {configPath: 'observers'}})
 export class LifeCycleObserverBooter extends BaseArtifactBooter {
   observers: LifeCycleObserverClass[];
 
@@ -35,7 +36,7 @@ export class LifeCycleObserverBooter extends BaseArtifactBooter {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: Application,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#observers`)
+    @config()
     public observerConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/lifecyle-observer.booter.ts
+++ b/packages/boot/src/booters/lifecyle-observer.booter.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, config, Constructor, inject} from '@loopback/context';
+import {config, Constructor, inject} from '@loopback/context';
 import {
   Application,
   CoreBindings,
@@ -11,8 +11,8 @@ import {
   LifeCycleObserver,
 } from '@loopback/core';
 import * as debugFactory from 'debug';
-import {ArtifactOptions} from '../interfaces';
 import {BootBindings} from '../keys';
+import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';
 
 const debug = debugFactory('loopback:boot:lifecycle-observer-booter');
@@ -28,7 +28,7 @@ type LifeCycleObserverClass = Constructor<LifeCycleObserver>;
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - LifeCycleObserver Artifact Options Object
  */
-@bind({tags: {configPath: 'observers'}})
+@booter('observers')
 export class LifeCycleObserverBooter extends BaseArtifactBooter {
   observers: LifeCycleObserverClass[];
 

--- a/packages/boot/src/booters/repository.booter.ts
+++ b/packages/boot/src/booters/repository.booter.ts
@@ -3,11 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, config, inject} from '@loopback/context';
+import {config, inject} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {ApplicationWithRepositories} from '@loopback/repository';
-import {ArtifactOptions} from '../interfaces';
 import {BootBindings} from '../keys';
+import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
@@ -21,7 +21,7 @@ import {BaseArtifactBooter} from './base-artifact.booter';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Repository Artifact Options Object
  */
-@bind({tags: {configPath: 'repositories'}})
+@booter('repositories')
 export class RepositoryBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/packages/boot/src/booters/repository.booter.ts
+++ b/packages/boot/src/booters/repository.booter.ts
@@ -3,12 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {bind, config, inject} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
-import {inject} from '@loopback/context';
 import {ApplicationWithRepositories} from '@loopback/repository';
-import {BaseArtifactBooter} from './base-artifact.booter';
-import {BootBindings} from '../keys';
 import {ArtifactOptions} from '../interfaces';
+import {BootBindings} from '../keys';
+import {BaseArtifactBooter} from './base-artifact.booter';
 
 /**
  * A class that extends BaseArtifactBooter to boot the 'Repository' artifact type.
@@ -21,12 +21,13 @@ import {ArtifactOptions} from '../interfaces';
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Repository Artifact Options Object
  */
+@bind({tags: {configPath: 'repositories'}})
 export class RepositoryBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: ApplicationWithRepositories,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#repositories`)
+    @config()
     public repositoryOptions: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -4,7 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  bind,
   BINDING_METADATA_KEY,
+  config,
   Constructor,
   inject,
   MetadataInspector,
@@ -28,12 +30,13 @@ const debug = debugFactory('loopback:boot:service-booter');
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Service Artifact Options Object
  */
+@bind({tags: {configPath: 'services'}})
 export class ServiceBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     public app: ApplicationWithServices,
     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
-    @inject(`${BootBindings.BOOT_OPTIONS}#services`)
+    @config()
     public serviceConfig: ArtifactOptions = {},
   ) {
     super(

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BINDING_METADATA_KEY,
   config,
   Constructor,
@@ -14,8 +13,8 @@ import {
 import {CoreBindings} from '@loopback/core';
 import {ApplicationWithServices} from '@loopback/service-proxy';
 import * as debugFactory from 'debug';
-import {ArtifactOptions} from '../interfaces';
 import {BootBindings} from '../keys';
+import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';
 
 const debug = debugFactory('loopback:boot:service-booter');
@@ -30,7 +29,7 @@ const debug = debugFactory('loopback:boot:service-booter');
  * @param projectRoot - Root of User Project relative to which all paths are resolved
  * @param bootConfig - Service Artifact Options Object
  */
-@bind({tags: {configPath: 'services'}})
+@booter('services')
 export class ServiceBooter extends BaseArtifactBooter {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -3,19 +3,19 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {resolve} from 'path';
 import {Context, inject, resolveList} from '@loopback/context';
-import {CoreBindings, Application} from '@loopback/core';
-import {
-  BootOptions,
-  BootExecutionOptions,
-  BOOTER_PHASES,
-  Bootable,
-} from './interfaces';
-import {BootBindings} from './keys';
-import {_bindBooter} from './mixins';
-
+import {Application, CoreBindings} from '@loopback/core';
 import * as debugModule from 'debug';
+import {resolve} from 'path';
+import {BootBindings, BootTags} from './keys';
+import {_bindBooter} from './mixins';
+import {
+  Bootable,
+  BOOTER_PHASES,
+  BootExecutionOptions,
+  BootOptions,
+} from './types';
+
 const debug = debugModule('loopback:boot:bootstrapper');
 
 /**
@@ -81,7 +81,7 @@ export class Bootstrapper {
       : BOOTER_PHASES;
 
     // Find booters registered to the BOOTERS_TAG by getting the bindings
-    const bindings = bootCtx.findByTag(BootBindings.BOOTER_TAG);
+    const bindings = bootCtx.findByTag(BootTags.BOOTER);
 
     // Prefix length. +1 because of `.` => 'booters.'
     const prefixLength = BootBindings.BOOTER_PREFIX.length + 1;

--- a/packages/boot/src/index.ts
+++ b/packages/boot/src/index.ts
@@ -8,4 +8,4 @@ export * from './bootstrapper';
 export * from './boot.component';
 export * from './keys';
 export * from './mixins';
-export * from './interfaces';
+export * from './types';

--- a/packages/boot/src/keys.ts
+++ b/packages/boot/src/keys.ts
@@ -4,15 +4,15 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingKey} from '@loopback/context';
-import {BootOptions} from './interfaces';
 import {Bootstrapper} from './bootstrapper';
+import {BootOptions} from './types';
 
 /**
- * Namespace for core binding keys
+ * Namespace for boot related binding keys
  */
 export namespace BootBindings {
   /**
-   * Binding key for Boot configuration
+   * Binding key for boot options
    */
   export const BOOT_OPTIONS = BindingKey.create<BootOptions>('boot.options');
   /**
@@ -27,6 +27,16 @@ export namespace BootBindings {
     'application.bootstrapper',
   );
 
-  export const BOOTER_TAG = 'booter';
   export const BOOTER_PREFIX = 'booters';
+}
+
+/**
+ * Namespace for boot related tags
+ */
+export namespace BootTags {
+  export const BOOTER = 'booter';
+  /**
+   * @deprecated Use `BootTags.BOOTER` instead.
+   */
+  export const BOOTER_TAG = BootTags.BOOTER;
 }

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -12,8 +12,8 @@ import {
 } from '@loopback/context';
 import {BootComponent} from '../boot.component';
 import {Bootstrapper} from '../bootstrapper';
-import {Bootable, Booter, BootOptions} from '../interfaces';
-import {BootBindings} from '../keys';
+import {BootBindings, BootTags} from '../keys';
+import {Bootable, Booter, BootOptions} from '../types';
 
 // Binding is re-exported as Binding / Booter types are needed when consuming
 // BootMixin and this allows a user to import them from the same package (UX!)
@@ -146,16 +146,18 @@ export function _bindBooter(
   const binding = createBindingFromClass(booterCls, {
     namespace: BootBindings.BOOTER_PREFIX,
     defaultScope: BindingScope.SINGLETON,
-  }).tag(BootBindings.BOOTER_TAG);
+  }).tag(BootTags.BOOTER);
   ctx.add(binding);
   /**
    * Set up configuration binding as alias to `BootBindings.BOOT_OPTIONS`
    * so that the booter can use `@config`.
    */
-  if (binding.tagMap.configPath) {
+  if (binding.tagMap.artifactNamespace) {
     ctx
       .configure(binding.key)
-      .toAlias(`${BootBindings.BOOT_OPTIONS.key}#${binding.tagMap.configPath}`);
+      .toAlias(
+        `${BootBindings.BOOT_OPTIONS.key}#${binding.tagMap.artifactNamespace}`,
+      );
   }
   return binding;
 }

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -5,10 +5,10 @@
 
 import {
   Binding,
+  BindingScope,
   Constructor,
   Context,
   createBindingFromClass,
-  BindingScope,
 } from '@loopback/context';
 import {BootComponent} from '../boot.component';
 import {Bootstrapper} from '../bootstrapper';
@@ -145,9 +145,17 @@ export function _bindBooter(
 ): Binding {
   const binding = createBindingFromClass(booterCls, {
     namespace: BootBindings.BOOTER_PREFIX,
-  })
-    .tag(BootBindings.BOOTER_TAG)
-    .inScope(BindingScope.SINGLETON);
+    defaultScope: BindingScope.SINGLETON,
+  }).tag(BootBindings.BOOTER_TAG);
   ctx.add(binding);
+  /**
+   * Set up configuration binding as alias to `BootBindings.BOOT_OPTIONS`
+   * so that the booter can use `@config`.
+   */
+  if (binding.tagMap.configPath) {
+    ctx
+      .configure(binding.key)
+      .toAlias(`${BootBindings.BOOT_OPTIONS.key}#${binding.tagMap.configPath}`);
+  }
   return binding;
 }

--- a/packages/boot/src/types.ts
+++ b/packages/boot/src/types.ts
@@ -3,7 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, Constructor} from '@loopback/context';
+import {bind, Binding, BindingSpec, Constructor} from '@loopback/context';
+import {BootTags} from './keys';
 
 /**
  * Type definition for ArtifactOptions. These are the options supported by
@@ -124,4 +125,37 @@ export interface Bootable {
    * @param booterClasses - A list of booter classes
    */
   booters(...booterClasses: Constructor<Booter>[]): Binding[];
+}
+
+/**
+ * `@booter` decorator to mark a class as a `Booter` and specify the artifact
+ * namespace for the configuration of the booter
+ *
+ * @example
+ * ```ts
+ * @booter('controllers')
+ * export class ControllerBooter extends BaseArtifactBooter {
+ *   constructor(
+ *     @inject(CoreBindings.APPLICATION_INSTANCE) public app: Application,
+ *     @inject(BootBindings.PROJECT_ROOT) projectRoot: string,
+ *     @config()
+ *    public controllerConfig: ArtifactOptions = {},
+ *   ) {
+ *   // ...
+ *   }
+ * }
+ * ```
+ *
+ * @param artifactNamespace - Namespace for the artifact. It will be used to
+ * inject configuration from boot options. For example, the Booter class
+ * decorated with `@booter('controllers')` can receive its configuration via
+ * `@config()` from the `controllers` property of boot options.
+ *
+ * @param specs - Extra specs for the binding
+ */
+export function booter(artifactNamespace: string, ...specs: BindingSpec[]) {
+  return bind(
+    {tags: {artifactNamespace, [BootTags.BOOTER]: BootTags.BOOTER}},
+    ...specs,
+  );
 }


### PR DESCRIPTION
Switch to `@config` and `ctx.configure` for booter options.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
