### PR TITLE
feat(repository): implement inclusionResolver for hasMany relation

### DIFF
--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
@@ -98,10 +98,12 @@ export function belongsToRelationAcceptance(
         name: 'Order McForder',
       });
       const order = await orderRepo.create({
-        customerId: deletedCustomer.id, // does not exist
-        description: 'Order of a fictional customer',
+        customerId: deletedCustomer.id,
+        description: 'custotmer will be deleted',
       });
       await customerRepo.deleteAll();
+
+      await orderRepo.deleteAll();
 
       await expect(findCustomerOfOrder(order.id)).to.be.rejectedWith(
         EntityNotFoundError,

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/customer.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/customer.repository.ts
@@ -49,8 +49,8 @@ export function createCustomerRepo(repoClass: CrudRepositoryCtor) {
       addressRepositoryGetter: Getter<typeof repoClass.prototype>,
     ) {
       super(Customer, db);
-      // create a has-many relation from this public method
       const ordersMeta = this.entityClass.definition.relations['orders'];
+      // create a has-many relation through this public method
       this.orders = createHasManyRepositoryFactory(
         ordersMeta as HasManyDefinition,
         orderRepositoryGetter,

--- a/packages/repository-tests/src/crud/relations/helpers.ts
+++ b/packages/repository-tests/src/crud/relations/helpers.ts
@@ -45,6 +45,16 @@ export function givenBoundCrudRepositories(
     async () => addressRepo,
   );
 
+  // register the inclusionResolvers here for customerRepo
+  customerRepo.inclusionResolvers.set(
+    'orders',
+    customerRepo.orders.inclusionResolver,
+  );
+  customerRepo.inclusionResolvers.set(
+    'customers',
+    customerRepo.customers.inclusionResolver,
+  );
+
   const orderRepoClass = createOrderRepo(repositoryClass);
   const orderRepo: OrderRepository = new orderRepoClass(
     db,
@@ -69,5 +79,10 @@ export function givenBoundCrudRepositories(
     async () => customerRepo,
   );
 
-  return {customerRepo, orderRepo, shipmentRepo, addressRepo};
+  return {
+    customerRepo,
+    orderRepo,
+    shipmentRepo,
+    addressRepo,
+  };
 }

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/flatten-targets-of-one-to-many-relation-helpers.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/flatten-targets-of-one-to-many-relation-helpers.unit.ts
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {flattenTargetsOfOneToManyRelation} from '../../../..';
+import {createProduct} from './relations-helpers-fixtures';
+
+describe('flattenTargetsOfOneToManyRelation', () => {
+  describe('gets the result of using reduceAsArray strategy for hasMany relation', () => {
+    it('gets the result of passing in a single sourceId', () => {
+      const pen = createProduct({name: 'pen', categoryId: 1});
+      const pencil = createProduct({name: 'pencil', categoryId: 1});
+      createProduct({name: 'eraser', categoryId: 2});
+
+      const result = flattenTargetsOfOneToManyRelation(
+        [1],
+        [pen, pencil],
+        'categoryId',
+      );
+      expect(result).to.eql([[pen, pencil]]);
+    });
+    it('gets the result of passing in multiple sourceIds', () => {
+      const pen = createProduct({name: 'pen', categoryId: 1});
+      const pencil = createProduct({name: 'pencil', categoryId: 1});
+      const eraser = createProduct({name: 'eraser', categoryId: 2});
+      // use [2, 1] here to show the order of sourceIds matters
+      const result = flattenTargetsOfOneToManyRelation(
+        [2, 1],
+        [pen, pencil, eraser],
+        'categoryId',
+      );
+      expect(result).to.deepEqual([[eraser], [pen, pencil]]);
+    });
+  });
+});

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/relations-helpers-fixtures.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/relations-helpers-fixtures.ts
@@ -124,7 +124,7 @@ export class Category extends Entity {
   }
 }
 interface CategoryRelations {
-  products?: Product[];
+  products?: ProductWithRelations;
 }
 type CategoryWithRelations = Category & CategoryRelations;
 

--- a/packages/repository/src/relations/has-many/has-many.helpers.ts
+++ b/packages/repository/src/relations/has-many/has-many.helpers.ts
@@ -7,7 +7,7 @@ import * as debugFactory from 'debug';
 import {camelCase} from 'lodash';
 import {InvalidRelationError} from '../../errors';
 import {isTypeResolver} from '../../type-resolver';
-import {HasManyDefinition} from '../relation.types';
+import {HasManyDefinition, RelationType} from '../relation.types';
 
 const debug = debugFactory('loopback:repository:has-many-helpers');
 
@@ -30,6 +30,11 @@ export type HasManyResolvedDefinition = HasManyDefinition & {
 export function resolveHasManyMetadata(
   relationMeta: HasManyDefinition,
 ): HasManyResolvedDefinition {
+  if ((relationMeta.type as RelationType) !== RelationType.hasMany) {
+    const reason = 'relation type must be HasMany';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
   if (!isTypeResolver(relationMeta.target)) {
     const reason = 'target must be a type resolver';
     throw new InvalidRelationError(reason, relationMeta);

--- a/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
@@ -1,0 +1,80 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as debugFactory from 'debug';
+import {AnyObject, Options} from '../../common-types';
+import {Entity} from '../../model';
+import {Filter, Inclusion} from '../../query';
+import {EntityCrudRepository} from '../../repositories/repository';
+import {
+  findByForeignKeys,
+  flattenTargetsOfOneToManyRelation,
+  StringKeyOf,
+} from '../relation.helpers';
+import {Getter, HasManyDefinition, InclusionResolver} from '../relation.types';
+import {resolveHasManyMetadata} from './has-many.helpers';
+
+const debug = debugFactory('loopback:repository:has-many-inclusion-resolver');
+
+/**
+ * Creates InclusionResolver for HasMany relation.
+ * Notice that this function only generates the inclusionResolver.
+ * It doesn't register it for the source repository.
+ *
+ * Notice: scope field for inclusion is not supported yet.
+ *
+ * @param meta - resolved metadata of the hasMany relation
+ * @param getTargetRepo - target repository i.e where related instances are
+ */
+export function createHasManyInclusionResolver<
+  Target extends Entity,
+  TargetID,
+  TargetRelations extends object
+>(
+  meta: HasManyDefinition,
+  getTargetRepo: Getter<
+    EntityCrudRepository<Target, TargetID, TargetRelations>
+  >,
+): InclusionResolver<Entity, Target> {
+  const relationMeta = resolveHasManyMetadata(meta);
+
+  return async function fetchHasManyModels(
+    entities: Entity[],
+    inclusion: Inclusion<Entity>,
+    options?: Options,
+  ): Promise<((Target & TargetRelations)[] | undefined)[]> {
+    if (!entities.length) return [];
+
+    debug('Fetching target models for entities:', entities);
+    debug('Relation metadata:', relationMeta);
+
+    const sourceKey = relationMeta.keyFrom;
+    const sourceIds = entities.map(e => (e as AnyObject)[sourceKey]);
+    const targetKey = relationMeta.keyTo as StringKeyOf<Target>;
+
+    debug('Parameters:', {sourceKey, sourceIds, targetKey});
+    debug('sourceId types', sourceIds.map(i => typeof i));
+
+    const targetRepo = await getTargetRepo();
+    const targetsFound = await findByForeignKeys(
+      targetRepo,
+      targetKey,
+      sourceIds,
+      inclusion.scope as Filter<Target>,
+      options,
+    );
+
+    debug('Targets found:', targetsFound);
+
+    const result = flattenTargetsOfOneToManyRelation(
+      sourceIds,
+      targetsFound,
+      targetKey,
+    );
+
+    debug('fetchHasManyModels result', result);
+    return result;
+  };
+}

--- a/packages/repository/src/relations/has-many/index.ts
+++ b/packages/repository/src/relations/has-many/index.ts
@@ -6,3 +6,4 @@
 export * from './has-many.decorator';
 export * from './has-many.repository';
 export * from './has-many-repository.factory';
+export * from './has-many.inclusion-resolver';

--- a/packages/repository/src/relations/relation.helpers.ts
+++ b/packages/repository/src/relations/relation.helpers.ts
@@ -169,6 +169,39 @@ export function flattenTargetsOfOneToOneRelation<
 }
 
 /**
+ * Returns an array of instances. The order of arrays is based on
+ * as a result of one to many relation. The order of arrays is based on
+ * the order of sourceIds
+ *
+ * @param sourceIds - One value or array of values of the target key
+ * @param targetEntities - target entities that satisfy targetKey's value (ids).
+ * @param targetKey - name of the target key
+ *
+ * @return
+ */
+export function flattenTargetsOfOneToManyRelation<Target extends Entity>(
+  sourceIds: unknown[],
+  targetEntities: Target[],
+  targetKey: StringKeyOf<Target>,
+): (Target[] | undefined)[] {
+  debug('flattenTargetsOfOneToManyRelation');
+  debug('sourceIds', sourceIds);
+  debug('sourceId types', sourceIds.map(i => typeof i));
+  debug('targetEntities', targetEntities);
+  debug('targetKey', targetKey);
+
+  const lookup = buildLookupMap<unknown, Target, Target[]>(
+    targetEntities,
+    targetKey,
+    reduceAsArray,
+  );
+
+  debug('lookup map', lookup);
+
+  return flattenMapByKeys(sourceIds, lookup);
+}
+
+/**
  * Returns an array of instances from the target map. The order of arrays is based on
  * the order of sourceIds
  *


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
resolves https://github.com/strongloop/loopback-next/issues/3447

This PR implements the inclusionResolver for `hasMany` relation:
- Add a helper `flattenTargetsOfOneToManyRelation` and its unit tests for `hasMany` 
- Add a new function `createHasManyInclusionResolver` to hasMany factory.
- Add tests for `hasManyInclusionResolver` in `repository-tests`.
  - introduce a new test-suite flag `supportsInclusionResolvers`.
- Add docs to explain the idea of `hasManyInclusionResolver`, and the basic setup/usages.

**Suggested way to review:**
-> start with the document file and `hasmany-inclusion-resolver.acceptance.ts` to get the idea of the inclusion resolver
->  review `has-many.inclusion-resolver.ts` to see the implementation details.
-> review the rest of files.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
