### PR TITLE
feat(booter-lb3app): signal to lb3app that it is mounted inside lb4

### DIFF
--- a/packages/booter-lb3app/src/lb3app.booter.ts
+++ b/packages/booter-lb3app/src/lb3app.booter.ts
@@ -74,6 +74,7 @@ export class Lb3AppBooter implements Booter {
   private async loadAndBootTheApp() {
     debug('Loading LB3 app from', this.appPath);
     const lb3App = require(this.appPath);
+    lb3App.set('lb4', this.options.mode);
 
     debug(
       'If your LB3 app does not boot correctly then make sure it is using loopback-boot version 3.2.1 or higher.',


### PR DESCRIPTION
Send a signal to a lb3app that is is mounted inside of lb4.
Idea 1 to fix #3624.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
