### PR TITLE
removed ts-lint remark, added instructions for nyc

### DIFF
--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -7,7 +7,6 @@ LoopBack 4 or other TypeScript modules, including:
   [`tsc`](https://www.typescriptlang.org/docs/handbook/compiler-options.html) to
   compile typescript files
 - lb-eslint: Run [`eslint`](https://typescript-eslint.io/)
-- lb-tslint: Run [`tslint`](https://github.com/palantir/tslint)
 - lb-prettier: Run [`prettier`](https://github.com/prettier/prettier)
 - lb-mocha: Run [`mocha`](https://mochajs.org/) to execute test cases
 - lb-nyc: Run [`nyc`](https://github.com/istanbuljs/nyc)
@@ -100,6 +99,42 @@ Now you run the scripts, such as:
 ```sh
 npm run build
 ```
+
+5. Run code coverage reports
+- lb-nyc
+
+  By default, `lb-nyc` is a plain wrapper for https://github.com/istanbuljs/nyc
+
+  To customize the configuration:
+
+  - Create `.nycrc` in your project's root
+    directory
+
+    ```json
+    {
+      "include": [
+        "dist"
+      ],
+      "exclude": [
+        "dist/__tests__/"
+      ],
+      "extension": [
+        ".js",
+        ".ts"
+      ],
+      "reporter": [
+        "text",
+        "html"
+      ],
+      "exclude-after-remap": false
+    }
+    ```
+
+  - To run code coverage with every test execution update your package.json:
+  ```json
+    "coverage": "lb-nyc",
+    "test": "npm run coverage lb-mocha \"dist/__tests__\"",
+  ```
 
 ## Contributions
 


### PR DESCRIPTION
Updating the description for `lb-nyc`. Solving #3227 
## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
