### PR TITLE
fix(docs): add contributing guide to LB4 docs

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -2,8 +2,8 @@
 lang: en
 title: 'Contributing code in LoopBack 4'
 keywords: LoopBack 4.0, contributing, community
-sidebar: contrib_sidebar
-permalink: /doc/en/contrib/code-contrib-lb4.html
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/code-contrib-lb4.html
 toc: false
 ---
 

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -646,6 +646,15 @@ children:
     url: Testing-your-application.html
     output: 'web, pdf'
 
+- title: 'Contribute to LoopBack 4'
+  url: code-contrib-lb4.html
+  output: 'web, pdf'
+  children:
+
+    - title: 'Submitting a pull request to LoopBack 4'
+      url: submitting_a_pr.html
+      output: 'web, pdf'
+
 - title: 'Reference'
   url: Reference.html
   output: 'web, pdf'

--- a/docs/site/submitting_a_pr.md
+++ b/docs/site/submitting_a_pr.md
@@ -2,7 +2,7 @@
 title: Submitting a pull request to LoopBack 4
 lang: en
 keywords: contributing, LoopBack community, pull request, PR, loopback
-sidebar: contrib_sidebar
+sidebar: lb4_sidebar
 permalink: /doc/en/lb4/submitting_a_pr.html
 ---
 


### PR DESCRIPTION
As @raymondfeng suggested, adding `Contribute to LoopBack 4` to the sidebar. 

![Screen Shot 2019-08-23 at 2 36 58 PM](https://user-images.githubusercontent.com/25489897/63615503-886a5a80-c5b3-11e9-84d7-752af5bcd3c6.png)
 
Both the `Contribute to LoopBack 4` and `Submitting a pull request to LoopBack 4` are existing pages.  As much as I don't want to change the permalink for `DEVELOPING.md`, I find it's problematic to keep it this way.  

Here are the user experience:
- In LB4 docs, user clicks on either page, sidebar will remain the same, i.e. LB4 sidebar
- In "Contributing", loopback.io/doc > Contributing to LB > Contributing code > LB4, the sidebar will be switched to the LB4 one.  It is problematic to use the `contrib_sidebar`, because it will cause broken links in the subsequent links you click.


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
