### PR TITLE
feat(rest): allow AJV error messages customization

### DIFF
--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -107,6 +107,11 @@ export interface RequestBodyValidationOptions extends ajv.Options {
    * - `string[]`: Add an array of keywords from `ajv-keywords`
    */
   ajvKeywords?: true | string[];
+  /**
+   * A function that transform the `ErrorObject`s reported by AJV.
+   * This could be used for error messages customization, localization, etc.
+   */
+  ajvErrorTransformer?: (errors: ajv.ErrorObject[]) => ajv.ErrorObject[];
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -137,7 +137,7 @@ function validateValueAgainstSchema(
     return;
   }
 
-  const validationErrors = validate.errors;
+  let validationErrors = validate.errors as AJV.ErrorObject[];
 
   /* istanbul ignore if */
   if (debug.enabled) {
@@ -146,6 +146,10 @@ function validateValueAgainstSchema(
       util.inspect(body, {depth: null}),
       util.inspect(validationErrors),
     );
+  }
+
+  if (typeof options.ajvErrorTransformer === 'function') {
+    validationErrors = options.ajvErrorTransformer(validationErrors);
   }
 
   const error = RestHttpErrors.invalidRequestBody();


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

I'm currently doing some localization works, it should be easy by just using [`ajv-i18n`](https://github.com/epoberezkin/ajv-i18n):

```typescript
const localize_zh = require('ajv-i18n/localize/zh');

// option `i18n` is required for this package to work
var ajv = Ajv({ allErrors: true });
var validate = ajv.compile(schema);
var valid = validate(data);

if (!valid) {
    localize_zh(validate.errors);
    console.log(ajv.errorsText(validate.errors, { separator: '\n' }));
}
```

But I could find a way to do that.

After some searching & reading, I found #2146, I really need this feature, so I'm submitting a minimal change.

Advice needed (we can discus in #2146 ), thank you!

> See also #2146 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈