### PR TITLE
feat(eslint-config): enable "no-misused-promises" rule

### DIFF
--- a/packages/cli/generators/example/index.js
+++ b/packages/cli/generators/example/index.js
@@ -116,8 +116,8 @@ module.exports = class extends BaseGenerator {
     return super.install();
   }
 
-  end() {
-    if (!super.end()) return false;
+  async end() {
+    await super.end();
     this.log();
     this.log(`The example was cloned to ${chalk.green(this.outDir)}.`);
     this.log();

--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -146,6 +146,7 @@ module.exports = {
 
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/consistent-type-assertions': 'off',
+    '@typescript-eslint/no-misused-promises': 'error',
   },
 };
 

--- a/packages/rest/src/__tests__/integration/rest.application.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.application.integration.ts
@@ -171,7 +171,7 @@ describe('RestApplication (integration)', () => {
     await client.get(response.header.location).expect(200, 'Hi');
   });
 
-  context('mounting an Express router on a LoopBack application', async () => {
+  context('mounting an Express router on a LoopBack application', () => {
     beforeEach('set up RestApplication', async () => {
       givenApplication();
       await restApp.start();


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

# Proposal

I suggest we add this useful new rule [`no-misused-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md) to core. It catches a common mistake of forgetting to await a `Promise<boolean>`:

```js
const isAllowed = checkIsAllowed(user);
if (isAllowed) {
  await doSomethingPrivileged();
}

// Mistake: checkIsAllowed() returns a promise, but we forgot to await it!
//
// So the condition will always pass, because `isAllowed: Promise<boolean>`
// is an object so is always truthy.
//
// This is not currently caught by eslint, until the rule is enabled.
```

It also complains if you pass an `async` function when a synchronous function is expected.

# Results

With default settings, the rule found three files of concern in the `loopback-next` project:

```
/Users/joey/src/loopback-next/examples/greeting-app/src/caching-service.ts
   33:31  error  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
  119:30  error  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises

/Users/joey/src/loopback-next/packages/cli/generators/example/index.js
  120:10  error  Expected non-Promise value in a boolean conditional  @typescript-eslint/no-misused-promises

/Users/joey/src/loopback-next/packages/rest/src/__tests__/integration/rest.application.integration.ts
  174:67  error  Promise returned in function argument where a void return was expected  @typescript-eslint/no-misused-promises
```

## rest.application.integration.ts

The last error was easily fixed. (There was just no need for [that context function](https://github.com/strongloop/loopback-next/blob/a6ef8c15c35605455c08bbb1d1ae5f6cefc6ab28/packages/rest/src/__tests__/integration/rest.application.integration.ts#L174) to be async.)

## caching-service.ts

The first two errors indicate an `async` function being used as an easy way to get `await`, but without handling rejections. There is a danger here that an uncaught rejection could crash the node process.

In [the first case](https://github.com/strongloop/loopback-next/blob/a6ef8c15c35605455c08bbb1d1ae5f6cefc6ab28/examples/greeting-app/src/caching-service.ts#L33-L37), perhaps crashing the process is desirable behaviour, since the service failing to restart is a critical problem. We could disable the rule locally for this function, but instead I opted to handle any rejection explicitly with `.catch(err => { console.error(err); process.exit(1); });`

[The second case](https://github.com/strongloop/loopback-next/blob/a6ef8c15c35605455c08bbb1d1ae5f6cefc6ab28/examples/greeting-app/src/caching-service.ts#L119-L121) is just cleaning the cache. If a rejection happens in this case, I think it is non critical, so I just opted to log a warning message, and continue.

@raymondfeng may wish to approve/reject these resolutions.

## cli/generators/example/index.js

The final warning has detected some messy code:

The class [overrides](https://github.com/strongloop/loopback-next/blob/a6ef8c15c35605455c08bbb1d1ae5f6cefc6ab28/packages/cli/generators/example/index.js#L119-L124) the `async end()` function of the [parent](https://github.com/strongloop/loopback-next/blob/a6ef8c15c35605455c08bbb1d1ae5f6cefc6ab28/packages/cli/lib/base-generator.js#L437-L446) class with a _synchronous_ `end()` function. And when it calls `super.end()` it forgets to await!

```js
    // This condition will never be met
    // because super.end() is a promise
    if (!super.end()) return false;
```

Furthermore, the parent method can never actually resolve true, since its return type is `Promise<void>`.

My recommendation is to remove that redundant if, and make the function `async`:

```js
    await super.end();
```

This seems to be how all other calls to `super.end()` are made in the code.

@bajtos may like to confirm this resolution.

## Checklist

- [x] [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next)

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)