### PR TITLE
chore: reduce concurrency to avoid bootstrap issues due to npm locks

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
   ],
   "command": {
     "bootstrap": {
-      "concurrency": 8,
+      "concurrency": 4,
       "forceLocal": true
     },
     "version": {


### PR DESCRIPTION
It happens very frequently for me with `npm run update-packages`, which is also part of our release process.

Sample error:

```
lerna ERR! npm install exited 254 in '@loopback/service-proxy'
lerna ERR! npm install stderr:
npm ERR! code ENOENT
npm ERR! syscall lchown
npm ERR! path /Users/rfeng/.npm/_locks/staging-1f9c9b6dc2a3f888.lock
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, lchown '/Users/rfeng/.npm/_locks/staging-1f9c9b6dc2a3f888.lock'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
