### PR TITLE
fix: emit "type: 'object'," for schema definitions

### DIFF
--- a/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
@@ -74,11 +74,20 @@ describe('controller spec', () => {
       },
       components: {
         schemas: {
-          Bar: {title: 'Bar', properties: {name: {type: 'string'}}},
-          Baz: {title: 'Baz', properties: {name: {type: 'string'}}},
+          Bar: {
+            title: 'Bar',
+            type: 'object',
+            properties: {name: {type: 'string'}},
+          },
+          Baz: {
+            title: 'Baz',
+            type: 'object',
+            properties: {name: {type: 'string'}},
+          },
           Foo: {
             // guarantee `definition` is deleted
             title: 'Foo',
+            type: 'object',
             properties: {
               bar: {$ref: '#/components/schemas/Bar'},
               baz: {$ref: '#/components/schemas/Baz'},
@@ -404,6 +413,7 @@ describe('controller spec', () => {
           schemas: {
             Todo: {
               title: 'Todo',
+              type: 'object',
               properties: {
                 title: {
                   type: 'string',
@@ -444,6 +454,7 @@ describe('controller spec', () => {
       expect(globalSchemas).to.deepEqual({
         Todo: {
           title: 'Todo',
+          type: 'object',
           properties: {
             title: {
               type: 'string',
@@ -478,6 +489,7 @@ describe('controller spec', () => {
           schemas: {
             Todo: {
               title: 'Todo',
+              type: 'object',
               properties: {
                 title: {
                   type: 'string',
@@ -504,6 +516,7 @@ describe('controller spec', () => {
       expect(globalSchemas).to.deepEqual({
         Todo: {
           title: 'Todo',
+          type: 'object',
           properties: {
             title: {
               type: 'string',
@@ -528,6 +541,7 @@ describe('controller spec', () => {
         },
       },
       title: 'MyModel',
+      type: 'object',
     };
 
     it('generates schema for response content', () => {
@@ -770,6 +784,7 @@ describe('controller spec', () => {
       expect(globalSchemas).to.deepEqual({
         MyModel: {
           title: 'MyModel',
+          type: 'object',
           properties: {
             name: {
               type: 'string',

--- a/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
@@ -64,6 +64,7 @@ describe('operation arguments', () => {
         schemas: {
           User: {
             title: 'User',
+            type: 'object',
             properties: {name: {type: 'string'}, password: {type: 'number'}},
           },
         },

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -350,6 +350,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomType: {
               title: 'CustomType',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -406,6 +407,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomType: {
               title: 'CustomType',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -478,6 +480,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             Address: {
               title: 'Address',
+              type: 'object',
               properties: {
                 city: {
                   type: 'string',
@@ -569,6 +572,7 @@ describe('build-schema', () => {
           expect(schemaDefs).to.deepEqual({
             CustomTypeFoo: {
               title: 'CustomTypeFoo',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -577,6 +581,7 @@ describe('build-schema', () => {
             },
             CustomTypeBar: {
               title: 'CustomTypeBar',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'array',
@@ -607,6 +612,7 @@ describe('build-schema', () => {
 
       const expectedSchema = {
         title: 'Category',
+        type: 'object',
         properties: {
           products: {
             type: 'array',
@@ -616,6 +622,7 @@ describe('build-schema', () => {
         definitions: {
           Product: {
             title: 'Product',
+            type: 'object',
             properties: {
               category: {
                 $ref: '#/definitions/Category',
@@ -723,6 +730,7 @@ describe('build-schema', () => {
 
       const expectedSchemaForCategory = {
         title: 'Category',
+        type: 'object',
         properties: {
           products: {
             type: 'array',
@@ -732,6 +740,7 @@ describe('build-schema', () => {
         definitions: {
           Product: {
             title: 'Product',
+            type: 'object',
             properties: {
               category: {
                 $ref: '#/definitions/Category',
@@ -771,6 +780,7 @@ describe('build-schema', () => {
           ProductWithRelations: {
             title: 'ProductWithRelations',
             description: `(Schema options: { includeRelations: true })`,
+            type: 'object',
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -787,6 +797,7 @@ describe('build-schema', () => {
         },
         title: 'CategoryWithRelations',
         description: `(Schema options: { includeRelations: true })`,
+        type: 'object',
       };
       const jsonSchema = getJsonSchema(Category, {includeRelations: true});
       expect(jsonSchema).to.deepEqual(expectedSchema);
@@ -812,6 +823,7 @@ describe('build-schema', () => {
           ProductWithRelations: {
             title: 'ProductWithRelations',
             description: `(Schema options: { includeRelations: true })`,
+            type: 'object',
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -829,6 +841,7 @@ describe('build-schema', () => {
         },
         title: 'CategoryWithoutPropWithRelations',
         description: `(Schema options: { includeRelations: true })`,
+        type: 'object',
       };
 
       // To check for case when there are no other properties than relational
@@ -861,6 +874,7 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
+            type: 'object',
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -877,6 +891,7 @@ describe('build-schema', () => {
           },
         },
         title: 'CategoryWithRelations',
+        type: 'object',
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
@@ -910,6 +925,7 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
+            type: 'object',
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -926,6 +942,7 @@ describe('build-schema', () => {
           },
         },
         title: 'CategoryWithRelations',
+        type: 'object',
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
@@ -940,6 +957,7 @@ describe('build-schema', () => {
           id: {type: 'number'},
         },
         title: 'Category',
+        type: 'object',
       });
     });
 

--- a/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
@@ -22,6 +22,7 @@ describe('getJsonSchemaRef', () => {
       definitions: {
         MyModel: {
           title: 'MyModel',
+          type: 'object',
           properties: {
             name: {
               type: 'string',

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -391,6 +391,7 @@ export function modelToJsonSchema<T extends object>(
   } else if (descriptionSuffix) {
     result.description = descriptionSuffix;
   }
+  result.type = 'object';
 
   for (const p in meta.properties) {
     if (options.exclude && options.exclude.includes(p as keyof T)) {

--- a/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
@@ -29,6 +29,15 @@ describe('Validation at REST level', () => {
   let client: Client;
 
   @model()
+  class Category {
+    @property({required: true, type: 'string'})
+    name: string;
+
+    @property({required: false, type: 'string'})
+    description?: string;
+  }
+
+  @model()
   class Product {
     @property({required: true})
     name: string;
@@ -41,12 +50,18 @@ describe('Validation at REST level', () => {
     @property({required: true, jsonSchema: {range: [0, 100]}})
     price: number;
 
+    @property({required: true, type: Category})
+    category: Category;
+
     constructor(data: Partial<Product>) {
       Object.assign(this, data);
     }
   }
 
   const PRODUCT_SPEC: SchemaObject = jsonToSchemaObject(getJsonSchema(Product));
+  const CATEGORY_SPEC: SchemaObject = jsonToSchemaObject(
+    getJsonSchema(Category),
+  );
 
   // Add a schema that requires `description`
   const PRODUCT_SPEC_WITH_DESCRIPTION: SchemaObject = {
@@ -125,6 +140,7 @@ describe('Validation at REST level', () => {
         name: 'iPhone',
         description: null,
         price: 10,
+        category: {name: 'Phones'},
       };
       const res = await client
         .post('/products')
@@ -157,6 +173,7 @@ describe('Validation at REST level', () => {
         name: 'iPhone',
         description: 'iPhone',
         price: 200,
+        category: {name: 'Phones'},
       };
       const res = await client
         .post('/products')
@@ -214,6 +231,7 @@ describe('Validation at REST level', () => {
         name: 'iPhone',
         description: 'iPhone',
         price: 200,
+        category: {name: 'Phones'},
       };
       const res = await client
         .post('/products')
@@ -277,6 +295,7 @@ describe('Validation at REST level', () => {
         const DATA = {
           name: 'iPhone',
           description: 'iPhone',
+          category: {name: 'Phones'},
         };
         const res = await client
           .post('/products')
@@ -370,6 +389,7 @@ describe('Validation at REST level', () => {
       components: {
         schemas: {
           Product: PRODUCT_SPEC,
+          Category: CATEGORY_SPEC,
         },
       },
     })
@@ -400,6 +420,7 @@ describe('Validation at REST level', () => {
       name: 'Pencil',
       description: 'An optional description of a pencil',
       price: 10,
+      category: {name: 'Stationary'},
     };
     await client
       .post('/products')
@@ -412,6 +433,7 @@ describe('Validation at REST level', () => {
       name: 'Pencil',
       description: null,
       price: 10,
+      category: {name: 'Stationary'},
     };
     await client
       .post('/products')
@@ -421,7 +443,7 @@ describe('Validation at REST level', () => {
 
   async function serverAcceptsValidRequestBodyForUrlencoded() {
     const DATA =
-      'name=Pencil&price=10&description=An optional description of a pencil';
+      'name=Pencil&price=10&description=An optional description of a pencil&category[name]=Stationary';
     await client
       .post('/products')
       .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -430,6 +452,7 @@ describe('Validation at REST level', () => {
         name: 'Pencil',
         description: 'An optional description of a pencil',
         price: 10,
+        category: {name: 'Stationary'},
       });
   }
 

--- a/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
@@ -99,6 +99,21 @@ describe('Validation at REST level', () => {
         .expect(400);
     });
 
+    it('rejects requests with empty required object', async () => {
+      const DATA = {
+        name: 'iPhone',
+        description: null,
+        price: 10,
+        category: null,
+      };
+
+      await client
+        .post('/products')
+        .type('json')
+        .send(DATA)
+        .expect(422);
+    });
+
     it('rejects requests with empty json body', async () => {
       await client
         .post('/products')

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -272,6 +272,7 @@ describe('RestServer.getApiSpec()', () => {
     expect(spec.components && spec.components.schemas).to.deepEqual({
       MyModel: {
         title: 'MyModel',
+        type: 'object',
         properties: {
           bar: {
             type: 'string',


### PR DESCRIPTION
- JSON Schema makes provision for structuring a complex schema into re-usable elements.
- Loopback makes use of reference schema re-use through the '$ref' keyword.
- in the JSON Schema documentation for complex schemas https://json-schema.org/understanding-json-schema/structuring.html the complex schema definitions are declared as type: 'object'.
- Loopback generated JSON Schema omits this declaration. build-schema.ts:353.
- Omitting this declaration causes ajv validation to pass when a required element (which is a reference to a different object) is set to null.
- Adding the declaration: "type: 'object'" to generated schemas enables ajv validation to correctly fail when a required referenced property is present but the value set to null.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
