### PR TITLE
Improve auth decorators

### DIFF
--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -96,7 +96,7 @@ export class AuthenticationComponent implements Component {
 ```
 
 As you can see, there are a few [providers](Creating-components.md#providers)
-which make up the bulk of the authenticaton component.
+which make up the bulk of the authentication component.
 
 Essentially
 
@@ -123,6 +123,12 @@ The decorator's syntax is:
 
 ```ts
 @authenticate(strategyName: string, options?: object)
+```
+
+or
+
+```ts
+@authenticate(metadata: AuthenticationMetadata)
 ```
 
 The **strategyName** is the **unique** name of the authentication strategy.
@@ -186,6 +192,18 @@ data of type `AuthenticationMetadata` provided by `AuthMetadataProvider`. The
 `AuthenticationStrategyProvider`, discussed in a later section, makes use of
 `AuthenticationMetadata` to figure out what **name** you specified as a
 parameter in the `@authenticate` decorator of a specific controller endpoint.
+
+## Default authentication metadata
+
+In some cases, it's desirable to have a default authentication enforcement for
+methods that are not explicitly decorated with `@authenticate`. To do so, we can
+simply configure the authentication component with `defaultMetadata` as follows:
+
+```ts
+app
+  .configure(AuthenticationBindings.COMPONENT)
+  .to({defaultMetadata: {strategy: 'xyz'}});
+```
 
 ## Adding an Authentication Action to a Custom Sequence
 

--- a/docs/site/decorators/Decorators_authenticate.md
+++ b/docs/site/decorators/Decorators_authenticate.md
@@ -40,6 +40,31 @@ export class WhoAmIController {
 }
 ```
 
+Please note that `@authenticate` can also be applied at class level for all
+methods within the class. In the code below, `whoAmI` is protected with
+`BasicStrategy` (inherited from the class level) while `hello` does not require
+authentication (skipped by `@authenticate.skip`).
+
+```ts
+@authenticate('BasicStrategy')
+export class WhoAmIController {
+  constructor(
+    @inject(AuthenticationBindings.CURRENT_USER) private user: UserProfile,
+  ) {}
+
+  @get('/whoami')
+  whoAmI(): string {
+    return this.user.id;
+  }
+
+  @authenticate.skip()
+  @get('/hello')
+  hello(): string {
+    return 'Hello';
+  }
+}
+```
+
 {% include note.html content="If only <b>some</b> of the controller methods are decorated with the <b>@authenticate</b> decorator, then the injection decorator for CURRENT_USER in the controller's constructor must be specified as <b>@inject(AuthenticationBindings.CURRENT_USER, {optional:true})</b> to avoid a binding error when an unauthenticated endpoint is accessed. Alternatively, do not inject CURRENT_USER in the controller <b>constructor</b>, but in the controller <b>methods</b> which are actually decorated with the <b>@authenticate</b> decorator. See [Method Injection](../Dependency-injection.md#method-injection), [Constructor Injection](../Dependency-injection.md#constructor-injection) and [Optional Dependencies](../Dependency-injection.md#optional-dependencies) for details.
 " %}
 

--- a/docs/site/decorators/Decorators_authenticate.md
+++ b/docs/site/decorators/Decorators_authenticate.md
@@ -8,7 +8,8 @@ permalink: /doc/en/lb4/Decorators_authenticate.html
 
 ## Authentication Decorator
 
-Syntax: `@authenticate(strategyName: string, options?: object)`
+Syntax: `@authenticate(strategyName: string, options?: object)` or
+`@authenticate(metadata: AuthenticationMetadata)`
 
 Marks a controller method as needing an authenticated user. This decorator
 requires a strategy name as a parameter.
@@ -20,6 +21,7 @@ Here's an example using 'BasicStrategy': to authenticate user in function
 
 ```ts
 import {inject} from '@loopback/context';
+import {securityId} from '@loopback/security';
 import {
   AuthenticationBindings,
   UserProfile,
@@ -35,15 +37,17 @@ export class WhoAmIController {
   @authenticate('BasicStrategy')
   @get('/whoami')
   whoAmI(): string {
-    return this.user.id;
+    return this.user[securityId];
   }
 }
 ```
 
-Please note that `@authenticate` can also be applied at class level for all
-methods within the class. In the code below, `whoAmI` is protected with
-`BasicStrategy` (inherited from the class level) while `hello` does not require
-authentication (skipped by `@authenticate.skip`).
+To configure a default authentication for all methods within a class,
+`@authenticate` can also be applied at the class level. In the code below,
+`whoAmI` is protected with `BasicStrategy` even though there is no
+`@authenticate` is present for the method itself. The configuration is inherited
+from the class. The `hello` method does not require authentication as it's
+skipped by `@authenticate.skip`.
 
 ```ts
 @authenticate('BasicStrategy')
@@ -54,7 +58,7 @@ export class WhoAmIController {
 
   @get('/whoami')
   whoAmI(): string {
-    return this.user.id;
+    return this.user[securityId];
   }
 
   @authenticate.skip()

--- a/packages/authentication/src/__tests__/unit/decorators/authenticate.decorator.unit.ts
+++ b/packages/authentication/src/__tests__/unit/decorators/authenticate.decorator.unit.ts
@@ -21,6 +21,22 @@ describe('Authentication', () => {
       });
     });
 
+    it('can add authenticate metadata to target method with an object', () => {
+      class TestClass {
+        @authenticate({
+          strategy: 'my-strategy',
+          options: {option1: 'value1', option2: 'value2'},
+        })
+        whoAmI() {}
+      }
+
+      const metaData = getAuthenticateMetadata(TestClass, 'whoAmI');
+      expect(metaData).to.eql({
+        strategy: 'my-strategy',
+        options: {option1: 'value1', option2: 'value2'},
+      });
+    });
+
     it('can add authenticate metadata to target method without options', () => {
       class TestClass {
         @authenticate('my-strategy')
@@ -70,6 +86,16 @@ describe('Authentication', () => {
     }
 
     const metaData = getAuthenticateMetadata(TestClass, 'whoAmI');
-    expect(metaData).to.be.undefined();
+    expect(metaData).to.containEql({skip: true});
+  });
+
+  it('can skip authentication at class level', () => {
+    @authenticate.skip()
+    class TestClass {
+      whoAmI() {}
+    }
+
+    const metaData = getAuthenticateMetadata(TestClass, 'whoAmI');
+    expect(metaData).to.containEql({skip: true});
   });
 });

--- a/packages/authentication/src/__tests__/unit/decorators/authenticate.decorator.unit.ts
+++ b/packages/authentication/src/__tests__/unit/decorators/authenticate.decorator.unit.ts
@@ -30,5 +30,46 @@ describe('Authentication', () => {
       const metaData = getAuthenticateMetadata(TestClass, 'whoAmI');
       expect(metaData).to.eql({strategy: 'my-strategy', options: {}});
     });
+
+    it('adds authenticate metadata to target class', () => {
+      @authenticate('my-strategy', {option1: 'value1', option2: 'value2'})
+      class TestClass {
+        whoAmI() {}
+      }
+
+      const metaData = getAuthenticateMetadata(TestClass, 'whoAmI');
+      expect(metaData).to.eql({
+        strategy: 'my-strategy',
+        options: {option1: 'value1', option2: 'value2'},
+      });
+    });
+
+    it('overrides class level metadata by method level', () => {
+      @authenticate('my-strategy', {option1: 'value1', option2: 'value2'})
+      class TestClass {
+        @authenticate('another-strategy', {
+          option1: 'valueA',
+          option2: 'value2',
+        })
+        whoAmI() {}
+      }
+
+      const metaData = getAuthenticateMetadata(TestClass, 'whoAmI');
+      expect(metaData).to.eql({
+        strategy: 'another-strategy',
+        options: {option1: 'valueA', option2: 'value2'},
+      });
+    });
+  });
+
+  it('can skip authentication', () => {
+    @authenticate('my-strategy', {option1: 'value1', option2: 'value2'})
+    class TestClass {
+      @authenticate.skip()
+      whoAmI() {}
+    }
+
+    const metaData = getAuthenticateMetadata(TestClass, 'whoAmI');
+    expect(metaData).to.be.undefined();
   });
 });

--- a/packages/authentication/src/authentication.component.ts
+++ b/packages/authentication/src/authentication.component.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Component, ProviderMap} from '@loopback/core';
+import {bind, Component, ContextTags, ProviderMap} from '@loopback/core';
 import {AuthenticationBindings} from './keys';
 import {
   AuthenticateActionProvider,
@@ -11,6 +11,7 @@ import {
   AuthMetadataProvider,
 } from './providers';
 
+@bind({tags: {[ContextTags.KEY]: AuthenticationBindings.COMPONENT}})
 export class AuthenticationComponent implements Component {
   providers?: ProviderMap;
 

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -95,9 +95,22 @@ export namespace AuthenticationBindings {
 }
 
 /**
- * The key used to store log-related via @loopback/metadata and reflection.
+ * The key used to store method-level metadata for `@authenticate`
  */
-export const AUTHENTICATION_METADATA_KEY = MetadataAccessor.create<
+export const AUTHENTICATION_METADATA_METHOD_KEY = MetadataAccessor.create<
   AuthenticationMetadata,
   MethodDecorator
->('authentication.operationsMetadata');
+>('authentication:method');
+
+/**
+ * Alias for AUTHENTICATION_METADATA_METHOD_KEY to keep it backward compatible
+ */
+export const AUTHENTICATION_METADATA_KEY = AUTHENTICATION_METADATA_METHOD_KEY;
+
+/**
+ * The key used to store class-level metadata for `@authenticate`
+ */
+export const AUTHENTICATION_METADATA_CLASS_KEY = MetadataAccessor.create<
+  AuthenticationMetadata,
+  ClassDecorator
+>('authentication:class');

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -6,13 +6,21 @@
 import {BindingKey} from '@loopback/context';
 import {MetadataAccessor} from '@loopback/metadata';
 import {SecurityBindings} from '@loopback/security';
-import {AuthenticationMetadata} from './decorators';
-import {AuthenticateFn, AuthenticationStrategy} from './types';
+import {AuthenticationComponent} from './authentication.component';
+import {
+  AuthenticateFn,
+  AuthenticationMetadata,
+  AuthenticationStrategy,
+} from './types';
 
 /**
  * Binding keys used by this component.
  */
 export namespace AuthenticationBindings {
+  export const COMPONENT = BindingKey.create<AuthenticationComponent>(
+    'components.AuthenticationComponent',
+  );
+
   /**
    * Key used to bind an authentication strategy to the context for the
    * authentication function to use.

--- a/packages/authentication/src/providers/auth-strategy.provider.ts
+++ b/packages/authentication/src/providers/auth-strategy.provider.ts
@@ -5,9 +5,9 @@
 
 import {BindingScope, Getter, inject} from '@loopback/context';
 import {extensionPoint, extensions, Provider} from '@loopback/core';
-import {AuthenticationMetadata} from '../decorators/authenticate.decorator';
 import {AuthenticationBindings} from '../keys';
 import {
+  AuthenticationMetadata,
   AuthenticationStrategy,
   AUTHENTICATION_STRATEGY_NOT_FOUND,
 } from '../types';

--- a/packages/authentication/src/types.ts
+++ b/packages/authentication/src/types.ts
@@ -9,11 +9,42 @@ import {UserProfile} from '@loopback/security';
 import {AuthenticationBindings} from './keys';
 
 /**
+ * Authentication metadata stored via Reflection API
+ */
+export interface AuthenticationMetadata {
+  /**
+   * Name of the authentication strategy
+   */
+  strategy: string;
+  /**
+   * Options for the authentication strategy
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options?: {[name: string]: any};
+  /**
+   * A flag to skip authentication
+   */
+  skip?: boolean;
+}
+
+/**
  * interface definition of a function which accepts a request
  * and returns an authenticated user
  */
 export interface AuthenticateFn {
   (request: Request): Promise<UserProfile | undefined>;
+}
+
+/**
+ * Options for authentication component
+ */
+export interface AuthenticationOptions {
+  /**
+   * Default authentication metadata if a method or class is not decorated with
+   * `@authenticate`. If not set, no default authentication will be enforced for
+   * those methods without authentication metadata.
+   */
+  defaultMetadata?: AuthenticationMetadata;
 }
 
 /**
@@ -51,7 +82,9 @@ export const AUTHENTICATION_STRATEGY_NOT_FOUND =
 export const USER_PROFILE_NOT_FOUND = 'USER_PROFILE_NOT_FOUND';
 
 /**
- * Registers an authentication strategy as an extension of the AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME extension point.
+ * Registers an authentication strategy as an extension of the
+ * AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME extension
+ * point.
  */
 export function registerAuthenticationStrategy(
   context: Context,

--- a/packages/authorization/README.md
+++ b/packages/authorization/README.md
@@ -118,6 +118,27 @@ export class MyController {
 }
 ```
 
+Please note that `@authorize` can also be applied at class level for all methods
+within the class. In the code below, `numOfViews` is protected with
+`BasicStrategy` (inherited from the class level) while `hello` does not require
+authorization (skipped by `@authorize.skip`).
+
+```ts
+@authorize({allow: ['ADMIN']})
+export class MyController {
+  @get('/number-of-views')
+  numOfViews(): number {
+    return 100;
+  }
+
+  @authorize.skip()
+  @get('/hello')
+  hello(): string {
+    return 'Hello';
+  }
+}
+```
+
 ## Extract common layer(TBD)
 
 `@loopback/authentication` and `@loopback/authorization` shares the client

--- a/packages/authorization/src/__tests__/unit/authorize-decorator.test.ts
+++ b/packages/authorization/src/__tests__/unit/authorize-decorator.test.ts
@@ -155,6 +155,16 @@ describe('Authentication', () => {
       });
     });
 
+    it('can skip authorization with a flag', () => {
+      class TestClass {
+        @authorize.skip()
+        getSecret() {}
+      }
+
+      const metaData = getAuthorizationMetadata(TestClass, 'getSecret');
+      expect(metaData).to.eql({skip: true});
+    });
+
     it('can stack decorators to target method', () => {
       class TestClass {
         @authorize.allow('a1', 'a2')

--- a/packages/authorization/src/authorize-interceptor.ts
+++ b/packages/authorization/src/authorize-interceptor.ts
@@ -68,7 +68,7 @@ export class AuthorizationInterceptor implements Provider<Interceptor> {
       debug('No authorization metadata is found for %s', description);
     }
     metadata = metadata || this.options.defaultMetadata;
-    if (!metadata) {
+    if (!metadata || (metadata && metadata.skip)) {
       debug('Authorization is skipped for %s', description);
       const result = await next();
       return result;

--- a/packages/authorization/src/decorators/authorize.ts
+++ b/packages/authorization/src/decorators/authorize.ts
@@ -88,6 +88,7 @@ export class AuthorizeMethodDecoratorFactory extends MethodDecoratorFactory<
     return list;
   }
 }
+
 /**
  * Decorator `@authorize` to mark methods that require authorization
  *
@@ -191,6 +192,11 @@ export namespace authorize {
    * Deny unauthenticated users
    */
   export const denyUnauthenticated = () => deny(UNAUTHENTICATED);
+
+  /**
+   * Skip authorization
+   */
+  export const skip = () => authorize({skip: true});
 }
 
 /**

--- a/packages/authorization/src/types.ts
+++ b/packages/authorization/src/types.ts
@@ -58,6 +58,10 @@ export interface AuthorizationMetadata {
    * Define the access scopes
    */
   scopes?: string[];
+  /**
+   * A flag to skip authorization
+   */
+  skip?: boolean;
 }
 
 /**


### PR DESCRIPTION
This PR improves `@authenticate` (implements https://github.com/strongloop/loopback-next/issues/2460)

1. Allow `@authenticate` to be applied at class level
2. Add `@authenticate.skip` to skip authentication

It also improves `@authorize`:

1. Add `@authorize.skip` to skip authorization


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
