### PR TITLE
fix(cli): remove extra SPACE at EOL in help output

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -120,7 +120,7 @@ function printVersions(log) {
  * @param log - Log function
  */
 function printCommands(env, log) {
-  log('Available commands: ');
+  log('Available commands:');
   const list = Object.keys(env.getGeneratorsMeta())
     .filter(name => /^loopback4:/.test(name))
     .map(name => name.replace(/^loopback4:/, '  lb4 '));

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -8,7 +8,7 @@
 'use strict';
 
 exports[`cli lists available commands 1`] = `
-Available commands: 
+Available commands:
   lb4 app
   lb4 extension
   lb4 controller
@@ -26,7 +26,7 @@ Available commands:
 
 
 exports[`cli prints commands with --help 1`] = `
-Available commands: 
+Available commands:
   lb4 app
   lb4 extension
   lb4 controller

--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -42,6 +42,6 @@ describe('cli', () => {
   it('does not print commands with --help for a given command', () => {
     const entries = [];
     main({help: true, _: ['app']}, getLog(entries), true);
-    expect(entries).to.not.containEql('Available commands: ');
+    expect(entries).to.not.containEql('Available commands:');
   });
 });


### PR DESCRIPTION
I noticed the extra space while reviewing and editing snapshot files. At the moment, I cannot edit snapshot files manually because my editor is configured to remove trailing spaces, and thus breaks the snapshot on save.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
