### PR TITLE
chore: fix a typo in GITHUB bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -28,7 +28,7 @@ Please fill in the *entire* template below.
 
 <!-- Describe what did you expect instead, what is the desired outcome? -->
 
-## Link to reproduction sanbox
+## Link to reproduction sandbox
 
 <!-- See https://loopback.io/doc/en/contrib/Reporting-issues.html#loopback-4x-bugs  -->
 


### PR DESCRIPTION
fix the spelling of "sandbox" the 'd' was missing

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
