### PR TITLE
feat: rebuild package locks using a Node.js script

### DIFF
--- a/acceptance/repository-mongodb/package-lock.json
+++ b/acceptance/repository-mongodb/package-lock.json
@@ -61,9 +61,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -174,9 +174,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -349,6 +349,13 @@
 				"p-is-promise": "^2.1.0"
 			}
 		},
+		"memory-pager": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"dev": true,
+			"optional": true
+		},
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -380,14 +387,15 @@
 			}
 		},
 		"mongodb": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.2.tgz",
-			"integrity": "sha512-fqJt3iywelk4yKu/lfwQg163Bjpo5zDKhXiohycvon4iQHbrfflSAz9AIlRE6496Pm/dQKQK5bMigdVo2s6gBg==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
+			"integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
 			"dev": true,
 			"requires": {
 				"bson": "^1.1.1",
 				"require_optional": "^1.0.1",
-				"safe-buffer": "^5.1.2"
+				"safe-buffer": "^5.1.2",
+				"saslprep": "^1.0.0"
 			}
 		},
 		"ms": {
@@ -534,6 +542,16 @@
 			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
 			"dev": true
 		},
+		"saslprep": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"sparse-bitfield": "^3.0.3"
+			}
+		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -560,6 +578,16 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
+		},
+		"sparse-bitfield": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"memory-pager": "^1.0.2"
+			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",

--- a/acceptance/repository-mysql/package-lock.json
+++ b/acceptance/repository-mysql/package-lock.json
@@ -67,9 +67,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -174,9 +174,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -13,9 +13,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -53,9 +53,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -391,9 +391,9 @@
 			"dev": true
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",

--- a/bin/rebuild-package-locks.js
+++ b/bin/rebuild-package-locks.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * This is an internal script to rebuild package-lock files for all packages
+ * within a lerna monorepo.
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const Project = require('@lerna/project');
+const build = require('../packages/build');
+
+/**
+ * Remove all package-lock.json and node_modules for all packages
+ * @param {Project} project The lerna project
+ */
+async function removePackageLocks(project) {
+  const packages = await project.getPackages();
+  const rootPath = project.rootPath;
+  const pkgRoots = [];
+  for (const pkg of packages) {
+    pkgRoots.push(pkg.location);
+  }
+  pkgRoots.push(rootPath);
+
+  console.log('Cleaning package-lock.json and node_modules...');
+  await Promise.all(
+    pkgRoots.map(async root => {
+      await fs.remove(path.join(root, 'package-lock.json'));
+      await fs.remove(path.join(root, 'node_modules'));
+    }),
+  );
+}
+
+/**
+ * Rebuild package-lock.json files:
+ *
+ * 1. Remove node_modules and package-lock.json for all packages, including the
+ * root one
+ * 2. Run `npm install` to regenerate package-lock.json files
+ */
+async function rebuildPackageLocks() {
+  const project = new Project(process.cwd());
+
+  await removePackageLocks(project);
+  console.log('Running npm install...');
+  build.runShell('npm', ['install'], {cwd: project.rootPth});
+}
+
+if (require.main === module) {
+  rebuildPackageLocks().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/examples/context/package-lock.json
+++ b/examples/context/package-lock.json
@@ -363,12 +363,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -378,13 +378,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -507,9 +507,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/examples/express-composition/package-lock.json
+++ b/examples/express-composition/package-lock.json
@@ -542,12 +542,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -557,13 +557,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -752,9 +752,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/examples/greeter-extension/package-lock.json
+++ b/examples/greeter-extension/package-lock.json
@@ -363,12 +363,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -378,13 +378,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -507,9 +507,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/examples/greeting-app/package-lock.json
+++ b/examples/greeting-app/package-lock.json
@@ -363,12 +363,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -378,13 +378,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -507,9 +507,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -363,12 +363,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -378,13 +378,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -507,9 +507,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/examples/lb3-application/package-lock.json
+++ b/examples/lb3-application/package-lock.json
@@ -323,9 +323,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg=="
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
 		},
 		"body-parser": {
 			"version": "1.19.0",
@@ -717,9 +717,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
@@ -854,12 +854,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -869,13 +869,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -1184,9 +1184,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -2007,9 +2007,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.3.tgz",
-			"integrity": "sha512-SbgVmGjEUAR/rYdAM0p0TCdKtJILZeYk3JavV2cmNVmIeR0SaKDudLRk58au6gpJqyFM9qz8ufEsS91D7RZyYA=="
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.5.tgz",
+			"integrity": "sha512-c3uWj6AnYHjbhhhzW9MEFApJX6Ts4XDShNgHPj2OAXgEAmtaxwFDQ61QUYW2exLHsJ1fsare5/3MkmaKIFvKmw=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -2780,9 +2780,9 @@
 			}
 		},
 		"strong-remoting": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/strong-remoting/-/strong-remoting-3.15.0.tgz",
-			"integrity": "sha512-OiGzc1Tvp9UNz+vw1346nsaSHqPA2yqnz21bwXJebuAVXRuJBjTvvXqqsk53j5Y6CfbCUOFqJK2pbJmcir+Tww==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/strong-remoting/-/strong-remoting-3.16.0.tgz",
+			"integrity": "sha512-Zw8zVe/GnaAdXqiwVrZ+Kbqd2VhG80Xlt5psqfLg4Ae1ZXO1ySVkUysJi4ppvH9NLVuo69XuhqmNEs0xN+7Sig==",
 			"requires": {
 				"async": "^3.1.0",
 				"body-parser": "^1.12.4",

--- a/examples/log-extension/package-lock.json
+++ b/examples/log-extension/package-lock.json
@@ -363,12 +363,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -378,13 +378,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -507,9 +507,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/examples/rpc-server/package-lock.json
+++ b/examples/rpc-server/package-lock.json
@@ -542,12 +542,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -557,13 +557,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -752,9 +752,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",

--- a/examples/soap-calculator/package-lock.json
+++ b/examples/soap-calculator/package-lock.json
@@ -482,9 +482,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.0",
@@ -604,12 +604,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -619,13 +619,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -843,9 +843,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",

--- a/examples/todo-list/package-lock.json
+++ b/examples/todo-list/package-lock.json
@@ -483,12 +483,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -498,13 +498,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -679,9 +679,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",

--- a/examples/todo/package-lock.json
+++ b/examples/todo/package-lock.json
@@ -483,12 +483,12 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -498,13 +498,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -679,9 +679,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1446,9 +1446,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.33.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.33.1.tgz",
-      "integrity": "sha512-lOQ+fJZwkeJ/1PRTdnY1uNja01aKOMioRhQfZtei64gZMXIX3EAfF4koMQMvoLFwsnVBu3ifj1JW1WAAKdXcnA==",
+      "version": "16.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.0.tgz",
+      "integrity": "sha512-EBe5qMQQOZRuezahWCXCnSe0J6tAqrW2hrEH9U8esXzKor1+HUDf8jgImaZf5lkTyWCQA296x9kAH5c0pxEgVQ==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.2.0",
@@ -1507,9 +1507,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
+      "version": "12.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+      "integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1573,21 +1573,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2339,6 +2324,20 @@
             "word-wrap": "^1.0.3"
           }
         },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -2909,12 +2908,12 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "debuglog": {
@@ -3257,23 +3256,6 @@
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "eslint-config-prettier": {
@@ -3319,12 +3301,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -3334,13 +3316,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -3416,6 +3398,15 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -3433,6 +3424,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -4215,9 +4212,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4458,6 +4455,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -4490,12 +4493,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
@@ -5322,16 +5319,16 @@
       }
     },
     "make-fetch-happen": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
-      "integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
+      "integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
       "dev": true,
       "requires": {
         "agentkeepalive": "^3.4.1",
         "cacache": "^12.0.0",
         "http-cache-semantics": "^3.8.1",
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "^2.2.3",
         "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "node-fetch-npm": "^2.0.2",
@@ -5562,9 +5559,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "multimatch": {
@@ -6886,6 +6883,15 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -6903,6 +6909,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -7535,9 +7547,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
+      "integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-eslint-plugin": "^2.1.0",
     "eslint-plugin-mocha": "^6.2.0",
+    "fs-extra": "^8.1.0",
     "husky": "^3.0.9",
     "lerna": "^3.18.3",
     "typescript": "~3.6.4"
@@ -32,7 +33,7 @@
     "update-packages": "npm run -s update-package-locks",
     "prerelease": "npm run build:full && npm run mocha && npm run lint",
     "release": "lerna version && lerna publish from-git --yes",
-    "update-package-locks": "lerna clean && lerna bootstrap --no-ci",
+    "update-package-locks": "node bin/rebuild-package-locks",
     "update-template-deps": "node bin/update-template-deps -f",
     "update-all-deps": "npm update && lerna exec -- npm update && npm run update-package-locks",
     "sync-dev-deps": "node bin/sync-dev-deps",

--- a/packages/authentication/package-lock.json
+++ b/packages/authentication/package-lock.json
@@ -14,9 +14,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -29,9 +29,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -55,9 +55,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},

--- a/packages/boot/package-lock.json
+++ b/packages/boot/package-lock.json
@@ -25,9 +25,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},

--- a/packages/booter-lb3app/package-lock.json
+++ b/packages/booter-lb3app/package-lock.json
@@ -40,9 +40,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -55,9 +55,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -87,9 +87,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -275,9 +275,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg=="
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
 		},
 		"body-parser": {
 			"version": "1.19.0",
@@ -532,9 +532,9 @@
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"core-js": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.1.tgz",
-			"integrity": "sha512-1PGI49Lz5qYo3EBz0kymSfJgTvn2G/c03lBTJ7PO0R1liQ7Yd6E570odu5p4CxG/WB0yUwCmAWummo79yOQUcQ=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.3.tgz",
+			"integrity": "sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -673,9 +673,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
@@ -945,9 +945,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1705,9 +1705,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.3.tgz",
-			"integrity": "sha512-SbgVmGjEUAR/rYdAM0p0TCdKtJILZeYk3JavV2cmNVmIeR0SaKDudLRk58au6gpJqyFM9qz8ufEsS91D7RZyYA=="
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.5.tgz",
+			"integrity": "sha512-c3uWj6AnYHjbhhhzW9MEFApJX6Ts4XDShNgHPj2OAXgEAmtaxwFDQ61QUYW2exLHsJ1fsare5/3MkmaKIFvKmw=="
 		},
 		"negotiator": {
 			"version": "0.6.2",
@@ -2559,9 +2559,9 @@
 			}
 		},
 		"strong-remoting": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/strong-remoting/-/strong-remoting-3.15.0.tgz",
-			"integrity": "sha512-OiGzc1Tvp9UNz+vw1346nsaSHqPA2yqnz21bwXJebuAVXRuJBjTvvXqqsk53j5Y6CfbCUOFqJK2pbJmcir+Tww==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/strong-remoting/-/strong-remoting-3.16.0.tgz",
+			"integrity": "sha512-Zw8zVe/GnaAdXqiwVrZ+Kbqd2VhG80Xlt5psqfLg4Ae1ZXO1ySVkUysJi4ppvH9NLVuo69XuhqmNEs0xN+7Sig==",
 			"requires": {
 				"async": "^3.1.0",
 				"body-parser": "^1.12.4",
@@ -2870,11 +2870,11 @@
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yaml": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.1.tgz",
-			"integrity": "sha512-sR0mJ2C3LVBgMST+0zrrrsKSijbw64bfHmTt4nEXLZTZFyIAuUVARqA/LO5kaZav2OVQMaZ+5WRrZv7QjxG3uQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+			"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
 			"requires": {
-				"@babel/runtime": "^7.5.5"
+				"@babel/runtime": "^7.6.3"
 			}
 		},
 		"yamljs": {

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -344,9 +344,9 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"optional": true
 		},
 		"commondir": {
@@ -450,9 +450,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
@@ -608,11 +608,11 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -621,12 +621,12 @@
 			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -853,9 +853,9 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"handlebars": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-			"integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+			"integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -2057,12 +2057,12 @@
 			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
 		},
 		"uglify-js": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-			"integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
+			"integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
 			"optional": true,
 			"requires": {
-				"commander": "2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -541,9 +541,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg=="
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
 		},
 		"body-parser": {
 			"version": "1.19.0",
@@ -1159,9 +1159,9 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.1.tgz",
-			"integrity": "sha512-1PGI49Lz5qYo3EBz0kymSfJgTvn2G/c03lBTJ7PO0R1liQ7Yd6E570odu5p4CxG/WB0yUwCmAWummo79yOQUcQ=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.3.tgz",
+			"integrity": "sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1468,9 +1468,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
 			"requires": {
 				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
@@ -1805,9 +1805,9 @@
 			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
 		},
 		"figures": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+			"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -2333,9 +2333,9 @@
 			"integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8="
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+			"integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
@@ -3288,15 +3288,15 @@
 			}
 		},
 		"make-fetch-happen": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
-			"integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
+			"integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
 			"requires": {
 				"agentkeepalive": "^3.4.1",
 				"cacache": "^12.0.0",
 				"http-cache-semantics": "^3.8.1",
 				"http-proxy-agent": "^2.1.0",
-				"https-proxy-agent": "^2.2.1",
+				"https-proxy-agent": "^2.2.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"node-fetch-npm": "^2.0.2",
@@ -3873,9 +3873,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.3.tgz",
-			"integrity": "sha512-SbgVmGjEUAR/rYdAM0p0TCdKtJILZeYk3JavV2cmNVmIeR0SaKDudLRk58au6gpJqyFM9qz8ufEsS91D7RZyYA=="
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.5.tgz",
+			"integrity": "sha512-c3uWj6AnYHjbhhhzW9MEFApJX6Ts4XDShNgHPj2OAXgEAmtaxwFDQ61QUYW2exLHsJ1fsare5/3MkmaKIFvKmw=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -5785,9 +5785,9 @@
 			}
 		},
 		"strong-remoting": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/strong-remoting/-/strong-remoting-3.15.0.tgz",
-			"integrity": "sha512-OiGzc1Tvp9UNz+vw1346nsaSHqPA2yqnz21bwXJebuAVXRuJBjTvvXqqsk53j5Y6CfbCUOFqJK2pbJmcir+Tww==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/strong-remoting/-/strong-remoting-3.16.0.tgz",
+			"integrity": "sha512-Zw8zVe/GnaAdXqiwVrZ+Kbqd2VhG80Xlt5psqfLg4Ae1ZXO1ySVkUysJi4ppvH9NLVuo69XuhqmNEs0xN+7Sig==",
 			"requires": {
 				"async": "^3.1.0",
 				"body-parser": "^1.12.4",
@@ -6649,11 +6649,11 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"yaml": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.1.tgz",
-			"integrity": "sha512-sR0mJ2C3LVBgMST+0zrrrsKSijbw64bfHmTt4nEXLZTZFyIAuUVARqA/LO5kaZav2OVQMaZ+5WRrZv7QjxG3uQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+			"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
 			"requires": {
-				"@babel/runtime": "^7.5.5"
+				"@babel/runtime": "^7.6.3"
 			}
 		},
 		"yamljs": {
@@ -7727,12 +7727,11 @@
 			}
 		},
 		"z-schema": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.1.1.tgz",
-			"integrity": "sha512-0aKvR9FgrghUXXndYNDmAEazl8jykuHSkqkmPw2ZSuTWuLcEscn1zUTbR3LEfyxHl5EEHpqqOpF+Sd7wZvuDxw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.1.tgz",
+			"integrity": "sha512-UWhAk5QzeIhks51TjHa6d4WexEokzbbwT+Dzq9yOBOx9sNnALo4hpYz9CfJ6IUE2cmzB0vWW3KHePYOfw3L4gQ==",
 			"requires": {
 				"commander": "^2.7.1",
-				"core-js": "^3.2.1",
 				"lodash.get": "^4.4.2",
 				"lodash.isequal": "^4.5.0",
 				"validator": "^11.0.0"

--- a/packages/http-caching-proxy/package-lock.json
+++ b/packages/http-caching-proxy/package-lock.json
@@ -370,9 +370,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",

--- a/packages/repository/package-lock.json
+++ b/packages/repository/package-lock.json
@@ -414,9 +414,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.4.tgz",
-			"integrity": "sha512-PijW88Ry+swMFfArOrm7uRAdVmJilLbej7WwVY6L5QwLDckqxSOinGGMV596yp5C8+MH3VvCXCSZ6AodGtKrYQ=="
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.5.tgz",
+			"integrity": "sha512-c3uWj6AnYHjbhhhzW9MEFApJX6Ts4XDShNgHPj2OAXgEAmtaxwFDQ61QUYW2exLHsJ1fsare5/3MkmaKIFvKmw=="
 		},
 		"nice-try": {
 			"version": "1.0.5",

--- a/packages/rest/package-lock.json
+++ b/packages/rest/package-lock.json
@@ -14,9 +14,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -29,9 +29,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -66,6 +66,13 @@
 			"requires": {
 				"@types/node": "*",
 				"@types/range-parser": "*"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
+				}
 			}
 		},
 		"@types/http-errors": {
@@ -102,7 +109,8 @@
 		"@types/node": {
 			"version": "10.14.22",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
-			"integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw=="
+			"integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
+			"dev": true
 		},
 		"@types/on-finished": {
 			"version": "2.3.1",
@@ -113,9 +121,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -148,9 +156,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -638,9 +646,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",

--- a/packages/service-proxy/package-lock.json
+++ b/packages/service-proxy/package-lock.json
@@ -356,9 +356,9 @@
 			}
 		},
 		"nanoid": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.4.tgz",
-			"integrity": "sha512-PijW88Ry+swMFfArOrm7uRAdVmJilLbej7WwVY6L5QwLDckqxSOinGGMV596yp5C8+MH3VvCXCSZ6AodGtKrYQ=="
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.5.tgz",
+			"integrity": "sha512-c3uWj6AnYHjbhhhzW9MEFApJX6Ts4XDShNgHPj2OAXgEAmtaxwFDQ61QUYW2exLHsJ1fsare5/3MkmaKIFvKmw=="
 		},
 		"nice-try": {
 			"version": "1.0.5",

--- a/packages/testlab/package-lock.json
+++ b/packages/testlab/package-lock.json
@@ -41,9 +41,9 @@
 			"integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
 		},
 		"@hapi/hoek": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
-			"integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
+			"integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
 		},
 		"@hapi/joi": {
 			"version": "16.1.7",
@@ -121,9 +121,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -136,9 +136,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -167,9 +167,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -179,6 +179,13 @@
 			"integrity": "sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==",
 			"requires": {
 				"@types/node": "*"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
+				}
 			}
 		},
 		"@types/mime": {
@@ -189,7 +196,8 @@
 		"@types/node": {
 			"version": "10.14.22",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
-			"integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw=="
+			"integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
+			"dev": true
 		},
 		"@types/range-parser": {
 			"version": "1.2.3",
@@ -214,9 +222,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -235,9 +243,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.7.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-					"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+					"version": "12.11.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+					"integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ=="
 				}
 			}
 		},
@@ -1479,11 +1487,11 @@
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yaml": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.1.tgz",
-			"integrity": "sha512-sR0mJ2C3LVBgMST+0zrrrsKSijbw64bfHmTt4nEXLZTZFyIAuUVARqA/LO5kaZav2OVQMaZ+5WRrZv7QjxG3uQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+			"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
 			"requires": {
-				"@babel/runtime": "^7.5.5"
+				"@babel/runtime": "^7.6.3"
 			}
 		},
 		"yargs": {

--- a/sandbox/example/package-lock.json
+++ b/sandbox/example/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
The PR introduces a Node.js script to rebuild package-lock.json files as follows:

1. Remove all `package-lock.json` and `node_modules` for all package, including the root
2. Run `npm install` to regenerate `package-lock.json` files

These steps seems to be most reliable to rebuild package-lock.json files for a lerna monorepo.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
