### PR TITLE
[RFC] feat(testlab): add docker support

### DIFF
--- a/packages/testlab/package-lock.json
+++ b/packages/testlab/package-lock.json
@@ -147,6 +147,14 @@
 			"resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
 			"integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw=="
 		},
+		"@types/dockerode": {
+			"version": "2.5.20",
+			"resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.20.tgz",
+			"integrity": "sha512-g2eM9q+pur7iZc897K/OSq8sCL7VdVcCPzNkdeTukUokfvgl3TaP+nT7G8BMpnSSojrJFKl7VdTciP7hbVgfKA==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/express": {
 			"version": "4.17.1",
 			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
@@ -249,6 +257,15 @@
 				"@types/superagent": "*"
 			}
 		},
+		"JSONStream": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+			"requires": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			}
+		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -292,10 +309,26 @@
 			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
 			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
 		},
+		"asn1": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
 		},
 		"better-ajv-errors": {
 			"version": "0.5.7",
@@ -309,6 +342,26 @@
 				"json-to-ast": "^2.0.3",
 				"jsonpointer": "^4.0.1",
 				"leven": "^2.1.0"
+			}
+		},
+		"bl": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+			"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+			"requires": {
+				"readable-stream": "^3.0.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"body-parser": {
@@ -327,6 +380,11 @@
 				"raw-body": "2.4.0",
 				"type-is": "~1.6.17"
 			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"bytes": {
 			"version": "3.1.0",
@@ -352,6 +410,11 @@
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
 			}
+		},
+		"chownr": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
 		},
 		"cliui": {
 			"version": "4.1.0",
@@ -403,6 +466,29 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+		},
+		"concat-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.0.2",
+				"typedarray": "^0.0.6"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"content-disposition": {
 			"version": "0.5.3",
@@ -486,6 +572,59 @@
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		},
+		"docker-modem": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.0.0.tgz",
+			"integrity": "sha512-5vu9zcU31DFOv7MxczteXTMH8LLVdto3wwDHICwyzDnJKWPNIrhL7K2nXMAflEagVz1JnzjfDJ4bCUxEGX0aVw==",
+			"requires": {
+				"JSONStream": "1.3.2",
+				"debug": "^3.2.6",
+				"readable-stream": "~1.0.26-4",
+				"split-ca": "^1.0.0",
+				"ssh2": "^0.8.5"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"dockerode": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.0.1.tgz",
+			"integrity": "sha512-l6C/1ZF3t5qNy5xD/pd0muY6qff3qMls6iiqWNl6prODBZXe06v9w2dlxe0xDxfXwvSk5NCH+nbAaZ5b3BqvSA==",
+			"requires": {
+				"concat-stream": "~2.0.0",
+				"docker-modem": "^2.0.0",
+				"tar-fs": "~2.0.0"
+			}
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -638,6 +777,11 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -763,6 +907,11 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+		},
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
@@ -860,6 +1009,19 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -1285,10 +1447,38 @@
 				"supports-color": "^5.5.0"
 			}
 		},
+		"split-ca": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+			"integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
+		},
+		"ssh2": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.5.tgz",
+			"integrity": "sha512-TkvzxSYYUSQ8jb//HbHnJVui4fVEW7yu/zwBxwro/QaK2EGYtwB+8gdEChwHHuj142c5+250poMC74aJiwApPw==",
+			"requires": {
+				"ssh2-streams": "~0.4.4"
+			}
+		},
+		"ssh2-streams": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.6.tgz",
+			"integrity": "sha512-jXq/nk2K82HuueO9CTCdas/a0ncX3fvYzEPKt1+ftKwE5RXTX25GyjcpjBh2lwVUYbk0c9yq6cBczZssWmU3Tw==",
+			"requires": {
+				"asn1": "~0.2.0",
+				"bcrypt-pbkdf": "^1.0.2",
+				"streamsearch": "~0.1.2"
+			}
+		},
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"streamsearch": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -1369,10 +1559,55 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"tar-fs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+			"integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp": "^0.5.1",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
+			}
+		},
+		"tar-stream": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+			"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+			"requires": {
+				"bl": "^3.0.0",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
 		"toidentifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-detect": {
 			"version": "4.0.8",
@@ -1387,6 +1622,11 @@
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
 			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"universalify": {
 			"version": "0.1.2",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -17,11 +17,13 @@
   "license": "MIT",
   "dependencies": {
     "@hapi/shot": "^4.1.2",
+    "@types/dockerode": "^2.5.20",
     "@types/express": "^4.17.1",
     "@types/fs-extra": "^8.0.1",
     "@types/shot": "^4.0.0",
     "@types/sinon": "^7.5.0",
     "@types/supertest": "^2.0.8",
+    "dockerode": "^3.0.1",
     "express": "^4.17.1",
     "fs-extra": "^8.1.0",
     "oas-validator": "^3.3.1",

--- a/packages/testlab/src/__tests__/integration/docker.integration.ts
+++ b/packages/testlab/src/__tests__/integration/docker.integration.ts
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {DockerClient} from '../..';
+import {expect} from '../../expect';
+
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+describe('docker', async function() {
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(30000);
+
+  let verb: typeof it | typeof it.skip = it;
+  const client = new DockerClient();
+  const result = await client.isAvailable();
+  if (!result) {
+    verb = it.skip;
+  }
+
+  before(async () => {
+    if (result) await client.pull('alpine:latest');
+  });
+
+  verb('inspects an image by name', async () => {
+    const image = client.docker.getImage('alpine:latest');
+    const info = await image.inspect();
+    expect(info).containEql({RepoTags: ['alpine:latest']});
+  });
+
+  verb('runs a docker container', async () => {
+    const [data, container] = await client.run(
+      'alpine',
+      ['sh', '-c', 'uname -a'],
+      // {HostConfig: {AutoRemove: true}},
+    );
+    expect(data.StatusCode).to.eql(0);
+    await container.remove();
+  });
+
+  verb('removes an image by name', async () => {
+    const image = client.docker.getImage('alpine:latest');
+    const info = await image.remove({force: true});
+    expect(info).to.containEql({Untagged: 'alpine:latest'});
+  });
+
+  verb('pulls and runs a docker container', async () => {
+    const [data, container] = await client.pullAndRun(
+      'alpine',
+      ['sh', '-c', 'uname -a'],
+      // {HostConfig: {AutoRemove: true}},
+    );
+    expect(data.StatusCode).to.eql(0);
+    await container.remove();
+  });
+});

--- a/packages/testlab/src/docker.ts
+++ b/packages/testlab/src/docker.ts
@@ -1,0 +1,99 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/testlab
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as Dockerode from 'dockerode';
+import {Container, DockerOptions} from 'dockerode';
+
+/**
+ * Options for docker pull/docker container create/docker container start
+ */
+export type DockerCommandOptions = {
+  pull?: object;
+  create?: object;
+  start?: object;
+  auth?: object;
+};
+
+export class DockerClient {
+  readonly docker: Dockerode;
+  constructor(options?: DockerOptions) {
+    this.docker = new Dockerode(options);
+  }
+
+  async isAvailable() {
+    try {
+      const data: Buffer = await this.docker.ping();
+      return data.toString('utf-8');
+    } catch (err) {
+      return false;
+    }
+  }
+
+  info() {
+    return this.docker.info();
+  }
+
+  /**
+   * Pull a docker image
+   * @param image - Docker image
+   * @param options
+   * @param auth
+   */
+  async pull(image: string, options: DockerCommandOptions = {}) {
+    const stream = await this.docker.pull(
+      image,
+      options.pull || {},
+      options.auth,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new Promise<any>((resolve, reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.docker.modem.followProgress(stream, (err: any, res: any) =>
+        err ? reject(err) : resolve(res),
+      );
+    });
+  }
+
+  /**
+   * Run a docker container from the image
+   * @param image - Docker image
+   * @param cmd - Command
+   * @param options - Options to create/start the container
+   */
+  async run(image: string, cmd: string[], options: DockerCommandOptions = {}) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: [any, Container] = await this.docker.run(
+      image,
+      cmd,
+      process.stdout,
+      options.create,
+      options.start,
+    );
+    return data;
+  }
+
+  async pullAndRun(
+    image: string,
+    cmd: string[],
+    options: {
+      pull?: object;
+      create?: object;
+      start?: object;
+      auth?: object;
+    } = {},
+  ) {
+    const img = this.docker.getImage(image);
+    try {
+      await img.inspect();
+    } catch (err) {
+      if (err.statusCode === 404) {
+        await this.pull(image, options);
+      } else {
+        throw err;
+      }
+    }
+    return this.run(image, cmd, options);
+  }
+}

--- a/packages/testlab/src/index.ts
+++ b/packages/testlab/src/index.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from './client';
+export * from './docker';
 export * from './expect';
 export * from './http-error-logger';
 export * from './http-server-config';


### PR DESCRIPTION
This PR adds a few helper functions to use `docker` for tests. It's based on `dockerode` that uses REST APIs to interact with the `docker` daemon.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
