### PR TITLE
fix(repository-json-schema): update to pass openapi validation in azure

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -770,6 +770,7 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
+            description: `(Schema options: { includeRelations: true })`,
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -785,6 +786,7 @@ describe('build-schema', () => {
           },
         },
         title: 'CategoryWithRelations',
+        description: `(Schema options: { includeRelations: true })`,
       };
       const jsonSchema = getJsonSchema(Category, {includeRelations: true});
       expect(jsonSchema).to.deepEqual(expectedSchema);
@@ -809,6 +811,7 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
+            description: `(Schema options: { includeRelations: true })`,
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -825,6 +828,7 @@ describe('build-schema', () => {
           },
         },
         title: 'CategoryWithoutPropWithRelations',
+        description: `(Schema options: { includeRelations: true })`,
       };
 
       // To check for case when there are no other properties than relational
@@ -988,7 +992,10 @@ describe('build-schema', () => {
           name: {type: 'string'},
           description: {type: 'string'},
         });
-        expect(excludeIdSchema.title).to.equal('ProductExcluding[id]');
+        expect(excludeIdSchema.title).to.equal('ProductExcluding_id_');
+        expect(excludeIdSchema.description).to.endWith(
+          `(Schema options: { exclude: [ 'id' ] })`,
+        );
       });
 
       it('excludes multiple properties when the option "exclude" is set to exclude multiple properties', () => {
@@ -1007,7 +1014,10 @@ describe('build-schema', () => {
           description: {type: 'string'},
         });
         expect(excludeIdAndNameSchema.title).to.equal(
-          'ProductExcluding[id,name]',
+          'ProductExcluding_id-name_',
+        );
+        expect(excludeIdAndNameSchema.description).to.endWith(
+          `(Schema options: { exclude: [ 'id', 'name' ] })`,
         );
       });
 
@@ -1050,7 +1060,10 @@ describe('build-schema', () => {
 
         const optionalIdSchema = getJsonSchema(Product, {optional: ['id']});
         expect(optionalIdSchema.required).to.deepEqual(['name']);
-        expect(optionalIdSchema.title).to.equal('ProductOptional[id]');
+        expect(optionalIdSchema.title).to.equal('ProductOptional_id_');
+        expect(optionalIdSchema.description).to.endWith(
+          `(Schema options: { optional: [ 'id' ] })`,
+        );
       });
 
       it('makes multiple properties optional when the option "optional" includes multiple properties', () => {
@@ -1063,7 +1076,10 @@ describe('build-schema', () => {
         });
         expect(optionalIdAndNameSchema.required).to.equal(undefined);
         expect(optionalIdAndNameSchema.title).to.equal(
-          'ProductOptional[id,name]',
+          'ProductOptional_id-name_',
+        );
+        expect(optionalIdAndNameSchema.description).to.endWith(
+          `(Schema options: { optional: [ 'id', 'name' ] })`,
         );
       });
 
@@ -1087,14 +1103,20 @@ describe('build-schema', () => {
           optional: ['name'],
         });
         expect(optionalNameSchema.required).to.deepEqual(['id']);
-        expect(optionalNameSchema.title).to.equal('ProductOptional[name]');
+        expect(optionalNameSchema.title).to.equal('ProductOptional_name_');
+        expect(optionalNameSchema.description).to.endWith(
+          `(Schema options: { optional: [ 'name' ] })`,
+        );
 
         optionalNameSchema = getJsonSchema(Product, {
           partial: false,
           optional: ['name'],
         });
         expect(optionalNameSchema.required).to.deepEqual(['id']);
-        expect(optionalNameSchema.title).to.equal('ProductOptional[name]');
+        expect(optionalNameSchema.title).to.equal('ProductOptional_name_');
+        expect(optionalNameSchema.description).to.endWith(
+          `(Schema options: { optional: [ 'name' ] })`,
+        );
       });
 
       it('uses "partial" option, if provided, when "optional" option is set but empty', () => {
@@ -1108,6 +1130,23 @@ describe('build-schema', () => {
         });
         expect(optionalNameSchema.required).to.equal(undefined);
         expect(optionalNameSchema.title).to.equal('ProductPartial');
+      });
+
+      it('can work with "optional" and "exclude" options together', () => {
+        const originalSchema = getJsonSchema(Product);
+        expect(originalSchema.required).to.deepEqual(['id', 'name']);
+        expect(originalSchema.title).to.equal('Product');
+
+        const bothOptionsSchema = getJsonSchema(Product, {
+          exclude: ['id'],
+          optional: ['name'],
+        });
+        expect(bothOptionsSchema.title).to.equal(
+          'ProductOptional_name_Excluding_id_',
+        );
+        expect(bothOptionsSchema.description).to.endWith(
+          `(Schema options: { exclude: [ 'id' ], optional: [ 'name' ] })`,
+        );
       });
     });
 

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -269,9 +269,9 @@ describe('build-schema', () => {
       expect(key).to.equal('modelPartial');
     });
 
-    it('returns "excluding[id,_rev]" when a single option "exclude" is set', () => {
+    it('returns "excluding_id-_rev_" when a single option "exclude" is set', () => {
       const key = buildModelCacheKey({exclude: ['id', '_rev']});
-      expect(key).to.equal('modelExcluding[id,_rev]');
+      expect(key).to.equal('modelExcluding_id-_rev_');
     });
 
     it('does not include "exclude" in concatenated option names if it is empty', () => {
@@ -283,9 +283,9 @@ describe('build-schema', () => {
       expect(key).to.equal('modelPartialWithRelations');
     });
 
-    it('returns "optional[id,_rev]" when "optional" is set with two items', () => {
+    it('returns "optional_id-_rev_" when "optional" is set with two items', () => {
       const key = buildModelCacheKey({optional: ['id', '_rev']});
-      expect(key).to.equal('modelOptional[id,_rev]');
+      expect(key).to.equal('modelOptional_id-_rev_');
     });
 
     it('does not include "optional" in concatenated option names if it is empty', () => {
@@ -302,7 +302,7 @@ describe('build-schema', () => {
         partial: true,
         optional: ['name'],
       });
-      expect(key).to.equal('modelOptional[name]');
+      expect(key).to.equal('modelOptional_name_');
     });
 
     it('includes "partial" in option names if "optional" is empty', () => {
@@ -322,7 +322,7 @@ describe('build-schema', () => {
         includeRelations: true,
       });
       expect(key).to.equal(
-        'modelOptional[name]Excluding[id,_rev]WithRelations',
+        'modelOptional_name_Excluding_id-_rev_WithRelations',
       );
     });
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [X] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈

This PR is related with my comment in https://github.com/strongloop/loopback-next/issues/1466 about problems found during the process of deploy an API in Azure.
With this PR is possible to deploy an API as "App Service" and connect it with the API Manager as OpenAPI.
I added the optional key 'itExtendsCompatibility' (boolean) in JsonSchemaOptions to tackle these cases. By default uses the current behaviour.
Added some tests, applied prettier & linter of the project.

P.S: by the way, trying to sign your CLA gives a 504 Error in Cloudfront.