### PR TITLE
chore: enable esModuleInterop compiler option

### DIFF
--- a/benchmark/src/__tests__/benchmark.integration.ts
+++ b/benchmark/src/__tests__/benchmark.integration.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import * as request from 'request-promise-native';
+import request from 'request-promise-native';
 import {Benchmark} from '..';
 import {Autocannon, EndpointStats} from '../autocannon';
 

--- a/benchmark/src/autocannon.ts
+++ b/benchmark/src/autocannon.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as assert from 'assert';
+import assert from 'assert';
 const autocannon = require('autocannon');
 
 export interface EndpointStats {

--- a/benchmark/src/benchmark.ts
+++ b/benchmark/src/benchmark.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as byline from 'byline';
+import byline from 'byline';
 import {ChildProcess, spawn} from 'child_process';
 import pEvent, {Emitter} from 'p-event';
 import {Autocannon, EndpointStats} from './autocannon';

--- a/benchmark/src/client.ts
+++ b/benchmark/src/client.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as request from 'request-promise-native';
 import {Todo} from '@loopback/example-todo';
+import request from 'request-promise-native';
 
 export class Client {
   constructor(private url: string) {}

--- a/docs/site/DataSources.md
+++ b/docs/site/DataSources.md
@@ -37,7 +37,7 @@ Example DataSource Class:
 ```ts
 import {inject} from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './db.datasource.config.json';
+import config from './db.datasource.config.json';
 
 export class DbDataSource extends juggler.DataSource {
   static dataSourceName = 'db';

--- a/docs/site/Defining-the-API-using-design-first-approach.shelved.md
+++ b/docs/site/Defining-the-API-using-design-first-approach.shelved.md
@@ -235,7 +235,7 @@ npm install --save lodash
 {% include code-caption.html content="/apidefs/product.api.ts" %}
 
 ```ts
-import * as _ from 'lodash';
+import _ from 'lodash';
 
 // Assuming you have created the "base" schema elsewhere.
 // If there are no common properties between all of the endpoint objects,
@@ -336,8 +336,8 @@ put them all together to produce the final OpenAPI spec.
 
 ```ts
 import {ProductAPI, DealAPI, CategoryAPI} from '../apidefs';
-import * as OpenApiSpec from '@loopback/openapi-spec';
-import * as _ from 'lodash';
+import OpenApiSpec from '@loopback/openapi-spec';
+import _ from 'lodash';
 
 // Import API fragments here
 

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -335,7 +335,7 @@ dependency injection.
    ```ts
    import {inject} from '@loopback/core';
    import {juggler, AnyObject} from '@loopback/repository';
-   import * as config from './redis.datasource.config.json';
+   import config from './redis.datasource.config.json';
 
    export class RedisDataSource extends juggler.DataSource {
      static dataSourceName = 'redis';

--- a/docs/site/Routes.md
+++ b/docs/site/Routes.md
@@ -250,7 +250,7 @@ Make sure [express](https://www.npmjs.com/package/express) is installed.
 
 ```ts
 import {Request, Response} from 'express';
-import * as express from 'express';
+import express from 'express';
 
 const legacyApp = express();
 

--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -160,7 +160,7 @@ certificate chain variant.
 
 ```ts
 import {RestApplication, RestServer, RestBindings} from '@loopback/rest';
-import * as fs from 'fs';
+import fs from 'fs';
 
 export async function main() {
   const options = {

--- a/docs/site/Serving-static-files.md
+++ b/docs/site/Serving-static-files.md
@@ -27,7 +27,7 @@ directory named `public` at `/`.
 {% include code-caption.html content="src/application.ts" %}
 
 ```ts
-import * as path from 'path';
+import path from 'path';
 
 export class TodoListApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -740,7 +740,7 @@ instance:
 
 ```ts
 import {merge} from 'lodash';
-import * as GEO_CODER_CONFIG from '../datasources/geo.datasource.config.json';
+import GEO_CODER_CONFIG from '../datasources/geo.datasource.config.json';
 
 function givenGeoService() {
   const config = merge({}, GEO_CODER_CONFIG, {

--- a/docs/site/decorators/Decorators_inject.md
+++ b/docs/site/decorators/Decorators_inject.md
@@ -29,8 +29,8 @@ results of functions that return those values!) in other areas of your code.
 
 ```ts
 import {Application} from '@loopback/core';
-import * as fs from 'fs-extra';
-import * as path from 'path';
+import fs from 'fs-extra';
+import path from 'path';
 
 export class MyApp extends RestApplication {
   constructor() {

--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -139,7 +139,7 @@ Create a new file **src/server.ts** to create your Express class:
 {% include code-caption.html content="src/server.ts" %}
 
 ```ts
-import * as express from 'express';
+import express from 'express';
 
 export class ExpressServer {
   constructor() {}
@@ -152,7 +152,7 @@ instance:
 ```ts
 import {NoteApplication} from './application';
 import {ApplicationConfig} from '@loopback/core';
-import * as express from 'express';
+import express from 'express';
 
 export class ExpressServer {
   private app: express.Application;
@@ -185,7 +185,7 @@ Then, we can add some custom Express routes, as follows:
 
 ```ts
 import {Request, Response} from 'express';
-import * as path from 'path';
+import path from 'path';
 
 export class ExpressServer {
   private app: express.Application;

--- a/docs/site/tutorials/authentication/Authentication-Tutorial.md
+++ b/docs/site/tutorials/authentication/Authentication-Tutorial.md
@@ -1222,7 +1222,7 @@ import {
 import {JWTService} from './services/jwt-service';
 import {MyUserService} from './services/user-service';
 
-import * as path from 'path';
+import path from 'path';
 import {
   AuthenticationComponent,
   registerAuthenticationStrategy,

--- a/examples/context/src/__tests__/acceptance/examples.acceptance.ts
+++ b/examples/context/src/__tests__/acceptance/examples.acceptance.ts
@@ -5,7 +5,7 @@
 
 import {expect} from '@loopback/testlab';
 import {readFileSync} from 'fs';
-import * as path from 'path';
+import path from 'path';
 import {format} from 'util';
 import {main} from '../..';
 

--- a/examples/context/src/index.ts
+++ b/examples/context/src/index.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as fs from 'fs';
+import fs from 'fs';
 import {promisify} from 'util';
 const readdirAsync = promisify(fs.readdir);
 

--- a/examples/express-composition/src/application.ts
+++ b/examples/express-composition/src/application.ts
@@ -5,15 +5,12 @@
 
 import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
-import {
-  RestExplorerComponent,
-  RestExplorerBindings,
-} from '@loopback/rest-explorer';
 import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
+import {RestExplorerComponent} from '@loopback/rest-explorer';
 import {ServiceMixin} from '@loopback/service-proxy';
+import path from 'path';
 import {MySequence} from './sequence';
-import * as path from 'path';
 
 export class NoteApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),

--- a/examples/express-composition/src/datasources/ds.datasource.ts
+++ b/examples/express-composition/src/datasources/ds.datasource.ts
@@ -5,7 +5,7 @@
 
 import {inject} from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './ds.datasource.config.json';
+import config from './ds.datasource.config.json';
 
 export class DsDataSource extends juggler.DataSource {
   static dataSourceName = 'ds';

--- a/examples/express-composition/src/server.ts
+++ b/examples/express-composition/src/server.ts
@@ -4,11 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {ApplicationConfig} from '@loopback/core';
-import * as express from 'express';
-import {Request, Response} from 'express';
-import * as http from 'http';
+import express, {Request, Response} from 'express';
+import http from 'http';
 import pEvent from 'p-event';
-import * as path from 'path';
+import path from 'path';
 import {NoteApplication} from './application';
 
 export class ExpressServer {

--- a/examples/greeter-extension/src/__tests__/acceptance/greeter-extension.acceptance.ts
+++ b/examples/greeter-extension/src/__tests__/acceptance/greeter-extension.acceptance.ts
@@ -5,7 +5,7 @@
 
 import {bind, createBindingFromClass} from '@loopback/core';
 import {expect} from '@loopback/testlab';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {
   asGreeter,
   Greeter,

--- a/examples/greeter-extension/src/greeting-service.ts
+++ b/examples/greeter-extension/src/greeting-service.ts
@@ -5,7 +5,7 @@
 
 import {config, Getter} from '@loopback/context';
 import {extensionPoint, extensions} from '@loopback/core';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {Greeter, GREETER_EXTENSION_POINT_NAME} from './types';
 
 /**

--- a/examples/greeting-app/src/caching-service.ts
+++ b/examples/greeting-app/src/caching-service.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {bind, BindingScope, config, ContextView} from '@loopback/core';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {Message} from './types';
 const debug = debugFactory('greeter-extension');
 

--- a/examples/greeting-app/src/interceptors/caching.interceptor.ts
+++ b/examples/greeting-app/src/interceptors/caching.interceptor.ts
@@ -14,7 +14,7 @@ import {
   ValueOrPromise,
 } from '@loopback/context';
 import {RestBindings} from '@loopback/rest';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {CachingService} from '../caching-service';
 import {CACHING_SERVICE} from '../keys';
 

--- a/examples/lb3-application/src/__tests__/acceptance/lb3app.acceptance.ts
+++ b/examples/lb3-application/src/__tests__/acceptance/lb3app.acceptance.ts
@@ -5,7 +5,7 @@
 
 import {OpenApiSpec} from '@loopback/rest';
 import {Client, expect} from '@loopback/testlab';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import {CoffeeShopApplication} from '../../application';
 import {givenCoffeeShop, setupApplication} from './test-helper';
 

--- a/examples/lb3-application/src/application.ts
+++ b/examples/lb3-application/src/application.ts
@@ -9,7 +9,7 @@ import {ApplicationConfig} from '@loopback/core';
 import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
 import {RestExplorerComponent} from '@loopback/rest-explorer';
-import * as path from 'path';
+import path from 'path';
 import {MySequence} from './sequence';
 
 export class CoffeeShopApplication extends BootMixin(

--- a/examples/log-extension/README.md
+++ b/examples/log-extension/README.md
@@ -297,7 +297,7 @@ import {
   LevelMetadata,
   LogWriterFn,
 } from '../types';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 export class LogActionProvider implements Provider<LogFn> {
   // LogWriteFn is an optional dependency and it falls back to `logToConsole`

--- a/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
+++ b/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
@@ -17,7 +17,7 @@ import {
   SequenceHandler,
 } from '@loopback/rest';
 import {Client, createClientForHandler, expect, sinon} from '@loopback/testlab';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {
   EXAMPLE_LOG_BINDINGS,
   HighResTime,

--- a/examples/log-extension/src/__tests__/in-memory-logger.ts
+++ b/examples/log-extension/src/__tests__/in-memory-logger.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {LOG_LEVEL} from '../';
 
 export class InMemoryLog {

--- a/examples/log-extension/src/__tests__/unit/providers/log-action.provider.unit.ts
+++ b/examples/log-extension/src/__tests__/unit/providers/log-action.provider.unit.ts
@@ -5,7 +5,7 @@
 
 import {Request} from '@loopback/rest';
 import {sinon} from '@loopback/testlab';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {
   HighResTime,
   log,

--- a/examples/log-extension/src/providers/log-action.provider.ts
+++ b/examples/log-extension/src/providers/log-action.provider.ts
@@ -6,7 +6,7 @@
 import {Constructor, Getter, inject, Provider} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {OperationArgs, Request} from '@loopback/rest';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {getLogMetadata} from '../decorators';
 import {EXAMPLE_LOG_BINDINGS, LOG_LEVEL} from '../keys';
 import {

--- a/examples/rpc-server/src/__tests__/unit/rpc.router.unit.ts
+++ b/examples/rpc-server/src/__tests__/unit/rpc.router.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect, sinon} from '@loopback/testlab';
-import * as express from 'express';
+import express from 'express';
 import {routeHandler} from '../../rpc.router';
 import {RPCServer} from '../../rpc.server';
 

--- a/examples/rpc-server/src/rpc.router.ts
+++ b/examples/rpc-server/src/rpc.router.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import parser from 'body-parser';
+import express from 'express';
 import {RPCServer} from './rpc.server';
-import * as express from 'express';
-import * as parser from 'body-parser';
 
 export function rpcRouter(server: RPCServer) {
   const jsonParser = parser.json();

--- a/examples/rpc-server/src/rpc.server.ts
+++ b/examples/rpc-server/src/rpc.server.ts
@@ -5,8 +5,8 @@
 
 import {Context, inject} from '@loopback/context';
 import {Application, CoreBindings, Server} from '@loopback/core';
-import * as express from 'express';
-import * as http from 'http';
+import express from 'express';
+import http from 'http';
 import pEvent from 'p-event';
 import {rpcRouter} from './rpc.router';
 

--- a/examples/soap-calculator/src/application.ts
+++ b/examples/soap-calculator/src/application.ts
@@ -5,11 +5,11 @@
 
 import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
-import {RestExplorerComponent} from '@loopback/rest-explorer';
 import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
+import {RestExplorerComponent} from '@loopback/rest-explorer';
 import {ServiceMixin} from '@loopback/service-proxy';
-import * as path from 'path';
+import path from 'path';
 import {MySequence} from './sequence';
 
 export class SoapCalculatorApplication extends BootMixin(

--- a/examples/soap-calculator/src/datasources/calculator.datasource.ts
+++ b/examples/soap-calculator/src/datasources/calculator.datasource.ts
@@ -5,7 +5,7 @@
 
 import {inject} from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './calculator.datasource.config.json';
+import config from './calculator.datasource.config.json';
 
 export class CalculatorDataSource extends juggler.DataSource {
   static dataSourceName = 'calculator';

--- a/examples/todo-list/src/application.ts
+++ b/examples/todo-list/src/application.ts
@@ -5,10 +5,10 @@
 
 import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
-import {RestExplorerComponent} from '@loopback/rest-explorer';
 import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
-import * as path from 'path';
+import {RestExplorerComponent} from '@loopback/rest-explorer';
+import path from 'path';
 import {MySequence} from './sequence';
 
 export class TodoListApplication extends BootMixin(

--- a/examples/todo-list/src/datasources/db.datasource.ts
+++ b/examples/todo-list/src/datasources/db.datasource.ts
@@ -5,7 +5,7 @@
 
 import {inject} from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './db.datasource.config.json';
+import config from './db.datasource.config.json';
 
 export class DbDataSource extends juggler.DataSource {
   static dataSourceName = 'db';

--- a/examples/todo/src/__tests__/helpers.ts
+++ b/examples/todo/src/__tests__/helpers.ts
@@ -5,8 +5,8 @@
 
 import {HttpCachingProxy} from '@loopback/http-caching-proxy';
 import {merge} from 'lodash';
-import * as path from 'path';
-import * as GEO_CODER_CONFIG from '../datasources/geocoder.datasource.config.json';
+import path from 'path';
+import GEO_CODER_CONFIG from '../datasources/geocoder.datasource.config.json';
 import {Todo} from '../models/index';
 import {GeocoderService, GeoPoint} from '../services/geocoder.service';
 

--- a/examples/todo/src/application.ts
+++ b/examples/todo/src/application.ts
@@ -5,11 +5,11 @@
 
 import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
-import {RestExplorerComponent} from '@loopback/rest-explorer';
 import {RepositoryMixin} from '@loopback/repository';
 import {RestApplication} from '@loopback/rest';
+import {RestExplorerComponent} from '@loopback/rest-explorer';
 import {ServiceMixin} from '@loopback/service-proxy';
-import * as path from 'path';
+import path from 'path';
 import {MySequence} from './sequence';
 
 export class TodoListApplication extends BootMixin(

--- a/examples/todo/src/datasources/db.datasource.ts
+++ b/examples/todo/src/datasources/db.datasource.ts
@@ -5,7 +5,7 @@
 
 import {inject} from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './db.datasource.config.json';
+import config from './db.datasource.config.json';
 
 export class DbDataSource extends juggler.DataSource {
   static dataSourceName = 'db';

--- a/examples/todo/src/datasources/geocoder.datasource.ts
+++ b/examples/todo/src/datasources/geocoder.datasource.ts
@@ -5,7 +5,7 @@
 
 import {inject} from '@loopback/core';
 import {AnyObject, juggler} from '@loopback/repository';
-import * as config from './geocoder.datasource.config.json';
+import config from './geocoder.datasource.config.json';
 
 export class GeocoderDataSource extends juggler.DataSource {
   static dataSourceName = 'geocoder';

--- a/extensions/metrics/src/__tests__/acceptance/mock-pushgateway.ts
+++ b/extensions/metrics/src/__tests__/acceptance/mock-pushgateway.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as express from 'express';
+import express from 'express';
 import {Server} from 'http';
 import pEvent from 'p-event';
 

--- a/packages/authentication/docs/authentication-action.md
+++ b/packages/authentication/docs/authentication-action.md
@@ -1,7 +1,7 @@
 ### Auth action
 
 ```ts
-import * as HttpErrors from 'http-errors';
+import HttpErrors from 'http-errors';
 
 async action(request: Request): Promise<UserProfile | undefined> {
     const authStrategy = await this.getAuthStrategy();

--- a/packages/authorization/src/__tests__/acceptance/authorization-casbin.acceptance.ts
+++ b/packages/authorization/src/__tests__/acceptance/authorization-casbin.acceptance.ts
@@ -8,7 +8,7 @@ import {Application} from '@loopback/core';
 import {SecurityBindings, securityId, UserProfile} from '@loopback/security';
 import {expect} from '@loopback/testlab';
 import * as casbin from 'casbin';
-import * as path from 'path';
+import path from 'path';
 import {
   AuthorizationComponent,
   AuthorizationContext,

--- a/packages/authorization/src/authorize-interceptor.ts
+++ b/packages/authorization/src/authorize-interceptor.ts
@@ -18,7 +18,7 @@ import {
   Provider,
 } from '@loopback/context';
 import {SecurityBindings, UserProfile} from '@loopback/security';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {getAuthorizationMetadata} from './decorators/authorize';
 import {AuthorizationBindings, AuthorizationTags} from './keys';
 import {

--- a/packages/boot/src/booters/application-metadata.booter.ts
+++ b/packages/boot/src/booters/application-metadata.booter.ts
@@ -3,13 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {CoreBindings, Application} from '@loopback/core';
 import {inject} from '@loopback/context';
+import {Application, CoreBindings} from '@loopback/core';
+import debugModule from 'debug';
 import {BootBindings} from '../keys';
 import {Booter} from '../types';
 import path = require('path');
 
-import * as debugModule from 'debug';
 const debug = debugModule('loopback:boot:booter:application-metadata');
 
 /**

--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Constructor} from '@loopback/context';
-import * as debugFactory from 'debug';
-import * as path from 'path';
+import debugFactory from 'debug';
+import path from 'path';
 import {ArtifactOptions, Booter} from '../types';
 import {discoverFiles, loadClassesFromFiles} from './booter-utils';
 

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Constructor} from '@loopback/context';
-import * as debugFactory from 'debug';
-import * as path from 'path';
+import debugFactory from 'debug';
+import path from 'path';
 import {promisify} from 'util';
 const glob = promisify(require('glob'));
 

--- a/packages/boot/src/booters/interceptor.booter.ts
+++ b/packages/boot/src/booters/interceptor.booter.ts
@@ -13,7 +13,7 @@ import {
   Provider,
 } from '@loopback/context';
 import {Application, CoreBindings} from '@loopback/core';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {BootBindings} from '../keys';
 import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';

--- a/packages/boot/src/booters/lifecyle-observer.booter.ts
+++ b/packages/boot/src/booters/lifecyle-observer.booter.ts
@@ -10,7 +10,7 @@ import {
   isLifeCycleObserverClass,
   LifeCycleObserver,
 } from '@loopback/core';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {BootBindings} from '../keys';
 import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -12,7 +12,7 @@ import {
 } from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {ApplicationWithServices} from '@loopback/service-proxy';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {BootBindings} from '../keys';
 import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -5,7 +5,7 @@
 
 import {Context, inject, resolveList} from '@loopback/context';
 import {Application, CoreBindings} from '@loopback/core';
-import * as debugModule from 'debug';
+import debugModule from 'debug';
 import {resolve} from 'path';
 import {BootBindings, BootTags} from './keys';
 import {_bindBooter} from './mixins';

--- a/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
+++ b/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
@@ -5,7 +5,7 @@
 
 import {OpenApiSpec, OperationObject} from '@loopback/rest';
 import {Client, expect} from '@loopback/testlab';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import {
   CoffeeApplication,
   givenCoffeeShop,

--- a/packages/booter-lb3app/src/__tests__/test-helper.ts
+++ b/packages/booter-lb3app/src/__tests__/test-helper.ts
@@ -12,7 +12,7 @@ import {
   createRestAppClient,
   givenHttpServerConfig,
 } from '@loopback/testlab';
-import * as path from 'path';
+import path from 'path';
 import {Lb3AppBooterComponent} from '../lb3app.booter.component';
 const lb3app = require('../../fixtures/lb3app/server/server');
 

--- a/packages/booter-lb3app/src/lb3app.booter.ts
+++ b/packages/booter-lb3app/src/lb3app.booter.ts
@@ -11,10 +11,10 @@ import {
   rebaseOpenApiSpec,
   RestApplication,
 } from '@loopback/rest';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {Application as ExpressApplication} from 'express';
 import pEvent from 'p-event';
-import * as path from 'path';
+import path from 'path';
 
 const {generateSwaggerSpec} = require('loopback-swagger');
 const swagger2openapi = require('swagger2openapi');

--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -14,6 +14,7 @@
 
     "lib": ["es2018", "esnext.asynciterable"],
     "module": "commonjs",
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "target": "es2017",
     "sourceMap": true,

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -11,7 +11,7 @@ import {RestApplication} from '@loopback/rest';
 <% if (project.services) { -%>
 import {ServiceMixin} from '@loopback/service-proxy';
 <% } -%>
-import * as path from 'path';
+import path from 'path';
 import {MySequence} from './sequence';
 
 <% if (project.appClassWithMixins) { -%>

--- a/packages/cli/generators/datasource/templates/datasource.ts.ejs
+++ b/packages/cli/generators/datasource/templates/datasource.ts.ejs
@@ -5,7 +5,7 @@ import {
   ValueOrPromise,
 } from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './<%= jsonFileName %>';
+import config from './<%= jsonFileName %>';
 
 @lifeCycleObserver('datasource')
 export class <%= className %>DataSource extends juggler.DataSource

--- a/packages/cli/generators/project/templates/tsconfig.json.ejs
+++ b/packages/cli/generators/project/templates/tsconfig.json.ejs
@@ -23,6 +23,7 @@
 
     "lib": ["es2018", "esnext.asynciterable"],
     "module": "commonjs",
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "target": "es2017",
     "sourceMap": true,

--- a/packages/cli/snapshots/integration/generators/datasource.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/datasource.integration.snapshots.js
@@ -15,7 +15,7 @@ import {
   ValueOrPromise,
 } from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './ds.datasource.config.json';
+import config from './ds.datasource.config.json';
 
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
@@ -56,7 +56,7 @@ import {
   ValueOrPromise,
 } from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './ds.datasource.config.json';
+import config from './ds.datasource.config.json';
 
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
@@ -97,7 +97,7 @@ import {
   ValueOrPromise,
 } from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './ds.datasource.config.json';
+import config from './ds.datasource.config.json';
 
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
@@ -138,7 +138,7 @@ import {
   ValueOrPromise,
 } from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './ds.datasource.config.json';
+import config from './ds.datasource.config.json';
 
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
@@ -179,7 +179,7 @@ import {
   ValueOrPromise,
 } from '@loopback/core';
 import {juggler} from '@loopback/repository';
-import * as config from './ds.datasource.config.json';
+import config from './ds.datasource.config.json';
 
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource

--- a/packages/context/src/__tests__/acceptance/method-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/method-level-bindings.acceptance.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import * as debugModule from 'debug';
-import {Context, inject, invokeMethod, BindingKey} from '../..';
+import debugModule from 'debug';
+import {BindingKey, Context, inject, invokeMethod} from '../..';
 const debug = debugModule('loopback:context:test');
 
 class InfoController {

--- a/packages/context/src/__tests__/unit/is-promise.unit.ts
+++ b/packages/context/src/__tests__/unit/is-promise.unit.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as bluebird from 'bluebird';
 import {expect} from '@loopback/testlab';
+import bluebird from 'bluebird';
 import {isPromiseLike} from '../..';
 
 describe('isPromise', () => {

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {MetadataAccessor, MetadataInspector} from '@loopback/metadata';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {Binding, BindingScope, BindingTag, BindingTemplate} from './binding';
 import {BindingAddress} from './binding-key';
 import {ContextTags} from './keys';

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {BindingAddress, BindingKey} from './binding-key';
 import {Context} from './context';
 import {createProxyWithInterceptors} from './interception-proxy';

--- a/packages/context/src/context-view.ts
+++ b/packages/context/src/context-view.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {EventEmitter} from 'events';
 import {promisify} from 'util';
 import {Binding} from './binding';

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {EventEmitter} from 'events';
 import {v1 as uuidv1} from 'uuid';
 import {Binding, BindingTag} from './binding';

--- a/packages/context/src/interceptor-chain.ts
+++ b/packages/context/src/interceptor-chain.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {BindingFilter} from './binding-filter';
 import {BindingAddress} from './binding-key';
 import {BindingComparator} from './binding-sorter';

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -11,8 +11,8 @@ import {
   MetadataMap,
   MethodDecoratorFactory,
 } from '@loopback/metadata';
-import * as assert from 'assert';
-import * as debugFactory from 'debug';
+import assert from 'assert';
+import debugFactory from 'debug';
 import {Binding, BindingTemplate} from './binding';
 import {bind} from './binding-decorator';
 import {filterByTag} from './binding-filter';

--- a/packages/context/src/invocation.ts
+++ b/packages/context/src/invocation.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {DecoratorFactory} from '@loopback/metadata';
-import * as assert from 'assert';
-import * as debugFactory from 'debug';
+import assert from 'assert';
+import debugFactory from 'debug';
 import {Context} from './context';
 import {invokeMethodWithInterceptors} from './interceptor';
 import {resolveInjectedArguments} from './resolver';

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {DecoratorFactory} from '@loopback/metadata';
-import * as debugModule from 'debug';
+import debugModule from 'debug';
 import {Binding} from './binding';
 import {Injection} from './inject';
 import {BoundValue, tryWithFinally, ValueOrPromise} from './value-promise';

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {DecoratorFactory} from '@loopback/metadata';
-import * as assert from 'assert';
-import * as debugModule from 'debug';
+import assert from 'assert';
+import debugModule from 'debug';
 import {BindingScope} from './binding';
 import {isBindingAddress} from './binding-filter';
 import {BindingAddress} from './binding-key';

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -11,9 +11,9 @@ import {
   createBindingFromClass,
   Provider,
 } from '@loopback/context';
-import * as assert from 'assert';
-import * as debugFactory from 'debug';
+import assert from 'assert';
 import pEvent from 'p-event';
+import debugFactory from 'debug';
 import {Component, mountComponent} from './component';
 import {CoreBindings, CoreTags} from './keys';
 import {

--- a/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
+++ b/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
@@ -5,13 +5,13 @@
 
 import {expect} from '@loopback/testlab';
 import delay from 'delay';
-import * as http from 'http';
+import http from 'http';
 import {AddressInfo} from 'net';
 import pEvent from 'p-event';
-import * as path from 'path';
-import * as makeRequest from 'request-promise-native';
-import * as rimrafCb from 'rimraf';
-import * as util from 'util';
+import path from 'path';
+import makeRequest from 'request-promise-native';
+import rimrafCb from 'rimraf';
+import util from 'util';
 import {HttpCachingProxy, ProxyOptions} from '../../http-caching-proxy';
 
 const CACHE_DIR = path.join(__dirname, '.cache');

--- a/packages/http-caching-proxy/src/http-caching-proxy.ts
+++ b/packages/http-caching-proxy/src/http-caching-proxy.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {
   createServer,
   IncomingMessage,
@@ -13,7 +13,7 @@ import {
 } from 'http';
 import {AddressInfo} from 'net';
 import pEvent from 'p-event';
-import * as makeRequest from 'request-promise-native';
+import makeRequest from 'request-promise-native';
 
 const cacache = require('cacache');
 

--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -12,11 +12,11 @@ import {
   supertest,
 } from '@loopback/testlab';
 import {EventEmitter} from 'events';
-import * as fs from 'fs';
+import fs from 'fs';
 import {Agent, IncomingMessage, Server, ServerResponse} from 'http';
-import * as os from 'os';
+import os from 'os';
 import pEvent from 'p-event';
-import * as path from 'path';
+import path from 'path';
 import {HttpOptions, HttpServer, HttpsOptions} from '../../';
 import {HttpServerOptions} from '../../http-server';
 

--- a/packages/http-server/src/http-server.ts
+++ b/packages/http-server/src/http-server.ts
@@ -3,14 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as assert from 'assert';
-import * as http from 'http';
-import {IncomingMessage, ServerResponse} from 'http';
-import * as https from 'https';
+import assert from 'assert';
+import http, {IncomingMessage, ServerResponse} from 'http';
+import https from 'https';
 import {AddressInfo, ListenOptions} from 'net';
-import * as os from 'os';
+import os from 'os';
 import pEvent from 'p-event';
-import * as stoppable from 'stoppable';
+import stoppable from 'stoppable';
 
 /**
  * Request listener function for http/https requests

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugModule from 'debug';
-import * as _ from 'lodash';
+import debugModule from 'debug';
+import _ from 'lodash';
 import {Reflector} from './reflect';
 import {DecoratorType, MetadataKey, MetadataMap} from './types';
 const debug = debugModule('loopback:metadata:decorator');

--- a/packages/openapi-spec-builder/src/openapi-spec-builder.ts
+++ b/packages/openapi-spec-builder/src/openapi-spec-builder.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as assert from 'assert';
+import assert from 'assert';
 import {
   ISpecificationExtension,
   OpenAPIObject,

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -9,7 +9,7 @@ import {
   getJsonSchemaRef,
   JsonSchemaOptions,
 } from '@loopback/repository-json-schema';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import {resolveSchema} from './generate-schema';
 import {jsonToSchemaObject, SchemaRef} from './json-to-schema';
 import {OAI3Keys} from './keys';

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {MetadataInspector, ParameterDecoratorFactory} from '@loopback/context';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import {inspect} from 'util';
 import {resolveSchema} from '../generate-schema';
 import {OAI3Keys} from '../keys';

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {JsonSchema} from '@loopback/repository-json-schema';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import {
   isSchemaObject,
   ReferenceObject,

--- a/packages/repository-json-schema/src/__tests__/helpers/expect-valid-json-schema.ts
+++ b/packages/repository-json-schema/src/__tests__/helpers/expect-valid-json-schema.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import * as Ajv from 'ajv';
+import Ajv from 'ajv';
 import {JsonSchema} from '../..';
 
 export function expectValidJsonSchema(schema: JsonSchema) {

--- a/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
@@ -5,7 +5,7 @@
 
 import {Entity, Filter, hasMany, model, property} from '@loopback/repository';
 import {expect} from '@loopback/testlab';
-import * as Ajv from 'ajv';
+import Ajv from 'ajv';
 import {JsonSchema} from '../..';
 import {
   getFilterJsonSchemaFor,

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -12,7 +12,7 @@ import {
   RelationMetadata,
   resolveType,
 } from '@loopback/repository';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {JSONSchema6 as JSONSchema} from 'json-schema';
 import {inspect} from 'util';
 import {JSON_SCHEMA_KEY, MODEL_TYPE_KEYS} from './keys';

--- a/packages/repository-tests/src/crud-test-suite.ts
+++ b/packages/repository-tests/src/crud-test-suite.ts
@@ -4,9 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {juggler} from '@loopback/repository';
-import * as debugFactory from 'debug';
-import * as fs from 'fs';
-import * as path from 'path';
+import debugFactory from 'debug';
+import fs from 'fs';
+import path from 'path';
 import {withCrudCtx} from './helpers.repository-tests';
 import {
   CrudFeatures,

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect, toJSON} from '@loopback/testlab';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import {
   CrudFeatures,
   CrudRepositoryCtor,

--- a/packages/repository/src/decorators/repository.decorator.ts
+++ b/packages/repository/src/decorators/repository.decorator.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context, inject, Injection} from '@loopback/context';
-import * as assert from 'assert';
+import assert from 'assert';
 import {Class} from '../common-types';
 import {DataSource} from '../datasource';
 import {Entity, Model} from '../model';

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -5,7 +5,7 @@
 
 import {Binding, BindingScope, createBindingFromClass} from '@loopback/context';
 import {Application} from '@loopback/core';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {Class} from '../common-types';
 import {SchemaMigrationOptions} from '../datasource';
 import {juggler, Repository} from '../repositories';

--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as assert from 'assert';
+import assert from 'assert';
 import {AnyObject} from './common-types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {DataObject} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories/repository';
@@ -13,8 +13,8 @@ import {
   InclusionResolver,
 } from '../relation.types';
 import {resolveBelongsToMetadata} from './belongs-to.helpers';
-import {DefaultBelongsToRepository} from './belongs-to.repository';
 import {createBelongsToInclusionResolver} from './belongs-to.inclusion-resolver';
+import {DefaultBelongsToRepository} from './belongs-to.repository';
 
 const debug = debugFactory('loopback:repository:belongs-to-accessor');
 

--- a/packages/repository/src/relations/belongs-to/belongs-to.helpers.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.helpers.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {InvalidRelationError} from '../../errors';
 import {isTypeResolver} from '../../type-resolver';
 import {BelongsToDefinition, RelationType} from '../relation.types';

--- a/packages/repository/src/relations/has-many/has-many-repository.factory.ts
+++ b/packages/repository/src/relations/has-many/has-many-repository.factory.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {DataObject} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories/repository';

--- a/packages/repository/src/relations/has-many/has-many.helpers.ts
+++ b/packages/repository/src/relations/has-many/has-many.helpers.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {camelCase} from 'lodash';
 import {InvalidRelationError} from '../../errors';
 import {isTypeResolver} from '../../type-resolver';

--- a/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
 import {Filter, Inclusion} from '../../query';

--- a/packages/repository/src/relations/has-one/has-one-repository.factory.ts
+++ b/packages/repository/src/relations/has-one/has-one-repository.factory.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {DataObject} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories/repository';

--- a/packages/repository/src/relations/has-one/has-one.helpers.ts
+++ b/packages/repository/src/relations/has-one/has-one.helpers.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {camelCase} from 'lodash';
 import {InvalidRelationError} from '../../errors';
 import {isTypeResolver} from '../../type-resolver';

--- a/packages/repository/src/relations/relation.helpers.ts
+++ b/packages/repository/src/relations/relation.helpers.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as assert from 'assert';
-import * as debugFactory from 'debug';
-import * as _ from 'lodash';
+import assert from 'assert';
+import debugFactory from 'debug';
+import _ from 'lodash';
 import {
   AnyObject,
   Entity,

--- a/packages/repository/src/repositories/kv.repository.bridge.ts
+++ b/packages/repository/src/repositories/kv.repository.bridge.ts
@@ -3,14 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as legacy from 'loopback-datasource-juggler';
-
-import {Options, DataObject} from '../common-types';
+import legacy from 'loopback-datasource-juggler';
+import {DataObject, Options} from '../common-types';
 import {Entity} from '../model';
-
-import {KeyValueRepository, KeyValueFilter} from './kv.repository';
-
-import {juggler, ensurePromise} from './legacy-juggler-bridge';
+import {KeyValueFilter, KeyValueRepository} from './kv.repository';
+import {ensurePromise, juggler} from './legacy-juggler-bridge';
 
 /**
  * Polyfill for Symbol.asyncIterator

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Getter} from '@loopback/context';
-import * as assert from 'assert';
-import * as legacy from 'loopback-datasource-juggler';
+import assert from 'assert';
+import legacy from 'loopback-datasource-juggler';
 import {
   AnyObject,
   Command,

--- a/packages/repository/src/types/array.ts
+++ b/packages/repository/src/types/array.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import util from 'util';
 import {Type} from './type';
-import * as util from 'util';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/packages/repository/src/types/buffer.ts
+++ b/packages/repository/src/types/buffer.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as util from 'util';
-import {Type} from './type';
+import util from 'util';
 import {Options} from '../common-types';
+import {Type} from './type';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/packages/repository/src/types/date.ts
+++ b/packages/repository/src/types/date.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as util from 'util';
+import util from 'util';
 import {Type} from './type';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/repository/src/types/number.ts
+++ b/packages/repository/src/types/number.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as util from 'util';
+import util from 'util';
 import {Type} from './type';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/repository/src/types/object.ts
+++ b/packages/repository/src/types/object.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as util from 'util';
-import {Class, AnyObject} from '../common-types';
+import util from 'util';
+import {AnyObject, Class} from '../common-types';
 import {Type} from './type';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/repository/src/types/union.ts
+++ b/packages/repository/src/types/union.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as util from 'util';
+import util from 'util';
 import {Type} from './type';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/rest-crud/src/repository-builder.ts
+++ b/packages/rest-crud/src/repository-builder.ts
@@ -9,7 +9,7 @@ import {
   EntityCrudRepository,
   juggler,
 } from '@loopback/repository';
-import * as assert from 'assert';
+import assert from 'assert';
 
 /**
  * Create (define) a repository class for the given model.

--- a/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
+++ b/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
@@ -9,7 +9,7 @@ import {
   createClientForHandler,
   givenHttpServerConfig,
 } from '@loopback/testlab';
-import * as express from 'express';
+import express from 'express';
 import {
   RestExplorerBindings,
   RestExplorerComponent,

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -11,9 +11,9 @@ import {
   RestServer,
   RestServerConfig,
 } from '@loopback/rest';
-import * as ejs from 'ejs';
-import * as fs from 'fs';
-import * as path from 'path';
+import ejs from 'ejs';
+import fs from 'fs';
+import path from 'path';
 import {RestExplorerBindings} from './rest-explorer.keys';
 import {RestExplorerConfig} from './rest-explorer.types';
 

--- a/packages/rest/src/__tests__/acceptance/file-upload/file-upload-with-parser.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/file-upload/file-upload-with-parser.acceptance.ts
@@ -9,8 +9,8 @@ import {
   expect,
   givenHttpServerConfig,
 } from '@loopback/testlab';
-import * as multer from 'multer';
-import * as path from 'path';
+import multer from 'multer';
+import path from 'path';
 import {
   BodyParser,
   post,

--- a/packages/rest/src/__tests__/acceptance/file-upload/file-upload.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/file-upload/file-upload.acceptance.ts
@@ -10,8 +10,8 @@ import {
   expect,
   givenHttpServerConfig,
 } from '@loopback/testlab';
-import * as multer from 'multer';
-import * as path from 'path';
+import multer from 'multer';
+import path from 'path';
 import {
   post,
   Request,

--- a/packages/rest/src/__tests__/integration/express.integration.ts
+++ b/packages/rest/src/__tests__/integration/express.integration.ts
@@ -11,7 +11,7 @@ import {
   expect,
   givenHttpServerConfig,
 } from '@loopback/testlab';
-import * as express from 'express';
+import express from 'express';
 import {RestComponent} from '../../rest.component';
 import {
   HttpRequestListener,

--- a/packages/rest/src/__tests__/integration/http-handler.integration.ts
+++ b/packages/rest/src/__tests__/integration/http-handler.integration.ts
@@ -17,8 +17,8 @@ import {
   createUnexpectedHttpErrorLogger,
   expect,
 } from '@loopback/testlab';
-import * as express from 'express';
-import * as HttpErrors from 'http-errors';
+import express from 'express';
+import HttpErrors from 'http-errors';
 import {is} from 'type-is';
 import {
   BodyParser,

--- a/packages/rest/src/__tests__/integration/request-context.integration.ts
+++ b/packages/rest/src/__tests__/integration/request-context.integration.ts
@@ -12,7 +12,7 @@ import {
   httpsGetAsync,
   supertest,
 } from '@loopback/testlab';
-import * as express from 'express';
+import express from 'express';
 import {RequestContext} from '../../request-context';
 import {RestApplication} from '../../rest.application';
 import {RestServer, RestServerConfig} from '../../rest.server';

--- a/packages/rest/src/__tests__/integration/rest.application.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.application.integration.ts
@@ -5,10 +5,9 @@
 
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
 import {Client, createRestAppClient, expect} from '@loopback/testlab';
-import * as express from 'express';
-import {Request, Response} from 'express';
-import * as fs from 'fs';
-import * as path from 'path';
+import express, {Request, Response} from 'express';
+import fs from 'fs';
+import path from 'path';
 import {
   get,
   RestApplication,

--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -13,12 +13,12 @@ import {
   skipOnTravis,
   supertest,
 } from '@loopback/testlab';
-import * as fs from 'fs';
+import fs from 'fs';
 import {IncomingMessage, ServerResponse} from 'http';
-import * as yaml from 'js-yaml';
-import * as path from 'path';
+import yaml from 'js-yaml';
+import path from 'path';
 import {is} from 'type-is';
-import * as util from 'util';
+import util from 'util';
 import {
   BodyParser,
   get,

--- a/packages/rest/src/__tests__/unit/coercion/paramObject.unit.ts
+++ b/packages/rest/src/__tests__/unit/coercion/paramObject.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {ParameterObject} from '@loopback/openapi-v3';
-import * as qs from 'qs';
+import qs from 'qs';
 import {RestHttpErrors} from '../../..';
 import {test} from './utils';
 

--- a/packages/rest/src/__tests__/unit/coercion/utils.ts
+++ b/packages/rest/src/__tests__/unit/coercion/utils.ts
@@ -9,8 +9,8 @@ import {
   ShotRequestOptions,
   stubExpressContext,
 } from '@loopback/testlab';
-import * as HttpErrors from 'http-errors';
-import * as qs from 'qs';
+import HttpErrors from 'http-errors';
+import qs from 'qs';
 import {format} from 'util';
 import {
   createResolvedRoute,

--- a/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
@@ -10,7 +10,7 @@ import {
   ShotRequestOptions,
   stubExpressContext,
 } from '@loopback/testlab';
-import * as HttpErrors from 'http-errors';
+import HttpErrors from 'http-errors';
 import {
   ControllerRoute,
   RegExpRouter,

--- a/packages/rest/src/body-parsers/body-parser.helpers.ts
+++ b/packages/rest/src/body-parsers/body-parser.helpers.ts
@@ -9,7 +9,7 @@ import {
   OptionsText,
   OptionsUrlencoded,
 } from 'body-parser';
-import * as debugModule from 'debug';
+import debugModule from 'debug';
 import {HttpError} from 'http-errors';
 import {Request, RequestBodyParserOptions, Response} from '../types';
 

--- a/packages/rest/src/body-parsers/body-parser.ts
+++ b/packages/rest/src/body-parsers/body-parser.ts
@@ -12,7 +12,7 @@ import {
   instantiateClass,
 } from '@loopback/context';
 import {isReferenceObject, OperationObject} from '@loopback/openapi-v3';
-import * as debugModule from 'debug';
+import debugModule from 'debug';
 import {is} from 'type-is';
 import {RestHttpErrors} from '../rest-http-error';
 import {Request} from '../types';

--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {isReferenceObject, ParameterObject} from '@loopback/openapi-v3';
-import * as debugModule from 'debug';
+import debugModule from 'debug';
 import {RestHttpErrors} from '../';
 import {parseJson} from '../parse-json';
 import {

--- a/packages/rest/src/coercion/utils.ts
+++ b/packages/rest/src/coercion/utils.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugModule from 'debug';
+import debugModule from 'debug';
 const debug = debugModule('loopback:rest:coercion');
 
 /**

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -3,27 +3,24 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './router';
-
-export * from './providers';
-
-export * from './parser';
+export * from '@loopback/openapi-v3';
 export * from './body-parsers';
-export * from './writer';
 export * from './http-handler';
-export * from './request-context';
-export * from './types';
 export * from './keys';
+export * from './parse-json';
+export * from './parser';
+export * from './providers';
+export * from './request-context';
+export * from './rest-http-error';
 export * from './rest.application';
 export * from './rest.component';
 export * from './rest.server';
+export * from './router';
 export * from './sequence';
-export * from './rest-http-error';
-export * from './parse-json';
+export * from './types';
 export * from './validation/request-body.validator';
-
-// export all errors from external http-errors package
-import * as HttpErrors from 'http-errors';
+export * from './writer';
 export {HttpErrors};
 
-export * from '@loopback/openapi-v3';
+// export all errors from external http-errors package
+import HttpErrors from 'http-errors';

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -7,7 +7,7 @@ import {BindingKey, Context} from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {HttpProtocol} from '@loopback/http-server';
 import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3';
-import * as https from 'https';
+import https from 'https';
 import {ErrorWriterOptions} from 'strong-error-handler';
 import {BodyParser, RequestBodyParser} from './body-parsers';
 import {HttpHandler} from './http-handler';

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -10,7 +10,7 @@ import {
   REQUEST_BODY_INDEX,
   SchemasObject,
 } from '@loopback/openapi-v3';
-import * as debugFactory from 'debug';
+import debugFactory from 'debug';
 import {RequestBody, RequestBodyParser} from './body-parsers';
 import {coerceParameter} from './coercion/coerce-parameter';
 import {RestHttpErrors} from './rest-http-error';

--- a/packages/rest/src/request-context.ts
+++ b/packages/rest/src/request-context.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Context} from '@loopback/context';
-import * as onFinished from 'on-finished';
+import onFinished from 'on-finished';
 import {RestBindings} from './keys';
 import {RestServerResolvedConfig} from './rest.server';
 import {HandlerContext, Request, Response} from './types';

--- a/packages/rest/src/rest-http-error.ts
+++ b/packages/rest/src/rest-http-error.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as HttpErrors from 'http-errors';
+import HttpErrors from 'http-errors';
 
 export namespace RestHttpErrors {
   export function invalidData<T, Props extends object = {}>(

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -21,9 +21,9 @@ import {
   ServerObject,
 } from '@loopback/openapi-v3';
 import {AssertionError} from 'assert';
-import * as cors from 'cors';
-import * as debugFactory from 'debug';
-import * as express from 'express';
+import cors from 'cors';
+import debugFactory from 'debug';
+import express from 'express';
 import {PathParams} from 'express-serve-static-core';
 import {IncomingMessage, ServerResponse} from 'http';
 import {ServerOptions} from 'https';
@@ -74,7 +74,7 @@ export interface HttpServerLike {
 
 const SequenceActions = RestBindings.SequenceActions;
 
-// NOTE(bajtos) we cannot use `import * as cloneDeep from 'lodash/cloneDeep'
+// NOTE(bajtos) we cannot use `import cloneDeep from 'lodash/cloneDeep'
 // because it produces the following TypeScript error:
 //  Module '"(...)/node_modules/@types/lodash/cloneDeep/index"' resolves to
 //  a non-module entity and cannot be imported using this construct.

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -13,7 +13,7 @@ import {
 } from '@loopback/context';
 import {CoreBindings} from '@loopback/core';
 import {OperationObject} from '@loopback/openapi-v3';
-import * as HttpErrors from 'http-errors';
+import HttpErrors from 'http-errors';
 import {RestBindings} from '../keys';
 import {OperationArgs, OperationRetval} from '../types';
 import {BaseRoute, RouteSource} from './base-route';

--- a/packages/rest/src/router/external-express-routes.ts
+++ b/packages/rest/src/router/external-express-routes.ts
@@ -9,11 +9,10 @@ import {
   OperationObject,
   SchemasObject,
 } from '@loopback/openapi-v3';
-import * as express from 'express';
-import {RequestHandler} from 'express';
+import express, {RequestHandler} from 'express';
 import {PathParams} from 'express-serve-static-core';
-import * as HttpErrors from 'http-errors';
-import * as onFinished from 'on-finished';
+import HttpErrors from 'http-errors';
+import onFinished from 'on-finished';
 import {ServeStaticOptions} from 'serve-static';
 import {promisify} from 'util';
 import {RequestContext} from '../request-context';

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -9,9 +9,9 @@ import {
   ParameterObject,
   PathObject,
 } from '@loopback/openapi-v3';
-import * as assert from 'assert';
-import * as debugFactory from 'debug';
-import * as HttpErrors from 'http-errors';
+import assert from 'assert';
+import debugFactory from 'debug';
+import HttpErrors from 'http-errors';
 import {inspect} from 'util';
 import {Request} from '../types';
 import {

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -5,7 +5,7 @@
 
 import {Binding, BoundValue} from '@loopback/context';
 import {ReferenceObject, SchemaObject} from '@loopback/openapi-v3';
-import * as ajv from 'ajv';
+import ajv from 'ajv';
 import {
   Options,
   OptionsJson,

--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -10,10 +10,10 @@ import {
   SchemaObject,
   SchemasObject,
 } from '@loopback/openapi-v3';
-import * as AJV from 'ajv';
-import * as debugModule from 'debug';
-import * as _ from 'lodash';
-import * as util from 'util';
+import AJV from 'ajv';
+import debugModule from 'debug';
+import _ from 'lodash';
+import util from 'util';
 import {HttpErrors, RequestBody, RestHttpErrors} from '..';
 import {RequestBodyValidationOptions, SchemaValidatorCache} from '../types';
 

--- a/packages/service-proxy/src/__tests__/mock-service.connector.ts
+++ b/packages/service-proxy/src/__tests__/mock-service.connector.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import legacy from 'loopback-datasource-juggler';
 import {juggler} from '..';
-import * as legacy from 'loopback-datasource-juggler';
 
 /**
  * A mockup service connector

--- a/packages/service-proxy/src/legacy-juggler-bridge.ts
+++ b/packages/service-proxy/src/legacy-juggler-bridge.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as legacy from 'loopback-datasource-juggler';
+import legacy from 'loopback-datasource-juggler';
 
 export namespace juggler {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/testlab/src/__tests__/integration/testlab.smoke.integration.ts
+++ b/packages/testlab/src/__tests__/integration/testlab.smoke.integration.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as assert from 'assert';
+import assert from 'assert';
 import * as testlab from '../..';
 
 describe('testlab smoke test', () => {

--- a/packages/testlab/src/client.ts
+++ b/packages/testlab/src/client.ts
@@ -7,7 +7,7 @@
  * HTTP client utilities
  */
 
-import * as http from 'http';
+import http from 'http';
 import supertest = require('supertest');
 
 export {supertest};

--- a/packages/testlab/src/http-server-config.ts
+++ b/packages/testlab/src/http-server-config.ts
@@ -6,7 +6,7 @@
 import {readFileSync} from 'fs';
 import {ServerOptions as HttpsServerOptions} from 'https';
 import {ListenOptions} from 'net';
-import * as path from 'path';
+import path from 'path';
 
 const FIXTURES = path.resolve(__dirname, '../fixtures');
 const DUMMY_TLS_CONFIG = {

--- a/packages/testlab/src/request.ts
+++ b/packages/testlab/src/request.ts
@@ -3,10 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as http from 'http';
-import {IncomingMessage} from 'http';
-import * as https from 'https';
-import * as url from 'url';
+import http, {IncomingMessage} from 'http';
+import https from 'https';
+import url from 'url';
 
 /**
  * Async wrapper for making HTTP GET requests

--- a/packages/testlab/src/shot.ts
+++ b/packages/testlab/src/shot.ts
@@ -10,14 +10,14 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as express from 'express';
+import express from 'express';
 import {IncomingMessage, ServerResponse} from 'http';
 import {
   Listener as ShotListener,
   RequestOptions as ShotRequestOptions,
   ResponseObject,
 } from 'shot'; // <-- workaround for missing type-defs for @hapi/shot
-import * as util from 'util';
+import util from 'util';
 
 const inject: (
   dispatchFunc: ShotListener,

--- a/packages/testlab/src/sinon.ts
+++ b/packages/testlab/src/sinon.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as sinon from 'sinon';
-import {SinonSpy} from 'sinon';
+import sinon, {SinonSpy} from 'sinon';
 
 export {sinon, SinonSpy};
 

--- a/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
+++ b/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
@@ -4,9 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import * as fs from 'fs-extra';
+import fs from 'fs-extra';
 import pEvent from 'p-event';
-import * as path from 'path';
+import path from 'path';
 import {runExtractorForMonorepo, updateApiDocs} from '../..';
 import {runExtractorForPackage} from '../../monorepo-api-extractor';
 

--- a/packages/tsdocs/src/helper.ts
+++ b/packages/tsdocs/src/helper.ts
@@ -4,8 +4,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {IConfigFile} from '@microsoft/api-extractor';
-import * as fs from 'fs-extra';
-import * as path from 'path';
+import fs from 'fs-extra';
+import path from 'path';
 
 const Project = require('@lerna/project');
 

--- a/packages/tsdocs/src/monorepo-api-extractor.ts
+++ b/packages/tsdocs/src/monorepo-api-extractor.ts
@@ -13,9 +13,9 @@ import {
   ExtractorResult,
   IConfigFile,
 } from '@microsoft/api-extractor';
-import * as debugFactory from 'debug';
-import * as fs from 'fs-extra';
-import * as path from 'path';
+import debugFactory from 'debug';
+import fs from 'fs-extra';
+import path from 'path';
 import {
   DEFAULT_APIDOCS_EXTRACTION_PATH,
   ExtractorOptions,

--- a/packages/tsdocs/src/update-api-md-docs.ts
+++ b/packages/tsdocs/src/update-api-md-docs.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import * as debugFactory from 'debug';
-import * as fs from 'fs-extra';
-import * as path from 'path';
+import debugFactory from 'debug';
+import fs from 'fs-extra';
+import path from 'path';
 import {
   ApiDocsOptions,
   DEFAULT_APIDOCS_EXTRACTION_PATH,


### PR DESCRIPTION
The flag allows `import fs from 'fs'`. It's highly recommended by TypeScript.
See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
