### PR TITLE
fix(context): allow `inject` to be explicitly invoked for class ctor args

### DIFF
--- a/packages/context/src/__tests__/unit/inject.unit.ts
+++ b/packages/context/src/__tests__/unit/inject.unit.ts
@@ -29,6 +29,16 @@ describe('function argument injection', () => {
     expect(meta.map(m => m.bindingSelector)).to.deepEqual(['foo']);
   });
 
+  it('allows decorator to be explicitly invoked for class ctor args', () => {
+    class TestClass {
+      constructor(foo: string) {}
+    }
+    inject('foo')(TestClass, undefined, 0);
+
+    const meta = describeInjectedArguments(TestClass);
+    expect(meta.map(m => m.bindingSelector)).to.deepEqual(['foo']);
+  });
+
   it('can retrieve information about injected method arguments', () => {
     class TestClass {
       test(@inject('foo') foo: string) {}

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -124,7 +124,7 @@ export function inject(
   }
   return function markParameterOrPropertyAsInjected(
     target: Object,
-    member: string,
+    member: string | undefined,
     methodDescriptorOrParameterIndex?:
       | TypedPropertyDescriptor<BoundValue>
       | number,


### PR DESCRIPTION
See the discussion in https://github.com/strongloop/loopback-next/pull/3617

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈