### PR TITLE
fix: server union type contains null

### DIFF
--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -135,7 +135,7 @@ describe('HttpServer (integration)', () => {
       .to.have.property('address')
       .which.is.an.Object();
     await server.stop();
-    expect(server.address).to.be.undefined();
+    expect(server.address).to.be.null();
   });
 
   it('exports listening', async () => {

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -50,7 +50,7 @@ export type HttpProtocol = 'http' | 'https'; // Will be extended to `http2` in t
 export class HttpServer {
   private _listening: boolean = false;
   private _protocol: HttpProtocol;
-  private _address: string | AddressInfo;
+  private _address: string | AddressInfo | null;
   private requestListener: RequestListener;
   readonly server: http.Server | https.Server;
   private serverOptions: HttpServerOptions;
@@ -132,12 +132,12 @@ export class HttpServer {
    * URL of the HTTP / HTTPS server
    */
   public get url(): string {
-    if (typeof this._address === 'string') {
+    if (typeof this._address === 'string' || this._address == null) {
       /* istanbul ignore if */
       if (isWin32()) {
-        return this._address;
+        return this._address || '';
       }
-      const basePath = encodeURIComponent(this._address);
+      const basePath = encodeURIComponent(this._address || '');
       return `${this.protocol}+unix://${basePath}`;
     }
     let host = this.host;
@@ -160,8 +160,8 @@ export class HttpServer {
   /**
    * Address of the HTTP / HTTPS server
    */
-  public get address(): string | AddressInfo | undefined {
-    return this._listening ? this._address : undefined;
+  public get address(): string | AddressInfo | null {
+    return this._listening ? this._address : null;
   }
 }
 


### PR DESCRIPTION
The `address()` method from `net` module has `null` in its union type, which results in build error in the `http-server` module. See pic 1:
![Screen Shot 2019-08-07 at 6 31 20 PM](https://user-images.githubusercontent.com/12554153/62662377-e0f9f080-b941-11e9-968f-0858d4aa6c04.png)

The type definition of `address` from `net` module:

![Screen Shot 2019-08-07 at 6 31 56 PM](https://user-images.githubusercontent.com/12554153/62662378-e0f9f080-b941-11e9-893a-3ec58a1720ff.png)

*I am not very familiar with the address resolve, so treated `null` as an empty string here. Should we throw error if it's null?*

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
