### PR TITLE
test(cli): use snapshots to match list of commands in help

### DIFF
--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1,0 +1,43 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`cli lists available commands 1`] = `
+Available commands: 
+  lb4 app
+  lb4 extension
+  lb4 controller
+  lb4 datasource
+  lb4 model
+  lb4 repository
+  lb4 service
+  lb4 example
+  lb4 openapi
+  lb4 observer
+  lb4 interceptor
+  lb4 discover
+  lb4 relation
+`;
+
+
+exports[`cli prints commands with --help 1`] = `
+Available commands: 
+  lb4 app
+  lb4 extension
+  lb4 controller
+  lb4 datasource
+  lb4 model
+  lb4 repository
+  lb4 service
+  lb4 example
+  lb4 openapi
+  lb4 observer
+  lb4 interceptor
+  lb4 discover
+  lb4 relation
+`;

--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -8,6 +8,7 @@
 const expect = require('@loopback/testlab').expect;
 const util = require('util');
 const main = require('../../../lib/cli');
+const {expectToMatchSnapshot} = require('../../snapshots');
 
 function getLog(buffer) {
   buffer = buffer || [];
@@ -21,13 +22,7 @@ describe('cli', () => {
   it('lists available commands', () => {
     const entries = [];
     main({commands: true}, getLog(entries));
-    expect(entries).to.eql([
-      'Available commands: ',
-      '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
-        'lb4 model\n  lb4 repository\n  lb4 service\n  lb4 example\n  ' +
-        'lb4 openapi\n  lb4 observer\n  lb4 interceptor\n  lb4 discover\n  ' +
-        'lb4 relation',
-    ]);
+    expectToMatchSnapshot(entries.join('\n'));
   });
 
   it('lists versions', () => {
@@ -41,13 +36,7 @@ describe('cli', () => {
   it('prints commands with --help', () => {
     const entries = [];
     main({help: true, _: []}, getLog(entries), true);
-    expect(entries).to.containEql('Available commands: ');
-    expect(entries).to.containEql(
-      '  lb4 app\n  lb4 extension\n  lb4 controller\n  lb4 datasource\n  ' +
-        'lb4 model\n  lb4 repository\n  lb4 service\n  lb4 example\n  ' +
-        'lb4 openapi\n  lb4 observer\n  lb4 interceptor\n  lb4 discover\n  ' +
-        'lb4 relation',
-    );
+    expectToMatchSnapshot(entries.join('\n'));
   });
 
   it('does not print commands with --help for a given command', () => {


### PR DESCRIPTION
I discovered this opportunity while working on https://github.com/strongloop/loopback-next/pull/3688 where I am adding a new CLI command.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
