### PR TITLE
test(repository): fix setup of relations with custom FK names

### DIFF
--- a/packages/repository/src/__tests__/fixtures/models/order.model.ts
+++ b/packages/repository/src/__tests__/fixtures/models/order.model.ts
@@ -30,7 +30,7 @@ export class Order extends Entity {
   @belongsTo(() => Customer)
   customerId: number;
 
-  @belongsTo(() => Shipment)
+  @belongsTo(() => Shipment, {name: 'shipment'})
   shipment_id: number;
 }
 

--- a/packages/repository/src/__tests__/fixtures/repositories/order.repository.ts
+++ b/packages/repository/src/__tests__/fixtures/repositories/order.repository.ts
@@ -40,7 +40,7 @@ export class OrderRepository extends DefaultCrudRepository<
       customerRepositoryGetter,
     );
     this.shipment = this.createBelongsToAccessorFor(
-      'shipment_id',
+      'shipment',
       shipmentRepositoryGetter,
     );
   }


### PR DESCRIPTION
Because the code infering relation name from FK name supports camelCase only, it's important to explicitly provide the relation name when calling `@belongsTo` decorator.

This is a follow-up for #3326, fixing a problem discovered while working on #3387

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈