### PR TITLE
docs: remove ambiguous warning

### DIFF
--- a/extensions/authentication-passport/README.md
+++ b/extensions/authentication-passport/README.md
@@ -8,13 +8,6 @@ This is an adapter module created for plugging in
 [`passport`](https://www.npmjs.com/package/passport) based strategies to the
 authentication system in `@loopback/authentication@3.x`.
 
-## Stability: :warning:Experimental:warning:
-
-> Experimental packages provide early access to advanced or experimental
-> functionality to get community feedback. Such modules are published to npm
-> using `0.x.y` versions. Their APIs and functionality may be subject to
-> breaking changes in future releases.
-
 ## Installation
 
 ```sh


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/4035

I shouldn't have added the "BREAKING CHANGE" keyword in https://github.com/strongloop/loopback-next/pull/3761/commits 's first commit, it bumps the version from 0.1.x to 1.x, while my intention was to release 0.2.x, that's why the experimental warning causes confusion.

I searched through our issues and I don't think or remember we have any further plan for the passport adapter module, and since it's already released for several months, I tend to remove the experimental warning. 

We can discuss better plan in this PR if people have different opinions.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
