### PR TITLE
[WIP] fix: add class name separation to multiple class names output

### DIFF
--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -550,7 +550,7 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
     );
 
     this.artifactInfo.name = this.artifactInfo.modelNameList
-      ? this.artifactInfo.modelNameList.join()
+      ? this.artifactInfo.modelNameList.join(this.classNameSeparator)
       : this.artifactInfo.modelName;
 
     await super.end();

--- a/packages/cli/lib/artifact-generator.js
+++ b/packages/cli/lib/artifact-generator.js
@@ -15,6 +15,8 @@ module.exports = class ArtifactGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.
   constructor(args, opts) {
     super(args, opts);
+    // how classes are separated when the output contains more than one
+    this.classNameSeparator = ', ';
   }
 
   _setupGenerator() {
@@ -131,12 +133,17 @@ module.exports = class ArtifactGenerator extends BaseGenerator {
     if (generationStatus) {
       await this._updateIndexFiles();
 
+      const classes = this.artifactInfo.name
+        .split(this.classNameSeparator)
+        .map(utils.toClassName);
+      const classesOutput = classes.join(this.classNameSeparator);
+
       // User Output
       this.log();
       this.log(
         utils.toClassName(this.artifactInfo.type),
-        chalk.yellow(utils.toClassName(this.artifactInfo.name)),
-        'was created in',
+        chalk.yellow(classesOutput),
+        classes.length > 1 ? 'were created in' : 'was created in',
         `${this.artifactInfo.relPath}/`,
       );
       this.log();


### PR DESCRIPTION
This commit adds a character defined in artifact-generator.js to be used when the output contains
multiple class names

The idea was to just add a comma as separator where the class names are merged, but at the end of the process, the class names variable is passed to a function in `artifact-generator.js`, `toClassName`, that transforms it to a PascalCaseName, removing any kind of invalid characters for a class name (whitespaces and commas included)
So the solution I've thought of is to apply that function for each class, instead of to every class at once

This is a work in progress and I'd appreciate if someone could help me with this, I won't be able to work on this anytime soon. And of course, any kind of feedback is appreciated!

fixes #3350

## TODO:
- [ ] Formatting tests aren't passing, I'd appreciate if someone can help with that
- [ ] Also have to update this branch, since at the moment of writing this is 73 commits behind the master branch

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated