### PR TITLE
Update API Docs and test to show that "optional" takes precedence over "partial"

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -1049,20 +1049,27 @@ describe('build-schema', () => {
         expect(optionalNothingSchema.title).to.equal('Product');
       });
 
-      it('overrides "partial" option when "optional" options is set', () => {
+      it('overrides "partial" option when "optional" option is set', () => {
         const originalSchema = getJsonSchema(Product);
         expect(originalSchema.required).to.deepEqual(['id', 'name']);
         expect(originalSchema.title).to.equal('Product');
 
-        const optionalNameSchema = getJsonSchema(Product, {
+        let optionalNameSchema = getJsonSchema(Product, {
           partial: true,
+          optional: ['name'],
+        });
+        expect(optionalNameSchema.required).to.deepEqual(['id']);
+        expect(optionalNameSchema.title).to.equal('ProductOptional[name]');
+
+        optionalNameSchema = getJsonSchema(Product, {
+          partial: false,
           optional: ['name'],
         });
         expect(optionalNameSchema.required).to.deepEqual(['id']);
         expect(optionalNameSchema.title).to.equal('ProductOptional[name]');
       });
 
-      it('uses "partial" option, if provided, when "optional" options is set but empty', () => {
+      it('uses "partial" option, if provided, when "optional" option is set but empty', () => {
         const originalSchema = getJsonSchema(Product);
         expect(originalSchema.required).to.deepEqual(['id', 'name']);
         expect(originalSchema.title).to.equal('Product');

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -26,7 +26,8 @@ export interface JsonSchemaOptions<T extends object> {
 
   /**
    * Set this flag to mark all model properties as optional. This is typically
-   * used to describe request body of PATCH endpoints.
+   * used to describe request body of PATCH endpoints. This option will be
+   * overridden by the "optional" option if it is set and non-empty.
    */
   partial?: boolean;
 
@@ -36,7 +37,8 @@ export interface JsonSchemaOptions<T extends object> {
   exclude?: (keyof T)[];
 
   /**
-   * List of model properties to mark as optional.
+   * List of model properties to mark as optional. Overrides the "partial"
+   * option if it is not empty.
    */
   optional?: (keyof T)[];
 


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/pull/3309#pullrequestreview-262253508.

- Explain in API docs that the "partial" option is overridden by the "optional" option. 
- Test that `partial` is still overridden when it is set to false

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
