### PR TITLE
Check if bundler is installed

### DIFF
--- a/bin/build-docs-site.sh
+++ b/bin/build-docs-site.sh
@@ -11,6 +11,11 @@
 # Set `-e` so that non-zero exit code from any step will be honored
 set -e
 
+if ! [ -x "$(command -v bundle)" ]; then
+  echo 'Error: You must have Bundler installed (http://bundler.io)' >&2
+  exit 1
+fi
+
 # Set `-v` (verbose) for travis build
 if [ -n "$TRAVIS" ]; then
   set -v


### PR DESCRIPTION
This implementation will return an error message if the bundle command does not exist, therefore it does not execute the entire code until the command does not exist

This comes because it happened to me when I tried to do this https://github.com/strongloop/loopback-next/issues/3501#issuecomment-517951472

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
