### PR TITLE
fix(cli): add 'generated: true' entry to id property when generating

### DIFF
--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -411,6 +411,13 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
           default: false,
         },
         {
+          name: 'generated',
+          message: `Is ${chalk.yellow(this.propName)} generated automatically?`,
+          type: 'confirm',
+          default: true,
+          when: answers => answers.id,
+        },
+        {
           name: 'default',
           message: `Default value ${chalk.yellow('[leave blank for none]')}:`,
           when: answers => {
@@ -431,6 +438,8 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
       Object.assign(this.artifactInfo.properties[this.propName], answers);
 
       // We prompt for `id` only once per model using idFieldSet flag.
+      // and 'generated' flag makes sure id is defined, especially for database like MySQL
+      // Skipped the test for `generated` for now.
       if (answers.id) {
         this.idFieldSet = true;
       }


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
connect to https://github.com/strongloop/loopback-next/pull/3538

We found in [refactor test PR](https://github.com/strongloop/loopback-next/pull/3538#discussion_r317624487) that id needs to be generated for any instances for the mysql tests, otherwise it complains with Error: `ER_NO_DEFAULT_FOR_FIELD: Field 'id' doesn't have a default value`.
It's not required for relations. But it might be problematic if models are migrated to databases such `MySQL`.
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
