### PR TITLE
feat(repository-tests): test `replaceById`, verify plain data handling + more

### DIFF
--- a/acceptance/repository-mysql/src/__tests__/mysql.datasource.ts
+++ b/acceptance/repository-mysql/src/__tests__/mysql.datasource.ts
@@ -20,4 +20,5 @@ export const MYSQL_CONFIG: DataSourceOptions = {
 export const MYSQL_FEATURES: Partial<CrudFeatures> = {
   idType: 'number',
   freeFormProperties: false,
+  emptyValue: null,
 };

--- a/packages/repository-tests/src/crud-test-suite.ts
+++ b/packages/repository-tests/src/crud-test-suite.ts
@@ -31,6 +31,7 @@ export function crudRepositoryTestSuite(
   const features: CrudFeatures = {
     idType: 'string',
     freeFormProperties: true,
+    emptyValue: undefined,
     ...partialFeatures,
   };
 

--- a/packages/repository-tests/src/crud/create-retrieve.suite.ts
+++ b/packages/repository-tests/src/crud/create-retrieve.suite.ts
@@ -3,8 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property} from '@loopback/repository';
-import {EntityCrudRepository} from '@loopback/repository/src';
+import {
+  Entity,
+  EntityCrudRepository,
+  model,
+  property,
+} from '@loopback/repository';
 import {expect, toJSON} from '@loopback/testlab';
 import {withCrudCtx} from '../helpers.repository-tests';
 import {

--- a/packages/repository-tests/src/crud/create-retrieve.suite.ts
+++ b/packages/repository-tests/src/crud/create-retrieve.suite.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  AnyObject,
   Entity,
   EntityCrudRepository,
   model,
@@ -63,6 +64,15 @@ export function createRetrieveSuite(
       expect(created.id).to.be.ok();
 
       const found = await repo.findById(created.id);
+      expect(toJSON(created)).to.deepEqual(toJSON(found));
+    });
+
+    it('retrieves a newly created model when id was transformed via JSON', async () => {
+      const created = await repo.create({name: 'Pen'});
+      expect(created.id).to.be.ok();
+
+      const id = (toJSON(created) as AnyObject).id;
+      const found = await repo.findById(id);
       expect(toJSON(created)).to.deepEqual(toJSON(found));
     });
   });

--- a/packages/repository-tests/src/crud/create-retrieve.suite.ts
+++ b/packages/repository-tests/src/crud/create-retrieve.suite.ts
@@ -10,7 +10,10 @@ import {
   property,
 } from '@loopback/repository';
 import {expect, toJSON} from '@loopback/testlab';
-import {withCrudCtx} from '../helpers.repository-tests';
+import {
+  deleteAllModelsInDefaultDataSource,
+  withCrudCtx,
+} from '../helpers.repository-tests';
 import {
   CrudFeatures,
   CrudRepositoryCtor,
@@ -44,6 +47,8 @@ export function createRetrieveSuite(
   }
 
   describe('create-retrieve', () => {
+    before(deleteAllModelsInDefaultDataSource);
+
     let repo: EntityCrudRepository<Product, typeof Product.prototype.id>;
     before(
       withCrudCtx(async function setupRepository(ctx: CrudTestContext) {

--- a/packages/repository-tests/src/crud/freeform-properties.suite.ts
+++ b/packages/repository-tests/src/crud/freeform-properties.suite.ts
@@ -7,7 +7,10 @@ import {Entity, model, property} from '@loopback/repository';
 import {EntityCrudRepository} from '@loopback/repository/src';
 import {expect, skipIf, toJSON} from '@loopback/testlab';
 import {Suite} from 'mocha';
-import {withCrudCtx} from '../helpers.repository-tests';
+import {
+  withCrudCtx,
+  deleteAllModelsInDefaultDataSource,
+} from '../helpers.repository-tests';
 import {
   CrudFeatures,
   CrudRepositoryCtor,
@@ -25,6 +28,8 @@ export function freeformPropertiesSuite(
     describe,
     'free-form properties (strict: false)',
     () => {
+      before(deleteAllModelsInDefaultDataSource);
+
       @model({settings: {strict: false}})
       class Freeform extends Entity {
         @property({

--- a/packages/repository-tests/src/crud/replace-by-id.suite.ts
+++ b/packages/repository-tests/src/crud/replace-by-id.suite.ts
@@ -1,0 +1,111 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity, model, property} from '@loopback/repository';
+import {AnyObject, EntityCrudRepository} from '@loopback/repository/src';
+import {expect, toJSON} from '@loopback/testlab';
+import {
+  deleteAllModelsInDefaultDataSource,
+  withCrudCtx,
+} from '../helpers.repository-tests';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../types.repository-tests';
+
+// Tests for `replaceById` method.
+export function createSuiteForReplaceById(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  @model()
+  class Product extends Entity {
+    @property({
+      type: features.idType,
+      id: true,
+      generated: true,
+      description: 'The unique identifier for a product',
+    })
+    id: number | string;
+
+    @property({type: 'string', required: true})
+    name: string;
+
+    @property({type: 'string', required: false})
+    description?: string;
+
+    constructor(data?: Partial<Product>) {
+      super(data);
+    }
+  }
+
+  describe('replaceById', () => {
+    before(deleteAllModelsInDefaultDataSource);
+
+    let repo: EntityCrudRepository<Product, typeof Product.prototype.id>;
+    before(
+      withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+        repo = new repositoryClass(Product, ctx.dataSource);
+        await ctx.dataSource.automigrate(Product.name);
+      }),
+    );
+
+    it('replaces all model properties (using model instance as data)', async () => {
+      const created = await repo.create({
+        name: 'Pencil',
+        description: 'some description',
+      });
+      expect(created.id).to.be.ok();
+
+      created.name = 'new name';
+      // This important! Not all databases allow `patchById` to set
+      // properties to "undefined", `replaceById` must always work.
+      created.description = undefined;
+
+      await repo.replaceById(created.id, created);
+
+      const found = await repo.findById(created.id);
+      expect(toJSON(found)).to.deepEqual(
+        toJSON({
+          id: created.id,
+          name: 'new name',
+          description: features.emptyValue,
+        }),
+      );
+    });
+
+    // This test simulates REST API scenario, where data returned from
+    // the database is converted to JSON and client sends plain data object
+    // encoded as JSON.
+    it('replaces all model properties (using plain data object)', async () => {
+      const created = toJSON(
+        await repo.create({
+          name: 'Pencil',
+          description: 'some description',
+        }),
+      ) as AnyObject;
+      expect(created.id).to.be.ok();
+
+      created.name = 'new name';
+      // This important! Not all databases allow `patchById` to set
+      // properties to "undefined", `replaceById` must always work.
+      created.description = undefined;
+
+      await repo.replaceById(created.id, created);
+
+      const found = await repo.findById(created.id);
+      expect(toJSON(found)).to.deepEqual(
+        toJSON({
+          id: created.id,
+          name: 'new name',
+          description: features.emptyValue,
+        }),
+      );
+    });
+  });
+}

--- a/packages/repository-tests/src/helpers.repository-tests.ts
+++ b/packages/repository-tests/src/helpers.repository-tests.ts
@@ -29,3 +29,14 @@ export function withCrudCtx(
     return fn.call(this, getCrudContext(this));
   };
 }
+
+/**
+ * Remove any models created by previous tests from the default DataSource
+ * instance (`ctx.dataSource`).
+ *
+ * Call this method from the first `before` hook of your test suite to avoid
+ * conflicts when the same model name is used for different model classes.
+ */
+export const deleteAllModelsInDefaultDataSource = withCrudCtx(ctx => {
+  ctx.dataSource.deleteAllModels();
+});

--- a/packages/repository-tests/src/types.repository-tests.ts
+++ b/packages/repository-tests/src/types.repository-tests.ts
@@ -38,6 +38,14 @@ export interface CrudFeatures {
    * Default: `true`
    */
   freeFormProperties: boolean;
+
+  /**
+   * The value used by the database to store properties set to `undefined`.
+   * Typically, SQL databases store both `undefined` and `null` as `null`.
+   *
+   * Default: `undefined`
+   */
+  emptyValue: undefined | null;
 }
 
 /**


### PR DESCRIPTION
While working on the spike for Inclusion of related models (see #3387), I discovered that `replaceById` does not behave as expected when using MongoDB database and when implementing `fromEntity` repository method, extra care must be taken to not break MongoDB support.

In this pull request, I am adding new tests to verify that `replaceById` works correctly when called from JS/TS code (using a model instance as the data parameter) and via REST API (using a plain data object as the data parameter).

- The first commit fixes a wrong `import` statement. While it's not directly related to my changes, I feel it's not worth opening a new PR for that.
- The second commit introduces a new helper `deleteAllModelsInDefaultDataSource` that leverages the recently introduced juggler API (see https://github.com/strongloop/loopback-datasource-juggler/pull/1759)
- The third commits adds the new tests.

This pull request requires https://github.com/strongloop/loopback-datasource-juggler/pull/1763 to be landed & published first. Before that happens, our test suite fails with console warnings that are detected & rejected by our test suite runner.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈