### PR TITLE
Fixes inconsistent naming.

### DIFF
--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -187,7 +187,7 @@ export class TodoController {
 }
 ```
 
-Modify `createTodo` method to look up the address provided in `remindAtAddress`
+Modify `create` method to look up the address provided in `remindAtAddress`
 property and convert it to GPS coordinates stored in `remindAtGeo`.
 
 {% include code-caption.html content="src/controllers/todo.controller.ts" %}
@@ -204,7 +204,7 @@ export class TodoController {
       },
     },
   })
-  async createTodo(
+  async create(
     @requestBody({
       content: {
         'application/json': {


### PR DESCRIPTION
After following all steps of the tutorial user ends up with `create` method name, not with the `createTodo` one.
There are no references of `createTodo` name on previous pages/steps.
So it looks confusing.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
