### PR TITLE
feat(context): allow @config.* to specify the target binding key

### DIFF
--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -599,9 +599,9 @@ export class RestServer {
 }
 ```
 
-The `@config.*` decorators can take an optional `configPath` parameter to allow
-the configuration value to be a deep property of the bound value. For example,
-`@config('port')` injects `RestServerConfig.port` to the target.
+The `@config.*` decorators can take an optional `propertyPath` parameter to
+allow the configuration value to be a deep property of the bound value. For
+example, `@config('port')` injects `RestServerConfig.port` to the target.
 
 ```ts
 export class MyRestServer {
@@ -609,6 +609,25 @@ export class MyRestServer {
     @config('host')
     host: string,
     @config('port')
+    port: number,
+  ) {
+    // ...
+  }
+  // ...
+}
+```
+
+We also allow `@config.*` to be resolved from another binding than the current
+one:
+
+```ts
+export class MyRestServer {
+  constructor(
+    // Inject the `rest.host` from the application config
+    @config({fromBinding: 'application', propertyPath: 'rest.host'})
+    host: string,
+    // Inject the `rest.port` from the application config
+    @config({fromBinding: 'application', propertyPath: 'rest.port'})
     port: number,
   ) {
     // ...

--- a/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
@@ -767,7 +767,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.optionXY).to.eql('y');
   });
 
-  it('injects config if the configPath is not present', () => {
+  it('injects config if the propertyPath is not present', () => {
     class Store {
       constructor(@config() public configObj: object) {}
     }
@@ -778,7 +778,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.configObj).to.eql({x: 1, y: 'a'});
   });
 
-  it("injects config if the configPath is ''", () => {
+  it("injects config if the propertyPath is ''", () => {
     class Store {
       constructor(@config('') public configObj: object) {}
     }
@@ -789,7 +789,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.configObj).to.eql({x: 1, y: 'a'});
   });
 
-  it('injects config with configPath', () => {
+  it('injects config with propertyPath', () => {
     class Store {
       constructor(@config('x') public optionX: number) {}
     }
@@ -800,7 +800,7 @@ describe('Context bindings - Injecting dependencies of classes', () => {
     expect(store.optionX).to.eql(1);
   });
 
-  it('injects undefined option if configPath not found', () => {
+  it('injects undefined option if propertyPath not found', () => {
     class Store {
       constructor(@config('not-exist') public option: string | undefined) {}
     }

--- a/packages/context/src/__tests__/unit/context-config.unit.ts
+++ b/packages/context/src/__tests__/unit/context-config.unit.ts
@@ -56,7 +56,7 @@ describe('Context binding configuration', () => {
       expect(await ctx.getConfig('foo')).to.eql({x: 1});
     });
 
-    it('gets config for a binding with configPath', async () => {
+    it('gets config for a binding with propertyPath', async () => {
       ctx
         .configure('foo')
         .toDynamicValue(() => Promise.resolve({a: {x: 0, y: 0}}));
@@ -91,7 +91,7 @@ describe('Context binding configuration', () => {
       expect(ctx.getConfigSync('foo')).to.eql({x: 1});
     });
 
-    it('gets config for a binding with configPath', () => {
+    it('gets config for a binding with propertyPath', () => {
       ctx.configure('foo').to({x: 1});
       expect(ctx.getConfigSync('foo', 'x')).to.eql(1);
       expect(ctx.getConfigSync('foo', 'y')).to.be.undefined();
@@ -109,7 +109,7 @@ describe('Context binding configuration', () => {
     class MyConfigResolver implements ConfigurationResolver {
       getConfigAsValueOrPromise<ConfigValueType>(
         key: BindingAddress<unknown>,
-        configPath?: string,
+        propertyPath?: string,
         resolutionOptions?: ResolutionOptions,
       ): ValueOrPromise<ConfigValueType | undefined> {
         return (`Dummy config for ${key}` as unknown) as ConfigValueType;

--- a/packages/context/src/binding-config.ts
+++ b/packages/context/src/binding-config.ts
@@ -21,7 +21,7 @@ export interface ConfigurationResolver {
    * Resolve config for the binding key
    *
    * @param key - Binding key
-   * @param configPath - Property path for the option. For example, `x.y`
+   * @param propertyPath - Property path for the option. For example, `x.y`
    * requests for `<config>.x.y`. If not set, the `config` object will be
    * returned.
    * @param resolutionOptions - Options for the resolution.
@@ -30,7 +30,7 @@ export interface ConfigurationResolver {
    */
   getConfigAsValueOrPromise<ConfigValueType>(
     key: BindingAddress<unknown>,
-    configPath?: string,
+    propertyPath?: string,
     resolutionOptions?: ResolutionOptions,
   ): ValueOrPromise<ConfigValueType | undefined>;
 }
@@ -43,11 +43,11 @@ export class DefaultConfigurationResolver implements ConfigurationResolver {
 
   getConfigAsValueOrPromise<ConfigValueType>(
     key: BindingAddress<unknown>,
-    configPath?: string,
+    propertyPath?: string,
     resolutionOptions?: ResolutionOptions,
   ): ValueOrPromise<ConfigValueType | undefined> {
-    configPath = configPath || '';
-    const configKey = configBindingKeyFor(key, configPath);
+    propertyPath = propertyPath || '';
+    const configKey = configBindingKeyFor(key, propertyPath);
 
     const options: ResolutionOptions = Object.assign(
       {optional: true},
@@ -60,14 +60,14 @@ export class DefaultConfigurationResolver implements ConfigurationResolver {
 /**
  * Create binding key for configuration of the binding
  * @param key - Binding key for the target binding
- * @param configPath - Property path for the configuration
+ * @param propertyPath - Property path for the configuration
  */
 export function configBindingKeyFor<ConfigValueType = unknown>(
   key: BindingAddress,
-  configPath?: string,
+  propertyPath?: string,
 ) {
   return BindingKey.create<ConfigValueType>(
     BindingKey.buildKeyForConfig<ConfigValueType>(key).toString(),
-    configPath,
+    propertyPath,
   );
 }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -384,7 +384,7 @@ export class Context extends EventEmitter {
    * Get the value or promise of configuration for a given binding by key
    *
    * @param key - Binding key
-   * @param configPath - Property path for the option. For example, `x.y`
+   * @param propertyPath - Property path for the option. For example, `x.y`
    * requests for `<config>.x.y`. If not set, the `<config>` object will be
    * returned.
    * @param resolutionOptions - Options for the resolution.
@@ -393,13 +393,13 @@ export class Context extends EventEmitter {
    */
   getConfigAsValueOrPromise<ConfigValueType>(
     key: BindingAddress,
-    configPath?: string,
+    propertyPath?: string,
     resolutionOptions?: ResolutionOptions,
   ): ValueOrPromise<ConfigValueType | undefined> {
     this.setupConfigurationResolverIfNeeded();
     return this.configResolver.getConfigAsValueOrPromise(
       key,
-      configPath,
+      propertyPath,
       resolutionOptions,
     );
   }
@@ -435,19 +435,19 @@ export class Context extends EventEmitter {
    * Resolve configuration for the binding by key
    *
    * @param key - Binding key
-   * @param configPath - Property path for the option. For example, `x.y`
+   * @param propertyPath - Property path for the option. For example, `x.y`
    * requests for `<config>.x.y`. If not set, the `<config>` object will be
    * returned.
    * @param resolutionOptions - Options for the resolution.
    */
   async getConfig<ConfigValueType>(
     key: BindingAddress,
-    configPath?: string,
+    propertyPath?: string,
     resolutionOptions?: ResolutionOptions,
   ): Promise<ConfigValueType | undefined> {
     return await this.getConfigAsValueOrPromise<ConfigValueType>(
       key,
-      configPath,
+      propertyPath,
       resolutionOptions,
     );
   }
@@ -456,23 +456,23 @@ export class Context extends EventEmitter {
    * Resolve configuration synchronously for the binding by key
    *
    * @param key - Binding key
-   * @param configPath - Property path for the option. For example, `x.y`
+   * @param propertyPath - Property path for the option. For example, `x.y`
    * requests for `config.x.y`. If not set, the `config` object will be
    * returned.
    * @param resolutionOptions - Options for the resolution.
    */
   getConfigSync<ConfigValueType>(
     key: BindingAddress,
-    configPath?: string,
+    propertyPath?: string,
     resolutionOptions?: ResolutionOptions,
   ): ConfigValueType | undefined {
     const valueOrPromise = this.getConfigAsValueOrPromise<ConfigValueType>(
       key,
-      configPath,
+      propertyPath,
       resolutionOptions,
     );
     if (isPromiseLike(valueOrPromise)) {
-      const prop = configPath ? ` property ${configPath}` : '';
+      const prop = propertyPath ? ` property ${propertyPath}` : '';
       throw new Error(
         `Cannot get config${prop} for ${key} synchronously: the value is a promise`,
       );


### PR DESCRIPTION
Sometimes we want to inject configuration from another binding instead of
the current one.

This PR allows the following config injections:

```ts
@config({targetBindingKey: 'parent', configPath: 'child1'})
@config.getter({targetBindingKey: 'parent', configPath: 'child2'})
@config({targetBindingKey: 'anotherBinding'})
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
