### PR TITLE
docs: fix 'commit message format' link

### DIFF
--- a/docs/site/submitting_a_pr.md
+++ b/docs/site/submitting_a_pr.md
@@ -33,7 +33,7 @@ Our commit messages are formatted according to
 [Conventional Commits](https://conventionalcommits.org/).
 
 Please read the
-[Commit Message Format](https://loopback.io/doc/en/contrib/code-contrib-lb4.html#commit-message-guidelines)
+[Commit Message Format](https://loopback.io/doc/en/lb4/code-contrib-lb4.html#commit-message-guidelines)
 guidelines to correctly format your commit messages.
 
 To change an existing commit please refer to
@@ -209,7 +209,7 @@ Our commit messages are formatted according to
 [Conventional Commits](https://conventionalcommits.org/).
 
 Please read the
-[Commit Message Format](https://loopback.io/doc/en/contrib/code-contrib-lb4.html#commit-message-guidelines)
+[Commit Message Format](https://loopback.io/doc/en/lb4/code-contrib-lb4.html#commit-message-guidelines)
 guidelines to correctly format your commit messages.
 
 To help with abiding by the rules of commit messages, please use the
@@ -514,7 +514,7 @@ When a project maintainer is satisfied with the pull request, he/she will
 
 - [Contributing to docs](https://loopback.io/doc/en/contrib/doc-contrib.html)
 
-- [Commit Message Format](https://loopback.io/doc/en/contrib/code-contrib-lb4.html#commit-message-guidelines)
+- [Commit Message Format](https://loopback.io/doc/en/lb4/code-contrib-lb4.html#commit-message-guidelines)
 
 - [Agreeing to the CLA](https://loopback.io/doc/en/contrib/code-contrib.html#agreeing-to-the-cla)
 


### PR DESCRIPTION
In the document `Submitting a pull request to LoopBack 4`, the link for `Commit Message Format` became invalid.

This PR fixes it.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
