### PR TITLE
feat(openapi-v3): allow optional spec for `@param.*` shortcut decorators

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-header.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-header.decorator.unit.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
+import {get, getControllerSpec, param} from '../../../..';
 
 describe('Routing metadata for parameters', () => {
   describe('@param.header.string', () => {
@@ -16,6 +16,24 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'header',
+        schema: {
+          type: 'string',
+        },
+      };
+      expectSpecToBeEqual(MyController, expectedParamSpec);
+    });
+
+    it('allows additional spec properties with in:header type:string', () => {
+      class MyController {
+        @get('/greet')
+        greet(
+          @param.header.string('name', {description: 'Name'}) name: string,
+        ) {}
+      }
+      const expectedParamSpec = {
+        name: 'name',
+        in: 'header',
+        description: 'Name',
         schema: {
           type: 'string',
         },

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-path.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-path.decorator.unit.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {get, param, getControllerSpec} from '../../../..';
 import {expect} from '@loopback/testlab';
+import {get, getControllerSpec, param} from '../../../..';
 
 describe('Routing metadata for parameters', () => {
   describe('@param.path.string', () => {
@@ -16,6 +16,23 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = {
         name: 'name',
         in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+        },
+      };
+      expectSpecToBeEqual(MyController, expectedParamSpec);
+    });
+
+    it('allows additional spec properties with in:path type:string', () => {
+      class MyController {
+        @get('/greet/{name}')
+        greet(@param.path.string('name', {description: 'Name'}) name: string) {}
+      }
+      const expectedParamSpec = {
+        name: 'name',
+        in: 'path',
+        description: 'Name',
         required: true,
         schema: {
           type: 'string',

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
@@ -269,6 +269,46 @@ describe('Routing metadata for parameters', () => {
       expectSpecToBeEqual(MyController, expectedParamSpec);
     });
   });
+
+  it('allows additional properties for parameter object', () => {
+    class MyController {
+      @get('/greet')
+      greet(@param.query.string('name', {description: 'Name'}) name: string) {}
+    }
+    const expectedParamSpec = {
+      name: 'name',
+      in: 'query',
+      description: 'Name',
+      schema: {
+        type: 'string',
+      },
+    };
+    expectSpecToBeEqual(MyController, expectedParamSpec);
+  });
+
+  it('allows additional spec properties for @param.query.object', () => {
+    class MyController {
+      @get('/greet')
+      greet(
+        @param.query.object('filter', undefined, {
+          description: 'Search criteria',
+        })
+        filter: object,
+      ) {}
+    }
+    const expectedParamSpec = <ParameterObject>{
+      name: 'filter',
+      in: 'query',
+      description: 'Search criteria',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        additionalProperties: true,
+      },
+    };
+    expectSpecToBeEqual(MyController, expectedParamSpec);
+  });
 });
 
 function expectSpecToBeEqual(controller: Function, paramSpec: object) {

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -95,32 +95,13 @@ const builtinTypes = {
   password: {type: 'string', format: 'password'},
 };
 
-// FIXME: Typedoc does not feed `param` as both a function and a namespace.
-// As a workaround, we add the apidocs for `@param` under the namespace.
 /**
- *
- * Describe an input parameter of a Controller method. The `@param` decorator
- * takes an argument of `ParameterObject` to define how to map the parameter
- * to OpenAPI specification.
- *
- * `@param(paramSpec)` must be applied to parameters.
- *
- * @example
- * ```ts
- * class MyController {
- *   @get('/')
- *   list(
- *     @param(offsetSpec) offset?: number,
- *     @param(pageSizeSpec) pageSize?: number,
- *   ) {}
- * }
- * ```
- *
- * @param paramSpec - Parameter specification.
- *
- * Please also see `@param.*` shortcut parameter decorators
+ * Namespace for `@param.*` decorators
  */
 export namespace param {
+  /**
+   * Query parameter decorator
+   */
   export const query = {
     /**
      * Define a parameter of "integer" type that's read from the query string.
@@ -221,17 +202,26 @@ export namespace param {
         type: 'object',
         additionalProperties: true,
       },
+      spec?: Partial<ParameterObject>,
     ) {
+      schema = {
+        type: 'object',
+        ...schema,
+      };
       return param({
         name,
         in: 'query',
         style: 'deepObject',
         explode: true,
         schema,
+        ...spec,
       });
     },
   };
 
+  /**
+   * Header parameter decorator
+   */
   export const header = {
     /**
      * Define a parameter of "string" type that's read from a request header.
@@ -322,6 +312,10 @@ export namespace param {
      */
     password: createParamShortcut('header', builtinTypes.password),
   };
+
+  /**
+   * Path parameter decorator
+   */
   export const path = {
     /**
      * Define a parameter of "string" type that's read from request path.
@@ -448,7 +442,7 @@ function createParamShortcut(
   source: ParameterLocation,
   options: ParamShortcutOptions,
 ) {
-  return (name: string) => {
-    return param({name, in: source, schema: {...options}});
+  return (name: string, spec?: Partial<ParameterObject>) => {
+    return param({name, in: source, schema: {...options}, ...spec});
   };
 }


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/3457

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
