### PR TITLE
Simplify model schema with excluded properties

### DIFF
--- a/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
@@ -74,8 +74,16 @@ describe('controller spec', () => {
       },
       components: {
         schemas: {
-          Bar: {title: 'Bar', properties: {name: {type: 'string'}}},
-          Baz: {title: 'Baz', properties: {name: {type: 'string'}}},
+          Bar: {
+            title: 'Bar',
+            properties: {name: {type: 'string'}},
+            additionalProperties: false,
+          },
+          Baz: {
+            title: 'Baz',
+            properties: {name: {type: 'string'}},
+            additionalProperties: false,
+          },
           Foo: {
             // guarantee `definition` is deleted
             title: 'Foo',
@@ -83,6 +91,7 @@ describe('controller spec', () => {
               bar: {$ref: '#/components/schemas/Bar'},
               baz: {$ref: '#/components/schemas/Baz'},
             },
+            additionalProperties: false,
           },
         },
       },
@@ -527,6 +536,7 @@ describe('controller spec', () => {
           type: 'string',
         },
       },
+      additionalProperties: false,
       title: 'MyModel',
     };
 
@@ -775,6 +785,7 @@ describe('controller spec', () => {
               type: 'string',
             },
           },
+          additionalProperties: false,
         },
       });
     });

--- a/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect} from '@loopback/testlab';
 import {model, property} from '@loopback/repository';
-import {param, requestBody, getControllerSpec, post, get} from '../../';
+import {expect} from '@loopback/testlab';
+import {get, getControllerSpec, param, post, requestBody} from '../../';
 
 describe('operation arguments', () => {
   it('generate parameters and requestBody for operation', () => {
@@ -65,6 +65,7 @@ describe('operation arguments', () => {
           User: {
             title: 'User',
             properties: {name: {type: 'string'}, password: {type: 'number'}},
+            additionalProperties: false,
           },
         },
       },

--- a/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {getFilterSchemaFor} from '../..';
 import {Entity, model, property} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
+import {getFilterSchemaFor} from '../..';
 
 describe('filterSchema', () => {
   @model({
@@ -24,6 +24,7 @@ describe('filterSchema', () => {
       properties: {
         where: {
           type: 'object',
+          additionalProperties: true,
         },
         fields: {
           type: 'object',
@@ -31,12 +32,14 @@ describe('filterSchema', () => {
             id: {type: 'boolean'},
             age: {type: 'boolean'},
           },
+          additionalProperties: false,
         },
         offset: {type: 'integer', minimum: 0},
         limit: {type: 'integer', minimum: 0},
         skip: {type: 'integer', minimum: 0},
         order: {type: 'array', items: {type: 'string'}},
       },
+      additionalProperties: false,
     });
   });
 });

--- a/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
@@ -77,11 +77,27 @@ describe('jsonToSchemaObject', () => {
     });
 
     it('is converted properly when it is "false"', () => {
-      const noAdditionalDef: JsonSchema = {
+      const jsonSchema: JsonSchema = {
         additionalProperties: false,
       };
-      const expectedDef: SchemaObject = {};
-      propertyConversionTest(noAdditionalDef, expectedDef);
+
+      const openApiSchema = jsonToSchemaObject(jsonSchema);
+
+      expect(openApiSchema).to.deepEqual({
+        additionalProperties: false,
+      });
+    });
+
+    it('is converted properly when it is "true"', () => {
+      const jsonSchema: JsonSchema = {
+        additionalProperties: true,
+      };
+
+      const openApiSchema = jsonToSchemaObject(jsonSchema);
+
+      expect(openApiSchema).to.deepEqual({
+        additionalProperties: true,
+      });
     });
   });
 
@@ -106,6 +122,7 @@ describe('jsonToSchemaObject', () => {
           type: 'string',
         },
       },
+      additionalProperties: false,
       default: 'Default string',
     };
     const expectedDef: SchemaObject = {
@@ -116,6 +133,7 @@ describe('jsonToSchemaObject', () => {
           type: 'string',
         },
       },
+      additionalProperties: false,
       default: 'Default string',
     };
     expect(jsonToSchemaObject(inputDef)).to.eql(expectedDef);

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -75,7 +75,9 @@ export function jsonToSchemaObject(json: JsonSchema): SchemaObject | SchemaRef {
         break;
       }
       case 'additionalProperties': {
-        if (typeof json.additionalProperties !== 'boolean') {
+        if (typeof json.additionalProperties === 'boolean') {
+          result.additionalProperties = json.additionalProperties;
+        } else {
           result.additionalProperties = jsonToSchemaObject(
             json.additionalProperties!,
           );

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -1046,9 +1046,6 @@ describe('build-schema', () => {
             description: {type: 'string'},
           },
           additionalProperties: false,
-          not: {
-            anyOf: [{required: ['id']}],
-          },
           description: `(Schema options: { exclude: [ 'id' ] })`,
         });
       });
@@ -1071,9 +1068,6 @@ describe('build-schema', () => {
             description: {type: 'string'},
           },
           additionalProperties: false,
-          not: {
-            anyOf: [{required: ['id']}, {required: ['name']}],
-          },
           description: `(Schema options: { exclude: [ 'id', 'name' ] })`,
         });
       });

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -355,6 +355,7 @@ describe('build-schema', () => {
                   type: 'string',
                 },
               },
+              additionalProperties: false,
             },
           });
           expectValidJsonSchema(jsonSchema);
@@ -411,6 +412,7 @@ describe('build-schema', () => {
                   type: 'string',
                 },
               },
+              additionalProperties: false,
             },
           });
           expectValidJsonSchema(jsonSchema);
@@ -483,6 +485,7 @@ describe('build-schema', () => {
                   type: 'string',
                 },
               },
+              additionalProperties: false,
             },
           });
           expectValidJsonSchema(jsonSchema);
@@ -535,6 +538,7 @@ describe('build-schema', () => {
                 },
                 customerId: {type: 'number'},
               },
+              additionalProperties: false,
             },
           });
         });
@@ -574,6 +578,7 @@ describe('build-schema', () => {
                   type: 'string',
                 },
               },
+              additionalProperties: false,
             },
             CustomTypeBar: {
               title: 'CustomTypeBar',
@@ -585,6 +590,7 @@ describe('build-schema', () => {
                   },
                 },
               },
+              additionalProperties: false,
             },
           });
           expectValidJsonSchema(jsonSchema);
@@ -613,6 +619,7 @@ describe('build-schema', () => {
             items: {$ref: '#/definitions/Product'},
           },
         },
+        additionalProperties: false,
         definitions: {
           Product: {
             title: 'Product',
@@ -621,6 +628,7 @@ describe('build-schema', () => {
                 $ref: '#/definitions/Category',
               },
             },
+            additionalProperties: false,
           },
         },
       };
@@ -628,6 +636,38 @@ describe('build-schema', () => {
       it('handles circular references', () => {
         const schema = modelToJsonSchema(Category);
         expect(schema).to.deepEqual(expectedSchema);
+      });
+    });
+
+    context('additionalProperties', () => {
+      it('assumes "strict: true" when not set', () => {
+        @model()
+        class DefaultModel {}
+
+        const schema = modelToJsonSchema(DefaultModel);
+        expect(schema).to.containDeep({
+          additionalProperties: false,
+        });
+      });
+
+      it('respects model setting "strict: true"', () => {
+        @model({settings: {strict: true}})
+        class StrictModel {}
+
+        const schema = modelToJsonSchema(StrictModel);
+        expect(schema).to.containDeep({
+          additionalProperties: false,
+        });
+      });
+
+      it('respects model setting "strict: false"', () => {
+        @model({settings: {strict: false}})
+        class FreeFormModel {}
+
+        const schema = modelToJsonSchema(FreeFormModel);
+        expect(schema).to.containDeep({
+          additionalProperties: true,
+        });
       });
     });
 
@@ -729,6 +769,7 @@ describe('build-schema', () => {
             items: {$ref: '#/definitions/Product'},
           },
         },
+        additionalProperties: false,
         definitions: {
           Product: {
             title: 'Product',
@@ -737,6 +778,7 @@ describe('build-schema', () => {
                 $ref: '#/definitions/Category',
               },
             },
+            additionalProperties: false,
           },
         },
       };
@@ -776,6 +818,7 @@ describe('build-schema', () => {
               categoryId: {type: 'number'},
               category: {$ref: '#/definitions/CategoryWithRelations'},
             },
+            additionalProperties: false,
           },
         },
         properties: {
@@ -785,6 +828,7 @@ describe('build-schema', () => {
             items: {$ref: '#/definitions/ProductWithRelations'},
           },
         },
+        additionalProperties: false,
         title: 'CategoryWithRelations',
         description: `(Schema options: { includeRelations: true })`,
       };
@@ -819,6 +863,7 @@ describe('build-schema', () => {
                 $ref: '#/definitions/CategoryWithoutPropWithRelations',
               },
             },
+            additionalProperties: false,
           },
         },
         properties: {
@@ -827,6 +872,7 @@ describe('build-schema', () => {
             items: {$ref: '#/definitions/ProductWithRelations'},
           },
         },
+        additionalProperties: false,
         title: 'CategoryWithoutPropWithRelations',
         description: `(Schema options: { includeRelations: true })`,
       };
@@ -866,6 +912,7 @@ describe('build-schema', () => {
               categoryId: {type: 'number'},
               category: {$ref: '#/definitions/CategoryWithRelations'},
             },
+            additionalProperties: false,
           },
         },
         properties: {
@@ -876,6 +923,7 @@ describe('build-schema', () => {
             items: {$ref: '#/definitions/ProductWithRelations'},
           },
         },
+        additionalProperties: false,
         title: 'CategoryWithRelations',
       };
       MetadataInspector.defineMetadata(
@@ -915,6 +963,7 @@ describe('build-schema', () => {
               categoryId: {type: 'number'},
               category: {$ref: '#/definitions/CategoryWithRelations'},
             },
+            additionalProperties: false,
           },
         },
         properties: {
@@ -925,6 +974,7 @@ describe('build-schema', () => {
             items: {$ref: '#/definitions/ProductWithRelations'},
           },
         },
+        additionalProperties: false,
         title: 'CategoryWithRelations',
       };
       MetadataInspector.defineMetadata(
@@ -939,6 +989,7 @@ describe('build-schema', () => {
         properties: {
           id: {type: 'number'},
         },
+        additionalProperties: false,
         title: 'Category',
       });
     });
@@ -994,6 +1045,7 @@ describe('build-schema', () => {
             name: {type: 'string'},
             description: {type: 'string'},
           },
+          additionalProperties: false,
           not: {
             anyOf: [{required: ['id']}],
           },
@@ -1018,6 +1070,7 @@ describe('build-schema', () => {
           properties: {
             description: {type: 'string'},
           },
+          additionalProperties: false,
           not: {
             anyOf: [{required: ['id']}, {required: ['name']}],
           },

--- a/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
@@ -27,6 +27,7 @@ describe('getJsonSchemaRef', () => {
               type: 'string',
             },
           },
+          additionalProperties: false,
         },
       },
     });

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -439,6 +439,8 @@ export function modelToJsonSchema<T extends object>(
     includeReferencedSchema(referenceType.name, propSchema);
   }
 
+  result.additionalProperties = meta.settings.strict === false;
+
   if (options.includeRelations) {
     for (const r in meta.relations) {
       result.properties = result.properties || {};

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -397,9 +397,6 @@ export function modelToJsonSchema<T extends object>(
 
   for (const p in meta.properties) {
     if (options.exclude && options.exclude.includes(p as keyof T)) {
-      result.not = (result.not as JSONSchema) || {};
-      result.not.anyOf = result.not.anyOf || [];
-      result.not.anyOf.push({required: [p]});
       continue;
     }
 

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -366,6 +366,7 @@ export function modelToJsonSchema<T extends object>(
     delete options.partial;
   }
 
+  debug('Creating schema for model %s', ctor.name);
   debug('JSON schema options: %o', options);
 
   const meta: ModelDefinition | {} = ModelMetadataHelper.getModelMetadata(ctor);
@@ -374,6 +375,8 @@ export function modelToJsonSchema<T extends object>(
   if (!(meta instanceof ModelDefinition)) {
     return {};
   }
+
+  debug('Model settings', meta.settings);
 
   const title = buildSchemaTitle(ctor, meta, options);
 
@@ -440,6 +443,7 @@ export function modelToJsonSchema<T extends object>(
   }
 
   result.additionalProperties = meta.settings.strict === false;
+  debug('  additionalProperties?', result.additionalProperties);
 
   if (options.includeRelations) {
     for (const r in meta.relations) {

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Model, model, getModelRelations} from '@loopback/repository';
+import {getModelRelations, Model, model} from '@loopback/repository';
 import {JSONSchema6 as JsonSchema} from 'json-schema';
 
 @model({settings: {strict: false}})
@@ -49,6 +49,7 @@ export function getFilterJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
         },
       },
     },
+    additionalProperties: false,
   };
 
   const modelRelations = getModelRelations(modelCtor);
@@ -107,7 +108,7 @@ export function getFieldsJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
         [k]: {type: 'boolean'},
       })),
     ),
-    additionalProperties: !modelCtor.definition.settings.strict,
+    additionalProperties: modelCtor.definition.settings.strict === false,
   };
   return schema;
 }

--- a/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
+++ b/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
@@ -79,10 +79,22 @@ describe('CrudRestController for a simple Product model', () => {
     });
 
     it('rejects request with `id` value', async () => {
-      await client
+      const {body} = await client
         .post('/products')
         .send({id: 1, name: 'a name'})
         .expect(422);
+
+      expect(body.error).to.containDeep({
+        code: 'VALIDATION_FAILED',
+        details: [
+          {
+            path: '',
+            code: 'additionalProperties',
+            message: 'should NOT have additional properties',
+            info: {additionalProperty: 'id'},
+          },
+        ],
+      });
     });
   });
 

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {expect, validateApiSpec} from '@loopback/testlab';
 import {Application} from '@loopback/core';
-import {
-  RestServer,
-  RestComponent,
-  createControllerFactoryForClass,
-} from '../../..';
-import {get, post, requestBody} from '@loopback/openapi-v3';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
+import {get, post, requestBody} from '@loopback/openapi-v3';
 import {model, property} from '@loopback/repository';
+import {expect, validateApiSpec} from '@loopback/testlab';
+import {
+  createControllerFactoryForClass,
+  RestComponent,
+  RestServer,
+} from '../../..';
 
 describe('RestServer.getApiSpec()', () => {
   let app: Application;
@@ -277,6 +277,7 @@ describe('RestServer.getApiSpec()', () => {
             type: 'string',
           },
         },
+        additionalProperties: false,
       },
     });
   });

--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  isReferenceObject,
   ReferenceObject,
   RequestBodyObject,
   SchemaObject,
@@ -53,7 +54,15 @@ export function validateRequestBody(
   const schema = body.schema;
   /* istanbul ignore if */
   if (debug.enabled) {
-    debug('Request body schema: %j', util.inspect(schema, {depth: null}));
+    debug('Request body schema:', util.inspect(schema, {depth: null}));
+    if (
+      schema &&
+      isReferenceObject(schema) &&
+      schema.$ref.startsWith('#/components/schemas/')
+    ) {
+      const ref = schema.$ref.slice('#/components/schemas/'.length);
+      debug('  referencing:', util.inspect(globalSchemas[ref], {depth: null}));
+    }
   }
   if (!schema) return;
 


### PR DESCRIPTION
In a recent discussion about using [openapi-to-graphql](https://loopback.io/openapi-to-graphql.html) with LoopBack apps, we found that the schema created by LoopBack 4 is difficult to interpret. Schema for creating new model instances (e.g. `NewTodo`) is excluding the PK property (e.g. `id`) using `not` and `anyOf` operators, see #3297.

IMO, we should not need to use such construct, it should be enough to omit the excluded property from the schema.

While investigating such fix, I found out that JSON Schema allows arbitrary additional properties by default (`additionalProperties: true`). At the same time, LoopBack 4 models are strict by default and don't allow arbitrary properties.

The first commit removes this inconsistency by modifying `repository-json-schema` to correctly set `additionalProperties` based on `strict` model setting.

The second commits fixes `openapi-v3` to preserve boolean values of `additionalProperties` field. (Before my change, only objects were honored.)

The last commit finally simplifies the schema with excluded properties.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
