### PR TITLE
fix(cli): remove -p option from eslint

### DIFF
--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -30,7 +30,7 @@
     "prettier:fix": "npm run prettier:cli -- --write",
 <% } -%>
 <% if (project.eslint) { -%>
-    "eslint": "eslint -p .",
+    "eslint": "eslint .",
     "eslint:fix": "npm run eslint -- --fix",
 <% } -%>
     "pretest": "npm run clean && npm run build",


### PR DESCRIPTION
Remove the eslint `-p` option in the project generator template for plain `package.json`, as `eslint` does not support this option.

Fixes: #3424
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
