### PR TITLE
test(example-todo): mark geocoding tests as skipped when the service is down

### DIFF
--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -87,7 +87,8 @@ describe('TodoApplication', () => {
   });
 
   it('creates an address-based reminder', async function() {
-    if (!available) return;
+    // eslint-disable-next-line no-invalid-this
+    if (!available) return this.skip();
     // Increase the timeout to accommodate slow network connections
     // eslint-disable-next-line no-invalid-this
     this.timeout(30000);

--- a/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
+++ b/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
@@ -30,8 +30,10 @@ describe('GeoLookupService', function() {
     available = await isGeoCoderServiceAvailable(service);
   });
 
-  it('resolves an address to a geo point', async () => {
-    if (!available) return;
+  it('resolves an address to a geo point', async function() {
+    // eslint-disable-next-line no-invalid-this
+    if (!available) return this.skip();
+
     const points = await service.geocode(aLocation.address);
 
     expect(points).to.deepEqual([aLocation.geopoint]);


### PR DESCRIPTION
I find the solution introduced by https://github.com/strongloop/loopback-next/pull/3979 very problematic. When the geocoder service is not available, we skip the test body and yet mark the test as passed. This creates a false sense of security, leading us to believe that the geocoding functionality is covered by tests and working, despite the fact that eventually we may get to the point when the test is always skipped.

In this pull request, I am improving the code to report the tests as skipped when the Geocoder service is not available.

This is not perfect, because we won't have any automated notification to let us know when the geocoder service becomes permanently broken, but at least we have a chance to notice the problem.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
