### PR TITLE
test(repository-json-schema): verify "not.anyOf" in model schema

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -988,14 +988,17 @@ describe('build-schema', () => {
         expect(originalSchema.title).to.equal('Product');
 
         const excludeIdSchema = getJsonSchema(Product, {exclude: ['id']});
-        expect(excludeIdSchema.properties).to.deepEqual({
-          name: {type: 'string'},
-          description: {type: 'string'},
+        expect(excludeIdSchema).to.deepEqual({
+          title: 'ProductExcluding_id_',
+          properties: {
+            name: {type: 'string'},
+            description: {type: 'string'},
+          },
+          not: {
+            anyOf: [{required: ['id']}],
+          },
+          description: `(Schema options: { exclude: [ 'id' ] })`,
         });
-        expect(excludeIdSchema.title).to.equal('ProductExcluding_id_');
-        expect(excludeIdSchema.description).to.endWith(
-          `(Schema options: { exclude: [ 'id' ] })`,
-        );
       });
 
       it('excludes multiple properties when the option "exclude" is set to exclude multiple properties', () => {
@@ -1010,15 +1013,16 @@ describe('build-schema', () => {
         const excludeIdAndNameSchema = getJsonSchema(Product, {
           exclude: ['id', 'name'],
         });
-        expect(excludeIdAndNameSchema.properties).to.deepEqual({
-          description: {type: 'string'},
+        expect(excludeIdAndNameSchema).to.deepEqual({
+          title: 'ProductExcluding_id-name_',
+          properties: {
+            description: {type: 'string'},
+          },
+          not: {
+            anyOf: [{required: ['id']}, {required: ['name']}],
+          },
+          description: `(Schema options: { exclude: [ 'id', 'name' ] })`,
         });
-        expect(excludeIdAndNameSchema.title).to.equal(
-          'ProductExcluding_id-name_',
-        );
-        expect(excludeIdAndNameSchema.description).to.endWith(
-          `(Schema options: { exclude: [ 'id', 'name' ] })`,
-        );
       });
 
       it(`doesn't exclude properties when the option "exclude" is set to exclude no properties`, () => {


### PR DESCRIPTION
Modify the tests for JsonSchemaOption "exclude" to verify that"not" + "anyOf" is used to forbid excluded properties in data.

See the following discussion for background context: https://github.com/strongloop/loopback-next/pull/3895#discussion_r332545593

The PR that introduced the tests I am modifying: https://github.com/strongloop/loopback-next/pull/3297

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
