### PR TITLE
fix(cli): exclude *.tsbuildinfo from Docker image

### DIFF
--- a/packages/cli/generators/app/templates/.dockerignore
+++ b/packages/cli/generators/app/templates/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
 npm-debug.log
 /dist
-
+# Cache used by TypeScript's incremental build
+*.tsbuildinfo

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -116,6 +116,7 @@ describe('app-generator specific files', () => {
   it('generates docker files', () => {
     assert.fileContent('Dockerfile', /FROM node:10-slim/);
     assert.fileContent('.dockerignore', /node_modules/);
+    assert.fileContent('.dockerignore', '*.tsbuildinfo');
 
     assert.fileContent('package.json', /"docker:build": "docker build/);
     assert.fileContent('package.json', /"docker:run": "docker run/);


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/3684

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
