### PR TITLE
test(booter-lb3app): throw error if lb3 app is not found

### DIFF
--- a/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
+++ b/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
@@ -30,6 +30,16 @@ describe('booter-lb3app', () => {
     if (app) await app.stop();
   });
 
+  it('throws error if lb3 app is not found', async () => {
+    await expect(
+      setupApplication({
+        lb3app: {
+          path: '../fixtures/lb3app/wrong/server',
+        },
+      }),
+    ).to.be.rejectedWith(/Cannot find module/);
+  });
+
   context('generated OpenAPI spec', () => {
     it('uses different request-body schema for "create" operation', () => {
       const spec = app.restServer.getApiSpec();


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-next/issues/3859.

Verify that an error is thrown if we can't find the lb3 application.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
