### PR TITLE
feat(eslint-config): enable "no-return-await" rule

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -103,6 +103,13 @@
         "clean"
       ],
       "problemMatcher": []
+    },
+    {
+      "type": "npm",
+      "script": "lint:fix",
+      "problemMatcher": [
+        "$eslint-stylish"
+      ]
     }
   ]
 }

--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -188,7 +188,7 @@ export class OrderController {
   async getCustomer(
     @param.path.number('id') orderId: typeof Order.prototype.id,
   ): Promise<Customer> {
-    return await this.orderRepository.customer(orderId);
+    return this.orderRepository.customer(orderId);
   }
 }
 ```

--- a/docs/site/Calling-other-APIs-and-Web-Services.md
+++ b/docs/site/Calling-other-APIs-and-Web-Services.md
@@ -213,7 +213,7 @@ Service interface.
   ): Promise<AddResponse> {
     //Preconditions
 
-    return await this.calculatorService.add(<CalculatorParameters>{
+    return this.calculatorService.add(<CalculatorParameters>{
       intA,
       intB,
     });

--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -140,7 +140,7 @@ export class TodoController {
     })
     todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
-    return await this.todoRepository.create(todo);
+    return this.todoRepository.create(todo);
   }
 
   @get('/todos/count', {
@@ -154,7 +154,7 @@ export class TodoController {
   async count(
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
-    return await this.todoRepository.count(where);
+    return this.todoRepository.count(where);
   }
 
   @get('/todos', {
@@ -173,7 +173,7 @@ export class TodoController {
     @param.query.object('filter', getFilterSchemaFor(Todo))
     filter?: Filter<Todo>,
   ): Promise<Todo[]> {
-    return await this.todoRepository.find(filter);
+    return this.todoRepository.find(filter);
   }
 
   @patch('/todos', {
@@ -195,7 +195,7 @@ export class TodoController {
     todo: Partial<Todo>
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
-    return await this.todoRepository.updateAll(todo, where);
+    return this.todoRepository.updateAll(todo, where);
   }
 
   @get('/todos/{id}', {
@@ -207,7 +207,7 @@ export class TodoController {
     },
   })
   async findById(@param.path.number('id') id: number): Promise<Todo> {
-    return await this.todoRepository.findById(id);
+    return this.todoRepository.findById(id);
   }
 
   @patch('/todos/{id}', {

--- a/docs/site/Controllers.md
+++ b/docs/site/Controllers.md
@@ -182,7 +182,7 @@ export class HelloController {
   @get('/messages')
   async list(@param.query.number('limit') limit = 10): Promise<HelloMessage[]> {
     if (limit > 100) limit = 100; // your logic
-    return await this.repository.find({limit}); // a CRUD method from our repository
+    return this.repository.find({limit}); // a CRUD method from our repository
   }
 }
 ```
@@ -265,7 +265,7 @@ export class HelloController {
     } else if (limit > 100) {
       limit = 100;
     }
-    return await this.repo.find({limit});
+    return this.repo.find({limit});
   }
 }
 ```

--- a/docs/site/Dependency-injection.md
+++ b/docs/site/Dependency-injection.md
@@ -175,7 +175,7 @@ class ProductController {
   }
 
   async list() {
-    return await this.repo.find({where: {available: true}});
+    return this.repo.find({where: {available: true}});
   }
 }
 ```

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -294,7 +294,7 @@ export class CustomerOrdersController {
     @param.path.number('id') customerId: typeof Customer.prototype.id,
     @requestBody() orderData: Order,
   ): Promise<Order> {
-    return await this.customerRepository.orders(customerId).create(orderData);
+    return this.customerRepository.orders(customerId).create(orderData);
   }
 }
 ```

--- a/docs/site/Implementing-features.shelved.md
+++ b/docs/site/Implementing-features.shelved.md
@@ -344,7 +344,7 @@ async function givenEmptyDatabase() {
 }
 
 async function givenProduct(data: Partial<Product>) {
-  return await new ProductRepository().create(
+  return new ProductRepository().create(
     Object.assign(
       {
         name: 'a-product-name',

--- a/docs/site/Interceptors.md
+++ b/docs/site/Interceptors.md
@@ -635,7 +635,7 @@ class NameValidator implements Provider<Interceptor> {
         `Name '${name}' is not on the list of '${this.validNames}`,
       );
     }
-    return await next();
+    return next();
   }
 }
 ```

--- a/docs/site/Loopback-component-authorization.md
+++ b/docs/site/Loopback-component-authorization.md
@@ -542,7 +542,7 @@ decorator as below.
   },
 })
 async create(@requestBody() role: Role): Promise<Role> {
-  return await this.roleRepository.create(role);
+  return this.roleRepository.create(role);
 }
 ```
 

--- a/docs/site/Parsing-requests.md
+++ b/docs/site/Parsing-requests.md
@@ -33,7 +33,7 @@ class TodoController {
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
   ): Promise<boolean> {
-    return await this.todoRepo.replaceById(id, todo);
+    return this.todoRepo.replaceById(id, todo);
   }
 }
 ```
@@ -74,7 +74,7 @@ async replaceTodo(
   // NO need to do the "string to number" convertion now,
   // coercion automatically handles it for you.
   id = +id;
-  return await this.todoRepo.replaceById(id, todo);
+  return this.todoRepo.replaceById(id, todo);
 }
 ```
 
@@ -157,7 +157,7 @@ import {Todo} from './models';
     @param.path.number('id') id: number,
     @requestBody() todo: Todo,
   ): Promise<boolean> {
-    return await this.todoRepo.replaceById(id, todo);
+    return this.todoRepo.replaceById(id, todo);
   }
 ...
 ```

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -252,7 +252,7 @@ Create Controller method:
 
 ```ts
 async createAccount(accountInstance: Account) {
-  return await this.repository.create(accountInstance);
+  return this.repository.create(accountInstance);
 }
 ```
 
@@ -287,7 +287,7 @@ Find Controller method:
 
 ```ts
 async getAccount() {
-  return await this.repository.find();
+  return this.repository.find();
 }
 ```
 

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -236,7 +236,7 @@ from the path object.
   },
 })
 async findById(@param.path.string('id') id: string): Promise<Note> {
-  return await this.noteRepository.findById(id);
+  return this.noteRepository.findById(id);
 }
 ```
 

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -223,7 +223,7 @@ export function givenProductData(data?: Partial<Product>) {
 }
 
 export async function givenProduct(data?: Partial<Product>) {
-  return await new ProductRepository(testdb).create(givenProductData(data));
+  return new ProductRepository(testdb).create(givenProductData(data));
 }
 // ...
 ```

--- a/docs/site/decorators/Decorators_inject.md
+++ b/docs/site/decorators/Decorators_inject.md
@@ -199,7 +199,7 @@ export class HelloController {
     // Bind `greeting` to a factory function that reads default greeting
     // from a file or database
     this.greetingBinding.toDynamicValue(() => readDefaultGreeting());
-    return await this.greetingBinding.get<string>(this.greetingBinding.key);
+    return this.greetingBinding.get<string>(this.greetingBinding.key);
   }
 }
 ```
@@ -279,7 +279,7 @@ export class DataSourceTracker {
 
   async listDataSources(): Promise<DataSource[]> {
     // Use the Getter function to resolve data source instances
-    return await this.dataSources.values();
+    return this.dataSources.values();
   }
 }
 ```

--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -275,9 +275,7 @@ export class SupplierAccountController {
     @param.path.number('id') supplierId: typeof Supplier.prototype.id,
     @requestBody() accountData: Account,
   ): Promise<Account> {
-    return await this.supplierRepository
-      .account(supplierId)
-      .create(accountData);
+    return this.supplierRepository.account(supplierId).create(accountData);
   }
 }
 ```

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
@@ -113,7 +113,7 @@ async divide(intA: number, intB: number): Promise<DivideResponse> {
   if (intB === 0) {
     throw new HttpErrors.PreconditionFailed('Cannot divide by zero');
   }
-  return await this.calculatorService.divide(<CalculatorParameters>{
+  return this.calculatorService.divide(<CalculatorParameters>{
     intA,
     intB,
   });
@@ -145,7 +145,7 @@ async divide(
   if (intB === 0) {
     throw new HttpErrors.PreconditionFailed('Cannot divide by zero');
   }
-  return await this.calculatorService.divide(<CalculatorParameters>{
+  return this.calculatorService.divide(<CalculatorParameters>{
     intA,
     intB,
   });
@@ -163,7 +163,7 @@ async multiply(
   @param.path.integer('intA') intA: number,
   @param.path.integer('intB') intB: number,
 ): Promise<MultiplyResponse> {
-  return await this.calculatorService.multiply(<CalculatorParameters>{
+  return this.calculatorService.multiply(<CalculatorParameters>{
     intA,
     intB,
   });
@@ -173,7 +173,7 @@ async add(
   @param.path.integer('intA') intA: number,
   @param.path.integer('intB') intB: number,
 ): Promise<AddResponse> {
-  return await this.calculatorService.add(<CalculatorParameters>{
+  return this.calculatorService.add(<CalculatorParameters>{
     intA,
     intB,
   });
@@ -184,7 +184,7 @@ async subtract(
   @param.path.integer('intA') intA: number,
   @param.path.integer('intB') intB: number,
 ): Promise<SubtractResponse> {
-  return await this.calculatorService.subtract(<CalculatorParameters>{
+  return this.calculatorService.subtract(<CalculatorParameters>{
     intA,
     intB,
   });

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -187,7 +187,7 @@ export class TodoListTodoController {
     })
     todo: Omit<Todo, 'id'>,
   ) {
-    return await this.todoListRepo.todos(id).create(todo);
+    return this.todoListRepo.todos(id).create(todo);
   }
 }
 ```
@@ -243,7 +243,7 @@ export class TodoListTodoController {
     })
     todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
-    return await this.todoListRepo.todos(id).create(todo);
+    return this.todoListRepo.todos(id).create(todo);
   }
 
   @get('/todo-lists/{id}/todos', {
@@ -262,7 +262,7 @@ export class TodoListTodoController {
     @param.path.number('id') id: number,
     @param.query.object('filter') filter?: Filter<Todo>,
   ): Promise<Todo[]> {
-    return await this.todoListRepo.todos(id).find(filter);
+    return this.todoListRepo.todos(id).find(filter);
   }
 
   @patch('/todo-lists/{id}/todos', {
@@ -285,7 +285,7 @@ export class TodoListTodoController {
     todo: Partial<Todo>
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
-    return await this.todoListRepo.todos(id).patch(todo, where);
+    return this.todoListRepo.todos(id).patch(todo, where);
   }
 
   @del('/todo-lists/{id}/todos', {
@@ -300,7 +300,7 @@ export class TodoListTodoController {
     @param.path.number('id') id: number,
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
-    return await this.todoListRepo.todos(id).delete(where);
+    return this.todoListRepo.todos(id).delete(where);
   }
 }
 ```

--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -209,7 +209,7 @@ export class TodoController {
       todo.remindAtGeo = `${geo[0].y},${geo[0].x}`;
     }
 
-    return await this.todoRepo.create(todo);
+    return this.todoRepo.create(todo);
   }
 
   // other endpoints remain unchanged

--- a/examples/context/src/interceptor-proxy.ts
+++ b/examples/context/src/interceptor-proxy.ts
@@ -65,7 +65,7 @@ class TracingInterceptor implements Provider<Interceptor> {
         reqId,
       );
     }
-    return await next();
+    return next();
   }
 }
 

--- a/examples/express-composition/src/controllers/note.controller.ts
+++ b/examples/express-composition/src/controllers/note.controller.ts
@@ -49,7 +49,7 @@ export class NoteController {
     })
     note: Omit<Note, 'id'>,
   ): Promise<Note> {
-    return await this.noteRepository.create(note);
+    return this.noteRepository.create(note);
   }
 
   @get('/notes/count', {
@@ -63,7 +63,7 @@ export class NoteController {
   async count(
     @param.query.object('where', getWhereSchemaFor(Note)) where?: Where<Note>,
   ): Promise<Count> {
-    return await this.noteRepository.count(where);
+    return this.noteRepository.count(where);
   }
 
   @get('/notes', {
@@ -82,7 +82,7 @@ export class NoteController {
     @param.query.object('filter', getFilterSchemaFor(Note))
     filter?: Filter<Note>,
   ): Promise<Note[]> {
-    return await this.noteRepository.find(filter);
+    return this.noteRepository.find(filter);
   }
 
   @patch('/notes', {
@@ -104,7 +104,7 @@ export class NoteController {
     note: Partial<Note>,
     @param.query.object('where', getWhereSchemaFor(Note)) where?: Where<Note>,
   ): Promise<Count> {
-    return await this.noteRepository.updateAll(note, where);
+    return this.noteRepository.updateAll(note, where);
   }
 
   @get('/notes/{id}', {
@@ -116,7 +116,7 @@ export class NoteController {
     },
   })
   async findById(@param.path.number('id') id: number): Promise<Note> {
-    return await this.noteRepository.findById(id);
+    return this.noteRepository.findById(id);
   }
 
   @patch('/notes/{id}', {

--- a/examples/greeter-extension/src/application.ts
+++ b/examples/greeter-extension/src/application.ts
@@ -22,6 +22,6 @@ export class GreetingApplication extends Application {
   }
 
   async getGreetingService() {
-    return await this.get(GREETING_SERVICE);
+    return this.get(GREETING_SERVICE);
   }
 }

--- a/examples/greeting-app/src/interceptors/caching.interceptor.ts
+++ b/examples/greeting-app/src/interceptors/caching.interceptor.ts
@@ -37,7 +37,7 @@ export class CachingInterceptor implements Provider<Interceptor> {
       /* istanbul ignore if */
       if (!httpReq) {
         // Not http request
-        return await next();
+        return next();
       }
       const key = httpReq.path;
       const lang = httpReq.acceptsLanguages(['en', 'zh']) || 'en';

--- a/examples/rpc-server/src/rpc.server.ts
+++ b/examples/rpc-server/src/rpc.server.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject, Context} from '@loopback/context';
-import {Server, Application, CoreBindings} from '@loopback/core';
+import {Context, inject} from '@loopback/context';
+import {Application, CoreBindings, Server} from '@loopback/core';
 import * as express from 'express';
 import * as http from 'http';
 import pEvent from 'p-event';
@@ -34,12 +34,12 @@ export class RPCServer extends Context implements Server {
       (this.config && this.config.port) || 3000,
     );
     this._listening = true;
-    return await pEvent(this._server, 'listening');
+    return pEvent(this._server, 'listening');
   }
   async stop(): Promise<void> {
     this._server.close();
     this._listening = false;
-    return await pEvent(this._server, 'close');
+    return pEvent(this._server, 'close');
   }
 }
 

--- a/examples/soap-calculator/src/controllers/calculator.controller.ts
+++ b/examples/soap-calculator/src/controllers/calculator.controller.ts
@@ -4,14 +4,13 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {inject} from '@loopback/core';
-import {get, param, HttpErrors} from '@loopback/rest';
-
+import {get, HttpErrors, param} from '@loopback/rest';
 import {
-  CalculatorService,
-  CalculatorParameters,
   AddResponse,
-  MultiplyResponse,
+  CalculatorParameters,
+  CalculatorService,
   DivideResponse,
+  MultiplyResponse,
   SubtractResponse,
 } from '../services/calculator.service';
 
@@ -26,7 +25,7 @@ export class CalculatorController {
     @param.path.integer('intA') intA: number,
     @param.path.integer('intB') intB: number,
   ): Promise<MultiplyResponse> {
-    return await this.calculatorService.multiply(<CalculatorParameters>{
+    return this.calculatorService.multiply(<CalculatorParameters>{
       intA,
       intB,
     });
@@ -36,7 +35,7 @@ export class CalculatorController {
     @param.path.integer('intA') intA: number,
     @param.path.integer('intB') intB: number,
   ): Promise<AddResponse> {
-    return await this.calculatorService.add(<CalculatorParameters>{
+    return this.calculatorService.add(<CalculatorParameters>{
       intA,
       intB,
     });
@@ -47,7 +46,7 @@ export class CalculatorController {
     @param.path.integer('intA') intA: number,
     @param.path.integer('intB') intB: number,
   ): Promise<SubtractResponse> {
-    return await this.calculatorService.subtract(<CalculatorParameters>{
+    return this.calculatorService.subtract(<CalculatorParameters>{
       intA,
       intB,
     });
@@ -62,7 +61,7 @@ export class CalculatorController {
     if (intB === 0) {
       throw new HttpErrors.PreconditionFailed('Cannot divide by zero');
     }
-    return await this.calculatorService.divide(<CalculatorParameters>{
+    return this.calculatorService.divide(<CalculatorParameters>{
       intA,
       intB,
     });

--- a/examples/todo-list/src/__tests__/acceptance/todo-list-image.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-image.acceptance.ts
@@ -92,6 +92,6 @@ describe('TodoListApplication', () => {
   ) {
     const data = givenTodoListImage(todoListImage);
     delete data.todoListId;
-    return await todoListRepo.image(id).create(data);
+    return todoListRepo.image(id).create(data);
   }
 });

--- a/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
@@ -224,7 +224,7 @@ describe('TodoListApplication', () => {
   }
 
   async function givenTodoInstance(todo?: Partial<Todo>) {
-    return await todoRepo.create(givenTodo(todo));
+    return todoRepo.create(givenTodo(todo));
   }
 
   async function givenTodoInstanceOfTodoList(
@@ -233,10 +233,10 @@ describe('TodoListApplication', () => {
   ) {
     const data = givenTodo(todo);
     delete data.todoListId;
-    return await todoListRepo.todos(id).create(data);
+    return todoListRepo.todos(id).create(data);
   }
 
   async function givenTodoListInstance(todoList?: Partial<TodoList>) {
-    return await todoListRepo.create(givenTodoList(todoList));
+    return todoListRepo.create(givenTodoList(todoList));
   }
 });

--- a/examples/todo-list/src/__tests__/helpers.ts
+++ b/examples/todo-list/src/__tests__/helpers.ts
@@ -115,21 +115,21 @@ export async function givenTodoInstance(
   todoRepo: TodoRepository,
   todo?: Partial<Todo>,
 ) {
-  return await todoRepo.create(givenTodo(todo));
+  return todoRepo.create(givenTodo(todo));
 }
 
 export async function givenTodoListInstance(
   todoListRepo: TodoListRepository,
   data?: Partial<TodoList>,
 ) {
-  return await todoListRepo.create(givenTodoList(data));
+  return todoListRepo.create(givenTodoList(data));
 }
 
 export async function givenTodoListImageInstance(
   todoListImageRepo: TodoListImageRepository,
   data?: Partial<TodoListImage>,
 ) {
-  return await todoListImageRepo.create(givenTodoListImage(data));
+  return todoListImageRepo.create(givenTodoListImage(data));
 }
 
 export async function givenEmptyDatabase() {

--- a/examples/todo-list/src/controllers/todo-list-image.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-image.controller.ts
@@ -27,7 +27,7 @@ export class TodoListImageController {
     @param.path.number('id') id: number,
     @requestBody() image: TodoListImage,
   ): Promise<TodoListImage> {
-    return await this.todoListRepo.image(id).create(image);
+    return this.todoListRepo.image(id).create(image);
   }
 
   @get('/todo-lists/{id}/image', {
@@ -43,6 +43,6 @@ export class TodoListImageController {
     },
   })
   async find(@param.path.number('id') id: number): Promise<TodoListImage> {
-    return await this.todoListRepo.image(id).get();
+    return this.todoListRepo.image(id).get();
   }
 }

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -50,7 +50,7 @@ export class TodoListTodoController {
     })
     todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
-    return await this.todoListRepo.todos(id).create(todo);
+    return this.todoListRepo.todos(id).create(todo);
   }
 
   @get('/todo-lists/{id}/todos', {
@@ -69,7 +69,7 @@ export class TodoListTodoController {
     @param.path.number('id') id: number,
     @param.query.object('filter') filter?: Filter<Todo>,
   ): Promise<Todo[]> {
-    return await this.todoListRepo.todos(id).find(filter);
+    return this.todoListRepo.todos(id).find(filter);
   }
 
   @patch('/todo-lists/{id}/todos', {
@@ -92,7 +92,7 @@ export class TodoListTodoController {
     todo: Partial<Todo>,
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
-    return await this.todoListRepo.todos(id).patch(todo, where);
+    return this.todoListRepo.todos(id).patch(todo, where);
   }
 
   @del('/todo-lists/{id}/todos', {
@@ -107,6 +107,6 @@ export class TodoListTodoController {
     @param.path.number('id') id: number,
     @param.query.object('where', getWhereSchemaFor(Todo)) where?: Where<Todo>,
   ): Promise<Count> {
-    return await this.todoListRepo.todos(id).delete(where);
+    return this.todoListRepo.todos(id).delete(where);
   }
 }

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -48,7 +48,7 @@ export class TodoListController {
     })
     todoList: Omit<TodoList, 'id'>,
   ): Promise<TodoList> {
-    return await this.todoListRepository.create(todoList);
+    return this.todoListRepository.create(todoList);
   }
 
   @get('/todo-lists/count', {
@@ -63,7 +63,7 @@ export class TodoListController {
     @param.query.object('where', getWhereSchemaFor(TodoList))
     where?: Where<TodoList>,
   ): Promise<Count> {
-    return await this.todoListRepository.count(where);
+    return this.todoListRepository.count(where);
   }
 
   @get('/todo-lists', {
@@ -85,7 +85,7 @@ export class TodoListController {
     @param.query.object('filter', getFilterSchemaFor(TodoList))
     filter?: Filter<TodoList>,
   ): Promise<TodoList[]> {
-    return await this.todoListRepository.find(filter);
+    return this.todoListRepository.find(filter);
   }
 
   @patch('/todo-lists', {
@@ -108,7 +108,7 @@ export class TodoListController {
     @param.query.object('where', getWhereSchemaFor(TodoList))
     where?: Where<TodoList>,
   ): Promise<Count> {
-    return await this.todoListRepository.updateAll(todoList, where);
+    return this.todoListRepository.updateAll(todoList, where);
   }
 
   @get('/todo-lists/{id}', {
@@ -128,7 +128,7 @@ export class TodoListController {
     @param.query.object('filter', getFilterSchemaFor(TodoList))
     filter?: Filter<TodoList>,
   ): Promise<TodoList> {
-    return await this.todoListRepository.findById(id, filter);
+    return this.todoListRepository.findById(id, filter);
   }
 
   @patch('/todo-lists/{id}', {

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -39,7 +39,7 @@ export class TodoController {
     })
     todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
-    return await this.todoRepo.create(todo);
+    return this.todoRepo.create(todo);
   }
 
   @get('/todos/{id}', {
@@ -59,7 +59,7 @@ export class TodoController {
     @param.query.object('filter', getFilterSchemaFor(Todo))
     filter?: Filter<Todo>,
   ): Promise<Todo> {
-    return await this.todoRepo.findById(id, filter);
+    return this.todoRepo.findById(id, filter);
   }
 
   @get('/todos', {
@@ -81,7 +81,7 @@ export class TodoController {
     @param.query.object('filter', getFilterSchemaFor(Todo))
     filter?: Filter<Todo>,
   ): Promise<Todo[]> {
-    return await this.todoRepo.find(filter);
+    return this.todoRepo.find(filter);
   }
 
   @put('/todos/{id}', {
@@ -139,6 +139,6 @@ export class TodoController {
     },
   })
   async findOwningList(@param.path.number('id') id: number): Promise<TodoList> {
-    return await this.todoRepo.todoList(id);
+    return this.todoRepo.todoList(id);
   }
 }

--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -214,6 +214,6 @@ describe('TodoApplication', () => {
   }
 
   async function givenTodoInstance(todo?: Partial<Todo>) {
-    return await todoRepo.create(givenTodo(todo));
+    return todoRepo.create(givenTodo(todo));
   }
 });

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -53,7 +53,7 @@ export class TodoController {
       // eslint-disable-next-line require-atomic-updates
       todo.remindAtGeo = `${geo[0].y},${geo[0].x}`;
     }
-    return await this.todoRepo.create(todo);
+    return this.todoRepo.create(todo);
   }
 
   @get('/todos/{id}', {
@@ -68,7 +68,7 @@ export class TodoController {
     @param.path.number('id') id: number,
     @param.query.boolean('items') items?: boolean,
   ): Promise<Todo> {
-    return await this.todoRepo.findById(id);
+    return this.todoRepo.findById(id);
   }
 
   @get('/todos', {
@@ -87,7 +87,7 @@ export class TodoController {
     @param.query.object('filter', getFilterSchemaFor(Todo))
     filter?: Filter<Todo>,
   ): Promise<Todo[]> {
-    return await this.todoRepo.find(filter);
+    return this.todoRepo.find(filter);
   }
 
   @put('/todos/{id}', {

--- a/packages/authentication/docs/strategies/basic-auth.md
+++ b/packages/authentication/docs/strategies/basic-auth.md
@@ -23,7 +23,7 @@ class BasicAuthenticationStrategy implements AuthenticationStrategy {
     const credentials = await this.extractCredentials(request);
     // `verifyCredentials` throws error accordingly: user doesn't exist OR invalid credentials
     const user = await userService.verifyCredentials(credentials);
-    return await userService.convertToUserProfile(user);
+    return userService.convertToUserProfile(user);
   }
 
   extractCredentials(request): Promise<Credentials> {

--- a/packages/authentication/docs/strategies/jwt.md
+++ b/packages/authentication/docs/strategies/jwt.md
@@ -24,7 +24,7 @@ class JWTAuthenticationStrategy implements AuthenticationStrategy {
     const token = await this.extractCredentials(request);
     // `verifyToken` should decode the payload from the token and convert the token payload to
     // userProfile object.
-    return await tokenService.verifyToken(token);
+    return tokenService.verifyToken(token);
   }
 
   extractCredentials(request): Promise<string> {

--- a/packages/authentication/src/__tests__/acceptance/jwt-auth-extension.acceptance.ts
+++ b/packages/authentication/src/__tests__/acceptance/jwt-auth-extension.acceptance.ts
@@ -57,9 +57,7 @@ describe('JWT Authentication', () => {
         //
 
         // Now with a valid userProfile, let's create a JSON web token
-        return await this.tokenService.generateToken(
-          createUserProfile(joeUser),
-        );
+        return this.tokenService.generateToken(createUserProfile(joeUser));
       }
 
       @get('/whoAmI')
@@ -106,9 +104,7 @@ describe('JWT Authentication', () => {
         //
 
         // Now with a valid userProfile, let's create a JSON web token
-        return await this.tokenService.generateToken(
-          createUserProfile(joeUser),
-        );
+        return this.tokenService.generateToken(createUserProfile(joeUser));
       }
 
       @get('/whoAmI')
@@ -158,9 +154,7 @@ describe('JWT Authentication', () => {
         //
 
         // Now with a valid userProfile, let's create a JSON web token
-        return await this.tokenService.generateToken(
-          createUserProfile(joeUser),
-        );
+        return this.tokenService.generateToken(createUserProfile(joeUser));
       }
 
       @get('/whoAmI')
@@ -213,9 +207,7 @@ describe('JWT Authentication', () => {
         // ...Other code for verifying a valid user (e.g. basic or local strategy)...
         //
 
-        return await this.tokenService.generateToken(
-          createUserProfile(joeUser),
-        );
+        return this.tokenService.generateToken(createUserProfile(joeUser));
       }
 
       @get('/whoAmI')
@@ -357,7 +349,7 @@ describe('JWT Authentication', () => {
 
       @get('/createtoken')
       async createToken() {
-        return await this.tokenService.generateToken(undefined);
+        return this.tokenService.generateToken(undefined);
       }
     }
 
@@ -454,7 +446,7 @@ describe('JWT Authentication', () => {
   async function getExpiredToken() {
     const userProfile = createUserProfile(joeUser);
     const tokenService = new JWTService(TOKEN_SECRET_VALUE, '-10');
-    return await tokenService.generateToken(userProfile);
+    return tokenService.generateToken(userProfile);
   }
 
   function givenAuthenticatedSequence() {

--- a/packages/authentication/src/__tests__/unit/fixtures/mock-strategy.ts
+++ b/packages/authentication/src/__tests__/unit/fixtures/mock-strategy.ts
@@ -27,7 +27,7 @@ export class MockStrategy implements AuthenticationStrategy {
   }
 
   async authenticate(req: Request): Promise<UserProfile> {
-    return await this.verify(req);
+    return this.verify(req);
   }
   /**
    * @param req

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -22,7 +22,7 @@ export async function discoverFiles(
   pattern: string,
   root: string,
 ): Promise<string[]> {
-  return await glob(pattern, {root: root});
+  return glob(pattern, {root: root});
 }
 
 /**

--- a/packages/booter-lb3app/src/__tests__/test-helper.ts
+++ b/packages/booter-lb3app/src/__tests__/test-helper.ts
@@ -67,7 +67,7 @@ export function givenCoffeeShop() {
 export async function givenUser() {
   const User = lb3app.models.User;
 
-  return await User.create({
+  return User.create({
     email: 'sample@email.com',
     password: 'L00pBack!',
   });

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -44,7 +44,7 @@ export class <%= className %>Controller {
     })
     <%= modelVariableName %>: Omit<<%= modelName %>, '<%= id %>'>,
   ): Promise<<%= modelName %>> {
-    return await this.<%= repositoryNameCamel %>.create(<%= modelVariableName %>);
+    return this.<%= repositoryNameCamel %>.create(<%= modelVariableName %>);
   }
 
   @get('<%= httpPathName %>/count', {
@@ -58,7 +58,7 @@ export class <%= className %>Controller {
   async count(
     @param.query.object('where', getWhereSchemaFor(<%= modelName %>)) where?: Where<<%= modelName %>>,
   ): Promise<Count> {
-    return await this.<%= repositoryNameCamel %>.count(where);
+    return this.<%= repositoryNameCamel %>.count(where);
   }
 
   @get('<%= httpPathName %>', {
@@ -76,7 +76,7 @@ export class <%= className %>Controller {
   async find(
     @param.query.object('filter', getFilterSchemaFor(<%= modelName %>)) filter?: Filter<<%= modelName %>>,
   ): Promise<<%= modelName %>[]> {
-    return await this.<%= repositoryNameCamel %>.find(filter);
+    return this.<%= repositoryNameCamel %>.find(filter);
   }
 
   @patch('<%= httpPathName %>', {
@@ -98,7 +98,7 @@ export class <%= className %>Controller {
     <%= modelVariableName %>: <%= modelName %>,
     @param.query.object('where', getWhereSchemaFor(<%= modelName %>)) where?: Where<<%= modelName %>>,
   ): Promise<Count> {
-    return await this.<%= repositoryNameCamel %>.updateAll(<%= modelVariableName %>, where);
+    return this.<%= repositoryNameCamel %>.updateAll(<%= modelVariableName %>, where);
   }
 
   @get('<%= httpPathName %>/{id}', {
@@ -110,7 +110,7 @@ export class <%= className %>Controller {
     },
   })
   async findById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<<%= modelName %>> {
-    return await this.<%= repositoryNameCamel %>.findById(id);
+    return this.<%= repositoryNameCamel %>.findById(id);
   }
 
   @patch('<%= httpPathName %>/{id}', {

--- a/packages/cli/generators/relation/index.js
+++ b/packages/cli/generators/relation/index.js
@@ -221,17 +221,14 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
   async promptSourceModels() {
     if (this.shouldExit()) return false;
 
-    return await this._promptModelList(
-      PROMPT_MESSAGE_SOURCE_MODEL,
-      'sourceModel',
-    );
+    return this._promptModelList(PROMPT_MESSAGE_SOURCE_MODEL, 'sourceModel');
   }
 
   // Get model list for target model.
   async promptTargetModels() {
     if (this.shouldExit()) return false;
 
-    return await this._promptModelList(
+    return this._promptModelList(
       PROMPT_MESSAGE_TARGET_MODEL,
       'destinationModel',
     );

--- a/packages/cli/generators/relation/templates/controller-relation-template-belongs-to.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-belongs-to.ts.ejs
@@ -33,6 +33,6 @@ export class <%= controllerClassName %> {
   async get<%= targetModelClassName %>(
     @param.path.<%= sourceModelPrimaryKeyType %>('id') id: typeof <%= sourceModelClassName %>.prototype.<%= sourceModelPrimaryKey %>,
   ): Promise<<%= targetModelClassName %>> {
-    return await this.<%= paramSourceRepository %>.<%= paramTargetModel %>(id);
+    return this.<%= paramSourceRepository %>.<%= paramTargetModel %>(id);
   }
 }

--- a/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
@@ -42,7 +42,7 @@ export class <%= controllerClassName %> {
     @param.path.<%= sourceModelPrimaryKeyType %>('id') id: <%= sourceModelPrimaryKeyType %>,
     @param.query.object('filter') filter?: Filter<<%= targetModelClassName %>>,
   ): Promise<<%= targetModelClassName %>[]> {
-    return await this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).find(filter);
+    return this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).find(filter);
   }
 
   @post('/<%= sourceModelPath %>/{id}/<%= targetModelPath %>', {
@@ -63,7 +63,7 @@ export class <%= controllerClassName %> {
       },
     }) <%= targetModelRequestBody %>: Omit<<%= targetModelClassName %>, '<%= targetModelPrimaryKey %>'>,
   ): Promise<<%= targetModelClassName %>> {
-    return await this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).create(<%= targetModelRequestBody %>);
+    return this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).create(<%= targetModelRequestBody %>);
   }
 
   @patch('/<%= sourceModelPath %>/{id}/<%= targetModelPath %>', {
@@ -86,7 +86,7 @@ export class <%= controllerClassName %> {
     <%= targetModelRequestBody %>: Partial<<%= targetModelClassName %>>,
     @param.query.object('where', getWhereSchemaFor(<%= targetModelClassName %>)) where?: Where<<%= targetModelClassName %>>,
   ): Promise<Count> {
-    return await this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).patch(<%= targetModelRequestBody %>, where);
+    return this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).patch(<%= targetModelRequestBody %>, where);
   }
 
   @del('/<%= sourceModelPath %>/{id}/<%= targetModelPath %>', {
@@ -101,6 +101,6 @@ export class <%= controllerClassName %> {
     @param.path.<%= sourceModelPrimaryKeyType %>('id') id: <%= sourceModelPrimaryKeyType %>,
     @param.query.object('where', getWhereSchemaFor(<%= targetModelClassName %>)) where?: Where<<%= targetModelClassName %>>,
   ): Promise<Count> {
-    return await this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).delete(where);
+    return this.<%= paramSourceRepository %>.<%= relationPropertyName %>(id).delete(where);
   }
 }

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -206,7 +206,7 @@ module.exports = class BaseGenerator extends Generator {
         return;
       }
       // Non-express mode, continue to prompt
-      return await super.prompt(questions);
+      return super.prompt(questions);
     }
 
     const answers = Object.assign({}, this.options);

--- a/packages/cli/lib/model-discoverer.js
+++ b/packages/cli/lib/model-discoverer.js
@@ -12,7 +12,7 @@ async function discoverModelNames(ds, options) {
       ds.on('connected', resolve);
     });
   }
-  return await ds.discoverModelDefinitions(options);
+  return ds.discoverModelDefinitions(options);
 }
 
 /**

--- a/packages/cli/test/integration/generators/belongsto.relation.integration.js
+++ b/packages/cli/test/integration/generators/belongsto.relation.integration.js
@@ -282,14 +282,14 @@ context('check if the controller file created ', () => {
           /content: \{\n {10}'application\/json': \{\n/,
           /async getCustomer\(\n {4}\@param\.path\.number\('id'\) id: typeof Order\.prototype\.id,\n/,
           /\)\: Promise<Customer> \{\n/,
-          /return await this\.orderRepository\.customer\(id\);\n {2}\}\n/,
+          /return this\.orderRepository\.customer\(id\);\n {2}\}\n/,
         ];
         const getOrdersClassByCustomerClassIdRegEx = [
           /\@get\('\/order-classes\/{id}\/customer-class', \{\n {4}responses: \{\n {6}'200': \{\n/,
           /content: \{\n {10}'application\/json': \{\n/,
           /async getCustomerClass\(\n {4}\@param\.path\.number\('id'\) id: typeof OrderClass\.prototype\.orderNumber,\n/,
           /\)\: Promise<CustomerClass> \{\n/,
-          /return await this\.orderClassRepository\.customerClass\(id\);\n {2}\}\n/,
+          /return this\.orderClassRepository\.customerClass\(id\);\n {2}\}\n/,
         ];
 
         const getOrdersClassTypeByCustomerClassTypeIdRegEx = [
@@ -297,7 +297,7 @@ context('check if the controller file created ', () => {
           /content: \{\n {10}'application\/json': \{\n/,
           /async getCustomerClassType\(\n {4}\@param\.path\.string\('id'\) id: typeof OrderClassType\.prototype\.orderString,\n/,
           /\)\: Promise<CustomerClassType> \{\n/,
-          /return await this\.orderClassTypeRepository\.customerClassType\(id\);\n {2}\}\n/,
+          /return this\.orderClassTypeRepository\.customerClassType\(id\);\n {2}\}\n/,
         ];
 
         const getRegEx = [

--- a/packages/cli/test/integration/generators/hasmany.relation.integration.js
+++ b/packages/cli/test/integration/generators/hasmany.relation.integration.js
@@ -388,7 +388,7 @@ context('check if the controller file created ', () => {
           /async find\(\n . {2}\@param.path.number\('id'\) id: number,\n/,
           /\@param.query.object\('filter'\) filter\?: Filter<Order>,\n/,
           /\)\: Promise<Order\[]> {\n/,
-          /return await this\.customerRepository\.orders\(id\)\.find\(filter\);\n {2}}\n/,
+          /return this\.customerRepository\.orders\(id\)\.find\(filter\);\n {2}}\n/,
         ];
         const getOrdersClassByCustomerClassIdRegEx = [
           /\@get\('\/customer-classes\/{id}\/order-classes', {\n {4}responses: {\n {6}'200': {\n/,
@@ -399,7 +399,7 @@ context('check if the controller file created ', () => {
           /async find\(\n . {2}\@param.path.number\('id'\) id: number,\n/,
           /\@param.query.object\('filter'\) filter\?: Filter<OrderClass>,\n/,
           /\)\: Promise<OrderClass\[]> {\n/,
-          /return await this\.customerClassRepository\.orderClasses\(id\)\.find\(filter\);\n {2}}\n/,
+          /return this\.customerClassRepository\.orderClasses\(id\)\.find\(filter\);\n {2}}\n/,
         ];
         const getOrdersClassTypeByCustomerClassTypeIdRegEx = [
           /\@get\('\/customer-class-types\/{id}\/order-class-types', {\n {4}responses: {\n {6}'200': {\n/,
@@ -410,7 +410,7 @@ context('check if the controller file created ', () => {
           /async find\(\n . {2}\@param.path.number\('id'\) id: number,\n/,
           /\@param.query.object\('filter'\) filter\?: Filter<OrderClassType>,\n/,
           /\)\: Promise<OrderClassType\[]> {\n/,
-          /return await this\.customerClassTypeRepository\.orderClassTypes\(id\).find\(filter\);\n {2}}\n/,
+          /return this\.customerClassTypeRepository\.orderClassTypes\(id\).find\(filter\);\n {2}}\n/,
         ];
 
         const getRegEx = [
@@ -441,7 +441,7 @@ context('check if the controller file created ', () => {
           /\@param\.path\.number\('id'\) id: typeof Customer\.prototype\.id,\n/,
           /\@requestBody\(\{\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(Order, {exclude: \['id'\]}\),\s+},\s+},\s+}\) order: Omit<Order, 'id'>,\n/,
           /\): Promise<Order> {\n/,
-          /return await this\.customerRepository\.orders\(id\)\.create\(order\);\n {2}}\n/,
+          /return this\.customerRepository\.orders\(id\)\.create\(order\);\n {2}}\n/,
         ];
         const postMultiWordClassCreateRegEx = [
           /\@post\('\/customer-classes\/{id}\/order-classes', {\n {4}responses: {\n {6}'200': {\n/,
@@ -451,7 +451,7 @@ context('check if the controller file created ', () => {
           /\@param\.path\.number\('id'\) id: typeof CustomerClass\.prototype\.custNumber,\n/,
           /\@requestBody\(\{\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(OrderClass, {exclude: \['orderNumber'\]}\),\s+},\s+},\s+}\) orderClass: Omit<OrderClass, 'orderNumber'>,\n/,
           /\): Promise<OrderClass> {\n/,
-          /return await this\.customerClassRepository\.orderClasses\(id\)\.create\(orderClass\);\n {2}}\n/,
+          /return this\.customerClassRepository\.orderClasses\(id\)\.create\(orderClass\);\n {2}}\n/,
         ];
         const postTypeClassCreateRegEx = [
           /\@post\('\/customer-class-types\/{id}\/order-class-types', {\n {4}responses: {\n {6}'200': {\n/,
@@ -461,7 +461,7 @@ context('check if the controller file created ', () => {
           /\@param\.path\.number\('id'\) id: typeof CustomerClassType\.prototype\.custNumber,\n/,
           /\@requestBody\(\{\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(OrderClassType, {exclude: \['orderString'\]}\),\s+},\s+},\s+}\) orderClassType: Omit<OrderClassType, 'orderString'>,\n/,
           /\): Promise<OrderClassType> {\n/,
-          /return await this\.customerClassTypeRepository\.orderClassTypes\(id\)\.create\(orderClassType\);\n {2}}\n/,
+          /return this\.customerClassTypeRepository\.orderClassTypes\(id\)\.create\(orderClassType\);\n {2}}\n/,
         ];
 
         const expectedControllerFile = path.join(
@@ -498,7 +498,7 @@ context('check if the controller file created ', () => {
           /\@requestBody\({\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(Order, {partial: true}\),\s+},\s+},\s+}\)\s+order: Partial<Order>,\n/,
           /\@param\.query\.object\('where', getWhereSchemaFor\(Order\)\) where\?: Where<Order>,\n/,
           /\): Promise<Count> {\n/,
-          /return await this\.customerRepository\.orders\(id\).patch\(order, where\);\n {2}}\n/,
+          /return this\.customerRepository\.orders\(id\).patch\(order, where\);\n {2}}\n/,
         ];
 
         const updateOrderClassByCustomerClassIdRegEx = [
@@ -510,7 +510,7 @@ context('check if the controller file created ', () => {
           /\@requestBody\({\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(OrderClass, {partial: true}\),\s+},\s+},\s+}\)\s+orderClass: Partial<OrderClass>,\n/,
           /\@param\.query\.object\('where', getWhereSchemaFor\(OrderClass\)\) where\?: Where<OrderClass>,\n/,
           /\): Promise<Count> {\n/,
-          /return await this\.customerClassRepository\.orderClasses\(id\)\.patch\(orderClass, where\);\n {2}}\n/,
+          /return this\.customerClassRepository\.orderClasses\(id\)\.patch\(orderClass, where\);\n {2}}\n/,
         ];
 
         const updateOrderClassByCustomerClassTypeIdRegEx = [
@@ -522,7 +522,7 @@ context('check if the controller file created ', () => {
           /\@requestBody\({\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(OrderClassType, {partial: true}\),\s+},\s+},\s+}\)\s+orderClassType: Partial<OrderClassType>,\n/,
           /\@param\.query\.object\('where', getWhereSchemaFor\(OrderClassType\)\) where\?: Where<OrderClassType>,\n/,
           /\): Promise<Count> {\n/,
-          /return await this\.customerClassTypeRepository\.orderClassTypes\(id\).patch\(orderClassType, where\);\n {2}}\n/,
+          /return this\.customerClassTypeRepository\.orderClassTypes\(id\).patch\(orderClassType, where\);\n {2}}\n/,
         ];
 
         const expectedControllerFile = path.join(
@@ -558,7 +558,7 @@ context('check if the controller file created ', () => {
           /\@param\.path\.number\('id'\) id: number,\n /,
           /\@param\.query\.object\('where', getWhereSchemaFor\(Order\)\) where\?: Where<Order>,\n/,
           /\): Promise<Count> {\n/,
-          /return await this\.customerRepository\.orders\(id\)\.delete\(where\);\n {2}}\n}\n/,
+          /return this\.customerRepository\.orders\(id\)\.delete\(where\);\n {2}}\n}\n/,
         ];
 
         const deleteOrderClassByCustomerClassIdRegEx = [
@@ -569,7 +569,7 @@ context('check if the controller file created ', () => {
           /\@param\.path\.number\('id'\) id: number,\n /,
           /\@param\.query\.object\('where', getWhereSchemaFor\(OrderClass\)\) where\?: Where<OrderClass>,\n/,
           /\): Promise<Count> {\n/,
-          /return await this\.customerClassRepository\.orderClasses\(id\)\.delete\(where\);\n {2}}\n}\n/,
+          /return this\.customerClassRepository\.orderClasses\(id\)\.delete\(where\);\n {2}}\n}\n/,
         ];
 
         const deleteOrderClassTypeByCustomerClassTypeIdRegEx = [
@@ -580,7 +580,7 @@ context('check if the controller file created ', () => {
           /\@param\.path\.number\('id'\) id: number,\n /,
           /\@param\.query\.object\('where', getWhereSchemaFor\(OrderClassType\)\) where\?: Where<OrderClassType>,\n/,
           /\): Promise<Count> {\n/,
-          /return await this\.customerClassTypeRepository\.orderClassTypes\(id\)\.delete\(where\);\n {2}}\n}\n/,
+          /return this\.customerClassTypeRepository\.orderClassTypes\(id\)\.delete\(where\);\n {2}}\n}\n/,
         ];
 
         const expectedControllerFile = path.join(

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -501,7 +501,7 @@ module.exports = function(projGenerator, props, projectType) {
       // eslint-disable-next-line require-atomic-updates
       gen.prompt = sinon.stub(gen, 'prompt');
       gen.prompt.resolves(prompts);
-      return await gen[fnName]();
+      return gen[fnName]();
     }
   };
 };

--- a/packages/cli/test/unit/utils.unit.js
+++ b/packages/cli/test/unit/utils.unit.js
@@ -388,12 +388,7 @@ describe('Utils', () => {
         return files;
       };
       const artifactPath = path.join('tmp', 'app', folder);
-      return await utils.getArtifactList(
-        artifactPath,
-        artifactType,
-        suffix,
-        reader,
-      );
+      return utils.getArtifactList(artifactPath, artifactType, suffix, reader);
     }
   });
 

--- a/packages/context/src/__tests__/acceptance/interceptor.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/interceptor.acceptance.ts
@@ -176,7 +176,7 @@ describe('Interceptor', () => {
       // Add observers to the invocation context, which in turn adds listeners
       // to its parent - `ctx`
       invocationCtx.subscribe(() => {});
-      return await next();
+      return next();
     };
 
     class MyController {
@@ -447,7 +447,7 @@ describe('Interceptor', () => {
     class MyController {
       @intercept(async (invocationCtx, next) => {
         invocationCtx.bind('name').to('Mary');
-        return await next();
+        return next();
       })
       async interceptedHello(@inject('name') name: string) {
         return `Hello, ${name}`;
@@ -730,7 +730,7 @@ describe('Interceptor', () => {
           `Name '${name}' is not on the list of '${this.validNames}`,
         );
       }
-      return await next();
+      return next();
     }
   }
 

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -445,7 +445,7 @@ export class Context extends EventEmitter {
     propertyPath?: string,
     resolutionOptions?: ResolutionOptions,
   ): Promise<ConfigValueType | undefined> {
-    return await this.getConfigAsValueOrPromise<ConfigValueType>(
+    return this.getConfigAsValueOrPromise<ConfigValueType>(
       key,
       propertyPath,
       resolutionOptions,
@@ -762,7 +762,7 @@ export class Context extends EventEmitter {
     optionsOrSession?: ResolutionOptionsOrSession,
   ): Promise<ValueType | undefined> {
     this._debug('Resolving binding: %s', keyWithPath);
-    return await this.getValueOrPromise<ValueType | undefined>(
+    return this.getValueOrPromise<ValueType | undefined>(
       keyWithPath,
       optionsOrSession,
     );

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -153,7 +153,7 @@ export class Application extends Context implements LifeCycleObserver {
       const ctor = target as Constructor<T>;
       key = `${CoreBindings.SERVERS}.${ctor.name}`;
     }
-    return await this.get<T>(key);
+    return this.get<T>(key);
   }
 
   /**
@@ -173,7 +173,7 @@ export class Application extends Context implements LifeCycleObserver {
   }
 
   private async getLifeCycleObserverRegistry() {
-    return await this.get(CoreBindings.LIFE_CYCLE_OBSERVER_REGISTRY);
+    return this.get(CoreBindings.LIFE_CYCLE_OBSERVER_REGISTRY);
   }
 
   /**

--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -56,6 +56,10 @@ module.exports = {
     // TypeScript allows the same name for namespace and function
     'no-redeclare': 'off',
 
+    // Avoid promise rewrapping
+    // https://exploringjs.com/es2016-es2017/ch_async-functions.html#_returned-promises-are-not-wrapped
+    'no-return-await': 'error',
+
     /**
      * Rules imported from eslint-config-loopback
      */

--- a/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
+++ b/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
@@ -26,7 +26,7 @@ describe('HttpCachingProxy', () => {
   let proxy: HttpCachingProxy;
   after(stopProxy);
 
-  beforeEach('clean cache dir', async () => await rimraf(CACHE_DIR));
+  beforeEach('clean cache dir', async () => rimraf(CACHE_DIR));
 
   it('provides "url" property when running', async () => {
     await givenRunningProxy();

--- a/packages/repository/src/__tests__/acceptance/belongs-to.relation.acceptance.ts
+++ b/packages/repository/src/__tests__/acceptance/belongs-to.relation.acceptance.ts
@@ -65,11 +65,11 @@ describe('BelongsTo relation', () => {
     ) {}
 
     async findOwnerOfOrder(orderId: string) {
-      return await this.orderRepository.customer(orderId);
+      return this.orderRepository.customer(orderId);
     }
 
     async findOrderShipment(orderId: string) {
-      return await this.orderRepository.shipment(orderId);
+      return this.orderRepository.shipment(orderId);
     }
   }
 

--- a/packages/repository/src/__tests__/acceptance/has-many-without-di.relation.acceptance.ts
+++ b/packages/repository/src/__tests__/acceptance/has-many-without-di.relation.acceptance.ts
@@ -37,7 +37,7 @@ describe('HasMany relation', () => {
       customerId: number,
       orderData: Partial<Order>,
     ): Promise<Order> {
-      return await customerRepo.orders(customerId).create(orderData);
+      return customerRepo.orders(customerId).create(orderData);
     }
     const order = await createCustomerOrders(existingCustomerId, {
       description: 'order 1',
@@ -56,10 +56,10 @@ describe('HasMany relation', () => {
       customerId: number,
       orderData: Partial<Order>,
     ): Promise<Order> {
-      return await customerRepo.orders(customerId).create(orderData);
+      return customerRepo.orders(customerId).create(orderData);
     }
     async function findCustomerOrders(customerId: number) {
-      return await customerRepo.orders(customerId).find();
+      return customerRepo.orders(customerId).find();
     }
 
     const order = await createCustomerOrders(existingCustomerId, {

--- a/packages/repository/src/__tests__/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository/src/__tests__/acceptance/has-many.relation.acceptance.ts
@@ -194,36 +194,34 @@ describe('HasMany relation', () => {
       customerId: number,
       orderData: Partial<Order>,
     ): Promise<Order> {
-      return await this.customerRepository.orders(customerId).create(orderData);
+      return this.customerRepository.orders(customerId).create(orderData);
     }
 
     async findCustomerOrders(customerId: number) {
-      return await this.customerRepository.orders(customerId).find();
+      return this.customerRepository.orders(customerId).find();
     }
 
     async patchCustomerOrders(customerId: number, order: Partial<Order>) {
-      return await this.customerRepository.orders(customerId).patch(order);
+      return this.customerRepository.orders(customerId).patch(order);
     }
 
     async deleteCustomerOrders(customerId: number) {
-      return await this.customerRepository.orders(customerId).delete();
+      return this.customerRepository.orders(customerId).delete();
     }
 
     async getParentCustomer(customerId: number) {
-      return await this.customerRepository.parent(customerId);
+      return this.customerRepository.parent(customerId);
     }
 
     async createCustomerChildren(
       customerId: number,
       customerData: Partial<Customer>,
     ) {
-      return await this.customerRepository
-        .customers(customerId)
-        .create(customerData);
+      return this.customerRepository.customers(customerId).create(customerData);
     }
 
     async findCustomerChildren(customerId: number) {
-      return await this.customerRepository.customers(customerId).find();
+      return this.customerRepository.customers(customerId).find();
     }
   }
 

--- a/packages/repository/src/__tests__/acceptance/has-one.relation.acceptance.ts
+++ b/packages/repository/src/__tests__/acceptance/has-one.relation.acceptance.ts
@@ -210,32 +210,28 @@ describe('hasOne relation', () => {
       customerId: number,
       addressData: Partial<Address>,
     ): Promise<Address> {
-      return await this.customerRepository
-        .address(customerId)
-        .create(addressData);
+      return this.customerRepository.address(customerId).create(addressData);
     }
 
     async findCustomerAddress(customerId: number) {
-      return await this.customerRepository.address(customerId).get();
+      return this.customerRepository.address(customerId).get();
     }
 
     async findCustomerAddressWithFilter(
       customerId: number,
       filter: Filter<Address>,
     ) {
-      return await this.customerRepository.address(customerId).get(filter);
+      return this.customerRepository.address(customerId).get(filter);
     }
     async patchCustomerAddress(
       customerId: number,
       addressData: Partial<Address>,
     ) {
-      return await this.customerRepository
-        .address(customerId)
-        .patch(addressData);
+      return this.customerRepository.address(customerId).patch(addressData);
     }
 
     async deleteCustomerAddress(customerId: number) {
-      return await this.customerRepository.address(customerId).delete();
+      return this.customerRepository.address(customerId).delete();
     }
   }
 

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -3,12 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingScope, Binding, createBindingFromClass} from '@loopback/context';
+import {Binding, BindingScope, createBindingFromClass} from '@loopback/context';
 import {Application} from '@loopback/core';
 import * as debugFactory from 'debug';
 import {Class} from '../common-types';
-import {juggler, Repository} from '../repositories';
 import {SchemaMigrationOptions} from '../datasource';
+import {juggler, Repository} from '../repositories';
 
 const debug = debugFactory('loopback:repository:mixin');
 
@@ -85,7 +85,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async getRepository<R extends Repository<any>>(repo: Class<R>): Promise<R> {
-      return await this.get(`repositories.${repo.name}`);
+      return this.get(`repositories.${repo.name}`);
     }
 
     /**

--- a/packages/repository/src/relations/has-one/has-one.repository.ts
+++ b/packages/repository/src/relations/has-one/has-one.repository.ts
@@ -78,7 +78,7 @@ export class DefaultHasOneRepository<
     options?: Options,
   ): Promise<TargetEntity> {
     const targetRepository = await this.getTargetRepository();
-    return await targetRepository.create(
+    return targetRepository.create(
       constrainDataObject(targetModelData, this.constraint),
       options,
     );
@@ -116,7 +116,7 @@ export class DefaultHasOneRepository<
     options?: Options,
   ): Promise<Count> {
     const targetRepository = await this.getTargetRepository();
-    return await targetRepository.updateAll(
+    return targetRepository.updateAll(
       constrainDataObject(dataObject, this.constraint),
       constrainWhere({}, this.constraint),
       options,

--- a/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.ts
+++ b/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.ts
@@ -66,7 +66,7 @@ export async function cache<T>(
   });
   if (!req || req.method.toLowerCase() !== 'get') {
     // The method is not invoked by an http request, no caching
-    return await next();
+    return next();
   }
   const url = req.url;
   const cachedValue = cachedResults.get(url);

--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -859,7 +859,7 @@ describe('Routing', () => {
   }
 
   async function givenAServer(app: Application) {
-    return await app.getServer(RestServer);
+    return app.getServer(RestServer);
   }
 
   function givenControllerInApp(

--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -880,7 +880,7 @@ paths:
     options.rest = givenHttpServerConfig(options.rest);
     const app = new Application(options);
     app.component(RestComponent);
-    return await app.getServer(RestServer);
+    return app.getServer(RestServer);
   }
 
   function dummyRequestHandler(handler: {

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -136,12 +136,7 @@ export class ControllerRoute<T> extends BaseRoute {
       );
     }
     // Invoke the method with dependency injection
-    return await invokeMethod(
-      controller,
-      this._methodName,
-      requestContext,
-      args,
-    );
+    return invokeMethod(controller, this._methodName, requestContext, args);
   }
 }
 

--- a/packages/rest/src/router/handler-route.ts
+++ b/packages/rest/src/router/handler-route.ts
@@ -32,11 +32,6 @@ export class Route extends BaseRoute {
   ): Promise<OperationRetval> {
     // Use `invokeMethodWithInterceptors` to invoke the handler function so
     // that global interceptors are applied
-    return await invokeMethodWithInterceptors(
-      requestContext,
-      this,
-      '_handler',
-      args,
-    );
+    return invokeMethodWithInterceptors(requestContext, this, '_handler', args);
   }
 }


### PR DESCRIPTION
See https://eslint.org/docs/rules/no-return-await:

> Since the return value of an async function is always wrapped in
> `Promise.resolve, `return await` doesn’t actually do anything except
> add extra time before the overarching `Promise` resolves or rejects.

- The first commit modifies `@loopback/eslint-config`. This is a breaking change.
- The second commits fixes violations in our code base. This is a backwards-compatible chore.
- The third commit adds a new task to VSCode config to configure eslint problem matcher for `npm run lint:fix`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈