### PR TITLE
feat(repository): add static method Entity.getIdProperties()

### DIFF
--- a/packages/repository/src/__tests__/unit/model/model.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/model.unit.ts
@@ -395,6 +395,11 @@ describe('model', () => {
     expect(() => instance.getId()).to.throw(/missing.*id/);
   });
 
+  it('gets id names via a static method', () => {
+    const names = Customer.getIdProperties();
+    expect(names).to.deepEqual(['id']);
+  });
+
   it('reads model name from the definition', () => {
     expect(Customer.modelName).to.equal('Customer');
   });

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -264,6 +264,13 @@ export abstract class ValueObject extends Model implements Persistable {}
  */
 export abstract class Entity extends Model implements Persistable {
   /**
+   * Get the names of identity properties (primary keys).
+   */
+  static getIdProperties(): string[] {
+    return this.definition.idProperties();
+  }
+
+  /**
    * Get the identity value for a given entity instance or entity data object.
    *
    * @param entityOrData - The data object for which to determine the identity


### PR DESCRIPTION
While working on a spike for "Resolve included models", I discovered a need to access the list of id properties via model class constructor (no model instance is available).

In this pull request, I am adding such API.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
