### PR TITLE
Custom schema title for POST requests

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -134,7 +134,7 @@ export class TodoController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+          schema: getModelSchemaRef(Todo, {title: 'NewTodo', exclude: ['id']}),
         },
       },
     })

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -181,7 +181,7 @@ export class TodoListTodoController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+          schema: getModelSchemaRef(Todo, {title: 'NewTodo', exclude: ['id']}),
         },
       },
     })
@@ -237,7 +237,7 @@ export class TodoListTodoController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+          schema: getModelSchemaRef(Todo, {title: 'NewTodo', exclude: ['id']}),
         },
       },
     })

--- a/examples/express-composition/src/controllers/note.controller.ts
+++ b/examples/express-composition/src/controllers/note.controller.ts
@@ -43,7 +43,7 @@ export class NoteController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Note, {exclude: ['id']}),
+          schema: getModelSchemaRef(Note, {title: 'NewNote', exclude: ['id']}),
         },
       },
     })

--- a/examples/todo-list/src/controllers/todo-list-todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list-todo.controller.ts
@@ -42,6 +42,7 @@ export class TodoListTodoController {
       content: {
         'application/json': {
           schema: getModelSchemaRef(Todo, {
+            title: 'NewTodoInTodoList',
             exclude: ['id'],
             optional: ['todoListId'],
           }),

--- a/examples/todo-list/src/controllers/todo-list.controller.ts
+++ b/examples/todo-list/src/controllers/todo-list.controller.ts
@@ -42,7 +42,10 @@ export class TodoListController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(TodoList, {exclude: ['id']}),
+          schema: getModelSchemaRef(TodoList, {
+            title: 'NewTodoList',
+            exclude: ['id'],
+          }),
         },
       },
     })

--- a/examples/todo-list/src/controllers/todo.controller.ts
+++ b/examples/todo-list/src/controllers/todo.controller.ts
@@ -33,7 +33,7 @@ export class TodoController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+          schema: getModelSchemaRef(Todo, {title: 'NewTodo', exclude: ['id']}),
         },
       },
     })

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -38,7 +38,7 @@ export class TodoController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Todo, {exclude: ['id']}),
+          schema: getModelSchemaRef(Todo, {title: 'NewTodo', exclude: ['id']}),
         },
       },
     })

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -38,7 +38,10 @@ export class <%= className %>Controller {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(<%= modelName %>, {exclude: ['<%= id %>']}),
+          schema: getModelSchemaRef(<%= modelName %>, {
+            title: 'New<%= modelName %>',
+            exclude: ['<%= id %>'],
+          }),
         },
       },
     })

--- a/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
@@ -59,6 +59,7 @@ export class <%= controllerClassName %> {
       content: {
         'application/json': {
           schema: getModelSchemaRef(<%= targetModelClassName %>, {
+            title: 'New <%= targetModelClassName %>In<%= sourceModelClassName %>',
             exclude: ['<%= targetModelPrimaryKey %>'],
             optional: ['<%= foreignKeyName %>']
           }),

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -249,7 +249,7 @@ function checkRestCrudContents() {
     /'200': {/,
     /description: 'ProductReview model instance'/,
     /content: {'application\/json': {schema: getModelSchemaRef\(ProductReview\)}},\s{1,}},\s{1,}},\s{1,}}\)/,
-    /async create\(\s+\@requestBody\({\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(ProductReview, {exclude: \['productId'\]}\),\s+},\s+},\s+}\)\s+productReview: Omit<ProductReview, 'productId'>,\s+\)/,
+    /async create\(\s+\@requestBody\({\s+content: {\s+'application\/json': {\s+schema: getModelSchemaRef\(ProductReview, {\s+title: 'NewProductReview',\s+exclude: \['productId'\],\s+}\),\s+},\s+},\s+}\)\s+productReview: Omit<ProductReview, 'productId'>,\s+\)/,
   ];
   postCreateRegEx.forEach(regex => {
     assert.fileContent(expectedFile, regex);

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -630,6 +630,34 @@ describe('build-schema', () => {
         expect(schema).to.deepEqual(expectedSchema);
       });
     });
+
+    it('uses title from model metadata instead of model name', () => {
+      @model({title: 'MyCustomer'})
+      class Customer {}
+
+      const schema = modelToJsonSchema(Customer, {
+        // trigger build of a custom title
+        partial: true,
+      });
+
+      expect(schema.title).to.equal('MyCustomerPartial');
+    });
+
+    it('uses title from options instead of model name and computed suffix', () => {
+      @model({title: 'ShouldBeIgnored'})
+      class TestModel {
+        @property()
+        id: string;
+      }
+
+      const schema = modelToJsonSchema(TestModel, {
+        title: 'NewTestModel',
+        partial: true,
+        exclude: ['id'],
+      });
+
+      expect(schema.title).to.equal('NewTestModel');
+    });
   });
 
   describe('getJsonSchema', () => {
@@ -1081,6 +1109,22 @@ describe('build-schema', () => {
         expect(optionalNameSchema.required).to.equal(undefined);
         expect(optionalNameSchema.title).to.equal('ProductPartial');
       });
+    });
+
+    it('creates new cache entry for each custom title', () => {
+      @model()
+      class TestModel {}
+
+      // populate the cache
+      getJsonSchema(TestModel, {title: 'First'});
+      getJsonSchema(TestModel, {title: 'Second'});
+
+      // obtain cached instances & verify the title
+      const schema1 = getJsonSchema(TestModel, {title: 'First'});
+      expect(schema1.title).to.equal('First');
+
+      const schema2 = getJsonSchema(TestModel, {title: 'Second'});
+      expect(schema2.title).to.equal('Second');
     });
   });
 });

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -325,5 +325,10 @@ describe('build-schema', () => {
         'modelOptional[name]Excluding[id,_rev]WithRelations',
       );
     });
+
+    it('includes custom title', () => {
+      const key = buildModelCacheKey({title: 'NewProduct', partial: true});
+      expect(key).to.equal('modelNewProductPartial');
+    });
   });
 });

--- a/packages/rest-crud/src/crud-rest.controller.ts
+++ b/packages/rest-crud/src/crud-rest.controller.ts
@@ -152,7 +152,10 @@ export function defineCrudRestController<
       ...response.model(200, `${modelName} instance created`, modelCtor),
     })
     async create(
-      @body(modelCtor, {exclude: modelCtor.getIdProperties() as (keyof T)[]})
+      @body(modelCtor, {
+        title: `New${modelName}`,
+        exclude: modelCtor.getIdProperties() as (keyof T)[],
+      })
       data: Omit<T, IdName>,
     ): Promise<T> {
       return this.repository.create(


### PR DESCRIPTION
While reviewing #3698, #3504 and #1466, it occurred to me that schema titles like `TodoExcluding[id]` or `ProductPartialExcluding[id,_rev]` are not very friendly to human consumers.

In this pull request, I am introducing a new JsonSchemaOption `title` that allows developer to specify a title that described the intent (data of a new Todo to be created - `NewTodo`) instead of the implementation details (Todo data excluding `id` property).

The second commit updates controller templates and `rest-crud` package to leverage this new schema option for POST requests.

/cc @ericzon @remkohdev

IMPORTANT: Although this change is very likely to fix the issues described in #3698, #3504 and #1466 _for newly created controllers_, it's not meant as a replacement for https://github.com/strongloop/loopback-next/pull/3504. I'd like #3504 to be landed, because it solves the problems for existing applications and users that decide to not use the `title` option for whatever reasons.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈