### PR TITLE
feat(openapi-v3): copy first example from examples to schema

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
@@ -35,7 +35,7 @@ describe('filterSchema', () => {
           additionalProperties: false,
         },
         offset: {type: 'integer', minimum: 0},
-        limit: {type: 'integer', minimum: 0},
+        limit: {type: 'integer', minimum: 1, example: 100, examples: [100]},
         skip: {type: 'integer', minimum: 0},
         order: {type: 'array', items: {type: 'string'}},
       },

--- a/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
@@ -149,6 +149,19 @@ describe('jsonToSchemaObject', () => {
     );
   });
 
+  it('copies first example from examples', () => {
+    const itemsDef: JsonSchema = {
+      type: 'integer',
+      examples: [100, 500],
+    };
+    const expectedItems: SchemaObject = {
+      type: 'integer',
+      example: 100,
+      examples: [100, 500],
+    };
+    propertyConversionTest(itemsDef, expectedItems);
+  });
+
   // Helper function to check conversion of JSON Schema properties
   // to Swagger versions
   function propertyConversionTest(property: object, expected: object) {

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -96,6 +96,13 @@ export function jsonToSchemaObject(json: JsonSchema): SchemaObject | SchemaRef {
         );
         break;
       }
+      case 'examples': {
+        if (Array.isArray(json.examples)) {
+          result.examples = json.examples;
+          result.example = json.examples[0];
+        }
+        break;
+      }
       default: {
         result[property] = json[property as keyof JsonSchema];
         break;

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -34,7 +34,8 @@ export function getFilterJsonSchemaFor(modelCtor: typeof Model): JsonSchema {
 
       limit: {
         type: 'integer',
-        minimum: 0,
+        minimum: 1,
+        examples: [100],
       },
 
       skip: {


### PR DESCRIPTION
Follow up to #2379

Copy first example from examples in JsonSchema to SchemaObject to be used in api explorer. This is a kind of workaround until the api explorer uses one of the listed examples or the default object.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

