### PR TITLE
refactor: clean up after CrudConnectorFeatures rename

### DIFF
--- a/packages/repository-tests/README.md
+++ b/packages/repository-tests/README.md
@@ -67,7 +67,7 @@ tests:
 export function createRetrieveSuite(
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: CrudConnectorFeatures,
+  features: CrudFeatures,
 ) {
   // test code
 }

--- a/packages/repository-tests/src/crud-test-suite.ts
+++ b/packages/repository-tests/src/crud-test-suite.ts
@@ -20,18 +20,18 @@ const debug = debugFactory('loopback:repository-tests');
 type SuiteFn = (
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: CrudFeatures,
+  features: CrudFeatures,
 ) => void;
 
 export function crudRepositoryTestSuite(
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: Partial<CrudFeatures>,
+  partialFeatures: Partial<CrudFeatures>,
 ) {
   const features: CrudFeatures = {
     idType: 'string',
     freeFormProperties: true,
-    ...connectorFeatures,
+    ...partialFeatures,
   };
 
   describe('CRUD Repository operations', () => {
@@ -39,7 +39,7 @@ export function crudRepositoryTestSuite(
       withCrudCtx(function setupContext(ctx: CrudTestContext) {
         ctx.dataSourceOptions = dataSourceOptions;
         ctx.repositoryClass = repositoryClass;
-        ctx.connectorFeatures = features;
+        ctx.features = features;
       }),
     );
     before(
@@ -70,7 +70,7 @@ export function crudRepositoryTestSuite(
           suite.name,
           dataSourceOptions,
           'class ' + repositoryClass.name,
-          connectorFeatures,
+          partialFeatures,
         );
         suite(dataSourceOptions, repositoryClass, features);
       }

--- a/packages/repository-tests/src/crud/create-retrieve.suite.ts
+++ b/packages/repository-tests/src/crud/create-retrieve.suite.ts
@@ -19,12 +19,12 @@ import {
 export function createRetrieveSuite(
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: CrudFeatures,
+  features: CrudFeatures,
 ) {
   @model()
   class Product extends Entity {
     @property({
-      type: connectorFeatures.idType,
+      type: features.idType,
       id: true,
       generated: true,
       description: 'The unique identifier for a product',

--- a/packages/repository-tests/src/crud/freeform-properties.suite.ts
+++ b/packages/repository-tests/src/crud/freeform-properties.suite.ts
@@ -18,17 +18,17 @@ import {
 export function freeformPropertiesSuite(
   dataSourceOptions: DataSourceOptions,
   repositoryClass: CrudRepositoryCtor,
-  connectorFeatures: CrudFeatures,
+  features: CrudFeatures,
 ) {
   skipIf<[(this: Suite) => void], void>(
-    !connectorFeatures.freeFormProperties,
+    !features.freeFormProperties,
     describe,
     'free-form properties (strict: false)',
     () => {
       @model({settings: {strict: false}})
       class Freeform extends Entity {
         @property({
-          type: connectorFeatures.idType,
+          type: features.idType,
           id: true,
           description: 'The unique identifier for a product',
         })

--- a/packages/repository-tests/src/types.repository-tests.ts
+++ b/packages/repository-tests/src/types.repository-tests.ts
@@ -60,6 +60,6 @@ export type CrudRepositoryCtor = new <
 export interface CrudTestContext {
   dataSourceOptions: DataSourceOptions;
   repositoryClass: CrudRepositoryCtor;
-  connectorFeatures: CrudFeatures;
+  features: CrudFeatures;
   dataSource: juggler.DataSource;
 }

--- a/packages/testlab/src/skip.ts
+++ b/packages/testlab/src/skip.ts
@@ -17,7 +17,7 @@ export type TestDefinition<ARGS extends unknown[], RETVAL> = (
  * @example
  * ```ts
  * skipIf(
- *   !connectorFeatures.freeFormProperties,
+ *   !features.freeFormProperties,
  *   describe,
  *  'free-form properties (strict: false)',
  *   () => {


### PR DESCRIPTION
Clean up remaining places referencing "connectorFeatures" to use "features" instead. See https://github.com/strongloop/loopback-next/pull/3411 which renamed `CrudConnectorFeatures` to `CrudFeatures` and the spike #3387 which triggered the need for these renames.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈