### PR TITLE
fix(repository-json-schema): guards against undefined in schema builder

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -1082,5 +1082,27 @@ describe('build-schema', () => {
         expect(optionalNameSchema.title).to.equal('ProductPartial');
       });
     });
+
+    it('can generate a schema involving recursive entities', () => {
+      @model()
+      class Category extends Entity {
+        @property({id: true})
+        id: number;
+
+        @hasMany(() => Category)
+        subCategories?: Category[];
+      }
+      const schema = getJsonSchema(Category, {includeRelations: true});
+      expect(schema.properties).to.deepEqual({
+        id: {type: 'number'},
+        subCategories: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/CategoryWithRelations',
+          },
+        },
+      });
+      expect(schema.title).to.equal('CategoryWithRelations');
+    });
   });
 });

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -405,7 +405,9 @@ export function modelToJsonSchema<T extends object>(
       delete schema.definitions;
     }
 
-    result.definitions[name] = schema;
+    if (result.definitions) {
+      result.definitions[name] = schema;
+    }
   }
   return result;
 }


### PR DESCRIPTION
Guards the includeReferencedSchemas function against assigning to
undefined.

This appears to happen when a model refers to itself and the delete
keyword wipes out the objects property.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
