### PR TITLE
[doc] Add `--port=3001` as documented

### DIFF
--- a/docs/site/exposing-graphql-apis.md
+++ b/docs/site/exposing-graphql-apis.md
@@ -45,7 +45,7 @@ todo-application as the parameter, start up the server by running the following
 command:
 
 ```sh
-npx openapi-to-graphql http://localhost:3000/openapi.json
+npx openapi-to-graphql --port=3001 http://localhost:3000/openapi.json
 ```
 
 _Haven't heard about `npx` yet? It's a cool helper provided by `npm` and


### PR DESCRIPTION
Without this, failed with address (port 3000) already in use

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

Error signing CLA: 👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

![image](https://user-images.githubusercontent.com/24123/65215049-5aa30380-dad6-11e9-9248-87e9d14e7236.png)

- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated

## Additional

Should add `--cors` as well?