### PR TITLE
feat: allow custom decorator name for error messages

### DIFF
--- a/packages/authentication/src/decorators/authenticate.decorator.ts
+++ b/packages/authentication/src/decorators/authenticate.decorator.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  MetadataInspector,
   Constructor,
+  MetadataInspector,
   MethodDecoratorFactory,
 } from '@loopback/context';
 import {AUTHENTICATION_METADATA_KEY} from '../keys';
@@ -31,6 +31,7 @@ export function authenticate(strategyName: string, options?: object) {
       strategy: strategyName,
       options: options || {},
     },
+    {decoratorName: '@authenticate'},
   );
 }
 

--- a/packages/authorization/src/decorators/authorize.ts
+++ b/packages/authorization/src/decorators/authorize.ts
@@ -109,6 +109,7 @@ export function authorize(spec: AuthorizationMetadata) {
       return AuthorizeMethodDecoratorFactory.createDecorator(
         AUTHORIZATION_METHOD_KEY,
         spec,
+        {decoratorName: '@authorize'},
       )(target, method, methodDescriptor!);
     }
     if (typeof target === 'function' && !method && !methodDescriptor) {
@@ -116,6 +117,7 @@ export function authorize(spec: AuthorizationMetadata) {
       return AuthorizeClassDecoratorFactory.createDecorator(
         AUTHORIZATION_CLASS_KEY,
         spec,
+        {decoratorName: '@authorize'},
       )(target);
     }
     // Not on a class or method

--- a/packages/context/src/__tests__/acceptance/binding-config.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/binding-config.acceptance.ts
@@ -59,6 +59,19 @@ describe('Context bindings - injecting configuration for bound artifacts', () =>
     expect(server1.configObj).to.eql({port: 3000});
   });
 
+  it('reports error if @config.* is applied more than once', () => {
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      class TestClass {
+        constructor() {}
+
+        @config('foo') @config('bar') foo: string;
+      }
+    }).to.throw(
+      '@config cannot be applied more than once on TestClass.prototype.foo',
+    );
+  });
+
   it('allows propertyPath for injection', async () => {
     class RestServerWithPort {
       constructor(@config('port') public port: number) {}

--- a/packages/context/src/__tests__/unit/inject.unit.ts
+++ b/packages/context/src/__tests__/unit/inject.unit.ts
@@ -131,6 +131,17 @@ describe('function argument injection', () => {
     const meta = describeInjectedArguments(Test);
     expect(meta.map(m => m.bindingSelector)).to.deepEqual(['controller']);
   });
+
+  it('reports error if @inject is applied more than once', () => {
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      class TestClass {
+        constructor(@inject('foo') @inject('bar') foo: string) {}
+      }
+    }).to.throw(
+      '@inject cannot be applied more than once on TestClass.constructor[0]',
+    );
+  });
 });
 
 describe('property injection', () => {
@@ -180,6 +191,19 @@ describe('property injection', () => {
         foo() {}
       }
     }).to.throw(/@inject cannot be used on a method/);
+  });
+
+  it('reports error if @inject.* is applied more than once', () => {
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      class TestClass {
+        constructor() {}
+
+        @inject.getter('foo') @inject('bar') foo: string;
+      }
+    }).to.throw(
+      '@inject.getter cannot be applied more than once on TestClass.prototype.foo',
+    );
   });
 
   it('supports inheritance without overriding property', () => {

--- a/packages/context/src/binding-decorator.ts
+++ b/packages/context/src/binding-decorator.ts
@@ -83,6 +83,7 @@ export function bind(...specs: BindingSpec[]): ClassDecorator {
     const decorator = BindDecoratorFactory.createDecorator(
       BINDING_METADATA_KEY,
       spec,
+      {decoratorName: '@bind'},
     );
     decorator(target);
   };

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -146,7 +146,7 @@ export function inject(
         },
         // Do not deep clone the spec as only metadata is mutable and it's
         // shallowly cloned
-        {cloneInputSpec: false},
+        {cloneInputSpec: false, decoratorName: injectionMetadata.decorator},
       );
       paramDecorator(target, member!, methodDescriptorOrParameterIndex);
     } else if (member) {
@@ -182,7 +182,7 @@ export function inject(
         },
         // Do not deep clone the spec as only metadata is mutable and it's
         // shallowly cloned
-        {cloneInputSpec: false},
+        {cloneInputSpec: false, decoratorName: injectionMetadata.decorator},
       );
       propDecorator(target, member!);
     } else {

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -263,6 +263,7 @@ export function intercept(...interceptorOrKeys: InterceptorOrKey[]) {
       return InterceptMethodDecoratorFactory.createDecorator(
         INTERCEPT_METHOD_KEY,
         interceptorOrKeys,
+        {decoratorName: '@intercept'},
       )(target, method, methodDescriptor!);
     }
     if (typeof target === 'function' && !method && !methodDescriptor) {
@@ -270,6 +271,7 @@ export function intercept(...interceptorOrKeys: InterceptorOrKey[]) {
       return InterceptClassDecoratorFactory.createDecorator(
         INTERCEPT_CLASS_KEY,
         interceptorOrKeys,
+        {decoratorName: '@intercept'},
       )(target);
     }
     // Not on a class or method

--- a/packages/metadata/README.md
+++ b/packages/metadata/README.md
@@ -28,6 +28,7 @@ function myClassDecorator(spec: MyClassMetadata): ClassDecorator {
   return ClassDecoratorFactory.createDecorator<MyClassMetadata>(
     'metadata-key-for-my-class-decorator',
     spec,
+    {decoratorName: '@myClassDecorator'},
   );
 }
 ```
@@ -209,6 +210,8 @@ functions. There are two flags for the options:
   Sometimes we use shared spec for the decoration, but the decorator function
   might need to mutate the object. Cloning the input spec makes it safe to use
   the same spec (`template`) to decorate different members. Default to `true`.
+- decoratorName: Name for the decorator such as `@inject` for error and
+  debugging messages.
 
 ### Customize inheritance of metadata
 

--- a/packages/metadata/src/__tests__/unit/decorator-factory.unit.ts
+++ b/packages/metadata/src/__tests__/unit/decorator-factory.unit.ts
@@ -80,6 +80,12 @@ describe('ClassDecoratorFactory', () => {
     return ClassDecoratorFactory.createDecorator('test', spec);
   }
 
+  function testDecorator(spec: object): ClassDecorator {
+    return ClassDecoratorFactory.createDecorator('test', spec, {
+      decoratorName: '@test',
+    });
+  }
+
   const xSpec = {x: 1};
   @classDecorator(xSpec)
   class BaseController {}
@@ -116,8 +122,17 @@ describe('ClassDecoratorFactory', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       class MyController {}
     }).to.throw(
-      /Decorator cannot be applied more than once on class MyController/,
+      /ClassDecorator cannot be applied more than once on class MyController/,
     );
+  });
+
+  it('throws with decoratorName if applied more than once on the target', () => {
+    expect(() => {
+      @testDecorator({x: 1})
+      @testDecorator({y: 2})
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      class MyController {}
+    }).to.throw(/@test cannot be applied more than once on class MyController/);
   });
 });
 
@@ -690,7 +705,9 @@ describe('MethodParameterDecoratorFactory with invalid decorations', () => {
    * @param spec
    */
   function methodParameterDecorator(spec: object): MethodDecorator {
-    return MethodParameterDecoratorFactory.createDecorator('test', spec);
+    return MethodParameterDecoratorFactory.createDecorator('test', spec, {
+      decoratorName: '@param',
+    });
   }
 
   it('reports error if the # of decorations exceeeds the # of params', () => {
@@ -703,7 +720,7 @@ describe('MethodParameterDecoratorFactory with invalid decorations', () => {
         myMethod(a: string, b: number) {}
       }
     }).to.throw(
-      /The decorator is used more than 2 time\(s\) on MyController\.prototype\.myMethod\(\)/,
+      /@param is used more than 2 time\(s\) on MyController\.prototype\.myMethod\(\)/,
     );
   });
 });

--- a/packages/openapi-v3/src/decorators/api.decorator.ts
+++ b/packages/openapi-v3/src/decorators/api.decorator.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ControllerSpec} from '../controller-spec';
 import {ClassDecoratorFactory} from '@loopback/context';
+import {ControllerSpec} from '../controller-spec';
 import {OAI3Keys} from '../keys';
 
 /**
@@ -30,5 +30,6 @@ export function api(spec: ControllerSpec) {
   return ClassDecoratorFactory.createDecorator<ControllerSpec>(
     OAI3Keys.CLASS_KEY,
     spec,
+    {decoratorName: '@api'},
   );
 }

--- a/packages/openapi-v3/src/decorators/operation.decorator.ts
+++ b/packages/openapi-v3/src/decorators/operation.decorator.ts
@@ -84,5 +84,6 @@ export function operation(verb: string, path: string, spec?: OperationObject) {
       path,
       spec,
     },
+    {decoratorName: '@operation'},
   );
 }

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -71,6 +71,7 @@ export function param(paramSpec: ParameterObject) {
     ParameterDecoratorFactory.createDecorator<ParameterObject>(
       OAI3Keys.PARAMETERS_KEY,
       paramSpec,
+      {decoratorName: '@param'},
     )(target, member, index);
   };
 }

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -119,6 +119,7 @@ export function requestBody(requestBodySpec?: Partial<RequestBodyObject>) {
     ParameterDecoratorFactory.createDecorator<RequestBodyObject>(
       OAI3Keys.REQUEST_BODY_KEY,
       requestBodySpec as RequestBodyObject,
+      {decoratorName: '@requestBody'},
     )(target, member, index);
   };
 }

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -48,6 +48,7 @@ export function model(definition?: Partial<ModelDefinitionSyntax>) {
     const decorator = ClassDecoratorFactory.createDecorator(
       MODEL_KEY,
       definition,
+      {decoratorName: '@model'},
     );
 
     decorator(target);
@@ -111,6 +112,7 @@ export function property(definition?: Partial<PropertyDefinition>) {
   return PropertyDecoratorFactory.createDecorator(
     MODEL_PROPERTIES_KEY,
     Object.assign({}, definition),
+    {decoratorName: '@property'},
   );
 }
 

--- a/packages/repository/src/relations/relation.decorator.ts
+++ b/packages/repository/src/relations/relation.decorator.ts
@@ -17,7 +17,9 @@ export const RELATIONS_KEY = 'loopback:relations';
  */
 export function relation(definition?: Object) {
   // Apply relation definition to the model class
-  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, definition);
+  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, definition, {
+    decoratorName: '@relation',
+  });
 }
 
 /**
@@ -46,7 +48,9 @@ export function getModelRelations(
  */
 export function embedsOne(definition?: Object) {
   const rel = Object.assign({type: RelationType.embedsOne}, definition);
-  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel);
+  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel, {
+    decoratorName: '@embedsOne',
+  });
 }
 
 /**
@@ -56,7 +60,9 @@ export function embedsOne(definition?: Object) {
  */
 export function embedsMany(definition?: Object) {
   const rel = Object.assign({type: RelationType.embedsMany}, definition);
-  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel);
+  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel, {
+    decoratorName: '@embedsMany',
+  });
 }
 
 /**
@@ -66,7 +72,9 @@ export function embedsMany(definition?: Object) {
  */
 export function referencesOne(definition?: Object) {
   const rel = Object.assign({type: RelationType.referencesOne}, definition);
-  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel);
+  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel, {
+    decoratorName: '@referencesOne',
+  });
 }
 
 /**
@@ -76,5 +84,7 @@ export function referencesOne(definition?: Object) {
  */
 export function referencesMany(definition?: Object) {
   const rel = Object.assign({type: RelationType.referencesMany}, definition);
-  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel);
+  return PropertyDecoratorFactory.createDecorator(RELATIONS_KEY, rel, {
+    decoratorName: '@referencesMany',
+  });
 }


### PR DESCRIPTION
Extracted and improved from https://github.com/strongloop/loopback-next/pull/3617

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
