### PR TITLE
fix: allow json schema with circular refs to be converted to OpenAPI schema

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -234,6 +234,8 @@ describe('build-schema', () => {
         benchmarkId: {type: 'string'},
         color: {type: 'string'},
       });
+      // No circular references in definitions
+      expect(schema.definitions).to.be.undefined();
     });
   });
 

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -459,18 +459,21 @@ export function modelToJsonSchema<T extends object>(
 
   function includeReferencedSchema(name: string, schema: JSONSchema) {
     if (!schema || !Object.keys(schema).length) return;
-    result.definitions = result.definitions || {};
 
     // promote nested definition to the top level
     if (result !== schema && schema.definitions) {
       for (const key in schema.definitions) {
         if (key === title) continue;
+        result.definitions = result.definitions || {};
         result.definitions[key] = schema.definitions[key];
       }
       delete schema.definitions;
     }
 
-    result.definitions[name] = schema;
+    if (result !== schema) {
+      result.definitions = result.definitions || {};
+      result.definitions[name] = schema;
+    }
   }
   return result;
 }


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/3706

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
