### PR TITLE
docs: update outdated links in todo tutorial

### DIFF
--- a/docs/site/tutorials/todo/todo-tutorial-controller.md
+++ b/docs/site/tutorials/todo/todo-tutorial-controller.md
@@ -54,7 +54,7 @@ that a new controller instance is created for each request. As a result, we want
 to inject our `TodoRepository` since the creation of these instances is more
 complex and expensive than making new controller instances.
 
-{% include note.html content="You can customize the lifecycle of _all_ bindings in LoopBack 4! Controllers can easily be made to use singleton lifecycles to minimize startup costs. For more information, see the [Dependency injection](Dependency-injection.md) section of our docs.
+{% include note.html content="You can customize the lifecycle of _all_ bindings in LoopBack 4! Controllers can easily be made to use singleton lifecycles to minimize startup costs. For more information, see the [Dependency injection](../../Dependency-injection.md) section of our docs.
 " %}
 
 In this example, there are two new decorators to provide LoopBack with metadata

--- a/docs/site/tutorials/todo/todo-tutorial-datasource.md
+++ b/docs/site/tutorials/todo/todo-tutorial-datasource.md
@@ -16,9 +16,9 @@ system. The Connector is used by `legacy-juggler-bridge` to power LoopBack 4
 Repositories for Data operations.
 
 In LoopBack 4, datasources can be represented as strongly-typed objects and
-freely made available for [injection](Dependency-injection.md) throughout the
-application. Typically, in LoopBack 4, datasources are used in conjunction with
-[Repositories](Repositories.md) to provide access to data.
+freely made available for [injection](../../Dependency-injection.md) throughout
+the application. Typically, in LoopBack 4, datasources are used in conjunction
+with [Repositories](../../Repositories.md) to provide access to data.
 
 For more information about datasources in LoopBack, see
 [DataSources](https://loopback.io/doc/en/lb4/DataSources.html).

--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -14,7 +14,7 @@ To call other APIs and web services from LoopBack applications, we recommend to
 use Service Proxies as a design pattern for encapsulating low-level
 implementation details of communication with 3rd-party services and providing
 JavaScript/TypeScript API that's easy to consume e.g. from Controllers. See
-[Calling other APIs and web services](./Calling-other-APIs-and-Web-Services.md)
+[Calling other APIs and web services](../../Calling-other-APIs-and-Web-Services.md)
 for more details.
 
 In LoopBack, each service proxy is backed by a

--- a/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
+++ b/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
@@ -10,9 +10,9 @@ summary: LoopBack 4 Todo Application Tutorial - Putting it all together
 ### Putting it all together
 
 We've got all of our artifacts now, and they are all automatically bound to our
-[Application](Application.md) so that LoopBack's
-[Dependency injection](Dependency-injection.md) system can tie it all together
-for us!
+[Application](../../Application.md) so that LoopBack's
+[Dependency injection](../../Dependency-injection.md) system can tie it all
+together for us!
 
 LoopBack's
 [boot module](https://github.com/strongloop/loopback-next/tree/master/packages/boot)
@@ -28,8 +28,8 @@ artifacts and inject them into our application for use.
 > - Repositories: `./src/repositories`
 >
 > To find out how to customize this behavior, see the
-> [Booters](Booting-an-Application.md#booters) section of
-> [Booting an Application](Booting-an-Application.md).
+> [Booters](../../Booting-an-Application.md#booters) section of
+> [Booting an Application](../../Booting-an-Application.md).
 
 Let's try out our application! First, you'll want to start the app.
 
@@ -72,8 +72,8 @@ left off here to guide you through adding in an additional feature:
 ### More examples and tutorials
 
 Eager to continue learning about LoopBack 4? Check out our
-[Examples](Examples.md) and [Tutorials](Tutorials.md) sections to find examples
-for creating your own custom components, sequences and more!
+[Examples](../../Examples.md) and [Tutorials](../../Tutorials.md) sections to
+find examples for creating your own custom components, sequences and more!
 
 ### Navigation
 


### PR DESCRIPTION

Fixes: https://github.com/strongloop/loopback.io/issues/889
