### PR TITLE
feat(booter-lb3app): process generated OpenApiSpec of lb3 app

### DIFF
--- a/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
+++ b/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {OperationObject} from '@loopback/rest';
+import {OperationObject, OpenApiSpec} from '@loopback/rest';
 import {Client, expect} from '@loopback/testlab';
 import * as _ from 'lodash';
 import {
@@ -187,6 +187,32 @@ describe('booter-lb3app', () => {
 
     it('does not get route defined outside a model', async () => {
       await client.get('/coffee').expect(404);
+    });
+  });
+
+  context('using specTransformer to modify OpenAPI spec', () => {
+    before(async () => {
+      ({app, client} = await setupApplication({
+        lb3app: {
+          path: '../fixtures/lb3app/server/server',
+          specTransformer: (spec: OpenApiSpec): OpenApiSpec =>
+            _.merge(spec, {
+              paths: {
+                '/CoffeeShops': {
+                  post: {
+                    summary: 'just a very simple modification',
+                  },
+                },
+              },
+            }),
+        },
+      }));
+    });
+
+    it('does apply the spec modification', () => {
+      const spec = app.restServer.getApiSpec();
+      const createOp: OperationObject = spec.paths['/api/CoffeeShops'].post;
+      expect(createOp.summary).to.eql('just a very simple modification');
     });
   });
 });

--- a/packages/booter-lb3app/src/lb3app.booter.ts
+++ b/packages/booter-lb3app/src/lb3app.booter.ts
@@ -101,7 +101,11 @@ export class Lb3AppBooter implements Booter {
       // swagger2openapi options
     });
 
-    return result.openapi as OpenApiSpec;
+    let spec = result.openapi as OpenApiSpec;
+    if (typeof this.options.specTransformer === 'function') {
+      spec = this.options.specTransformer(spec);
+    }
+    return spec;
   }
 
   private mountFullApp(lb3App: Lb3Application, spec: OpenApiSpec) {
@@ -128,6 +132,7 @@ export interface Lb3AppBooterOptions {
   path: string;
   mode: 'fullApp' | 'restRouter';
   restApiRoot: string;
+  specTransformer?: (spec: OpenApiSpec) => OpenApiSpec;
 }
 
 interface Lb3Application extends ExpressApplication {


### PR DESCRIPTION
While migration from lb3 to lb4 I had several issues with the converted openapi spec of my lb3app, e.g.:
  - incomplete return types which results in unuseable angular model interfaces
  - renaming of models in the spec to avoid name collisions between lb3 and lb4 implementations

We solved this by post processing the generated openapi spec before it gets published into lb4.
If you think this is the way to go, we can add some tests.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
