### PR TITLE
fix: migrate LB3 models mounted on LB4 app

### DIFF
--- a/docs/site/Migrating-from-LoopBack-3.md
+++ b/docs/site/Migrating-from-LoopBack-3.md
@@ -38,6 +38,10 @@ application to OpenAPI v3 and adds it to the LoopBack 4 project's OpenAPI v3
 spec.
 " %}
 
+Scaffolded LoopBack 4 apps come with a `migrate` npm script, which can be run
+using `npm run migrate`. This command will migrate all the LoopBack 3 models
+along with the LoopBack 4 models.
+
 ### Options
 
 [`Lb3AppBooterComponent`](https://loopback.io/doc/en/lb4/apidocs.booter-lb3app.lb3appbootercomponent.html)

--- a/examples/lb3-application/src/migrate.ts
+++ b/examples/lb3-application/src/migrate.ts
@@ -11,10 +11,6 @@ export async function migrate(args: string[]) {
 
   const app = new CoffeeShopApplication();
   await app.boot();
-  console.warn(
-    'Skipping migration of models from LB3 application (not supported yet).',
-  );
-  console.warn('See https://github.com/strongloop/loopback-next/issues/2825');
   await app.migrateSchema({existingSchema});
 
   // Connectors usually keep a pool of opened connections,

--- a/packages/booter-lb3app/fixtures/app-with-model.js
+++ b/packages/booter-lb3app/fixtures/app-with-model.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const loopback = require('loopback');
+const boot = require('loopback-boot');
+
+const app = (module.exports = loopback());
+
+app.dataSource('memory', {connector: 'memory'});
+const Color = app.registry.createModel('Color', {name: String});
+app.model(Color, {dataSource: 'memory'});
+
+app.get('/hello', (req, res) => {
+  res.send('hello');
+});
+
+boot(app, __dirname, function(err) {
+  if (err) throw err;
+});

--- a/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
+++ b/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {OperationObject, OpenApiSpec} from '@loopback/rest';
+import {OpenApiSpec, OperationObject} from '@loopback/rest';
 import {Client, expect} from '@loopback/testlab';
 import * as _ from 'lodash';
 import {
@@ -213,6 +213,23 @@ describe('booter-lb3app', () => {
       const spec = app.restServer.getApiSpec();
       const createOp: OperationObject = spec.paths['/api/CoffeeShops'].post;
       expect(createOp.summary).to.eql('just a very simple modification');
+    });
+  });
+
+  context('binding LoopBack 3 datasources', () => {
+    before(async () => {
+      ({app, client} = await setupApplication({
+        lb3app: {path: '../fixtures/app-with-model'},
+      }));
+    });
+
+    it('binds datasource to the context', async () => {
+      const expected = require('../../../fixtures/app-with-model').dataSources
+        .memory;
+      const dsBindings = app.findByTag('datasource');
+      const key = dsBindings[0].key;
+      const ds = await app.get(key);
+      expect(ds).to.eql(expected);
     });
   });
 });

--- a/packages/booter-lb3app/src/lb3app.booter.ts
+++ b/packages/booter-lb3app/src/lb3app.booter.ts
@@ -62,6 +62,20 @@ export class Lb3AppBooter implements Booter {
       this.mountRoutesOnly(lb3App, spec);
     }
 
+    const dataSources = lb3App.dataSources;
+    if (dataSources) {
+      const visited: unknown[] = [];
+      Object.keys(dataSources).forEach(key => {
+        const ds = dataSources[key];
+        if (visited.includes(ds)) return;
+        visited.push(ds);
+        this.app
+          .bind(`datasources.lb3-${key}`)
+          .to(ds)
+          .tag('datasource');
+      });
+    }
+
     // TODO(bajtos) Listen for the following events to update the OpenAPI spec:
     // - modelRemoted
     // - modelDeleted
@@ -137,4 +151,5 @@ export interface Lb3AppBooterOptions {
 
 interface Lb3Application extends ExpressApplication {
   handler(name: 'rest'): ExpressRequestHandler;
+  dataSources?: {[name: string]: unknown};
 }


### PR DESCRIPTION
Migrates LB4 models mounted on LB4 an app.

Fixes https://github.com/strongloop/loopback-next/issues/2825.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
