### PR TITLE
chore: update a comment about UserProfile interface

### DIFF
--- a/packages/security/src/types.ts
+++ b/packages/security/src/types.ts
@@ -36,7 +36,7 @@ export class TypedPrincipal implements Principal {
  */
 export interface UserProfile extends Principal {
   // `email` and `name` are added to be identical with the
-  // current `UserProfile` being exported from `@loopback/authentication`
+  // `UserProfile` that previously was exported by `@loopback/authentication`
   email?: string;
   name?: string;
 }


### PR DESCRIPTION
`UserProfile` used to be exported by `authentication` module, but now it is exported by `security` module.

There is a comment that implies the `authentication` module still has the `UserProfile` interface.

This PR will change the comment to make it clear that `UserProfile` was previously exported by `authentication` module, but it now is exported from `security`.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
