### PR TITLE
Rename CrudConnectorFeatures to CrudFeatures

### DIFF
--- a/acceptance/repository-mongodb/src/__tests__/mongodb.datasource.ts
+++ b/acceptance/repository-mongodb/src/__tests__/mongodb.datasource.ts
@@ -3,10 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  CrudConnectorFeatures,
-  DataSourceOptions,
-} from '@loopback/repository-tests';
+import {CrudFeatures, DataSourceOptions} from '@loopback/repository-tests';
 
 const connector = require('loopback-connector-mongodb');
 
@@ -17,6 +14,6 @@ export const MONGODB_CONFIG: DataSourceOptions = {
   database: process.env.MONGODB_DATABASE || 'repository-tests',
 };
 
-export const MONGODB_FEATURES: Partial<CrudConnectorFeatures> = {
+export const MONGODB_FEATURES: Partial<CrudFeatures> = {
   idType: 'string',
 };

--- a/acceptance/repository-mysql/src/__tests__/mysql.datasource.ts
+++ b/acceptance/repository-mysql/src/__tests__/mysql.datasource.ts
@@ -3,10 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  CrudConnectorFeatures,
-  DataSourceOptions,
-} from '@loopback/repository-tests';
+import {CrudFeatures, DataSourceOptions} from '@loopback/repository-tests';
 
 const connector = require('loopback-connector-mysql');
 
@@ -20,7 +17,7 @@ export const MYSQL_CONFIG: DataSourceOptions = {
   createDatabase: true,
 };
 
-export const MYSQL_FEATURES: Partial<CrudConnectorFeatures> = {
+export const MYSQL_FEATURES: Partial<CrudFeatures> = {
   idType: 'number',
   freeFormProperties: false,
 };

--- a/packages/repository-tests/src/crud-test-suite.ts
+++ b/packages/repository-tests/src/crud-test-suite.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {withCrudCtx} from './helpers.repository-tests';
 import {
-  CrudConnectorFeatures,
+  CrudFeatures,
   CrudRepositoryCtor,
   CrudTestContext,
   DataSourceOptions,
@@ -20,15 +20,15 @@ const debug = debugFactory('loopback:repository-tests');
 type SuiteFn = (
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: CrudConnectorFeatures,
+  connectorFeatures: CrudFeatures,
 ) => void;
 
 export function crudRepositoryTestSuite(
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: Partial<CrudConnectorFeatures>,
+  connectorFeatures: Partial<CrudFeatures>,
 ) {
-  const features: CrudConnectorFeatures = {
+  const features: CrudFeatures = {
     idType: 'string',
     freeFormProperties: true,
     ...connectorFeatures,

--- a/packages/repository-tests/src/crud/create-retrieve.suite.ts
+++ b/packages/repository-tests/src/crud/create-retrieve.suite.ts
@@ -8,7 +8,7 @@ import {EntityCrudRepository} from '@loopback/repository/src';
 import {expect, toJSON} from '@loopback/testlab';
 import {withCrudCtx} from '../helpers.repository-tests';
 import {
-  CrudConnectorFeatures,
+  CrudFeatures,
   CrudRepositoryCtor,
   CrudTestContext,
   DataSourceOptions,
@@ -19,7 +19,7 @@ import {
 export function createRetrieveSuite(
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: CrudConnectorFeatures,
+  connectorFeatures: CrudFeatures,
 ) {
   @model()
   class Product extends Entity {

--- a/packages/repository-tests/src/crud/freeform-properties.suite.ts
+++ b/packages/repository-tests/src/crud/freeform-properties.suite.ts
@@ -9,7 +9,7 @@ import {expect, skipIf, toJSON} from '@loopback/testlab';
 import {Suite} from 'mocha';
 import {withCrudCtx} from '../helpers.repository-tests';
 import {
-  CrudConnectorFeatures,
+  CrudFeatures,
   CrudRepositoryCtor,
   CrudTestContext,
   DataSourceOptions,
@@ -18,7 +18,7 @@ import {
 export function freeformPropertiesSuite(
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: CrudConnectorFeatures,
+  connectorFeatures: CrudFeatures,
 ) {
   skipIf<[(this: Suite) => void], void>(
     !connectorFeatures.freeFormProperties,

--- a/packages/repository-tests/src/types.repository-tests.ts
+++ b/packages/repository-tests/src/types.repository-tests.ts
@@ -16,11 +16,11 @@ import {
 export type DataSourceOptions = Options;
 
 /**
- * List of flags describing connector-specific behavior. These flags
- * are used by the test suite to tweak assertions and skip tests
- * for scenarios not supported by some connectors.
+ * List of flags describing behavior specific to different connectors and
+ * repository implementations. These flags are used by the test suite to tweak
+ * assertions and skip tests for scenarios not supported by some implementations.
  */
-export interface CrudConnectorFeatures {
+export interface CrudFeatures {
   /**
    * What type is used for auto-generated primary keys?
    * - SQL databases typically use auto-incremented numbers,
@@ -60,6 +60,6 @@ export type CrudRepositoryCtor = new <
 export interface CrudTestContext {
   dataSourceOptions: DataSourceOptions;
   repositoryClass: CrudRepositoryCtor;
-  connectorFeatures: CrudConnectorFeatures;
+  connectorFeatures: CrudFeatures;
   dataSource: juggler.DataSource;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "extends": "./packages/build/config/tsconfig.common.json",
   "include": [
+    "acceptance",
     "benchmark",
     "examples",
     "packages"
   ],
   "exclude": [
     "node_modules/**",
+    "acceptance/node_modules/**",
     "benchmark/node_modules/**",
     "examples/*/node_modules/**",
     "packages/*/node_modules/**",


### PR DESCRIPTION
In the future (see #3387), we are likely to add options that are specific to different Repository implementations, in addition to connector-specific options. Let's rename the interface to describe this enlarged scope.

The second commit adds "acceptance" packages like `acceptance/repository-mongodb` to `tsconfig.json` used by VSCode. Before this change, refactor-rename was not applied to packages in `acceptance` directory.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈