### PR TITLE
feat(rest): bind operation spec to the request context

### DIFF
--- a/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
@@ -3,15 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  ControllerRoute,
-  createControllerFactoryForClass,
-  createControllerFactoryForBinding,
-  ControllerFactory,
-} from '../../..';
-import {expect} from '@loopback/testlab';
+import {BindingScope, Context, CoreBindings} from '@loopback/core';
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
-import {Context, CoreBindings, BindingScope} from '@loopback/core';
+import {expect} from '@loopback/testlab';
+import {
+  ControllerFactory,
+  ControllerRoute,
+  createControllerFactoryForBinding,
+  createControllerFactoryForClass,
+  RestBindings,
+} from '../../..';
 
 describe('ControllerRoute', () => {
   it('rejects routes with no methodName', () => {
@@ -103,6 +104,12 @@ describe('ControllerRoute', () => {
       expect(
         await requestCtx.get(CoreBindings.CONTROLLER_METHOD_NAME),
       ).to.equal('greet');
+      expect(await requestCtx.get(RestBindings.OPERATION_SPEC_CURRENT)).to.eql({
+        'x-controller-name': 'MyController',
+        'x-operation-name': 'greet',
+        tags: ['MyController'],
+        responses: {'200': {description: 'An undocumented response body.'}},
+      });
     });
 
     it('binds current controller to the request context as singleton', async () => {

--- a/packages/rest/src/__tests__/unit/router/handler-route.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/handler-route.unit.ts
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Context} from '@loopback/core';
+import {anOperationSpec} from '@loopback/openapi-spec-builder';
+import {expect} from '@loopback/testlab';
+import {RestBindings, Route} from '../../..';
+
+describe('HandlerRoute', () => {
+  describe('updateBindings()', () => {
+    let appCtx: Context;
+    let requestCtx: Context;
+
+    before(givenContextsAndHandlerRoute);
+
+    it('adds bindings to the request context', async () => {
+      expect(await requestCtx.get(RestBindings.OPERATION_SPEC_CURRENT)).to.eql({
+        responses: {'200': {description: 'An undocumented response body.'}},
+      });
+    });
+
+    function givenContextsAndHandlerRoute() {
+      const spec = anOperationSpec().build();
+
+      const route = new Route('get', '/greet', spec, () => {});
+
+      appCtx = new Context('application');
+      requestCtx = new Context(appCtx, 'request');
+      route.updateBindings(requestCtx);
+    }
+  });
+});

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -6,11 +6,12 @@
 import {BindingKey, Context} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {HttpProtocol} from '@loopback/http-server';
-import {OpenApiSpec} from '@loopback/openapi-v3';
+import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3';
 import * as https from 'https';
 import {ErrorWriterOptions} from 'strong-error-handler';
 import {BodyParser, RequestBodyParser} from './body-parsers';
 import {HttpHandler} from './http-handler';
+import {RestServer} from './rest.server';
 import {RestRouter, RestRouterOptions} from './router';
 import {SequenceHandler} from './sequence';
 import {
@@ -26,7 +27,6 @@ import {
   Response,
   Send,
 } from './types';
-import {RestServer} from './rest.server';
 
 /**
  * RestServer-specific bindings
@@ -156,6 +156,14 @@ export namespace RestBindings {
    * Binding key for setting and injecting an OpenAPI spec
    */
   export const API_SPEC = BindingKey.create<OpenApiSpec>('rest.apiSpec');
+
+  /**
+   * Binding key for setting and injecting an OpenAPI operation spec
+   */
+  export const OPERATION_SPEC_CURRENT = BindingKey.create<OperationObject>(
+    'rest.operationSpec.current',
+  );
+
   /**
    * Binding key for setting and injecting a Sequence
    */

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -14,6 +14,7 @@ import {
 import {CoreBindings} from '@loopback/core';
 import {OperationObject} from '@loopback/openapi-v3';
 import * as HttpErrors from 'http-errors';
+import {RestBindings} from '../keys';
 import {OperationArgs, OperationRetval} from '../types';
 import {BaseRoute} from './base-route';
 
@@ -121,6 +122,7 @@ export class ControllerRoute<T> extends BaseRoute {
     requestContext
       .bind(CoreBindings.CONTROLLER_METHOD_NAME)
       .to(this._methodName);
+    requestContext.bind(RestBindings.OPERATION_SPEC_CURRENT).to(this.spec);
   }
 
   async invokeHandler(

--- a/packages/rest/src/router/handler-route.ts
+++ b/packages/rest/src/router/handler-route.ts
@@ -5,6 +5,7 @@
 
 import {Context, invokeMethodWithInterceptors} from '@loopback/context';
 import {OperationObject} from '@loopback/openapi-v3';
+import {RestBindings} from '../keys';
 import {OperationArgs, OperationRetval} from '../types';
 import {BaseRoute} from './base-route';
 
@@ -23,7 +24,7 @@ export class Route extends BaseRoute {
   }
 
   updateBindings(requestContext: Context) {
-    // no-op
+    requestContext.bind(RestBindings.OPERATION_SPEC_CURRENT).to(this.spec);
   }
 
   async invokeHandler(


### PR DESCRIPTION
Controller methods sometime want to access the corresponding OpenAPI operation spec.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
