### PR TITLE
fix(repository-tests): unify the usage of MixedIdType for all tests

### DIFF
--- a/packages/repository-tests/src/crud/create-retrieve.suite.ts
+++ b/packages/repository-tests/src/crud/create-retrieve.suite.ts
@@ -12,6 +12,7 @@ import {
   property,
 } from '@loopback/repository';
 import {expect, toJSON} from '@loopback/testlab';
+import {MixedIdType} from '../helpers.repository-tests';
 import {
   deleteAllModelsInDefaultDataSource,
   withCrudCtx,
@@ -38,7 +39,7 @@ export function createRetrieveSuite(
       generated: true,
       description: 'The unique identifier for a product',
     })
-    id: number | string;
+    id: MixedIdType;
 
     @property({type: 'string', required: true})
     name: string;

--- a/packages/repository-tests/src/crud/freeform-properties.suite.ts
+++ b/packages/repository-tests/src/crud/freeform-properties.suite.ts
@@ -7,6 +7,7 @@ import {Entity, model, property} from '@loopback/repository';
 import {EntityCrudRepository} from '@loopback/repository';
 import {expect, skipIf, toJSON} from '@loopback/testlab';
 import {Suite} from 'mocha';
+import {MixedIdType} from '../helpers.repository-tests';
 import {
   withCrudCtx,
   deleteAllModelsInDefaultDataSource,
@@ -37,7 +38,7 @@ export function freeformPropertiesSuite(
           id: true,
           description: 'The unique identifier for a product',
         })
-        id: number | string;
+        id: MixedIdType;
 
         @property({type: 'string', required: true})
         name: string;

--- a/packages/repository-tests/src/crud/replace-by-id.suite.ts
+++ b/packages/repository-tests/src/crud/replace-by-id.suite.ts
@@ -6,6 +6,7 @@
 import {Entity, model, property} from '@loopback/repository';
 import {AnyObject, EntityCrudRepository} from '@loopback/repository';
 import {expect, toJSON} from '@loopback/testlab';
+import {MixedIdType} from '../helpers.repository-tests';
 import {
   deleteAllModelsInDefaultDataSource,
   withCrudCtx,
@@ -31,7 +32,7 @@ export function createSuiteForReplaceById(
       generated: true,
       description: 'The unique identifier for a product',
     })
-    id: number | string;
+    id: MixedIdType;
 
     @property({type: 'string', required: true})
     name: string;

--- a/packages/repository-tests/src/crud/transactions.suite.ts
+++ b/packages/repository-tests/src/crud/transactions.suite.ts
@@ -14,7 +14,7 @@ import {
 } from '@loopback/repository';
 import {expect, skipIf, toJSON} from '@loopback/testlab';
 import {Suite} from 'mocha';
-import {withCrudCtx} from '../helpers.repository-tests';
+import {withCrudCtx, MixedIdType} from '../helpers.repository-tests';
 import {
   CrudFeatures,
   CrudTestContext,
@@ -42,7 +42,7 @@ export function transactionSuite(
           generated: true,
           description: 'The unique identifier for a product',
         })
-        id: number | string;
+        id: MixedIdType;
 
         @property({type: 'string', required: true})
         name: string;


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Unifies the usage of `MixedIdType` for all tests in `repository-tests`.
`MixedIdType` is introduced in https://github.com/strongloop/loopback-next/pull/3538
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
