### PR TITLE
fix(cli): belongsto property generation

### DIFF
--- a/packages/cli/generators/relation/utils.generator.js
+++ b/packages/cli/generators/relation/utils.generator.js
@@ -113,12 +113,23 @@ exports.doesPropertyExist = function(classObj, propertyName) {
 
 exports.doesRelationExist = function(classObj, propertyName) {
   if (this.doesPropertyExist(classObj, propertyName)) {
-    throw new Error(
-      'property ' +
-        propertyName +
-        ' already exist in the model ' +
-        classObj.getName(),
-    );
+    // If the property is decorated by `@property()`,
+    // turn it to be a relational property decorated by `@belongsTo()`
+    const decorators = classObj.getProperty(propertyName).getDecorators();
+    const hasPropertyDecorator =
+      decorators.length > 0 && decorators[0].getName() === 'property';
+    // If it's already decorated by a relational decorator,
+    // throw error
+    if (!hasPropertyDecorator) {
+      throw new Error(
+        'relational property ' +
+          propertyName +
+          ' already exist in the model ' +
+          classObj.getName(),
+      );
+    }
+
+    this.deleteProperty(classObj.getProperty(propertyName));
   }
 };
 
@@ -175,6 +186,10 @@ exports.addForeignKey = function(foreignKey, sourceModelPrimaryKeyType) {
 exports.addProperty = function(classOBj, property) {
   classOBj.insertProperty(this.getPropertiesCount(classOBj), property);
   classOBj.insertText(this.getPropertyStartPos(classOBj), '\n');
+};
+
+exports.deleteProperty = function(propObj) {
+  propObj.remove();
 };
 
 exports.getPropertiesCount = function(classObj) {

--- a/packages/cli/test/fixtures/relation/index.js
+++ b/packages/cli/test/fixtures/relation/index.js
@@ -623,3 +623,43 @@ exports.SANDBOX_FILES4 = [
     ),
   },
 ];
+
+exports.SANDBOX_FILES6 = [
+  {
+    path: MODEL_APP_PATH,
+    file: 'customer.model.ts',
+    content: fs.readFileSync(require.resolve('./models/customer5.model.ts'), {
+      encoding: 'utf-8',
+    }),
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'order.model.ts',
+    content: fs.readFileSync(
+      require.resolve('./models/order-with-fk.model.ts'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  },
+  {
+    path: REPOSITORY_APP_PATH,
+    file: 'customer.repository.ts',
+    content: fs.readFileSync(
+      require.resolve('./repositories/customer.repository.ts'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  },
+  {
+    path: REPOSITORY_APP_PATH,
+    file: 'order.repository.ts',
+    content: fs.readFileSync(
+      require.resolve('./repositories/order.repository.ts'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  },
+];

--- a/packages/cli/test/fixtures/relation/models/order-with-fk.model.ts
+++ b/packages/cli/test/fixtures/relation/models/order-with-fk.model.ts
@@ -1,0 +1,25 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Order extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  name?: string;
+
+  @property({
+    type: 'string',
+  })
+  customerId: string;
+
+  constructor(data?: Partial<Order>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/integration/generators/relation.integration.js
+++ b/packages/cli/test/integration/generators/relation.integration.js
@@ -15,11 +15,13 @@ const SANDBOX_FILES = require('../../fixtures/relation').SANDBOX_FILES2;
 const SANDBOX_FILES3 = require('../../fixtures/relation').SANDBOX_FILES3;
 const SANDBOX_FILES4 = require('../../fixtures/relation').SANDBOX_FILES4;
 const SANDBOX_FILES5 = require('../../fixtures/relation').SANDBOX_FILES5;
+const SANDBOX_FILES6 = require('../../fixtures/relation').SANDBOX_FILES6;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
 const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 const CONTROLLER_PATH = 'src/controllers';
+const MODEL_PATH = 'src/models';
 const sandbox = new TestSandbox(SANDBOX_PATH);
 
 describe('lb4 relation', function() {
@@ -254,7 +256,7 @@ describe('lb4 relation', function() {
   });
 
   context('Execute relation when property already exist in the model', () => {
-    it('rejects relation when property already exist in the model', () => {
+    it('rejects relation when relation already exist in the model', () => {
       const prompt = {
         relationType: 'hasMany',
         sourceModel: 'Customer',
@@ -271,8 +273,33 @@ describe('lb4 relation', function() {
           )
           .withPrompts(prompt),
       ).to.be.rejectedWith(
-        /property orders already exist in the model Customer/,
+        /relational property orders already exist in the model Customer/,
       );
+    });
+    it('update property decorator when property already exist in the model', async () => {
+      const prompt = {
+        relationType: 'belongsTo',
+        sourceModel: 'Order',
+        destinationModel: 'Customer',
+      };
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES6,
+          }),
+        )
+        .withPrompts(prompt);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        MODEL_PATH,
+        'order.model.ts',
+      );
+
+      const relationalPropertyRegEx = /\@belongsTo\(\(\) \=\> Customer\)/;
+      assert.fileContent(expectedFile, relationalPropertyRegEx);
     });
   });
 });


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-next/issues/3186
Fixes https://github.com/strongloop/loopback-next/issues/3186

### Description

#### Problem

- First create a hasMany relation: `Customer` hasMany `Orders`, there will be a property `customerId` created in the Order model class in `order.model.ts`, decorated by `@property`

- Second create a belongsTo relation: `Order` belongsTo `Customer`, the generator exits with error because `customerId` property already exist

#### Solution

In the second step, generator should only reject existing relational property NOT regular property, with this PR, the regular property decorator will be replaced with a relational one, e.g. `@property()` will be replaced with `@belongsTo()`. 


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
