### PR TITLE
docs: fix image links in READMEs when showing in npmjs.com

### DIFF
--- a/examples/greeter-extension/README.md
+++ b/examples/greeter-extension/README.md
@@ -16,7 +16,7 @@ We'll use the following scenario to walk through important steps to organize the
 `greet` service that allows extensible languages - each of them being supported
 by a `Greeter` extension.
 
-![greeters](greeters.png)
+![greeters](https://raw.githubusercontent.com/strongloop/loopback-next/master/examples/greeter-extension/greeters.png)
 
 Various constructs from LoopBack 4, such as `Context`, `@inject.*`, and
 `Component` are used to build the service in an extensible fashion.

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -4,7 +4,7 @@ A LoopBack 4 component for authentication support.
 
 ## Overview
 
-![AuthenticationComponent](./docs/imgs/authentication_overview_highlevel.png)
+![AuthenticationComponent](https://raw.githubusercontent.com/strongloop/loopback-next/master/packages/authentication/docs/imgs/authentication_overview_highlevel.png)
 
 This component contains the core logic for the authentication layer in
 LoopBack 4.


### PR DESCRIPTION
Fixes #3319 
Fixes the broken link on npmjs.com for authentication and example-greeter-extension.
