### PR TITLE
test(repository): verify relation type in `resolve{Relation}Metadata`

### DIFF
--- a/packages/repository/src/__tests__/integration/repositories/resolve-belongs-to-metadata.integration.ts
+++ b/packages/repository/src/__tests__/integration/repositories/resolve-belongs-to-metadata.integration.ts
@@ -1,0 +1,29 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {BelongsToDefinition, Entity, RelationType} from '../../..';
+import {resolveBelongsToMetadata} from '../../../relations/belongs-to/belongs-to.helpers';
+
+describe('resolveBelongsToMetadata', () => {
+  it('throws if the wrong metadata type is used', async () => {
+    const metadata: unknown = {
+      name: 'category',
+      type: RelationType.hasOne,
+      targetsMany: false,
+      source: Category,
+      target: () => Category,
+    };
+
+    expect(() => {
+      resolveBelongsToMetadata(metadata as BelongsToDefinition);
+    }).to.throw(
+      /Invalid hasOne definition for Category#category: relation type must be BelongsTo/,
+    );
+  });
+
+  /******  HELPERS *******/
+  class Category extends Entity {}
+});

--- a/packages/repository/src/__tests__/integration/repositories/resolve-has-many-metadata.integration.ts
+++ b/packages/repository/src/__tests__/integration/repositories/resolve-has-many-metadata.integration.ts
@@ -12,92 +12,109 @@ import {
 } from '../../..';
 import {resolveHasManyMetadata} from '../../../relations/has-many/has-many.helpers';
 
-describe('keyTo and keyFrom with resolveHasManyMetadata', () => {
-  it('resolves metadata using keyTo and keyFrom', () => {
-    const meta = resolveHasManyMetadata(Category.definition.relations[
-      'products'
-    ] as HasManyDefinition);
-
-    expect(meta).to.eql({
-      name: 'products',
-      type: 'hasMany',
+describe('resolveHasManyMetadata', () => {
+  it('throws if the wrong metadata type is used', async () => {
+    const metadata: unknown = {
+      name: 'category',
+      type: RelationType.hasOne,
       targetsMany: true,
       source: Category,
-      keyFrom: 'id',
-      target: () => Product,
-      keyTo: 'categoryId',
-    });
+      target: () => Category,
+    };
+
+    expect(() => {
+      resolveHasManyMetadata(metadata as HasManyDefinition);
+    }).to.throw(
+      /Invalid hasOne definition for Category#category: relation type must be HasMany/,
+    );
   });
 
-  it('infers keyFrom if it is not provided', () => {
-    const meta = resolveHasManyMetadata(Category.definition.relations[
-      'items'
-    ] as HasManyDefinition);
+  describe('keyTo and keyFrom with resolveHasManyMetadata', () => {
+    it('resolves metadata using keyTo and keyFrom', () => {
+      const meta = resolveHasManyMetadata(Category.definition.relations[
+        'products'
+      ] as HasManyDefinition);
 
-    expect(meta).to.eql({
-      name: 'items',
-      type: 'hasMany',
-      targetsMany: true,
-      source: Category,
-      keyFrom: 'id',
-      target: () => Item,
-      keyTo: 'categoryId',
+      expect(meta).to.eql({
+        name: 'products',
+        type: 'hasMany',
+        targetsMany: true,
+        source: Category,
+        keyFrom: 'id',
+        target: () => Product,
+        keyTo: 'categoryId',
+      });
     });
-  });
 
-  it('infers keyTo if it is not provided', () => {
-    const meta = resolveHasManyMetadata(Category.definition.relations[
-      'things'
-    ] as HasManyDefinition);
+    it('infers keyFrom if it is not provided', () => {
+      const meta = resolveHasManyMetadata(Category.definition.relations[
+        'items'
+      ] as HasManyDefinition);
 
-    expect(meta).to.eql({
-      name: 'things',
-      type: 'hasMany',
-      targetsMany: true,
-      source: Category,
-      keyFrom: 'id',
-      target: () => Thing,
-      keyTo: 'categoryId',
+      expect(meta).to.eql({
+        name: 'items',
+        type: 'hasMany',
+        targetsMany: true,
+        source: Category,
+        keyFrom: 'id',
+        target: () => Item,
+        keyTo: 'categoryId',
+      });
     });
-  });
 
-  it('throws if keyFrom, keyTo, and default foreign key name are not provided', async () => {
-    let error;
+    it('infers keyTo if it is not provided', () => {
+      const meta = resolveHasManyMetadata(Category.definition.relations[
+        'things'
+      ] as HasManyDefinition);
 
-    try {
-      resolveHasManyMetadata(Category.definition.relations[
+      expect(meta).to.eql({
+        name: 'things',
+        type: 'hasMany',
+        targetsMany: true,
+        source: Category,
+        keyFrom: 'id',
+        target: () => Thing,
+        keyTo: 'categoryId',
+      });
+    });
+
+    it('throws if keyFrom, keyTo, and default foreign key name are not provided', async () => {
+      let error;
+
+      try {
+        resolveHasManyMetadata(Category.definition.relations[
+          'categories'
+        ] as HasManyDefinition);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error.message).to.eql(
+        'Invalid hasMany definition for Category#categories: target model ' +
+          'Category is missing definition of foreign key categoryId',
+      );
+
+      expect(error.code).to.eql('INVALID_RELATION_DEFINITION');
+    });
+
+    it('resolves metadata if keyTo and keyFrom are not provided, but default foreign key is', async () => {
+      Category.definition.addProperty('categoryId', {type: 'number'});
+
+      const meta = resolveHasManyMetadata(Category.definition.relations[
         'categories'
       ] as HasManyDefinition);
-    } catch (err) {
-      error = err;
-    }
 
-    expect(error.message).to.eql(
-      'Invalid hasMany definition for Category#categories: target model ' +
-        'Category is missing definition of foreign key categoryId',
-    );
-
-    expect(error.code).to.eql('INVALID_RELATION_DEFINITION');
-  });
-
-  it('resolves metadata if keyTo and keyFrom are not provided, but default foreign key is', async () => {
-    Category.definition.addProperty('categoryId', {type: 'number'});
-
-    const meta = resolveHasManyMetadata(Category.definition.relations[
-      'categories'
-    ] as HasManyDefinition);
-
-    expect(meta).to.eql({
-      name: 'categories',
-      type: 'hasMany',
-      targetsMany: true,
-      source: Category,
-      keyFrom: 'id',
-      target: () => Category,
-      keyTo: 'categoryId',
+      expect(meta).to.eql({
+        name: 'categories',
+        type: 'hasMany',
+        targetsMany: true,
+        source: Category,
+        keyFrom: 'id',
+        target: () => Category,
+        keyTo: 'categoryId',
+      });
     });
   });
-
   /******  HELPERS *******/
 
   class Category extends Entity {}
@@ -147,7 +164,17 @@ describe('keyTo and keyFrom with resolveHasManyMetadata', () => {
 
       target: () => Category,
       // no keyTo
-    });
+    })
+    // need <unknown> to avoid Type 'RelationType.hasOne' is not comparable
+    // to type 'RelationType.hasMany'
+    .addRelation(<HasManyDefinition>(<unknown>{
+      name: 'category',
+      type: RelationType.hasOne,
+      targetsMany: true,
+      source: Category,
+      // no keyFrom
+      target: () => Category,
+    }));
 
   class Product extends Entity {}
 


### PR DESCRIPTION
Resolves https://github.com/strongloop/loopback-next/issues/3440.

Split into two commits: 
[1)](https://github.com/strongloop/loopback-next/pull/4046/commits/369d82850e6f3d040835de2e6e08e6d0d86fc957) Added tests to verify the correct relation type is used in `resolve{Relation}Metadata`.
[2)](https://github.com/strongloop/loopback-next/pull/4046/commits/00c95b1536251a3fcc173daf5ec5d73794bce480) Improved setup for `resolve{Relation}Metadata` tests based on https://github.com/strongloop/loopback-next/pull/4046#discussion_r343664021.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
