### PR TITLE
fix: enforce JsonSchemaOptions type when building model schema

### DIFF
--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -374,7 +374,7 @@ export function getControllerSpec(constructor: Function): ControllerSpec {
  * @param options - Additional options
  */
 export function getModelSchemaRef<T extends object>(
-  modelCtor: Function,
+  modelCtor: Function & {prototype: T},
   options?: JsonSchemaOptions<T>,
 ): SchemaRef {
   const jsonSchema = getJsonSchemaRef(modelCtor, options);

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -71,7 +71,7 @@ export function buildModelCacheKey<T extends object>(
  * @param ctor - Contructor of class to get JSON Schema from
  */
 export function getJsonSchema<T extends object>(
-  ctor: Function,
+  ctor: Function & {prototype: T},
   options?: JsonSchemaOptions<T>,
 ): JSONSchema {
   // In the near future the metadata will be an object with
@@ -124,7 +124,7 @@ export function getJsonSchema<T extends object>(
  * @param options - Additional options
  */
 export function getJsonSchemaRef<T extends object>(
-  modelCtor: Function,
+  modelCtor: Function & {prototype: T},
   options?: JsonSchemaOptions<T>,
 ): JSONSchema {
   const schemaWithDefinitions = getJsonSchema(modelCtor, options);
@@ -297,7 +297,7 @@ function getTitleSuffix<T extends object>(options: JsonSchemaOptions<T> = {}) {
  * @param ctor - Constructor of class to convert from
  */
 export function modelToJsonSchema<T extends object>(
-  ctor: Function,
+  ctor: Function & {prototype: T},
   jsonSchemaOptions: JsonSchemaOptions<T> = {},
 ): JSONSchema {
   const options = {...jsonSchemaOptions};


### PR DESCRIPTION
Modify functions like `getModelSchemaRef` to link the prototype of the constructor function with the `T` argument of `JsonSchemaOptions`.

Before this change, the following code happily compiles:

    schema: getModelSchemaRef(Note, {exclude: ['prop-doesnt-exist'])})

(The reason: compiler resolves `T` as `object`, therefore any properties are allowed in `exclude` list.)

With this change in place, the code above is rejected by the compiler, because the compiler understands that `T` is `Note` and therefore only `Note` properties are allowed in the `exclude` list.

    Argument of type '{ exclude: "prop-doesnt-exist"[]; }' is not
    assignable to parameter of type 'JsonSchemaOptions<Note>'.

      Types of property 'exclude' are incompatible.
        (...)

        Type '"prop-doesnt-exist"' is not assignable to
        type '"content" | "id" | "title" | "getId" | (...)'.

I discovered this problem while reviewing https://github.com/strongloop/loopback-next/pull/3466

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈