### PR TITLE
fix(docs): add content to usage-scenario page

### DIFF
--- a/docs/site/Usage-scenarios.md
+++ b/docs/site/Usage-scenarios.md
@@ -5,3 +5,13 @@ keywords: LoopBack 4.0, LoopBack-Next
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Usage-scenarios.html
 ---
+
+There are various usage scenario of using LoopBack, including accessing
+databases, integrating to other infrastructures and calling other services.
+
+- [create other forms of APIs](Create-other-forms-of-apis.md)
+- [access databases](Access-databases.md)
+- [call other services](Calling-other-APIs-and-Web-Services.md)
+- [integrate with infrastructures](Integrate-with-infrastructures.md)
+- [serve static files](Serving-static-files.md)
+- [deploy to cloud](Deployment.md)


### PR DESCRIPTION
Currently the [Usage scenario page](https://loopback.io/doc/en/lb4/Usage-scenarios.html) is empty. This PR adds some content in the page which serves as an index besides the sidebar. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
