### PR TITLE
Improve http-caching-proxy and geocoder test

### DIFF
--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -14,12 +14,14 @@ import {
 import {TodoListApplication} from '../../application';
 import {Todo} from '../../models/';
 import {TodoRepository} from '../../repositories/';
+import {GeocoderService} from '../../services';
 import {
   aLocation,
   getProxiedGeoCoderConfig,
   givenCachingProxy,
   givenTodo,
   HttpCachingProxy,
+  isGeoCoderServiceAvailable,
 } from '../helpers';
 
 describe('TodoApplication', () => {
@@ -33,6 +35,14 @@ describe('TodoApplication', () => {
 
   before(givenRunningApplicationWithCustomConfiguration);
   after(() => app.stop());
+
+  let available = true;
+  before(async function() {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(30 * 1000);
+    const service = await app.get<GeocoderService>('services.GeocoderService');
+    available = await isGeoCoderServiceAvailable(service);
+  });
 
   before(givenTodoRepository);
   before(() => {
@@ -77,6 +87,7 @@ describe('TodoApplication', () => {
   });
 
   it('creates an address-based reminder', async function() {
+    if (!available) return;
     // Increase the timeout to accommodate slow network connections
     // eslint-disable-next-line no-invalid-this
     this.timeout(30000);

--- a/examples/todo/src/__tests__/helpers.ts
+++ b/examples/todo/src/__tests__/helpers.ts
@@ -8,7 +8,7 @@ import {merge} from 'lodash';
 import * as path from 'path';
 import * as GEO_CODER_CONFIG from '../datasources/geocoder.datasource.json';
 import {Todo} from '../models/index';
-import {GeoPoint} from '../services/geocoder.service';
+import {GeocoderService, GeoPoint} from '../services/geocoder.service';
 
 /*
  ==============================================================================
@@ -67,7 +67,21 @@ export {HttpCachingProxy};
 export async function givenCachingProxy() {
   const proxy = new HttpCachingProxy({
     cachePath: path.resolve(__dirname, '.http-cache'),
+    logError: false,
+    timeout: 5000,
   });
   await proxy.start();
   return proxy;
+}
+
+export async function isGeoCoderServiceAvailable(service: GeocoderService) {
+  try {
+    await service.geocode(aLocation.address);
+    return true;
+  } catch (err) {
+    if (err.statusCode === 502) {
+      return false;
+    }
+    throw err;
+  }
 }

--- a/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
+++ b/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
@@ -7,9 +7,11 @@ import {expect} from '@loopback/testlab';
 import {GeocoderDataSource} from '../../../datasources/geocoder.datasource';
 import {GeocoderService, GeocoderServiceProvider} from '../../../services';
 import {
+  aLocation,
   getProxiedGeoCoderConfig,
   givenCachingProxy,
   HttpCachingProxy,
+  isGeoCoderServiceAvailable,
 } from '../../helpers';
 
 describe('GeoLookupService', function() {
@@ -23,15 +25,16 @@ describe('GeoLookupService', function() {
   let service: GeocoderService;
   before(givenGeoService);
 
-  it('resolves an address to a geo point', async () => {
-    const points = await service.geocode('1 New Orchard Road, Armonk, 10504');
+  let available = true;
+  before(async () => {
+    available = await isGeoCoderServiceAvailable(service);
+  });
 
-    expect(points).to.deepEqual([
-      {
-        y: 41.109653,
-        x: -73.72467,
-      },
-    ]);
+  it('resolves an address to a geo point', async () => {
+    if (!available) return;
+    const points = await service.geocode(aLocation.address);
+
+    expect(points).to.deepEqual([aLocation.geopoint]);
   });
 
   async function givenGeoService() {

--- a/examples/todo/src/datasources/geocoder.datasource.json
+++ b/examples/todo/src/datasources/geocoder.datasource.json
@@ -4,7 +4,8 @@
     "headers": {
       "accept": "application/json",
       "content-type": "application/json"
-    }
+    },
+    "timeout": 15000
   },
   "operations": [
     {


### PR DESCRIPTION
The examples/todo depends on https://geocoding.geo.census.gov/geocoder/, which can be down once a while.

The PR improves http-caching-proxy with two new options:

1. timeout - timeout connecting to the target endpoint
2. logError - a flag to control if errors should be logged to console

It also makes the todo tests conditional on the availability of the geocoding service.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
