### PR TITLE
fix(docs): add sidebar for core-tutorial

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -367,6 +367,55 @@ children:
     url: Authentication-Tutorial.html
     output: 'web, pdf'
 
+  - title: 'Build large scale Node.js projects with LoopBack 4'
+    url: core-tutorial.html
+    output: 'web, pdf'
+    children:
+
+      - title: 'Introduction of the application scenario'
+        url: core-tutorial-part1.html
+        output: 'web, pdf'
+
+      - title: 'Architectural challenges'
+        url: core-tutorial-part2.html
+        output: 'web, pdf'
+
+      - title: 'Context in action'
+        url: core-tutorial-part3.html
+        output: 'web, pdf'
+
+      - title: 'Dependency injection'
+        url: core-tutorial-part4.html
+        output: 'web, pdf'
+
+      - title: 'Extension point and extensions'
+        url: core-tutorial-part5.html
+        output: 'web, pdf'
+
+      - title: 'Interception'
+        url: core-tutorial-part6.html
+        output: 'web, pdf'
+
+      - title: 'Observation of life cycle events'
+        url: core-tutorial-part7.html
+        output: 'web, pdf'
+
+      - title: 'Configuration'
+        url: core-tutorial-part8.html
+        output: 'web, pdf'
+
+      - title: 'Discover and load artifacts by convention'
+        url: core-tutorial-part9.html
+        output: 'web, pdf'
+
+      - title: 'Advanced Recipes'
+        url: core-tutorial-part10.html
+        output: 'web, pdf'
+
+      - title: 'Summary'
+        url: core-tutorial-part11.html
+        output: 'web, pdf'
+
 - title: 'Examples'
   url: Examples.html
   output: 'web, pdf'


### PR DESCRIPTION
Add the sidebar for the core-tutorial

Here is what it looks like:
![Screen Shot 2019-11-08 at 3 29 20 PM](https://user-images.githubusercontent.com/25489897/68508743-28439600-023d-11ea-8a6f-9a2ef4badc05.png)




## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
