### PR TITLE
fix(authorization): remove userToPrinciple

### DIFF
--- a/packages/authorization/src/authorize-interceptor.ts
+++ b/packages/authorization/src/authorize-interceptor.ts
@@ -17,12 +17,7 @@ import {
   Next,
   Provider,
 } from '@loopback/context';
-import {
-  Principal,
-  SecurityBindings,
-  securityId,
-  UserProfile,
-} from '@loopback/security';
+import {SecurityBindings, UserProfile} from '@loopback/security';
 import * as debugFactory from 'debug';
 import {getAuthorizationMetadata} from './decorators/authorize';
 import {AuthorizationBindings, AuthorizationTags} from './keys';
@@ -83,7 +78,7 @@ export class AuthorizationInterceptor implements Provider<Interceptor> {
     debug('Current user', user);
 
     const authorizationCtx: AuthorizationContext = {
-      principals: user ? [userToPrinciple(user)] : [],
+      principals: user ? [user] : [],
       roles: [],
       scopes: [],
       resource: invocationCtx.targetName,
@@ -150,15 +145,4 @@ async function loadAuthorizers(
     }
   }
   return authorizerFunctions;
-}
-
-// This is a workaround before we extract a common layer
-// for authentication and authorization.
-function userToPrinciple(user: UserProfile): Principal {
-  return {
-    name: user.name || user[securityId],
-    [securityId]: user.id,
-    email: user.email,
-    type: 'USER',
-  };
 }


### PR DESCRIPTION
Fixes #3766
Fixes #3707

As `UserProfile` of `@loopback/security` is now also Principal, there is no need for this convertion anymore. The provided securityId should be used as provided. The workaround seems not necessary anymore.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

