### PR TITLE
fix(cli): rearrange interceptor cli prompts

### DIFF
--- a/packages/cli/generators/interceptor/index.js
+++ b/packages/cli/generators/interceptor/index.js
@@ -125,13 +125,17 @@ module.exports = class InterceptorGenerator extends ArtifactGenerator {
       'Global interceptors are sorted by the order of an array of' +
       ' group names bound to ContextBindings.GLOBAL_INTERCEPTOR_ORDERED_GROUPS.' +
       ' See https://loopback.io/doc/en/lb4/Interceptors.html#order-of-invocation-for-interceptors.';
+
+    this.log();
+    this.log(note);
+    this.log();
+
     const prompts = [
       {
         type: 'input',
         name: 'group',
         // capitalization
-        message: `${note}
-Group name for the global interceptor: ('')`,
+        message: `Group name for the global interceptor: ('')`,
       },
     ];
     return this.prompt(prompts).then(props => {


### PR DESCRIPTION
Fixes #3374 

Changes proposed by @bajtos:

- Print the information about group names as a regular text (not a prompt).
- Possibly wrap the long line at 80 chars so that it's consistently rendered everywhere.
- The prompt should ask about the group name only, so that the question mark is printed at the beginning of the prompt line.

The output now is:
```
$ lb4 interceptor
? Interceptor name: interceptor1
? Is it a global interceptor? Yes

Global interceptors are sorted by the order of an array of group names bound to ContextBindings.GLOBAL_INTERCEPTOR_ORDERED_GROUPS. See https://loopback.io/doc/en/lb4/Interceptors.html#order-of-invocation-for-interceptors.

? Group name for the global interceptor: ('') 
   create src/interceptors/interceptor1.interceptor.ts
   update src/interceptors/index.ts

Interceptor Interceptor1 was created in src/interceptors/
```

The message "Global interceptors are ..." seem to be wrapped automatically. 

Note: the spaces around the bracket in the PR were added automatically. 

cc @bajtos 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
