### PR TITLE
fix(cli): improve message for model discovery code generation

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -248,8 +248,9 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
 
     // This part at the end is just for the ArtifactGenerator
     // end message to output something nice, before it was "Discover undefined was created in src/models/"
+    this.artifactInfo.type = 'Models';
     this.artifactInfo.name = this.artifactInfo.modelDefinitions
-      .map(d => utils.getModelFileName(d.name))
+      .map(d => d.name)
       .join(',');
   }
 


### PR DESCRIPTION
Before this change, `lb4 discover` prints out:

```
Discover RegionsModelTs was created in src/models/
```

With this PR:
```
DiscoveredModels Regions was created in src/models/ 
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
