### PR TITLE
feat(example-todo-list): use real relation resolvers

### DIFF
--- a/examples/todo-list/src/__tests__/integration/todo-list-image.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo-list-image.repository.integration.ts
@@ -63,4 +63,20 @@ describe('TodoListImageRepository', () => {
       todoList: toJSON(list),
     });
   });
+
+  it('includes TodoList in findOne result', async () => {
+    const list = await givenTodoListInstance(todoListRepo, {});
+    const image = await givenTodoListImageInstance(todoListImageRepo, {
+      todoListId: list.id,
+    });
+
+    const response = await todoListImageRepo.findOne({
+      include: [{relation: 'todoList'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(image),
+      todoList: toJSON(list),
+    });
+  });
 });

--- a/examples/todo-list/src/__tests__/integration/todo-list.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo-list.repository.integration.ts
@@ -7,6 +7,7 @@ import {
 import {
   givenEmptyDatabase,
   givenTodoInstance,
+  givenTodoListImageInstance,
   givenTodoListInstance,
   testdb,
 } from '../helpers';
@@ -23,6 +24,10 @@ describe('TodoListRepository', () => {
       async () => todoListImageRepo,
     );
     todoRepo = new TodoRepository(testdb, async () => todoListRepo);
+    todoListImageRepo = new TodoListImageRepository(
+      testdb,
+      async () => todoListRepo,
+    );
   });
 
   beforeEach(givenEmptyDatabase);
@@ -55,5 +60,90 @@ describe('TodoListRepository', () => {
       ...toJSON(list),
       todos: [toJSON(todo)],
     });
+  });
+
+  it('includes Todos in findOne method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
+
+    const response = await todoListRepo.findOne({
+      where: {id: list.id},
+      include: [{relation: 'todos'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(list),
+      todos: [toJSON(todo)],
+    });
+  });
+
+  it('includes TodoListImage in find method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const image = await givenTodoListImageInstance(todoListImageRepo, {
+      todoListId: list.id,
+    });
+
+    const response = await todoListRepo.find({
+      include: [{relation: 'image'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual([
+      {
+        ...toJSON(list),
+        image: toJSON(image),
+      },
+    ]);
+  });
+
+  it('includes TodoListImage in findById method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const image = await givenTodoListImageInstance(todoListImageRepo, {
+      todoListId: list.id,
+    });
+
+    const response = await todoListRepo.findById(list.id, {
+      include: [{relation: 'image'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(list),
+      image: toJSON(image),
+    });
+  });
+
+  it('includes TodoListImage in findOne method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const image = await givenTodoListImageInstance(todoListImageRepo, {
+      todoListId: list.id,
+    });
+
+    const response = await todoListRepo.findOne({
+      include: [{relation: 'image'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(list),
+      image: toJSON(image),
+    });
+  });
+
+  it('includes both Todos and TodoListImage in find method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
+    const image = await givenTodoListImageInstance(todoListImageRepo, {
+      todoListId: list.id,
+    });
+
+    const response = await todoListRepo.find({
+      include: [{relation: 'image'}, {relation: 'todos'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual([
+      {
+        ...toJSON(list),
+        image: toJSON(image),
+        todos: [toJSON(todo)],
+      },
+    ]);
   });
 });

--- a/examples/todo-list/src/__tests__/integration/todo.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo.repository.integration.ts
@@ -56,4 +56,18 @@ describe('TodoRepository', () => {
       todoList: toJSON(list),
     });
   });
+
+  it('includes TodoList in findOne method result', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
+
+    const response = await todoRepo.findOne({
+      include: [{relation: 'todoList'}],
+    });
+
+    expect(toJSON(response)).to.deepEqual({
+      ...toJSON(todo),
+      todoList: toJSON(list),
+    });
+  });
 });

--- a/examples/todo-list/src/repositories/todo-list-image.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list-image.repository.ts
@@ -7,7 +7,6 @@ import {Getter, inject} from '@loopback/core';
 import {
   BelongsToAccessor,
   DefaultCrudRepository,
-  InclusionResolver,
   repository,
 } from '@loopback/repository';
 import {DbDataSource} from '../datasources';
@@ -29,27 +28,12 @@ export class TodoListImageRepository extends DefaultCrudRepository<
     protected todoListRepositoryGetter: Getter<TodoListRepository>,
   ) {
     super(TodoListImage, dataSource);
+
     this.todoList = this.createBelongsToAccessorFor(
       'todoList',
       todoListRepositoryGetter,
     );
 
-    // this is a temporary implementation until
-    // https://github.com/strongloop/loopback-next/issues/3450 is landed
-    const todoListResolver: InclusionResolver<
-      TodoListImage,
-      TodoList
-    > = async images => {
-      const todoLists = [];
-
-      for (const image of images) {
-        const todoList = await this.todoList(image.id);
-        todoLists.push(todoList);
-      }
-
-      return todoLists;
-    };
-
-    this.registerInclusionResolver('todoList', todoListResolver);
+    this.registerInclusionResolver('todoList', this.todoList.inclusionResolver);
   }
 }

--- a/examples/todo-list/src/repositories/todo-list.repository.ts
+++ b/examples/todo-list/src/repositories/todo-list.repository.ts
@@ -8,7 +8,6 @@ import {
   DefaultCrudRepository,
   HasManyRepositoryFactory,
   HasOneRepositoryFactory,
-  InclusionResolver,
   juggler,
   repository,
 } from '@loopback/repository';
@@ -38,50 +37,20 @@ export class TodoListRepository extends DefaultCrudRepository<
     protected todoListImageRepositoryGetter: Getter<TodoListImageRepository>,
   ) {
     super(TodoList, dataSource);
+
     this.todos = this.createHasManyRepositoryFactoryFor(
       'todos',
       todoRepositoryGetter,
     );
 
-    // this is a temporary implementation until
-    // https://github.com/strongloop/loopback-next/issues/3450 is landed
-    const todosResolver: InclusionResolver<
-      TodoList,
-      Todo
-    > = async todoLists => {
-      const todos: Todo[][] = [];
-      for (const todoList of todoLists) {
-        const todo = await this.todos(todoList.id).find();
-        todos.push(todo);
-      }
-
-      return todos;
-    };
-
-    this.registerInclusionResolver('todos', todosResolver);
+    this.registerInclusionResolver('todos', this.todos.inclusionResolver);
 
     this.image = this.createHasOneRepositoryFactoryFor(
       'image',
       todoListImageRepositoryGetter,
     );
 
-    // this is a temporary implementation until
-    // https://github.com/strongloop/loopback-next/issues/3450 is landed
-    const imageResolver: InclusionResolver<
-      TodoList,
-      TodoListImage
-    > = async todoLists => {
-      const images = [];
-
-      for (const todoList of todoLists) {
-        const image = await this.image(todoList.id).get();
-        images.push(image);
-      }
-
-      return images;
-    };
-
-    this.registerInclusionResolver('image', imageResolver);
+    this.registerInclusionResolver('image', this.image.inclusionResolver);
   }
 
   public findByTitle(title: string) {

--- a/examples/todo-list/src/repositories/todo.repository.ts
+++ b/examples/todo-list/src/repositories/todo.repository.ts
@@ -7,7 +7,6 @@ import {Getter, inject} from '@loopback/core';
 import {
   BelongsToAccessor,
   DefaultCrudRepository,
-  InclusionResolver,
   juggler,
   repository,
 } from '@loopback/repository';
@@ -35,20 +34,6 @@ export class TodoRepository extends DefaultCrudRepository<
       'todoList',
       todoListRepositoryGetter,
     );
-
-    // this is a temporary implementation until
-    // https://github.com/strongloop/loopback-next/issues/3450 is landed
-    const todoListResolver: InclusionResolver<Todo, TodoList> = async todos => {
-      const todoLists = [];
-
-      for (const todo of todos) {
-        const todoList = await this.todoList(todo.id);
-        todoLists.push(todoList);
-      }
-
-      return todoLists;
-    };
-
-    this.registerInclusionResolver('todoList', todoListResolver);
+    this.registerInclusionResolver('todoList', this.todoList.inclusionResolver);
   }
 }


### PR DESCRIPTION
`hasMany`, `belongsTo`, and `hasOne` factories have an inclusion resolver property that we can leverage in this example

Resolves https://github.com/strongloop/loopback-next/issues/3450

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
