### PR TITLE
feat(context): use invocation context for method dependency injection

### DIFF
--- a/packages/context/src/__tests__/unit/invocation-context.unit.ts
+++ b/packages/context/src/__tests__/unit/invocation-context.unit.ts
@@ -4,11 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context, InvocationContext} from '../..';
+import {Context, inject, InvocationContext} from '../..';
 
 describe('InvocationContext', () => {
   let ctx: Context;
   let invocationCtxForGreet: InvocationContext;
+  let invocationCtxForHello: InvocationContext;
   let invocationCtxForCheckName: InvocationContext;
   let invalidInvocationCtx: InvocationContext;
   let invalidInvocationCtxForStaticMethod: InvocationContext;
@@ -60,6 +61,14 @@ describe('InvocationContext', () => {
     expect(invocationCtxForCheckName.invokeTargetMethod()).to.eql(true);
   });
 
+  it('invokes target method with injection', async () => {
+    expect(
+      await invocationCtxForHello.invokeTargetMethod({
+        skipParameterInjection: false,
+      }),
+    ).to.eql('Hello, Jane');
+  });
+
   it('does not close when an interceptor is in processing', () => {
     const result = invocationCtxForGreet.invokeTargetMethod();
     expect(invocationCtxForGreet.isBound('abc'));
@@ -73,6 +82,10 @@ describe('InvocationContext', () => {
     }
 
     async greet(name: string) {
+      return `Hello, ${name}`;
+    }
+
+    async hello(@inject('name') name: string) {
       return `Hello, ${name}`;
     }
   }
@@ -89,6 +102,14 @@ describe('InvocationContext', () => {
       'greet',
       ['John'],
     );
+
+    invocationCtxForHello = new InvocationContext(
+      ctx,
+      new MyController(),
+      'hello',
+      [],
+    );
+    invocationCtxForHello.bind('name').to('Jane');
 
     invocationCtxForCheckName = new InvocationContext(
       ctx,


### PR DESCRIPTION
Use case: interceptors may add or change bindings to influence how the
method parameter injection is resolved.

The current implementation does not use the invocation context to resolve parameter injection. As a result, interceptors cannot rebind new values.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
