### PR TITLE
fix(docs): remove duplicate title in core-tutorial

### DIFF
--- a/docs/site/tutorials/core/1-introduction.md
+++ b/docs/site/tutorials/core/1-introduction.md
@@ -6,8 +6,6 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part1.html
 ---
 
-# Introduction
-
 At the core of LoopBack 4, we provide a powerful
 [Inversion of Control](https://loopback.io/doc/en/lb4/Context.html) and
 [Dependency Injection](https://loopback.io/doc/en/lb4/Dependency-injection.html)

--- a/docs/site/tutorials/core/2-architecture.md
+++ b/docs/site/tutorials/core/2-architecture.md
@@ -6,8 +6,6 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part2.html
 ---
 
-## Architectual challenges in building large scale Node.js applications
-
 There are interesting challenges in building complex Node.js projects such as an
 open framework or a large-scale application that involves many modules,
 components and teams. As platform developers, we love to have the foundation to

--- a/docs/site/tutorials/core/index.md
+++ b/docs/site/tutorials/core/index.md
@@ -6,8 +6,6 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial.html
 ---
 
-# Build large scale Node.js projects with LoopBack 4
-
 It's super easy to start developing in Node.js, but challenges will get in the
 way as your project grows with more and more modules, components, developers,
 teams, and releases. If you are building on an open framework or large-scale


### PR DESCRIPTION
There are duplicate titles appear in the core-tutorial by removing the title in the main content because there's already title in the front matter. 
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
