### PR TITLE
feat(context): allow @bind to be applied on the same class multiple times

### DIFF
--- a/packages/context/src/__tests__/unit/binding-decorator.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-decorator.unit.ts
@@ -6,12 +6,12 @@
 import {expect} from '@loopback/testlab';
 import {
   bind,
+  Binding,
   BindingScope,
   BindingScopeAndTags,
-  Constructor,
-  Binding,
-  bindingTemplateFor,
   BindingTemplate,
+  bindingTemplateFor,
+  Constructor,
   Provider,
 } from '../..';
 
@@ -113,6 +113,35 @@ describe('@bind', () => {
 
     expect(inspectScopeAndTags(MyController)).to.eql({
       tags: {rest: 'rest', name: 'my-controller'},
+      scope: BindingScope.SINGLETON,
+    });
+  });
+
+  it('allows the decorator to be applied multiple times', () => {
+    const spec: BindingTemplate = binding => {
+      binding.tag('rest').inScope(BindingScope.SINGLETON);
+    };
+
+    @bind(spec)
+    @bind({tags: [{name: 'my-controller'}]})
+    class MyController {}
+
+    expect(inspectScopeAndTags(MyController)).to.eql({
+      tags: {rest: 'rest', name: 'my-controller'},
+      scope: BindingScope.SINGLETON,
+    });
+  });
+
+  it('allows the decorator to override metadata from others', () => {
+    @bind({scope: BindingScope.SINGLETON, tags: {rest: 'rest', grpc: false}})
+    @bind({
+      scope: BindingScope.TRANSIENT,
+      tags: {name: 'my-controller', grpc: true},
+    })
+    class MyController {}
+
+    expect(inspectScopeAndTags(MyController)).to.eql({
+      tags: {rest: 'rest', name: 'my-controller', grpc: false},
       scope: BindingScope.SINGLETON,
     });
   });

--- a/packages/context/src/binding-decorator.ts
+++ b/packages/context/src/binding-decorator.ts
@@ -6,12 +6,12 @@
 import {ClassDecoratorFactory} from '@loopback/metadata';
 import {
   asBindingTemplate,
+  asClassOrProvider,
   asProvider,
   BindingMetadata,
   BindingSpec,
   BINDING_METADATA_KEY,
   isProviderClass,
-  asClassOrProvider,
   removeNameAndKeyTags,
 } from './binding-inspector';
 import {Provider} from './provider';
@@ -35,6 +35,13 @@ class BindDecoratorFactory extends ClassDecoratorFactory<BindingMetadata> {
       this.withTarget(this.spec, target);
       return this.spec;
     }
+  }
+
+  mergeWithOwn(ownMetadata: BindingMetadata) {
+    return {
+      templates: [...ownMetadata.templates, ...this.spec.templates],
+      target: this.spec.target,
+    };
   }
 
   withTarget(spec: BindingMetadata, target: Function) {


### PR DESCRIPTION
```ts
@bind({scope: BindingScope.TRANSIENT})
@bind({tags: {name: 'my-controller'}})
export class MyController {
}
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
