### PR TITLE
fix(todo-list tutorial): add missing code to the TodoRepository

### DIFF
--- a/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
@@ -174,53 +174,90 @@ Let's do the same on the `TodoRepository`:
 {% include code-caption.html content="src/repositories/todo.repository.ts" %}
 
 ```ts
-async find(
-  filter?: Filter<Todo>,
-  options?: Options,
-): Promise<TodoWithRelations[]> {
-  // Prevent juggler for applying "include" filter
-  // Juggler is not aware of LB4 relations
-  const include = filter && filter.include;
-  filter = {...filter, include: undefined};
+import {Getter, inject} from '@loopback/core';
+import {
+  BelongsToAccessor,
+  DefaultCrudRepository,
+  Filter,
+  juggler,
+  Options,
+  repository,
+} from '@loopback/repository';
+import {Todo, TodoList, TodoRelations, TodoWithRelations} from '../models';
+import {TodoListRepository} from './todo-list.repository';
 
-  const result = await super.find(filter, options);
+export class TodoRepository extends DefaultCrudRepository<
+  Todo,
+  typeof Todo.prototype.id,
+  TodoRelations
+> {
+  public readonly todoList: BelongsToAccessor<
+    TodoList,
+    typeof Todo.prototype.id
+  >;
 
-  // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
-    // and use `inq` operator to fetch related todo-lists in fewer DB queries
-    // this is a temporary implementation, please see
-    // https://github.com/strongloop/loopback-next/issues/3195
-  if (include && include.length && include[0].relation === 'todoList') {
-    await Promise.all(
-      result.map(async r => {
-        r.todoList = await this.todoList(r.id);
-      }),
+  constructor(
+    @inject('datasources.db') dataSource: juggler.DataSource,
+    @repository.getter('TodoListRepository')
+    protected todoListRepositoryGetter: Getter<TodoListRepository>,
+  ) {
+    super(Todo, dataSource);
+
+    this.todoList = this.createBelongsToAccessorFor(
+      'todoList',
+      todoListRepositoryGetter,
     );
   }
 
-  return result;
-}
+  async find(
+    filter?: Filter<Todo>,
+    options?: Options,
+  ): Promise<TodoWithRelations[]> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = {...filter, include: undefined};
 
-async findById(
-  id: typeof Todo.prototype.id,
-  filter?: Filter<Todo>,
-  options?: Options,
-): Promise<TodoWithRelations> {
-  // Prevent juggler for applying "include" filter
-  // Juggler is not aware of LB4 relations
-  const include = filter && filter.include;
-  filter = {...filter, include: undefined};
+    const result = await super.find(filter, options);
 
-  const result = await super.findById(id, filter, options);
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todo-lists in fewer DB queries
+    // this is a temporary implementation, please see
+    // https://github.com/strongloop/loopback-next/issues/3195
+    if (include && include.length && include[0].relation === 'todoList') {
+      await Promise.all(
+        result.map(async r => {
+          // eslint-disable-next-line require-atomic-updates
+          r.todoList = await this.todoList(r.id);
+        }),
+      );
+    }
 
-  // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
-  // and use `inq` operator to fetch related todo-lists in fewer DB queries
-  // this is a temporary implementation, please see
-  // https://github.com/strongloop/loopback-next/issues/3195
-  if (include && include.length && include[0].relation === 'todoList') {
-    result.todoList = await this.todoList(result.id);
+    return result;
   }
 
-  return result;
+  async findById(
+    id: typeof Todo.prototype.id,
+    filter?: Filter<Todo>,
+    options?: Options,
+  ): Promise<TodoWithRelations> {
+    // Prevent juggler for applying "include" filter
+    // Juggler is not aware of LB4 relations
+    const include = filter && filter.include;
+    filter = {...filter, include: undefined};
+
+    const result = await super.findById(id, filter, options);
+
+    // poor-mans inclusion resolver, this should be handled by DefaultCrudRepo
+    // and use `inq` operator to fetch related todo-lists in fewer DB queries
+    // this is a temporary implementation, please see
+    // https://github.com/strongloop/loopback-next/issues/3195
+    if (include && include.length && include[0].relation === 'todoList') {
+      result.todoList = await this.todoList(result.id);
+    }
+
+    return result;
+  }
 }
 ```
 


### PR DESCRIPTION
Code for adding `todoList` property to the `TodoRepository` was missing.
