### PR TITLE
feat(repository-json-schema): add an option to make properties optional

### DIFF
--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -41,7 +41,10 @@ export class TodoListTodoController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+          schema: getModelSchemaRef(Todo, {
+            exclude: ['id'],
+            optional: ['todoListId'],
+          }),
         },
       },
     })

--- a/packages/repository-json-schema/package-lock.json
+++ b/packages/repository-json-schema/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/debug": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.4.tgz",
+			"integrity": "sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==",
+			"dev": true
+		},
 		"@types/json-schema": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
@@ -27,6 +33,14 @@
 				"uri-js": "^4.2.2"
 			}
 		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -44,6 +58,11 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"punycode": {
 			"version": "2.1.1",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -26,12 +26,14 @@
     "@loopback/context": "^1.20.2",
     "@loopback/metadata": "^1.2.5",
     "@loopback/repository": "^1.8.2",
-    "@types/json-schema": "^7.0.3"
+    "@types/json-schema": "^7.0.3",
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "@loopback/build": "^2.0.3",
     "@loopback/eslint-config": "^2.0.0",
     "@loopback/testlab": "^1.6.3",
+    "@types/debug": "^4.1.4",
     "@types/node": "^10.14.12",
     "ajv": "^6.10.2"
   },

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -983,7 +983,7 @@ describe('build-schema', () => {
         );
       });
 
-      it('doesn\'t exclude properties when the option "exclude" is set to exclude no properties', () => {
+      it(`doesn't exclude properties when the option "exclude" is set to exclude no properties`, () => {
         const originalSchema = getJsonSchema(Product);
         expect(originalSchema.properties).to.deepEqual({
           id: {type: 'number'},
@@ -999,6 +999,80 @@ describe('build-schema', () => {
           description: {type: 'string'},
         });
         expect(excludeNothingSchema.title).to.equal('Product');
+      });
+    });
+
+    context('optional properties when option "optional" is set', () => {
+      @model()
+      class Product extends Entity {
+        @property({id: true, required: true})
+        id: number;
+
+        @property({required: true})
+        name: string;
+
+        @property()
+        description: string;
+      }
+
+      it('makes one property optional when the option "optional" includes one property', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.required).to.deepEqual(['id', 'name']);
+        expect(originalSchema.title).to.equal('Product');
+
+        const optionalIdSchema = getJsonSchema(Product, {optional: ['id']});
+        expect(optionalIdSchema.required).to.deepEqual(['name']);
+        expect(optionalIdSchema.title).to.equal('ProductOptional[id]');
+      });
+
+      it('makes multiple properties optional when the option "optional" includes multiple properties', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.required).to.deepEqual(['id', 'name']);
+        expect(originalSchema.title).to.equal('Product');
+
+        const optionalIdAndNameSchema = getJsonSchema(Product, {
+          optional: ['id', 'name'],
+        });
+        expect(optionalIdAndNameSchema.required).to.equal(undefined);
+        expect(optionalIdAndNameSchema.title).to.equal(
+          'ProductOptional[id,name]',
+        );
+      });
+
+      it(`doesn't make properties optional when the option "optional" includes no properties`, () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.required).to.deepEqual(['id', 'name']);
+        expect(originalSchema.title).to.equal('Product');
+
+        const optionalNothingSchema = getJsonSchema(Product, {optional: []});
+        expect(optionalNothingSchema.required).to.deepEqual(['id', 'name']);
+        expect(optionalNothingSchema.title).to.equal('Product');
+      });
+
+      it('overrides "partial" option when "optional" options is set', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.required).to.deepEqual(['id', 'name']);
+        expect(originalSchema.title).to.equal('Product');
+
+        const optionalNameSchema = getJsonSchema(Product, {
+          partial: true,
+          optional: ['name'],
+        });
+        expect(optionalNameSchema.required).to.deepEqual(['id']);
+        expect(optionalNameSchema.title).to.equal('ProductOptional[name]');
+      });
+
+      it('uses "partial" option, if provided, when "optional" options is set but empty', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.required).to.deepEqual(['id', 'name']);
+        expect(originalSchema.title).to.equal('Product');
+
+        const optionalNameSchema = getJsonSchema(Product, {
+          partial: true,
+          optional: [],
+        });
+        expect(optionalNameSchema.required).to.equal(undefined);
+        expect(optionalNameSchema.title).to.equal('ProductPartial');
       });
     });
   });

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -246,14 +246,47 @@ describe('build-schema', () => {
       expect(key).to.equal('modelPartialWithRelations');
     });
 
-    it('returns concatenated option names otherwise', () => {
+    it('returns "optional[id,_rev]" when "optional" is set with two items', () => {
+      const key = buildModelCacheKey({optional: ['id', '_rev']});
+      expect(key).to.equal('modelOptional[id,_rev]');
+    });
+
+    it('does not include "optional" in concatenated option names if it is empty', () => {
+      const key = buildModelCacheKey({
+        partial: true,
+        optional: [],
+        includeRelations: true,
+      });
+      expect(key).to.equal('modelPartialWithRelations');
+    });
+
+    it('does not include "partial" in option names if "optional" is not empty', () => {
+      const key = buildModelCacheKey({
+        partial: true,
+        optional: ['name'],
+      });
+      expect(key).to.equal('modelOptional[name]');
+    });
+
+    it('includes "partial" in option names if "optional" is empty', () => {
+      const key = buildModelCacheKey({
+        partial: true,
+        optional: [],
+      });
+      expect(key).to.equal('modelPartial');
+    });
+
+    it('returns concatenated option names except "partial" otherwise', () => {
       const key = buildModelCacheKey({
         // important: object keys are defined in reverse order
         partial: true,
         exclude: ['id', '_rev'],
+        optional: ['name'],
         includeRelations: true,
       });
-      expect(key).to.equal('modelPartialExcluding[id,_rev]WithRelations');
+      expect(key).to.equal(
+        'modelOptional[name]Excluding[id,_rev]WithRelations',
+      );
     });
   });
 });


### PR DESCRIPTION
Add a new option `optional: []` so that `getJsonSchema` and related helpers can request a model schema that marks specified properties as optional

Connect to https://github.com/strongloop/loopback-next/issues/2653

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
