### PR TITLE
fix(docs): add lb4_editme_path for docs pages in folders

### DIFF
--- a/docs/site/decorators/Decorators_authenticate.md
+++ b/docs/site/decorators/Decorators_authenticate.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Authentication Decorator'
 keywords: LoopBack 4.0, LoopBack-Next
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/decorators
 permalink: /doc/en/lb4/Decorators_authenticate.html
 ---
 

--- a/docs/site/decorators/Decorators_inject.md
+++ b/docs/site/decorators/Decorators_inject.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Dependency Injection Decorators'
 keywords: LoopBack 4.0, LoopBack-Next
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/decorators
 permalink: /doc/en/lb4/Decorators_inject.html
 ---
 

--- a/docs/site/decorators/Decorators_openapi.md
+++ b/docs/site/decorators/Decorators_openapi.md
@@ -3,6 +3,7 @@ lang: en
 title: 'OpenAPI Decorators'
 keywords: LoopBack 4.0, LoopBack-Next
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/decorators
 permalink: /doc/en/lb4/Decorators_openapi.html
 ---
 

--- a/docs/site/decorators/Decorators_repository.md
+++ b/docs/site/decorators/Decorators_repository.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Repository Decorators'
 keywords: LoopBack 4.0, LoopBack-Next
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/decorators
 permalink: /doc/en/lb4/Decorators_repository.html
 ---
 

--- a/docs/site/deployment/Deploy-for-GDPR-readiness.md
+++ b/docs/site/deployment/Deploy-for-GDPR-readiness.md
@@ -5,6 +5,7 @@ keywords: LoopBack, GDPR
 tags: gdpr
 lang: en
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/deployment
 permalink: /doc/en/lb4/Deploy-for-GDPR-readiness.html
 summary: LoopBack considerations for GDPR readiness.
 ---

--- a/docs/site/deployment/Deploying-to-IBM-Cloud.md
+++ b/docs/site/deployment/Deploying-to-IBM-Cloud.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Deploying to IBM Cloud'
 keywords: LoopBack
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/deployment
 permalink: /doc/en/lb4/Deploying-to-IBM-Cloud.html
 ---
 

--- a/docs/site/deployment/Deploying-with-pm2-and-nginx.md
+++ b/docs/site/deployment/Deploying-with-pm2-and-nginx.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Deploying with pm2 and nginx'
 keywords: LoopBack, pm2, nginx
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/deployment
 permalink: /doc/en/lb4/deploying-with-pm2-and-nginx.html
 ---
 

--- a/docs/site/deployment/Deploying_to_ibm_cloud_kubernetes.md
+++ b/docs/site/deployment/Deploying_to_ibm_cloud_kubernetes.md
@@ -4,6 +4,7 @@ title: 'Deploying to Kubernetes on IBM Cloud'
 keywords:
   LoopBack 4.0, LoopBack 4, Kubernetes, IBM Cloud, Docker, Container Registry
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/deployment
 permalink: /doc/en/lb4/deploying_to_ibm_cloud_kubernetes.html
 ---
 

--- a/docs/site/tutorials/authentication/Authentication-Tutorial.md
+++ b/docs/site/tutorials/authentication/Authentication-Tutorial.md
@@ -3,6 +3,7 @@ lang: en
 title: 'How to secure your LoopBack 4 application with JWT authentication'
 keywords: LoopBack 4.0, LoopBack 4, Authentication, Tutorial
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/authentication
 permalink: /doc/en/lb4/Authentication-Tutorial.html
 summary: A LoopBack 4 application that uses JWT authentication
 ---

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add a Controller'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/soap-calculator
 permalink: /doc/en/lb4/soap-calculator-tutorial-add-controller.html
 ---
 

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-datasource.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-datasource.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add a Datasource'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/soap-calculator
 permalink: /doc/en/lb4/soap-calculator-tutorial-add-datasource.html
 ---
 

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-service.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-service.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add a Service'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/soap-calculator
 permalink: /doc/en/lb4/soap-calculator-tutorial-add-service.html
 ---
 

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-run-and-test.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-run-and-test.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Run and Test it'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/soap-calculator
 permalink: /doc/en/lb4/soap-calculator-tutorial-run-and-test.html
 ---
 

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-scaffolding.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-scaffolding.md
@@ -3,6 +3,7 @@ lang: en
 title: 'App scaffolding'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/soap-calculator
 permalink: /doc/en/lb4/soap-calculator-tutorial-scaffolding.html
 ---
 

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-web-service-overview.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-web-service-overview.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Soap Web Service Overview'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/soap-calculator
 permalink: /doc/en/lb4/soap-calculator-tutorial-web-service-overview.html
 ---
 

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -3,6 +3,7 @@ lang: en
 title: "Add TodoList and TodoList's Todo Controller"
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo-list
 permalink: /doc/en/lb4/todo-list-tutorial-controller.html
 summary:
   LoopBack 4 TodoList Application Tutorial - Add TodoList and TodoList's Todo

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add TodoList Model'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo-list
 permalink: /doc/en/lb4/todo-list-tutorial-model.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Model
 ---

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add TodoList Repository'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo-list
 permalink: /doc/en/lb4/todo-list-tutorial-repository.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Repository
 ---

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-sqldb.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-sqldb.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Running on relational databases'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo-list
 permalink: /doc/en/lb4/todo-list-tutorial-sqldb.html
 summary:
   LoopBack 4 TodoList Application Tutorial - Running on Relational Databases

--- a/docs/site/tutorials/todo/todo-tutorial-controller.md
+++ b/docs/site/tutorials/todo/todo-tutorial-controller.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add a Controller'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo
 permalink: /doc/en/lb4/todo-tutorial-controller.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Controller
 ---

--- a/docs/site/tutorials/todo/todo-tutorial-datasource.md
+++ b/docs/site/tutorials/todo/todo-tutorial-datasource.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add a Datasource'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo
 permalink: /doc/en/lb4/todo-tutorial-datasource.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Datasource
 ---

--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Integrate with a geo-coding service'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo
 permalink: /doc/en/lb4/todo-tutorial-geocoding-service.html
 summary:
   LoopBack 4 Todo Application Tutorial - Integrate with a geo-coding service

--- a/docs/site/tutorials/todo/todo-tutorial-model.md
+++ b/docs/site/tutorials/todo/todo-tutorial-model.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add the Todo Model'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo
 permalink: /doc/en/lb4/todo-tutorial-model.html
 summary: LoopBack 4 Todo Application Tutorial - Add the Todo Model
 ---

--- a/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
+++ b/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Putting it all together'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo
 permalink: /doc/en/lb4/todo-tutorial-putting-it-together.html
 summary: LoopBack 4 Todo Application Tutorial - Putting it all together
 ---

--- a/docs/site/tutorials/todo/todo-tutorial-repository.md
+++ b/docs/site/tutorials/todo/todo-tutorial-repository.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Add a Repository'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo
 permalink: /doc/en/lb4/todo-tutorial-repository.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Repository
 ---

--- a/docs/site/tutorials/todo/todo-tutorial-scaffolding.md
+++ b/docs/site/tutorials/todo/todo-tutorial-scaffolding.md
@@ -3,6 +3,7 @@ lang: en
 title: 'Create your app scaffolding'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+lb4_editme_path: strongloop/loopback-next/blob/master/docs/site/tutorials/todo
 permalink: /doc/en/lb4/todo-tutorial-scaffolding.html
 summary: LoopBack 4 Todo Application Tutorial - Create app scaffolding
 ---


### PR DESCRIPTION
Add `lb4_editme_path` in front matter when docs pages are in folders. 
Part 2 of the fix for #3214.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
