### PR TITLE
fix(repository-json-schema): make exclude option reject properties

### DIFF
--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -67,6 +67,15 @@ describe('TodoApplication', () => {
       .expect(422);
   });
 
+  it('rejects requests with input that contains excluded properties', async () => {
+    const todo = givenTodo();
+    todo.id = 1;
+    await client
+      .post('/todos')
+      .send(todo)
+      .expect(422);
+  });
+
   it('creates an address-based reminder', async function() {
     // Increase the timeout to accommodate slow network connections
     // eslint-disable-next-line no-invalid-this

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -332,6 +332,9 @@ export function modelToJsonSchema<T extends object>(
 
   for (const p in meta.properties) {
     if (options.exclude && options.exclude.includes(p as keyof T)) {
+      result.not = (result.not as JSONSchema) || {};
+      result.not.anyOf = result.not.anyOf || [];
+      result.not.anyOf.push({required: [p]});
       continue;
     }
 


### PR DESCRIPTION
Before this, the `exclude` option would act as the `optional` option and would not reject any properties passed into the request body.

One thing to note is that the `details` of the error message is not helpful when rejecting e.g.:

```json
{
  "error": {
    "statusCode": 422,
    "name": "UnprocessableEntityError",
    "message": "The request body is invalid. See error object `details` property for more info.",
    "code": "VALIDATION_FAILED",
    "details": [
      {
        "path": "",
        "code": "not",
        "message": "should NOT be valid",
        "info": {}
      }
    ]
  }
}
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
