### PR TITLE
chore: update build to v2 in authentication-passport package

### DIFF
--- a/labs/authentication-passport/package.json
+++ b/labs/authentication-passport/package.json
@@ -49,10 +49,10 @@
     "util-promisifyall": "^1.0.6"
   },
   "devDependencies": {
-    "@loopback/build": "^1.5.5",
+    "@loopback/build": "^2.0.10",
     "@loopback/openapi-spec-builder": "^1.1.11",
     "@loopback/testlab": "^1.2.10",
-    "@loopback/eslint-config": "^1.1.1",
+    "@loopback/eslint-config": "^4.0.2",
     "@types/node": "^10.14.8",
     "@types/passport": "^1.0.0",
     "@types/passport-http": "^0.3.8",


### PR DESCRIPTION
Update build to v2 in authentication-passport package.
When running `npm test` currently, the local test failed, so updating the `@loopback/build` as the first step. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
