### PR TITLE
refactor: extract helpers resolving relation metadata into own files

### DIFF
--- a/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
@@ -5,11 +5,10 @@
 
 import * as debugFactory from 'debug';
 import {DataObject} from '../../common-types';
-import {InvalidRelationError} from '../../errors';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories/repository';
-import {isTypeResolver} from '../../type-resolver';
 import {BelongsToDefinition, Getter} from '../relation.types';
+import {resolveBelongsToMetadata} from './belongs-to.helpers';
 import {DefaultBelongsToRepository} from './belongs-to.repository';
 
 const debug = debugFactory('loopback:repository:belongs-to-accessor');
@@ -46,50 +45,4 @@ export function createBelongsToAccessor<
     );
     return constrainedRepo.get();
   };
-}
-
-type BelongsToResolvedDefinition = BelongsToDefinition & {keyTo: string};
-
-/**
- * Resolves given belongsTo metadata if target is specified to be a resolver.
- * Mainly used to infer what the `keyTo` property should be from the target's
- * property id metadata
- * @param relationMeta - belongsTo metadata to resolve
- */
-function resolveBelongsToMetadata(relationMeta: BelongsToDefinition) {
-  if (!isTypeResolver(relationMeta.target)) {
-    const reason = 'target must be a type resolver';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  if (!relationMeta.keyFrom) {
-    const reason = 'keyFrom is required';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  const sourceModel = relationMeta.source;
-  if (!sourceModel || !sourceModel.modelName) {
-    const reason = 'source model must be defined';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  const targetModel = relationMeta.target();
-  const targetName = targetModel.modelName;
-  debug('Resolved model %s from given metadata: %o', targetName, targetModel);
-
-  const targetProperties = targetModel.definition.properties;
-  debug('relation metadata from %o: %o', targetName, targetProperties);
-
-  if (relationMeta.keyTo && targetProperties[relationMeta.keyTo]) {
-    // The explict cast is needed because of a limitation of type inference
-    return relationMeta as BelongsToResolvedDefinition;
-  }
-
-  const targetPrimaryKey = targetModel.definition.idProperties()[0];
-  if (!targetPrimaryKey) {
-    const reason = `${targetName} does not have any primary key (id property)`;
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  return Object.assign(relationMeta, {keyTo: targetPrimaryKey});
 }

--- a/packages/repository/src/relations/belongs-to/belongs-to.helpers.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.helpers.ts
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+import * as debugFactory from 'debug';
+import {InvalidRelationError} from '../../errors';
+import {isTypeResolver} from '../../type-resolver';
+import {BelongsToDefinition} from '../relation.types';
+
+const debug = debugFactory('loopback:repository:belongs-to-helpers');
+
+/**
+ * Relation definition with optional metadata (e.g. `keyTo`) filled in.
+ * @internal
+ */
+export type BelongsToResolvedDefinition = BelongsToDefinition & {keyTo: string};
+
+/**
+ * Resolves given belongsTo metadata if target is specified to be a resolver.
+ * Mainly used to infer what the `keyTo` property should be from the target's
+ * property id metadata
+ * @param relationMeta - belongsTo metadata to resolve
+ * @internal
+ */
+export function resolveBelongsToMetadata(relationMeta: BelongsToDefinition) {
+  if (!isTypeResolver(relationMeta.target)) {
+    const reason = 'target must be a type resolver';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  if (!relationMeta.keyFrom) {
+    const reason = 'keyFrom is required';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const sourceModel = relationMeta.source;
+  if (!sourceModel || !sourceModel.modelName) {
+    const reason = 'source model must be defined';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const targetModel = relationMeta.target();
+  const targetName = targetModel.modelName;
+  debug('Resolved model %s from given metadata: %o', targetName, targetModel);
+
+  const targetProperties = targetModel.definition.properties;
+  debug('relation metadata from %o: %o', targetName, targetProperties);
+
+  if (relationMeta.keyTo && targetProperties[relationMeta.keyTo]) {
+    // The explicit cast is needed because of a limitation of type inference
+    return relationMeta as BelongsToResolvedDefinition;
+  }
+
+  const targetPrimaryKey = targetModel.definition.idProperties()[0];
+  if (!targetPrimaryKey) {
+    const reason = `${targetName} does not have any primary key (id property)`;
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  return Object.assign(relationMeta, {keyTo: targetPrimaryKey});
+}

--- a/packages/repository/src/relations/has-many/has-many-repository.factory.ts
+++ b/packages/repository/src/relations/has-many/has-many-repository.factory.ts
@@ -4,13 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import * as debugFactory from 'debug';
-import {camelCase} from 'lodash';
 import {DataObject} from '../../common-types';
-import {InvalidRelationError} from '../../errors';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories/repository';
-import {isTypeResolver} from '../../type-resolver';
 import {Getter, HasManyDefinition} from '../relation.types';
+import {resolveHasManyMetadata} from './has-many.helpers';
 import {
   DefaultHasManyRepository,
   HasManyRepository,
@@ -54,53 +52,4 @@ export function createHasManyRepositoryFactory<
       EntityCrudRepository<Target, TargetID>
     >(targetRepositoryGetter, constraint as DataObject<Target>);
   };
-}
-
-type HasManyResolvedDefinition = HasManyDefinition & {keyTo: string};
-
-/**
- * Resolves given hasMany metadata if target is specified to be a resolver.
- * Mainly used to infer what the `keyTo` property should be from the target's
- * belongsTo metadata
- * @param relationMeta - hasMany metadata to resolve
- */
-function resolveHasManyMetadata(
-  relationMeta: HasManyDefinition,
-): HasManyResolvedDefinition {
-  if (!isTypeResolver(relationMeta.target)) {
-    const reason = 'target must be a type resolver';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  const targetModel = relationMeta.target();
-  const targetModelProperties =
-    targetModel.definition && targetModel.definition.properties;
-
-  // Make sure that if it already keys to the foreign key property,
-  // the key exists in the target model
-  if (relationMeta.keyTo && targetModelProperties[relationMeta.keyTo]) {
-    // The explict cast is needed because of a limitation of type inference
-    return relationMeta as HasManyResolvedDefinition;
-  }
-
-  const sourceModel = relationMeta.source;
-  if (!sourceModel || !sourceModel.modelName) {
-    const reason = 'source model must be defined';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  debug(
-    'Resolved model %s from given metadata: %o',
-    targetModel.modelName,
-    targetModel,
-  );
-  const defaultFkName = camelCase(sourceModel.modelName + '_id');
-  const hasDefaultFkProperty = targetModelProperties[defaultFkName];
-
-  if (!hasDefaultFkProperty) {
-    const reason = `target model ${targetModel.name} is missing definition of foreign key ${defaultFkName}`;
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  return Object.assign(relationMeta, {keyTo: defaultFkName});
 }

--- a/packages/repository/src/relations/has-many/has-many.helpers.ts
+++ b/packages/repository/src/relations/has-many/has-many.helpers.ts
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as debugFactory from 'debug';
+import {camelCase} from 'lodash';
+import {InvalidRelationError} from '../../errors';
+import {isTypeResolver} from '../../type-resolver';
+import {HasManyDefinition} from '../relation.types';
+
+const debug = debugFactory('loopback:repository:has-many-helpers');
+
+/**
+ * Relation definition with optional metadata (e.g. `keyTo`) filled in.
+ * @internal
+ */
+export type HasManyResolvedDefinition = HasManyDefinition & {keyTo: string};
+
+/**
+ * Resolves given hasMany metadata if target is specified to be a resolver.
+ * Mainly used to infer what the `keyTo` property should be from the target's
+ * belongsTo metadata
+ * @param relationMeta - hasMany metadata to resolve
+ * @internal
+ */
+export function resolveHasManyMetadata(
+  relationMeta: HasManyDefinition,
+): HasManyResolvedDefinition {
+  if (!isTypeResolver(relationMeta.target)) {
+    const reason = 'target must be a type resolver';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const targetModel = relationMeta.target();
+  const targetModelProperties =
+    targetModel.definition && targetModel.definition.properties;
+
+  // Make sure that if it already keys to the foreign key property,
+  // the key exists in the target model
+  if (relationMeta.keyTo && targetModelProperties[relationMeta.keyTo]) {
+    // The explicit cast is needed because of a limitation of type inference
+    return relationMeta as HasManyResolvedDefinition;
+  }
+
+  const sourceModel = relationMeta.source;
+  if (!sourceModel || !sourceModel.modelName) {
+    const reason = 'source model must be defined';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  debug(
+    'Resolved model %s from given metadata: %o',
+    targetModel.modelName,
+    targetModel,
+  );
+  const defaultFkName = camelCase(sourceModel.modelName + '_id');
+  const hasDefaultFkProperty = targetModelProperties[defaultFkName];
+
+  if (!hasDefaultFkProperty) {
+    const reason = `target model ${targetModel.name} is missing definition of foreign key ${defaultFkName}`;
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  return Object.assign(relationMeta, {keyTo: defaultFkName});
+}

--- a/packages/repository/src/relations/has-one/has-one.helpers.ts
+++ b/packages/repository/src/relations/has-one/has-one.helpers.ts
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as debugFactory from 'debug';
+import {camelCase} from 'lodash';
+import {InvalidRelationError} from '../../errors';
+import {isTypeResolver} from '../../type-resolver';
+import {HasOneDefinition} from '../relation.types';
+
+const debug = debugFactory('loopback:repository:has-one-helpers');
+
+/**
+ * Relation definition with optional metadata (e.g. `keyTo`) filled in.
+ * @internal
+ */
+export type HasOneResolvedDefinition = HasOneDefinition & {keyTo: string};
+
+/**
+ * Resolves given hasOne metadata if target is specified to be a resolver.
+ * Mainly used to infer what the `keyTo` property should be from the target's
+ * hasOne metadata
+ * @param relationMeta - hasOne metadata to resolve
+ * @internal
+ */
+export function resolveHasOneMetadata(
+  relationMeta: HasOneDefinition,
+): HasOneResolvedDefinition {
+  if (!isTypeResolver(relationMeta.target)) {
+    const reason = 'target must be a type resolver';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const targetModel = relationMeta.target();
+  const targetModelProperties =
+    targetModel.definition && targetModel.definition.properties;
+
+  // Make sure that if it already keys to the foreign key property,
+  // the key exists in the target model
+  if (relationMeta.keyTo && targetModelProperties[relationMeta.keyTo]) {
+    // The explicit cast is needed because of a limitation of type inference
+    return relationMeta as HasOneResolvedDefinition;
+  }
+
+  const sourceModel = relationMeta.source;
+  if (!sourceModel || !sourceModel.modelName) {
+    const reason = 'source model must be defined';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  debug(
+    'Resolved model %s from given metadata: %o',
+    targetModel.modelName,
+    targetModel,
+  );
+  const defaultFkName = camelCase(sourceModel.modelName + '_id');
+  const hasDefaultFkProperty = targetModelProperties[defaultFkName];
+
+  if (!hasDefaultFkProperty) {
+    const reason = `target model ${targetModel.name} is missing definition of foreign key ${defaultFkName}`;
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  return Object.assign(relationMeta, {keyTo: defaultFkName});
+}


### PR DESCRIPTION
In https://github.com/strongloop/loopback-next/pull/3387 (spike for Inclusion of related models), I found a need to access resolved relation metadata from other files than just the repository factory. At the same time, I'd like to keep resolved metadata internal and don't export it from `@loopback/repository`, at least for now.

In this pull request, I am adding three new files (`belongs-to.helpers.ts`, `has-many.helpers.ts` and `has-one.helpers.ts`) and moving code related to resolution of relational metadata into these new files.

This pull request is a pure refactoring with no impact on our users.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈