### PR TITLE
feat(authentication): return binding for registerAuthenticationStrategy

### DIFF
--- a/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
+++ b/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/authentication
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Context} from '@loopback/context';
+import {Request} from '@loopback/rest';
+import {securityId, UserProfile} from '@loopback/security';
+import {expect} from '@loopback/testlab';
+import {
+  AuthenticationBindings,
+  AuthenticationStrategy,
+  registerAuthenticationStrategy,
+} from '../../..';
+
+describe('registerAuthenticationStrategy', () => {
+  let ctx: Context;
+
+  beforeEach(givenContext);
+
+  it('adds a binding for the strategy', () => {
+    const binding = registerAuthenticationStrategy(
+      ctx,
+      MyAuthenticationStrategy,
+    );
+    expect(binding.tagMap).to.containEql({
+      extensionFor:
+        AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME,
+    });
+    expect(binding.key).to.eql(
+      `${AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME}.MyAuthenticationStrategy`,
+    );
+  });
+
+  class MyAuthenticationStrategy implements AuthenticationStrategy {
+    name: 'my-auth';
+    async authenticate(request: Request): Promise<UserProfile | undefined> {
+      return {
+        [securityId]: 'somebody',
+      };
+    }
+  }
+
+  function givenContext() {
+    ctx = new Context('app');
+  }
+});

--- a/packages/authentication/src/types.ts
+++ b/packages/authentication/src/types.ts
@@ -85,12 +85,14 @@ export const USER_PROFILE_NOT_FOUND = 'USER_PROFILE_NOT_FOUND';
  * Registers an authentication strategy as an extension of the
  * AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME extension
  * point.
+ * @param context - Context object
+ * @param strategyClass - Class for the authentication strategy
  */
 export function registerAuthenticationStrategy(
   context: Context,
   strategyClass: Constructor<AuthenticationStrategy>,
 ) {
-  addExtension(
+  return addExtension(
     context,
     AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME,
     strategyClass,


### PR DESCRIPTION
Use case:

```ts
const binding = registerAuthenticationStrategy(app, MyAuthStrategy);
app.configure(binding.key).to(myAuthConfig);
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
