### PR TITLE
docs: fix wrong function name in relation docs

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -316,7 +316,7 @@ export class OrderRepository extends DefaultCrudRepository {
     );
 
     // add this line to register inclusion resolver.
-    this.registerInclusion('customer', this.customer.inclusionResolver);
+    this.registerInclusionResolver('customer', this.customer.inclusionResolver);
   }
 }
 ```

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -362,7 +362,7 @@ export class CustomerRepository extends DefaultCrudRepository {
     );
 
     // add this line to register inclusion resolver
-    this.registerInclusion('orders', this.orders.inclusionResolver);
+    this.registerInclusionResolver('orders', this.orders.inclusionResolver);
   }
 }
 ```

--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -340,7 +340,7 @@ export class SupplierRepository extends DefaultCrudRepository {
       accountRepositoryGetter,
     );
     // add this line to register inclusion resolver
-    this.registerInclusion('account', this.account.inclusionResolver);
+    this.registerInclusionResolver('account', this.account.inclusionResolver);
   }
 }
 ```


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Fixes wrong function name in relations docs: `registerInclusion` -> `registerInclusionResolver`

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
