### PR TITLE
fix(openapi-v3): remove examples from schema

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
@@ -35,7 +35,7 @@ describe('filterSchema', () => {
           additionalProperties: false,
         },
         offset: {type: 'integer', minimum: 0},
-        limit: {type: 'integer', minimum: 1, example: 100, examples: [100]},
+        limit: {type: 'integer', minimum: 1, example: 100},
         skip: {type: 'integer', minimum: 0},
         order: {type: 'array', items: {type: 'string'}},
       },

--- a/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
@@ -286,7 +286,6 @@ describe('jsonToSchemaObject', () => {
     const expectedItems: SchemaObject = {
       type: 'integer',
       example: 100,
-      examples: [100, 500],
     };
     propertyConversionTest(itemsDef, expectedItems);
   });

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -120,7 +120,6 @@ export function jsonToSchemaObject(
       }
       case 'examples': {
         if (Array.isArray(json.examples)) {
-          result.examples = json.examples;
           result.example = json.examples[0];
         }
         break;


### PR DESCRIPTION
LoopBack emits invalid OpenAPI spec document - `examples` field is not allowed in OpenAPI

Fixes #4043
Follow up to #3911

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

