### PR TITLE
feat(rest-crud): add "replaceById" endpoint

### DIFF
--- a/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
+++ b/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
@@ -213,6 +213,41 @@ describe('CrudRestController for a simple Product model', () => {
     });
   });
 
+  describe('replaceById', () => {
+    beforeEach(seedData);
+
+    it('replaces model with the given id', async () => {
+      const newData = Object.assign({}, pen.toJSON(), PATCH_DATA);
+      await client
+        .put(`/products/${pen.id}`)
+        .send(newData)
+        .expect(204);
+
+      const stored = await repo.find();
+      expect(toJSON(stored)).to.deepEqual([
+        {...newData},
+        {...toJSON(pencil) /* pencil was not modified */},
+      ]);
+    });
+
+    // TODO(bajtos) to fully verify this functionality, we should create
+    // a new test suite that will configure a PK with a different name
+    // and type, e.g. `pk: string` instead of `id: number`.
+    it('uses correct schema for the id parameter', async () => {
+      const spec = app.restServer.getApiSpec();
+      const findByIdOp = spec.paths['/products/{id}']['patch'];
+      expect(findByIdOp).to.containDeep({
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            schema: {type: 'number'},
+          },
+        ],
+      });
+    });
+  });
+
   describe('deleteById', () => {
     beforeEach(seedData);
 

--- a/packages/rest-crud/src/crud-rest.controller.ts
+++ b/packages/rest-crud/src/crud-rest.controller.ts
@@ -27,6 +27,7 @@ import {
   ParameterObject,
   patch,
   post,
+  put,
   requestBody,
   ResponsesObject,
   SchemaObject,
@@ -229,6 +230,18 @@ export function defineCrudRestController<
         // with no explicit type-casts required
         data as DataObject<T>,
       );
+    }
+
+    @put('/{id}', {
+      responses: {
+        '204': {description: `${modelName} was updated`},
+      },
+    })
+    async replaceById(
+      @param(idPathParam) id: IdType,
+      @body(modelCtor) data: T,
+    ): Promise<void> {
+      await this.repository.replaceById(id, data);
     }
 
     @del('/{id}', {


### PR DESCRIPTION
While working on #3617, I discovered that I forgot to implement `replaceById` in `@loopback/rest-crud`. This pull request is adding that operation.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈