### PR TITLE
fix(tsdocs): use model.name as canonicalReference is removed

### DIFF
--- a/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
+++ b/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
@@ -134,5 +134,13 @@ permalink: /doc/en/lb4/apidocs.index.html
       'utf-8',
     );
     expect(constructorDoc).to.not.match(/\.\(constructor\)\.md/);
+
+    const pkgDoc = await fs.readFile(
+      path.join(SITE_APIDOCS_ROOT, 'pkg1.md'),
+      'utf-8',
+    );
+    expect(pkgDoc).to.match(
+      /\[pkg1\]\(https\:\/\/github\.com\/strongloop\/loopback\-next\/tree\/master\/packages\/pkg1\)/,
+    );
   });
 });

--- a/packages/tsdocs/src/update-api-md-docs.ts
+++ b/packages/tsdocs/src/update-api-md-docs.ts
@@ -145,7 +145,7 @@ async function addJekyllMetadata(
       const model = await fs.readJson(modelFile, {encoding: 'utf-8'});
       debug('Package %s', name, model);
       if (model.kind === 'Package' && !model.docComment) {
-        const pkgDoc = `[${model.canonicalReference}](https://github.com/strongloop/loopback-next/tree/master/packages/${name})`;
+        const pkgDoc = `[${model.name}](https://github.com/strongloop/loopback-next/tree/master/packages/${name})`;
         doc = doc.replace(
           `## ${name} package`,
           `## ${name} package\n\n${pkgDoc}`,


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
