### PR TITLE
build: configure Renovate to update Node.js versions in Travis config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -43,6 +43,11 @@
     "groupName": "api-extractor packages"
   }],
 
+  "travis": {
+    "enabled": true,
+    "supportPolicy": ["lts", "current"]
+  },
+
   "masterIssue": true,
   "masterIssueApproval": false,
   "masterIssueAutoclose": true


### PR DESCRIPTION
With this changes in place, Renovate should open a new PR when a Node.js major version enters LTS or reaches end-of-life.

Inspired by https://github.com/nodejs/package-maintenance/issues/206

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈