### PR TITLE
Fix/model with id required

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -182,6 +182,12 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
         default: 'number',
       },
       {
+        type: 'confirm',
+        name: 'idOmitted',
+        message: 'Is the id omitted when creating a new instance?',
+        default: true,
+      },
+      {
         type: 'input',
         name: 'httpPathName',
         message: 'What is the base HTTP path name of the CRUD operations?',

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -40,12 +40,12 @@ export class <%= className %>Controller {
         'application/json': {
           schema: getModelSchemaRef(<%= modelName %>, {
             title: 'New<%= modelName %>',
-            exclude: ['<%= id %>'],
+            <%if (idOmitted) {%>exclude: ['<%= id %>'],<% } %>
           }),
         },
       },
     })
-    <%= modelVariableName %>: Omit<<%= modelName %>, '<%= id %>'>,
+    <%= modelVariableName %>: <% if (!idOmitted) { -%><%= modelName %><% } else { -%>Omit<<%= modelName %>, '<%= id %>'><% } -%>,
   ): Promise<<%= modelName %>> {
     return this.<%= repositoryNameCamel %>.create(<%= modelVariableName %>);
   }


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/3645

When `id` is required in a model, the expected `create` method in REST controller should be 
```ts
  @post('/todos', {
    responses: {
      '200': {
        description: 'Todo model instance',
        content: {'application/json': {schema: getModelSchemaRef(Todo)}},
      },
    },
  })
  async createTodo(
    @requestBody({
      content: {
        'application/json': {
          // DIFFERENCE
          // instead of `getModelSchemaRef(Todo, {exclude: ['id']})
          schema: getModelSchemaRef(Todo),
        },
      },
    })
   // DIFFERENCE
   // instead of `Omit<Todo, 'id'>`
    todo: Todo,
  ): Promise<Todo> {
    return this.todoRepo.create(todo);
  }
```

This PR generates the right signature for `create` in the controller generator's template.

At first I didn't know if `create` method is the only one affected, so I added another model with id required in the example `todo` to figure out the fix's scope. It turns out other methods are fine. 

I temporary keep the new `TodoWithId` model and its related tests in the example package so reviewers know what's the expected controller file content, and in case you have questions regarding other methods.

Will remove the changes in `examples/todo` when land the PR.
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
