### PR TITLE
feat(rest-server): add support for unix socket path

### DIFF
--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
@@ -94,6 +94,26 @@ describe('RestServer', () => {
       expect(server.getSync(RestBindings.HOST)).to.equal('my-host');
     });
 
+    it('honors unix socket path', async () => {
+      const path = '/var/run/loopback.sock';
+      const app = new Application({
+        rest: {path},
+      });
+      app.component(RestComponent);
+      const server = await app.getServer(RestServer);
+      expect(server.getSync(RestBindings.PATH)).to.equal(path);
+    });
+
+    it('honors named pipe path', async () => {
+      const path = '\\\\.\\pipe\\loopback';
+      const app = new Application({
+        rest: {path},
+      });
+      app.component(RestComponent);
+      const server = await app.getServer(RestServer);
+      expect(server.getSync(RestBindings.PATH)).to.equal(path);
+    });
+
     it('honors basePath in config', async () => {
       const app = new Application({
         rest: {port: 0, basePath: '/api'},

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -44,6 +44,10 @@ export namespace RestBindings {
    */
   export const PORT = BindingKey.create<number>('rest.port');
   /**
+   * Binding key for setting and injecting the socket path of the RestServer
+   */
+  export const PATH = BindingKey.create<string | undefined>('rest.path');
+  /**
    * Binding key for setting and injecting the URL of RestServer
    */
   export const URL = BindingKey.create<string>('rest.url');

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -192,6 +192,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
     this.bind(RestBindings.PORT).to(this.config.port);
     this.bind(RestBindings.HOST).to(config.host);
+    this.bind(RestBindings.PATH).to(config.path);
     this.bind(RestBindings.PROTOCOL).to(config.protocol || 'http');
     this.bind(RestBindings.HTTPS_OPTIONS).to(config as ServerOptions);
 
@@ -791,12 +792,13 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
     const port = await this.get(RestBindings.PORT);
     const host = await this.get(RestBindings.HOST);
+    const path = await this.get(RestBindings.PATH);
     const protocol = await this.get(RestBindings.PROTOCOL);
     const httpsOptions = await this.get(RestBindings.HTTPS_OPTIONS);
 
     const serverOptions = {};
     if (protocol === 'https') Object.assign(serverOptions, httpsOptions);
-    Object.assign(serverOptions, {port, host, protocol});
+    Object.assign(serverOptions, {port, host, protocol, path});
 
     this._httpServer = new HttpServer(this.requestHandler, serverOptions);
 
@@ -942,6 +944,7 @@ export type RestServerOptions = Partial<RestServerResolvedOptions>;
 
 export interface RestServerResolvedOptions {
   port: number;
+  path?: string;
 
   /**
    * Base path for API/static routes


### PR DESCRIPTION
<!--
See #2812 for unix socket support for the `http-server`. These changes were not made accessible through the `RestServer` however as it only accepts fixed arguments.
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
