### PR TITLE
feat: implement TestSandbox.writeTextFile

### DIFF
--- a/packages/testlab/src/__tests__/integration/test-sandbox.integration.ts
+++ b/packages/testlab/src/__tests__/integration/test-sandbox.integration.ts
@@ -73,6 +73,14 @@ describe('TestSandbox integration tests', () => {
     expect(content).to.equal('{\n  "key": "value"\n}\n');
   });
 
+  it('creates a text file in the sandbox', async () => {
+    await sandbox.writeTextFile('data.txt', 'Hello');
+    const fullPath = resolve(path, 'data.txt');
+    expect(await pathExists(fullPath)).to.be.True();
+    const content = await readFile(fullPath, 'utf-8');
+    expect(content).to.equal('Hello');
+  });
+
   it('resets the sandbox', async () => {
     const file = 'test.js';
     const resolvedFile = resolve(__dirname, '../fixtures/test.js');

--- a/packages/testlab/src/test-sandbox.ts
+++ b/packages/testlab/src/test-sandbox.ts
@@ -11,6 +11,7 @@ import {
   ensureDirSync,
   pathExists,
   remove,
+  writeFile,
   writeJson,
 } from 'fs-extra';
 import {parse, resolve} from 'path';
@@ -118,5 +119,18 @@ export class TestSandbox {
     const destDir = parse(dest).dir;
     await ensureDir(destDir);
     return writeJson(dest, data, {spaces: 2});
+  }
+
+  /**
+   * Creates a new file and writes the given data as a UTF-8-encoded text.
+   *
+   * @param dest - Destination filename, optionally including a relative path.
+   * @param data - The text to write.
+   */
+  async writeTextFile(dest: string, data: string): Promise<void> {
+    dest = resolve(this.path, dest);
+    const destDir = parse(dest).dir;
+    await ensureDir(destDir);
+    return writeFile(dest, data, {encoding: 'utf-8'});
   }
 }


### PR DESCRIPTION
Add `writeTextFile` method to `TestSandbox`.

Addresses https://github.com/strongloop/loopback-next/issues/3731.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
