### PR TITLE
Emit schema excluding certain model properties

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -123,8 +123,17 @@ export class TodoController {
       },
     },
   })
-  async create(@requestBody() data: Todo): Promise<Todo> {
-    return await this.todoRepository.create(data);
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+        },
+      },
+    })
+    todo: Omit<Todo, 'id'>,
+  ): Promise<Todo> {
+    return await this.todoRepository.create(todo);
   }
 
   @get('/todos/count', {

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -175,7 +175,17 @@ export class TodoListTodoController {
   ) {}
 
   @post('/todo-lists/{id}/todos')
-  async create(@param.path.number('id') id: number, @requestBody() todo: Todo) {
+  async create(
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+        },
+      },
+    })
+    todo: Omit<Todo, 'id'>,
+  ) {
     return await this.todoListRepo.todos(id).create(todo);
   }
 }
@@ -222,7 +232,14 @@ export class TodoListTodoController {
   })
   async create(
     @param.path.number('id') id: number,
-    @requestBody() todo: Todo,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+        },
+      },
+    })
+    todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
     return await this.todoListRepo.todos(id).create(todo);
   }

--- a/examples/express-composition/src/controllers/note.controller.ts
+++ b/examples/express-composition/src/controllers/note.controller.ts
@@ -39,7 +39,16 @@ export class NoteController {
       },
     },
   })
-  async create(@requestBody() note: Note): Promise<Note> {
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Note, {exclude: ['id']}),
+        },
+      },
+    })
+    note: Omit<Note, 'id'>,
+  ): Promise<Note> {
     return await this.noteRepository.create(note);
   }
 

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -38,7 +38,14 @@ export class TodoListTodoController {
   })
   async create(
     @param.path.number('id') id: number,
-    @requestBody() todo: Todo,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+        },
+      },
+    })
+    todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
     return await this.todoListRepo.todos(id).create(todo);
   }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -38,8 +38,17 @@ export class TodoListController {
       },
     },
   })
-  async create(@requestBody() obj: TodoList): Promise<TodoList> {
-    return await this.todoListRepository.create(obj);
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(TodoList, {exclude: ['id']}),
+        },
+      },
+    })
+    todoList: Omit<TodoList, 'id'>,
+  ): Promise<TodoList> {
+    return await this.todoListRepository.create(todoList);
   }
 
   @get('/todo-lists/count', {

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -29,7 +29,16 @@ export class TodoController {
       },
     },
   })
-  async createTodo(@requestBody() todo: Todo) {
+  async createTodo(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+        },
+      },
+    })
+    todo: Omit<Todo, 'id'>,
+  ): Promise<Todo> {
     return await this.todoRepo.create(todo);
   }
 

--- a/examples/todo-list/src/models/todo-list.model.ts
+++ b/examples/todo-list/src/models/todo-list.model.ts
@@ -16,7 +16,7 @@ export class TodoList extends Entity {
     type: 'number',
     id: true,
   })
-  id?: number;
+  id: number;
 
   @property({
     type: 'string',

--- a/examples/todo-list/src/models/todo.model.ts
+++ b/examples/todo-list/src/models/todo.model.ts
@@ -12,7 +12,7 @@ export class Todo extends Entity {
     type: 'number',
     id: true,
   })
-  id?: number;
+  id: number;
 
   @property({
     type: 'string',

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -34,7 +34,16 @@ export class TodoController {
       },
     },
   })
-  async createTodo(@requestBody() todo: Todo): Promise<Todo> {
+  async createTodo(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+        },
+      },
+    })
+    todo: Omit<Todo, 'id'>,
+  ): Promise<Todo> {
     if (todo.remindAtAddress) {
       // TODO(bajtos) handle "address not found"
       const geo = await this.geoService.geocode(todo.remindAtAddress);

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -34,7 +34,16 @@ export class <%= className %>Controller {
       },
     },
   })
-  async create(@requestBody() <%= modelVariableName %>: <%= modelName %>): Promise<<%= modelName %>> {
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(<%= modelName %>, {exclude: ['id']}),
+        },
+      },
+    })
+    <%= modelVariableName %>: Omit<<%= modelName %>, 'id'>,
+  ): Promise<<%= modelName %>> {
     return await this.<%= repositoryNameCamel %>.create(<%= modelVariableName %>);
   }
 

--- a/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
@@ -55,7 +55,13 @@ export class <%= controllerClassName %> {
   })
   async create(
     @param.path.<%= sourceModelPrimaryKeyType %>('id') id: typeof <%= sourceModelClassName %>.prototype.<%= sourceModelPrimaryKey %>,
-    @requestBody() <%= targetModelRequestBody %>: <%= targetModelClassName %>,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(<%= targetModelClassName %>, {exclude: ['id']}),
+        },
+      },
+    }) <%= targetModelRequestBody %>: Omit<<%= targetModelClassName %>, 'id'>,
   ): Promise<<%= targetModelClassName %>> {
     return await this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).create(<%= targetModelRequestBody %>);
   }

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -248,7 +248,7 @@ function checkRestCrudContents() {
     /'200': {/,
     /description: 'ProductReview model instance'/,
     /content: {'application\/json': {schema: {'x-ts-type': ProductReview}}},\s{1,}},\s{1,}},\s{1,}}\)/,
-    /async create\(\@requestBody\(\) productReview: ProductReview\)/,
+    /async create\(\s+\@requestBody\({\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(ProductReview, {exclude: \['id'\]}\),\s+},\s+},\s+}\)\s+productReview: Omit<ProductReview, 'id'>,\s+\)/,
   ];
   postCreateRegEx.forEach(regex => {
     assert.fileContent(expectedFile, regex);

--- a/packages/cli/test/integration/generators/hasmany.relation.integration.js
+++ b/packages/cli/test/integration/generators/hasmany.relation.integration.js
@@ -439,7 +439,7 @@ context('check if the controller file created ', () => {
           /content: { 'application\/json': { schema: { 'x-ts-type': Order } } },\n/,
           /},\n . {2}},\n .}\)\n {2}async create\(\n/,
           /\@param\.path\.number\('id'\) id: typeof Customer\.prototype\.id,\n/,
-          /\@requestBody\(\) order: Order,\n/,
+          /\@requestBody\(\{\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(Order, {exclude: \['id'\]}\),\s+},\s+},\s+}\) order: Omit<Order, 'id'>,\n/,
           /\): Promise<Order> {\n/,
           /return await this\.customerRepository\.orders\(id\)\.create\(order\);\n {2}}\n/,
         ];
@@ -449,7 +449,7 @@ context('check if the controller file created ', () => {
           /content: { 'application\/json': { schema: { 'x-ts-type': OrderClass } } },\n/,
           /},\n . {2}},\n .}\)\n {2}async create\(\n/,
           /\@param\.path\.number\('id'\) id: typeof CustomerClass\.prototype\.custNumber,\n/,
-          /\@requestBody\(\) orderClass: OrderClass,\n/,
+          /\@requestBody\(\{\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(OrderClass, {exclude: \['id'\]}\),\s+},\s+},\s+}\) orderClass: Omit<OrderClass, 'id'>,\n/,
           /\): Promise<OrderClass> {\n/,
           /return await this\.customerClassRepository\.orderClasses\(id\)\.create\(orderClass\);\n {2}}\n/,
         ];
@@ -459,7 +459,7 @@ context('check if the controller file created ', () => {
           /content: { 'application\/json': { schema: { 'x-ts-type': OrderClassType } } },\n/,
           /},\n . {2}},\n .}\)\n {2}async create\(\n/,
           /\@param\.path\.number\('id'\) id: typeof CustomerClassType\.prototype\.custNumber,\n/,
-          /\@requestBody\(\) orderClassType: OrderClassType,\n/,
+          /\@requestBody\(\{\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(OrderClassType, {exclude: \['id'\]}\),\s+},\s+},\s+}\) orderClassType: Omit<OrderClassType, 'id'>,\n/,
           /\): Promise<OrderClassType> {\n/,
           /return await this\.customerClassTypeRepository\.orderClassTypes\(id\)\.create\(orderClassType\);\n {2}}\n/,
         ];

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -373,9 +373,9 @@ export function getControllerSpec(constructor: Function): ControllerSpec {
  * @param modelCtor - The model constructor (e.g. `Product`)
  * @param options - Additional options
  */
-export function getModelSchemaRef(
+export function getModelSchemaRef<T extends object>(
   modelCtor: Function,
-  options?: JsonSchemaOptions,
+  options?: JsonSchemaOptions<T>,
 ): SchemaRef {
   const jsonSchema = getJsonSchemaRef(modelCtor, options);
   return jsonToSchemaObject(jsonSchema) as SchemaRef;

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -932,5 +932,74 @@ describe('build-schema', () => {
       expect(partialSchema.required).to.equal(undefined);
       expect(partialSchema.title).to.equal('ProductPartial');
     });
+
+    context('exclude properties when option "exclude" is set', () => {
+      @model()
+      class Product extends Entity {
+        @property({id: true, required: true})
+        id: number;
+
+        @property()
+        name: string;
+
+        @property()
+        description: string;
+      }
+
+      it('excludes one property when the option "exclude" is set to exclude one property', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.properties).to.deepEqual({
+          id: {type: 'number'},
+          name: {type: 'string'},
+          description: {type: 'string'},
+        });
+        expect(originalSchema.title).to.equal('Product');
+
+        const excludeIdSchema = getJsonSchema(Product, {exclude: ['id']});
+        expect(excludeIdSchema.properties).to.deepEqual({
+          name: {type: 'string'},
+          description: {type: 'string'},
+        });
+        expect(excludeIdSchema.title).to.equal('ProductExcluding[id]');
+      });
+
+      it('excludes multiple properties when the option "exclude" is set to exclude multiple properties', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.properties).to.deepEqual({
+          id: {type: 'number'},
+          name: {type: 'string'},
+          description: {type: 'string'},
+        });
+        expect(originalSchema.title).to.equal('Product');
+
+        const excludeIdAndNameSchema = getJsonSchema(Product, {
+          exclude: ['id', 'name'],
+        });
+        expect(excludeIdAndNameSchema.properties).to.deepEqual({
+          description: {type: 'string'},
+        });
+        expect(excludeIdAndNameSchema.title).to.equal(
+          'ProductExcluding[id,name]',
+        );
+      });
+
+      it('doesn\'t exclude properties when the option "exclude" is set to exclude no properties', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.properties).to.deepEqual({
+          id: {type: 'number'},
+          name: {type: 'string'},
+          description: {type: 'string'},
+        });
+        expect(originalSchema.title).to.equal('Product');
+
+        const excludeNothingSchema = getJsonSchema(Product, {exclude: []});
+        expect(excludeNothingSchema.properties).to.deepEqual({
+          id: {type: 'number'},
+          name: {type: 'string'},
+          description: {type: 'string'},
+        });
+        expect(excludeNothingSchema.title).to.equal('Product');
+      });
+    });
   });
 });

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -232,13 +232,28 @@ describe('build-schema', () => {
       expect(key).to.equal('modelPartial');
     });
 
+    it('returns "excluding[id,_rev]" when a single option "exclude" is set', () => {
+      const key = buildModelCacheKey({exclude: ['id', '_rev']});
+      expect(key).to.equal('modelExcluding[id,_rev]');
+    });
+
+    it('does not include "exclude" in concatenated option names if it is empty', () => {
+      const key = buildModelCacheKey({
+        partial: true,
+        exclude: [],
+        includeRelations: true,
+      });
+      expect(key).to.equal('modelPartialWithRelations');
+    });
+
     it('returns concatenated option names otherwise', () => {
       const key = buildModelCacheKey({
         // important: object keys are defined in reverse order
         partial: true,
+        exclude: ['id', '_rev'],
         includeRelations: true,
       });
-      expect(key).to.equal('modelPartialWithRelations');
+      expect(key).to.equal('modelPartialExcluding[id,_rev]WithRelations');
     });
   });
 });

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -15,7 +15,7 @@ import {
 import {JSONSchema6 as JSONSchema} from 'json-schema';
 import {JSON_SCHEMA_KEY, MODEL_TYPE_KEYS} from './keys';
 
-export interface JsonSchemaOptions {
+export interface JsonSchemaOptions<T extends object> {
   /**
    * Set this flag if you want the schema to define navigational properties
    * for model relations.
@@ -29,6 +29,11 @@ export interface JsonSchemaOptions {
   partial?: boolean;
 
   /**
+   * List of model properties to exclude from the schema.
+   */
+  exclude?: (keyof T)[];
+
+  /**
    * @internal
    */
   visited?: {[key: string]: JSONSchema};
@@ -37,7 +42,9 @@ export interface JsonSchemaOptions {
 /**
  * @internal
  */
-export function buildModelCacheKey(options: JsonSchemaOptions = {}): string {
+export function buildModelCacheKey<T extends object>(
+  options: JsonSchemaOptions<T> = {},
+): string {
   // Backwards compatibility: preserve cache key "modelOnly"
   if (Object.keys(options).length === 0) {
     return MODEL_TYPE_KEYS.ModelOnly;
@@ -54,9 +61,9 @@ export function buildModelCacheKey(options: JsonSchemaOptions = {}): string {
  * in a cache. If not, one is generated and then cached.
  * @param ctor - Contructor of class to get JSON Schema from
  */
-export function getJsonSchema(
+export function getJsonSchema<T extends object>(
   ctor: Function,
-  options?: JsonSchemaOptions,
+  options?: JsonSchemaOptions<T>,
 ): JSONSchema {
   // In the near future the metadata will be an object with
   // different titles as keys
@@ -107,9 +114,9 @@ export function getJsonSchema(
  * @param modelCtor - The model constructor (e.g. `Product`)
  * @param options - Additional options
  */
-export function getJsonSchemaRef(
+export function getJsonSchemaRef<T extends object>(
   modelCtor: Function,
-  options?: JsonSchemaOptions,
+  options?: JsonSchemaOptions<T>,
 ): JSONSchema {
   const schemaWithDefinitions = getJsonSchema(modelCtor, options);
   const key = schemaWithDefinitions.title;
@@ -255,14 +262,18 @@ export function getNavigationalPropertyForRelation(
   }
 }
 
-function getTitleSuffix(options: JsonSchemaOptions = {}) {
+function getTitleSuffix<T extends object>(options: JsonSchemaOptions<T> = {}) {
   let suffix = '';
   if (options.partial) {
     suffix += 'Partial';
   }
+  if (options.exclude && options.exclude.length) {
+    suffix += 'Excluding[' + options.exclude + ']';
+  }
   if (options.includeRelations) {
     suffix += 'WithRelations';
   }
+
   return suffix;
 }
 
@@ -274,9 +285,9 @@ function getTitleSuffix(options: JsonSchemaOptions = {}) {
  * reflection API
  * @param ctor - Constructor of class to convert from
  */
-export function modelToJsonSchema(
+export function modelToJsonSchema<T extends object>(
   ctor: Function,
-  jsonSchemaOptions: JsonSchemaOptions = {},
+  jsonSchemaOptions: JsonSchemaOptions<T> = {},
 ): JSONSchema {
   const options = {...jsonSchemaOptions};
   options.visited = options.visited || {};
@@ -300,6 +311,10 @@ export function modelToJsonSchema(
   }
 
   for (const p in meta.properties) {
+    if (options.exclude && options.exclude.includes(p as keyof T)) {
+      continue;
+    }
+
     if (!meta.properties[p].type) {
       continue;
     }


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/2653.

- Add `exclude` option to emit model schema excluding certain model properties.
- Update `POST` in example applications to exclude `id`.
  - Update their docs for consistency.
- Update the CLI templates to also exclude `id` from `POST` request body.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
