### PR TITLE
fix(repository): improve typings for model inclusion

### DIFF
--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -170,8 +170,18 @@ export type Fields<MT = AnyObject> = {[P in keyof MT]?: boolean};
  * `{relation: 'aRelationName', scope: {<AFilterObject>}}`
  */
 export interface Inclusion<MT extends object = AnyObject> {
+  // ^^^ TODO(semver-major): remove the generic argument <MT>
+
   relation: string;
-  scope?: Filter<MT>;
+
+  // Technically, we should restrict the filter to target model.
+  // That is unfortunately rather difficult to achieve, because
+  // an Entity does not provide type information about related models.
+  // We could use {ModelName}WithRelations interface for first-level inclusion,
+  // but that won't handle second-level (and deeper) inclusions.
+  // To keep things simple, we allow any filter here, effectively turning off
+  // compiler checks.
+  scope?: Filter<AnyObject>;
 }
 
 /**


### PR DESCRIPTION
Fix a problem discovered by the upcoming TypeScript compiler version 3.7, see the discussion in https://github.com/strongloop/loopback-next/pull/3858 for more details.

Here is gist of the problem:

Before my change, when querying an `Author` model and including let's say `BlogPost` models written by the author, the `include` part of the filter was expecting `scope` property with `Filter<Author>` instead of `Filter<BlogPost>`. The latter is difficult to express, because Filter is recursive and when a `BlogPost` has many comments, then `Filter<BlogPost>` needs to accept `Filter<Comment>` in its nested `include[].scope`.

In this pull request, I am changing `include[].scope` property to accept `Filter` for any model. This new style is consistent with `include[].relation` property which is accepting any string (as opposed to accepting only one of the known relations of the source models).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
