### PR TITLE
chore: exclude *.tsbuildinfo from published npm packages

### DIFF
--- a/examples/context/.npmignore
+++ b/examples/context/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/express-composition/.npmignore
+++ b/examples/express-composition/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/greeter-extension/.npmignore
+++ b/examples/greeter-extension/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/greeting-app/.npmignore
+++ b/examples/greeting-app/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/hello-world/.npmignore
+++ b/examples/hello-world/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/lb3-application/.npmignore
+++ b/examples/lb3-application/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/log-extension/.npmignore
+++ b/examples/log-extension/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/rpc-server/.npmignore
+++ b/examples/rpc-server/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/soap-calculator/.npmignore
+++ b/examples/soap-calculator/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/todo-list/.npmignore
+++ b/examples/todo-list/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo

--- a/examples/todo/.npmignore
+++ b/examples/todo/.npmignore
@@ -1,0 +1,2 @@
+# Exclude *.tsbuildinfo - cache for tsc incremental builds
+*.tsbuildinfo


### PR DESCRIPTION
There is no `files` section in example package.json. This change prevents
*.tsbuildinfo files to be published into npm.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
