### PR TITLE
feat: add app.service() and extend service booter to load classes with `@bind`

### DIFF
--- a/docs/site/Booting-an-Application.md
+++ b/docs/site/Booting-an-Application.md
@@ -243,12 +243,12 @@ The `datasources` object support the following options:
 
 #### Description
 
-Discovers and binds Service providers using `app.serviceProvider()` (Application
-must use `ServiceMixin` from `@loopback/service-proxy`).
+Discovers and binds remote service proxies or local service classes or providers
+using `app.service()`.
 
 **IMPORTANT:** For a class to be recognized by `ServiceBooter` as a service
-provider, its name must end with `Provider` suffix and its prototype must have a
-`value()` method.
+provider, it either has to be decorated with `@bind` or the class name must end
+with `Provider` suffix and its prototype must have a `value()` method.
 
 #### Options
 

--- a/docs/site/Service-generator.md
+++ b/docs/site/Service-generator.md
@@ -18,6 +18,8 @@ lb4 service [options] [<name>]
 
 ### Options
 
+`--type` : _(Optional)_ service type: proxy, class, or provider
+
 `--datasource` : _(Optional)_ name of a valid REST or SOAP datasource already
 created in src/datasources
 
@@ -34,20 +36,39 @@ file.
 }
 ```
 
-### Notes
+### Remote and local services
 
-There should be at least one valid _(REST or SOAP)_ data source created already
-in the `src/datasources` directory.
+We support three types of services now:
+
+- proxy: A service proxy for remote REST/SOAP/gRPC APIs
+- class: A TypeScript class that can be bound to the application context
+- provider: A TypeScript class that implements `Provider` interface and can be
+  bound to the application context
+
+For remote services (type=proxy), there should be at least one valid _(REST or
+SOAP)_ data source created already in the `src/datasources` directory.
 
 {% include_relative includes/CLI-std-options.md %}
 
 ### Arguments
 
-`<name>` - Optional argument specifyng the service name to be generated.
+`<name>` - Optional argument specifying the service name to be generated.
 
-### Interactive Prompts
+### Interactive prompts
 
 The tool will prompt you for:
+
+- **Service type.** _(serviceType)_ If the service type had been supplied from
+  the command line with `--type` or `--datasource` (implying `proxy`) option and
+  it is a valid one, then the prompt is skipped, otherwise it will present you
+  the list of all valid service types.
+
+  ```
+  ? Service type: (Use arrow keys)
+  ❯ Remote service proxy backed by a data source
+    Local service class bound to application context
+    Local service provider bound to application context
+  ```
 
 - **Please select the datasource.** _(datasource)_ If the name of the datasource
   had been supplied from the command line with `--datasource` option and it is a

--- a/docs/site/tables/lb4-artifact-commands.html
+++ b/docs/site/tables/lb4-artifact-commands.html
@@ -43,7 +43,7 @@
 
     <tr>
       <td><code>lb4 service</code></td>
-      <td>Add new service for a selected datasource to a LoopBack 4 application</td>
+      <td>Add a new remote or local service to a LoopBack 4 application</td>
       <td><a href="Service-generator.html">Service generator</a></td>
     </tr>
 

--- a/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {bind, BindingScope, Provider} from '@loopback/core';
+
+@bind({
+  tags: {serviceType: 'local'},
+  scope: BindingScope.SINGLETON,
+})
+export class BindableGreetingService {
+  greet(whom: string = 'world') {
+    return Promise.resolve(`Hello ${whom}`);
+  }
+}
+
+@bind({tags: {serviceType: 'local', name: 'CurrentDate'}})
+export class DateProvider implements Provider<Date> {
+  value(): Promise<Date> {
+    return Promise.resolve(new Date());
+  }
+}
+
+export class NotBindableGreetingService {
+  greet(whom: string = 'world') {
+    return Promise.resolve(`Hello ${whom}`);
+  }
+}
+
+export class NotBindableDateProvider implements Provider<Date> {
+  value(): Promise<Date> {
+    return Promise.resolve(new Date());
+  }
+}

--- a/packages/boot/src/__tests__/integration/service.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/service.booter.integration.ts
@@ -21,13 +21,27 @@ describe('service booter integration tests', () => {
 
   it('boots services when app.boot() is called', async () => {
     const expectedBindings = [
-      `${SERVICES_PREFIX}.GeocoderService`,
-      // greeting service is skipped - service classes are not supported (yet)
+      'services.BindableGreetingService',
+      'services.CurrentDate',
+      'services.GeocoderService',
+      'services.NotBindableDate',
     ];
 
     await app.boot();
 
     const bindings = app.findByTag(SERVICES_TAG).map(b => b.key);
+    expect(bindings.sort()).to.eql(expectedBindings.sort());
+  });
+
+  it('boots bindable classes when app.boot() is called', async () => {
+    const expectedBindings = [
+      `${SERVICES_PREFIX}.CurrentDate`,
+      `${SERVICES_PREFIX}.BindableGreetingService`,
+    ];
+
+    await app.boot();
+
+    const bindings = app.findByTag({serviceType: 'local'}).map(b => b.key);
     expect(bindings.sort()).to.eql(expectedBindings.sort());
   });
 
@@ -41,6 +55,11 @@ describe('service booter integration tests', () => {
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/service-class.artifact.js'),
       'services/greeting.service.js',
+    );
+
+    await sandbox.copyFile(
+      resolve(__dirname, '../fixtures/bindable-classes.artifact.js'),
+      'services/bindable-classes.service.js',
     );
 
     const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;

--- a/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
@@ -27,7 +27,7 @@ describe('service booter unit tests', () => {
   beforeEach(createStub);
   afterEach(restoreStub);
 
-  it('gives a warning if called on an app without RepositoryMixin', async () => {
+  it('does not require service mixin', async () => {
     const normalApp = new Application();
     await sandbox.copyFile(
       resolve(__dirname, '../../fixtures/service-provider.artifact.js'),
@@ -43,12 +43,7 @@ describe('service booter unit tests', () => {
     ];
     await booterInst.load();
 
-    sinon.assert.calledOnce(stub);
-    sinon.assert.calledWith(
-      stub,
-      'app.serviceProvider() function is needed for ServiceBooter. You can add ' +
-        'it to your Application using ServiceMixin from @loopback/service-proxy.',
-    );
+    sinon.assert.notCalled(stub);
   });
 
   it(`uses ServiceDefaults for 'options' if none are given`, () => {

--- a/packages/boot/src/booters/interceptor.booter.ts
+++ b/packages/boot/src/booters/interceptor.booter.ts
@@ -26,9 +26,9 @@ type InterceptorProviderClass = Constructor<Provider<Interceptor>>;
  *
  * Supported phases: configure, discover, load
  *
- * @param app Application instance
- * @param projectRoot Root of User Project relative to which all paths are resolved
- * @param [bootConfig] InterceptorProvider Artifact Options Object
+ * @param app - Application instance
+ * @param projectRoot - Root of User Project relative to which all paths are resolved
+ * @param bootConfig - InterceptorProvider Artifact Options Object
  */
 export class InterceptorProviderBooter extends BaseArtifactBooter {
   interceptors: InterceptorProviderClass[];
@@ -67,7 +67,7 @@ export class InterceptorProviderBooter extends BaseArtifactBooter {
 }
 
 /**
- * Default ArtifactOptions for DataSourceBooter.
+ * Default ArtifactOptions for InterceptorProviderBooter.
  */
 export const InterceptorProviderDefaults: ArtifactOptions = {
   dirs: ['interceptors'],

--- a/packages/cli/generators/service/templates/local-service-class-template.ts.ejs
+++ b/packages/cli/generators/service/templates/local-service-class-template.ts.ejs
@@ -1,0 +1,10 @@
+import {bind, /* inject, */ BindingScope} from '@loopback/core';
+
+@bind({scope: BindingScope.TRANSIENT})
+export class <%= className %> {
+  constructor(/* Add @inject to inject parameters */) {}
+
+  /*
+   * Add service methods here
+   */
+}

--- a/packages/cli/generators/service/templates/local-service-provider-template.ts.ejs
+++ b/packages/cli/generators/service/templates/local-service-provider-template.ts.ejs
@@ -1,0 +1,19 @@
+import {bind, /* inject, */ BindingScope, Provider} from '@loopback/core';
+
+/*
+ * Fix the service type. Possible options can be:
+ * - import {<%= className %>} from 'your-module';
+ * - export type <%= className %> = string;
+ * - export interface <%= className %> {}
+ */
+export type <%= className %> = unknown;
+
+@bind({scope: BindingScope.TRANSIENT})
+export class <%= className %>Provider implements Provider<<%= className %>> {
+  constructor(/* Add @inject to inject parameters */) {}
+
+  value() {
+    // Add your implementation here
+    throw new Error('To be implemented');
+  }
+}

--- a/packages/cli/generators/service/templates/remote-service-proxy-template.ts.ejs
+++ b/packages/cli/generators/service/templates/remote-service-proxy-template.ts.ejs
@@ -2,20 +2,20 @@ import {getService} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
 import {<%= dataSourceClassName %>} from '../datasources';
 
-export interface <%= className %>Service {
+export interface <%= className %> {
   // this is where you define the Node.js methods that will be
-  // mapped to the SOAP operations as stated in the datasource
+  // mapped to REST/SOAP/gRPC operations as stated in the datasource
   // json file.
 }
 
-export class <%= className %>ServiceProvider implements Provider<<%= className %>Service> {
+export class <%= className %>Provider implements Provider<<%= className %>> {
   constructor(
     // <%= dataSourceName %> must match the name property in the datasource json file
     @inject('datasources.<%= dataSourceName %>')
     protected dataSource: <%= dataSourceClassName %> = new <%= dataSourceClassName %>(),
   ) {}
 
-  value(): Promise<<%= className %>Service> {
+  value(): Promise<<%= className %>> {
     return getService(this.dataSource);
   }
 }

--- a/packages/cli/test/integration/generators/local-service.integration.js
+++ b/packages/cli/test/integration/generators/local-service.integration.js
@@ -1,0 +1,142 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const testlab = require('@loopback/testlab');
+
+const expect = testlab.expect;
+const TestSandbox = testlab.TestSandbox;
+
+const generator = path.join(__dirname, '../../../generators/service');
+const SANDBOX_FILES = require('../../fixtures/service').SANDBOX_FILES;
+const testUtils = require('../../test-utils');
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+
+describe('lb4 service (local)', () => {
+  beforeEach('reset sandbox', async () => {
+    await sandbox.reset();
+  });
+
+  describe('invalid generation of services', () => {
+    it('does not run with invalid service type', async () => {
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .withArguments('myService --type xyz')
+          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
+      ).to.be.rejectedWith(/Invalid service type\: xyz/);
+    });
+  });
+
+  describe('valid generation of services', () => {
+    it('generates a basic local service class from command line arguments', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments('myService --type class');
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        SERVICE_APP_PATH,
+        'my-service.service.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(expectedFile, /export class MyService {/);
+      assert.file(INDEX_FILE);
+      assert.fileContent(INDEX_FILE, /export \* from '.\/my-service.service';/);
+    });
+
+    it('generates a basic local service class from the prompts', async () => {
+      const multiItemPrompt = {
+        name: 'myService',
+        serviceType: 'class',
+      };
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(multiItemPrompt);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        SERVICE_APP_PATH,
+        'my-service.service.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(expectedFile, /export class MyService {/);
+      assert.file(INDEX_FILE);
+      assert.fileContent(INDEX_FILE, /export \* from '.\/my-service.service';/);
+    });
+
+    it('generates a basic local service provider from command line arguments', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments('myService --type provider');
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        SERVICE_APP_PATH,
+        'my-service.service.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /export class MyServiceProvider implements Provider<MyService> {/,
+      );
+      assert.fileContent(expectedFile, /value\(\) {/);
+      assert.file(INDEX_FILE);
+      assert.fileContent(INDEX_FILE, /export \* from '.\/my-service.service';/);
+    });
+
+    it('generates a basic local service provider from the prompts', async () => {
+      const multiItemPrompt = {
+        name: 'myService',
+        serviceType: 'provider',
+      };
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(multiItemPrompt);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        SERVICE_APP_PATH,
+        'my-service.service.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /export class MyServiceProvider implements Provider<MyService> {/,
+      );
+      assert.fileContent(expectedFile, /value\(\) {/);
+      assert.file(INDEX_FILE);
+      assert.fileContent(INDEX_FILE, /export \* from '.\/my-service.service';/);
+    });
+  });
+});
+
+// Sandbox constants
+const SERVICE_APP_PATH = 'src/services';
+const INDEX_FILE = path.join(SANDBOX_PATH, SERVICE_APP_PATH, 'index.ts');

--- a/packages/cli/test/integration/generators/remote-service.integration.js
+++ b/packages/cli/test/integration/generators/remote-service.integration.js
@@ -20,7 +20,7 @@ const testUtils = require('../../test-utils');
 const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 const sandbox = new TestSandbox(SANDBOX_PATH);
 
-describe('lb4 service', () => {
+describe('lb4 service (remote)', () => {
   beforeEach('reset sandbox', async () => {
     await sandbox.reset();
   });
@@ -53,14 +53,11 @@ describe('lb4 service', () => {
       assert.file(expectedFile);
       assert.fileContent(
         expectedFile,
-        /export class MyServiceServiceProvider implements Provider<MyServiceService> {/,
+        /export class MyServiceProvider implements Provider<MyService> {/,
       );
-      assert.fileContent(expectedFile, /export interface MyServiceService {/);
+      assert.fileContent(expectedFile, /export interface MyService {/);
       assert.fileContent(expectedFile, /\@inject\('datasources.myds'\)/);
-      assert.fileContent(
-        expectedFile,
-        /value\(\): Promise\<MyServiceService\> {/,
-      );
+      assert.fileContent(expectedFile, /value\(\): Promise\<MyService\> {/);
       assert.file(INDEX_FILE);
       assert.fileContent(INDEX_FILE, /export \* from '.\/my-service.service';/);
     });
@@ -82,7 +79,7 @@ describe('lb4 service', () => {
       assert.file(expectedFile);
       assert.fileContent(
         expectedFile,
-        /export class MultiWordServiceServiceProvider implements Provider\<MultiWordServiceService\> {/,
+        /export class MultiWordServiceProvider implements Provider\<MultiWordService\> {/,
       );
       assert.fileContent(
         expectedFile,
@@ -90,7 +87,7 @@ describe('lb4 service', () => {
       );
       assert.fileContent(
         expectedFile,
-        /value\(\): Promise\<MultiWordServiceService\> {/,
+        /value\(\): Promise\<MultiWordService\> {/,
       );
       assert.file(INDEX_FILE);
       assert.fileContent(
@@ -121,14 +118,11 @@ describe('lb4 service', () => {
       assert.file(expectedFile);
       assert.fileContent(
         expectedFile,
-        /export class MyServiceServiceProvider implements Provider<MyServiceService> {/,
+        /export class MyServiceProvider implements Provider<MyService> {/,
       );
-      assert.fileContent(expectedFile, /export interface MyServiceService {/);
+      assert.fileContent(expectedFile, /export interface MyService {/);
       assert.fileContent(expectedFile, /\@inject\('datasources.myds'\)/);
-      assert.fileContent(
-        expectedFile,
-        /value\(\): Promise\<MyServiceService\> {/,
-      );
+      assert.fileContent(expectedFile, /value\(\): Promise\<MyService\> {/);
       assert.file(INDEX_FILE);
       assert.fileContent(INDEX_FILE, /export \* from '.\/my-service.service';/);
     });
@@ -156,14 +150,11 @@ describe('lb4 service', () => {
       assert.file(expectedFile);
       assert.fileContent(
         expectedFile,
-        /export class MyserviceServiceProvider implements Provider<MyserviceService> {/,
+        /export class MyserviceProvider implements Provider<Myservice> {/,
       );
-      assert.fileContent(expectedFile, /export interface MyserviceService {/);
+      assert.fileContent(expectedFile, /export interface Myservice {/);
       assert.fileContent(expectedFile, /\@inject\('datasources.restdb'\)/);
-      assert.fileContent(
-        expectedFile,
-        /value\(\): Promise\<MyserviceService\> {/,
-      );
+      assert.fileContent(expectedFile, /value\(\): Promise\<Myservice\> {/);
       assert.file(INDEX_FILE);
       assert.fileContent(INDEX_FILE, /export \* from '.\/myservice.service';/);
     });
@@ -184,14 +175,11 @@ describe('lb4 service', () => {
       assert.file(expectedFile);
       assert.fileContent(
         expectedFile,
-        /export class MyserviceServiceProvider implements Provider<MyserviceService> {/,
+        /export class MyserviceProvider implements Provider<Myservice> {/,
       );
-      assert.fileContent(expectedFile, /export interface MyserviceService {/);
+      assert.fileContent(expectedFile, /export interface Myservice {/);
       assert.fileContent(expectedFile, /\@inject\('datasources.restdb'\)/);
-      assert.fileContent(
-        expectedFile,
-        /value\(\): Promise\<MyserviceService\> {/,
-      );
+      assert.fileContent(expectedFile, /value\(\): Promise\<Myservice\> {/);
       assert.file(INDEX_FILE);
       assert.fileContent(INDEX_FILE, /export \* from '.\/myservice.service';/);
     });
@@ -212,14 +200,11 @@ describe('lb4 service', () => {
       assert.file(expectedFile);
       assert.fileContent(
         expectedFile,
-        /export class MyserviceServiceProvider implements Provider<MyserviceService> {/,
+        /export class MyserviceProvider implements Provider<Myservice> {/,
       );
-      assert.fileContent(expectedFile, /export interface MyserviceService {/);
+      assert.fileContent(expectedFile, /export interface Myservice {/);
       assert.fileContent(expectedFile, /\@inject\('datasources.restdb'\)/);
-      assert.fileContent(
-        expectedFile,
-        /value\(\): Promise\<MyserviceService\> {/,
-      );
+      assert.fileContent(expectedFile, /value\(\): Promise\<Myservice\> {/);
       assert.file(INDEX_FILE);
       assert.fileContent(INDEX_FILE, /export \* from '.\/myservice.service';/);
     });
@@ -247,9 +232,9 @@ describe('lb4 service', () => {
       assert.file(expectedFile);
       assert.fileContent(
         expectedFile,
-        /export class MyserviceServiceProvider implements Provider<MyserviceService> {/,
+        /export class MyserviceProvider implements Provider<Myservice> {/,
       );
-      assert.fileContent(expectedFile, /export interface MyserviceService {/);
+      assert.fileContent(expectedFile, /export interface Myservice {/);
       assert.fileContent(
         expectedFile,
         /import {MapDsDataSource} from '..\/datasources';/,
@@ -260,10 +245,7 @@ describe('lb4 service', () => {
       );
 
       assert.fileContent(expectedFile, /\@inject\('datasources.MapDS'\)/);
-      assert.fileContent(
-        expectedFile,
-        /value\(\): Promise\<MyserviceService\> {/,
-      );
+      assert.fileContent(expectedFile, /value\(\): Promise\<Myservice\> {/);
       assert.file(INDEX_FILE);
       assert.fileContent(INDEX_FILE, /export \* from '.\/myservice.service';/);
     });

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -270,8 +270,23 @@ describe('Application', () => {
       const binding = app.service(MyServiceProvider);
       expect(Array.from(binding.tagNames)).to.containEql(CoreTags.SERVICE);
       expect(binding.tagMap.date).to.eql('now');
-      expect(binding.key).to.equal('localServices.MyServiceProvider');
+      expect(binding.key).to.equal('localServices.MyService');
       expect(binding.scope).to.equal(BindingScope.TRANSIENT);
+      expect(findKeysByTag(app, 'service')).to.containEql(binding.key);
+    });
+
+    it('binds a service provider with name tag', () => {
+      @bind({tags: {date: 'now', name: 'my-service'}})
+      class MyServiceProvider implements Provider<Date> {
+        value() {
+          return new Date();
+        }
+      }
+
+      const binding = app.service(MyServiceProvider);
+      expect(Array.from(binding.tagNames)).to.containEql(CoreTags.SERVICE);
+      expect(binding.tagMap.date).to.eql('now');
+      expect(binding.key).to.equal('services.my-service');
       expect(findKeysByTag(app, 'service')).to.containEql(binding.key);
     });
 

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -229,6 +229,57 @@ describe('Application', () => {
     }
   });
 
+  describe('service binding', () => {
+    let app: Application;
+    class MyService {}
+
+    beforeEach(givenApp);
+
+    it('binds a service', () => {
+      const binding = app.service(MyService);
+      expect(Array.from(binding.tagNames)).to.containEql(CoreTags.SERVICE);
+      expect(binding.key).to.equal('services.MyService');
+      expect(binding.scope).to.equal(BindingScope.TRANSIENT);
+      expect(findKeysByTag(app, CoreTags.SERVICE)).to.containEql(binding.key);
+    });
+
+    it('binds a service with custom name', () => {
+      const binding = app.service(MyService, 'my-service');
+      expect(Array.from(binding.tagNames)).to.containEql(CoreTags.SERVICE);
+      expect(binding.key).to.equal('services.my-service');
+      expect(findKeysByTag(app, CoreTags.SERVICE)).to.containEql(binding.key);
+    });
+
+    it('binds a singleton service', () => {
+      @bind({scope: BindingScope.SINGLETON})
+      class MySingletonService {}
+
+      const binding = app.service(MySingletonService);
+      expect(binding.scope).to.equal(BindingScope.SINGLETON);
+      expect(findKeysByTag(app, 'service')).to.containEql(binding.key);
+    });
+
+    it('binds a service provider', () => {
+      @bind({tags: {date: 'now', namespace: 'localServices'}})
+      class MyServiceProvider implements Provider<Date> {
+        value() {
+          return new Date();
+        }
+      }
+
+      const binding = app.service(MyServiceProvider);
+      expect(Array.from(binding.tagNames)).to.containEql(CoreTags.SERVICE);
+      expect(binding.tagMap.date).to.eql('now');
+      expect(binding.key).to.equal('localServices.MyServiceProvider');
+      expect(binding.scope).to.equal(BindingScope.TRANSIENT);
+      expect(findKeysByTag(app, 'service')).to.containEql(binding.key);
+    });
+
+    function givenApp() {
+      app = new Application();
+    }
+  });
+
   function findKeysByTag(ctx: Context, tag: string | RegExp) {
     return ctx.findByTag(tag).map(binding => binding.key);
   }

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -112,6 +112,11 @@ export namespace CoreTags {
   export const CONTROLLER = 'controller';
 
   /**
+   * Binding tag for services
+   */
+  export const SERVICE = 'service';
+
+  /**
    * Binding tag for life cycle observers
    */
   export const LIFE_CYCLE_OBSERVER = 'lifeCycleObserver';

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, createBindingFromClass, Provider} from '@loopback/context';
+import {Binding, Provider} from '@loopback/context';
 import {Application} from '@loopback/core';
 
 /**
@@ -41,6 +41,8 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
     /**
      * Add a service to this application.
      *
+     * @deprecated Use app.service() instead
+     *
      * @param provider - The service provider to register.
      *
      * @example
@@ -67,14 +69,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
       provider: Class<Provider<S>>,
       name?: string,
     ): Binding<S> {
-      const serviceName = name || provider.name.replace(/Provider$/, '');
-      const binding = createBindingFromClass(provider, {
-        name: serviceName,
-        namespace: 'services',
-        type: 'service',
-      });
-      this.add(binding);
-      return binding;
+      return this.service(provider, name);
     }
 
     /**


### PR DESCRIPTION
Replaces https://github.com/strongloop/loopback-next/pull/3262

This PR extends the `service` concept to be not only a service proxy but also a local service - classes decorated with `@bind`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
