### PR TITLE
feat(rest-explorer): use configuration apis/decorators

### DIFF
--- a/packages/rest-explorer/README.md
+++ b/packages/rest-explorer/README.md
@@ -31,6 +31,14 @@ By default, API Explorer is mounted at `/explorer`. This path can be customized
 via RestExplorer configuration as follows:
 
 ```ts
+this.configure(RestExplorerBindings.COMPONENT).to({
+  path: '/openapi/ui',
+});
+```
+
+Or:
+
+```ts
 this.bind(RestExplorerBindings.CONFIG).to({
   path: '/openapi/ui',
 });

--- a/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.acceptance.ts
+++ b/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.acceptance.ts
@@ -107,7 +107,7 @@ describe('API Explorer (acceptance)', () => {
       config: RestExplorerConfig,
     ) {
       app = givenRestApplication();
-      app.bind(RestExplorerBindings.CONFIG).to(config);
+      app.configure(RestExplorerBindings.COMPONENT).to(config);
       app.component(RestExplorerComponent);
       await app.start();
       request = createRestAppClient(app);

--- a/packages/rest-explorer/src/rest-explorer.component.ts
+++ b/packages/rest-explorer/src/rest-explorer.component.ts
@@ -3,26 +3,28 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import {bind, config, ContextTags, inject} from '@loopback/context';
 import {Component, CoreBindings} from '@loopback/core';
-import {RestApplication, createControllerFactoryForClass} from '@loopback/rest';
+import {createControllerFactoryForClass, RestApplication} from '@loopback/rest';
+import {ExplorerController} from './rest-explorer.controller';
 import {RestExplorerBindings} from './rest-explorer.keys';
 import {RestExplorerConfig} from './rest-explorer.types';
-import {ExplorerController} from './rest-explorer.controller';
 
 const swaggerUI = require('swagger-ui-dist');
 
 /**
  * A component providing a self-hosted API Explorer.
  */
+@bind({tags: {[ContextTags.KEY]: RestExplorerBindings.COMPONENT.key}})
 export class RestExplorerComponent implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     private application: RestApplication,
-    @inject(RestExplorerBindings.CONFIG, {optional: true})
-    config: RestExplorerConfig = {},
+    @config()
+    restExplorerConfig: RestExplorerConfig = {},
   ) {
-    const explorerPath = config.path || '/explorer';
+    const explorerPath = restExplorerConfig.path || '/explorer';
 
     this.registerControllerRoute('get', explorerPath, 'indexRedirect');
     this.registerControllerRoute('get', explorerPath + '/', 'index');

--- a/packages/rest-explorer/src/rest-explorer.keys.ts
+++ b/packages/rest-explorer/src/rest-explorer.keys.ts
@@ -4,13 +4,17 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingKey} from '@loopback/context';
+import {RestExplorerComponent} from './rest-explorer.component';
 import {RestExplorerConfig} from './rest-explorer.types';
 
 /**
  * Binding keys used by this component.
  */
 export namespace RestExplorerBindings {
-  export const CONFIG = BindingKey.create<RestExplorerConfig>(
-    'rest-explorer.config',
+  export const COMPONENT = BindingKey.create<RestExplorerComponent>(
+    'components.RestExplorerComponent',
+  );
+  export const CONFIG = BindingKey.buildKeyForConfig<RestExplorerConfig>(
+    COMPONENT,
   );
 }


### PR DESCRIPTION
Switch to `@config` and `ctx.configure` for rest-explorer options.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
