### PR TITLE
feat(core): allow application to accept a parent context

### DIFF
--- a/packages/core/src/__tests__/acceptance/application.acceptance.ts
+++ b/packages/core/src/__tests__/acceptance/application.acceptance.ts
@@ -3,9 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Constructor, inject, Provider} from '@loopback/context';
 import {expect} from '@loopback/testlab';
-import {Constructor, Provider, inject} from '@loopback/context';
-
 import {Application, ControllerClass} from '../..';
 
 describe('Bootstrapping the application', () => {
@@ -52,6 +51,35 @@ describe('Bootstrapping the application', () => {
       app.component(ProductComponent);
 
       expect(app.find('controllers.*').map(b => b.key)).to.eql([
+        'controllers.ProductController',
+      ]);
+    });
+
+    it('allows parent context', async () => {
+      class ProductController {}
+
+      class ProductComponent {
+        controllers: ControllerClass[] = [ProductController];
+      }
+
+      const parent = new Application();
+      parent.component(ProductComponent);
+
+      const app = new Application(parent);
+
+      expect(app.find('controllers.*').map(b => b.key)).to.eql([
+        'controllers.ProductController',
+      ]);
+
+      const app2 = new Application({}, parent);
+
+      expect(app2.find('controllers.*').map(b => b.key)).to.eql([
+        'controllers.ProductController',
+      ]);
+
+      const app3 = new Application();
+
+      expect(app3.find('controllers.*').map(b => b.key)).to.not.containEql([
         'controllers.ProductController',
       ]);
     });

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -32,8 +32,29 @@ const debug = debugFactory('loopback:core:application');
  * and models.
  */
 export class Application extends Context implements LifeCycleObserver {
-  constructor(public options: ApplicationConfig = {}) {
-    super('application');
+  public readonly options: ApplicationConfig;
+
+  /**
+   * Create an application with the given parent context
+   * @param parent - Parent context
+   */
+  constructor(parent: Context);
+  /**
+   * Create an application with the given configuration and parent context
+   * @param config - Application configuration
+   * @param parent - Parent context
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  constructor(config?: ApplicationConfig, parent?: Context);
+
+  constructor(configOrParent?: ApplicationConfig | Context, parent?: Context) {
+    super(
+      configOrParent instanceof Context ? configOrParent : parent,
+      'application',
+    );
+
+    if (configOrParent instanceof Context) configOrParent = {};
+    this.options = configOrParent || {};
 
     // Bind the life cycle observer registry
     this.bind(CoreBindings.LIFE_CYCLE_OBSERVER_REGISTRY)
@@ -42,7 +63,7 @@ export class Application extends Context implements LifeCycleObserver {
     // Bind to self to allow injection of application context in other modules.
     this.bind(CoreBindings.APPLICATION_INSTANCE).to(this);
     // Make options available to other modules as well.
-    this.bind(CoreBindings.APPLICATION_CONFIG).to(options);
+    this.bind(CoreBindings.APPLICATION_CONFIG).to(this.options);
   }
 
   /**

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingKey} from '@loopback/context';
-import {Application, ApplicationMetadata, ControllerClass} from './application';
+import {
+  Application,
+  ApplicationConfig,
+  ApplicationMetadata,
+  ControllerClass,
+} from './application';
 import {
   LifeCycleObserverOptions,
   LifeCycleObserverRegistry,
@@ -25,7 +30,7 @@ export namespace CoreBindings {
   /**
    * Binding key for application configuration
    */
-  export const APPLICATION_CONFIG = BindingKey.create<object>(
+  export const APPLICATION_CONFIG = BindingKey.create<ApplicationConfig>(
     'application.config',
   );
 

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, BindingAddress, Constructor} from '@loopback/context';
+import {Binding, BindingAddress, Constructor, Context} from '@loopback/context';
 import {Application, ApplicationConfig, Server} from '@loopback/core';
 import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3';
 import {PathParams} from 'express-serve-static-core';
@@ -68,8 +68,21 @@ export class RestApplication extends Application implements HttpServerLike {
     return this.restServer.requestHandler;
   }
 
-  constructor(config: ApplicationConfig = {}) {
-    super(config);
+  /**
+   * Create a REST application with the given parent context
+   * @param parent - Parent context
+   */
+  constructor(parent: Context);
+  /**
+   * Create a REST application with the given configuration and parent context
+   * @param config - Application configuration
+   * @param parent - Parent context
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  constructor(config?: ApplicationConfig, parent?: Context);
+
+  constructor(configOrParent?: ApplicationConfig | Context, parent?: Context) {
+    super(configOrParent, parent);
     this.component(RestComponent);
   }
 


### PR DESCRIPTION
This change allows an application to inherit bindings from a parent. For example, we can create a parent application that mounts extension components, such as health, metrics, and tracing and use it as the base image for appsody loopback stack. See https://github.com/appsody/stacks/pull/95

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
