### PR TITLE
chore: replace CURRENT_USER with SecurityBindings.USER

### DIFF
--- a/docs/site/Dependency-injection.md
+++ b/docs/site/Dependency-injection.md
@@ -33,7 +33,7 @@ export class AuthenticateActionProvider implements Provider<AuthenticateFn> {
     // is executed.
     @inject.getter(AuthenticationBindings.STRATEGY)
     readonly getStrategy: Getter<AuthenticationStrategy>,
-    @inject.setter(AuthenticationBindings.CURRENT_USER)
+    @inject.setter(SecurityBindings.USER)
     readonly setCurrentUser: Setter<UserProfile>,
   ) {}
 
@@ -206,7 +206,7 @@ dependencies as method arguments.
 
 ```ts
 class InfoController {
-  greet(@inject(AuthenticationBindings.CURRENT_USER) user: UserProfile) {
+  greet(@inject(SecurityBindings.USER) user: UserProfile) {
     return `Hello, ${user.name}`;
   }
 }

--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -151,9 +151,8 @@ import {get} from '@loopback/rest';
 
 export class WhoAmIController {
   constructor(
-    // After extracting the CURRENT_USER key to module `@loopback/security`,
-    // `AuthenticationBindings.CURRENT_USER` is turned to an alias of
-    // `SecurityBindings.USER`
+    // `AuthenticationBindings.CURRENT_USER` is now an alias of
+    // `SecurityBindings.USER` in @loopback/security
     @inject(SecurityBindings.USER)
     private userProfile: UserProfile,
   ) {}
@@ -169,7 +168,7 @@ export class WhoAmIController {
 }
 ```
 
-{% include note.html content="If only <b>some</b> of the controller methods are decorated with the <b>@authenticate</b> decorator, then the injection decorator for CURRENT_USER in the controller's constructor must be specified as <b>@inject(SecurityBindings.USER, {optional:true})</b> to avoid a binding error when an unauthenticated endpoint is accessed. Alternatively, do not inject CURRENT_USER in the controller <b>constructor</b>, but in the controller <b>methods</b> which are actually decorated with the <b>@authenticate</b> decorator. See [Method Injection](Dependency-injection.md#method-injection), [Constructor Injection](Dependency-injection.md#constructor-injection) and [Optional Dependencies](Dependency-injection.md#optional-dependencies) for details.
+{% include note.html content="If only <b>some</b> of the controller methods are decorated with the <b>@authenticate</b> decorator, then the injection decorator for SecurityBindings.USER in the controller's constructor must be specified as <b>@inject(SecurityBindings.USER, {optional:true})</b> to avoid a binding error when an unauthenticated endpoint is accessed. Alternatively, do not inject SecurityBindings.USER in the controller <b>constructor</b>, but in the controller <b>methods</b> which are actually decorated with the <b>@authenticate</b> decorator. See [Method Injection](Dependency-injection.md#method-injection), [Constructor Injection](Dependency-injection.md#constructor-injection) and [Optional Dependencies](Dependency-injection.md#optional-dependencies) for details.
 " %}
 
 An example of the decorator when options **are** specified looks like this:

--- a/docs/site/decorators/Decorators_authenticate.md
+++ b/docs/site/decorators/Decorators_authenticate.md
@@ -21,18 +21,12 @@ Here's an example using 'BasicStrategy': to authenticate user in function
 
 ```ts
 import {inject} from '@loopback/context';
-import {securityId} from '@loopback/security';
-import {
-  AuthenticationBindings,
-  UserProfile,
-  authenticate,
-} from '@loopback/authentication';
+import {securityId, SecurityBindings, UserProfile} from '@loopback/security';
+import {authenticate} from '@loopback/authentication';
 import {get} from '@loopback/rest';
 
 export class WhoAmIController {
-  constructor(
-    @inject(AuthenticationBindings.CURRENT_USER) private user: UserProfile,
-  ) {}
+  constructor(@inject(SecurityBindings.USER) private user: UserProfile) {}
 
   @authenticate('BasicStrategy')
   @get('/whoami')
@@ -52,9 +46,7 @@ skipped by `@authenticate.skip`.
 ```ts
 @authenticate('BasicStrategy')
 export class WhoAmIController {
-  constructor(
-    @inject(AuthenticationBindings.CURRENT_USER) private user: UserProfile,
-  ) {}
+  constructor(@inject(SecurityBindings.USER) private user: UserProfile) {}
 
   @get('/whoami')
   whoAmI(): string {
@@ -69,7 +61,7 @@ export class WhoAmIController {
 }
 ```
 
-{% include note.html content="If only <b>some</b> of the controller methods are decorated with the <b>@authenticate</b> decorator, then the injection decorator for CURRENT_USER in the controller's constructor must be specified as <b>@inject(AuthenticationBindings.CURRENT_USER, {optional:true})</b> to avoid a binding error when an unauthenticated endpoint is accessed. Alternatively, do not inject CURRENT_USER in the controller <b>constructor</b>, but in the controller <b>methods</b> which are actually decorated with the <b>@authenticate</b> decorator. See [Method Injection](../Dependency-injection.md#method-injection), [Constructor Injection](../Dependency-injection.md#constructor-injection) and [Optional Dependencies](../Dependency-injection.md#optional-dependencies) for details.
+{% include note.html content="If only <b>some</b> of the controller methods are decorated with the <b>@authenticate</b> decorator, then the injection decorator for SecurityBindings.USER in the controller's constructor must be specified as <b>@inject(SecurityBindings.USER, {optional:true})</b> to avoid a binding error when an unauthenticated endpoint is accessed. Alternatively, do not inject SecurityBindings.USER in the controller <b>constructor</b>, but in the controller <b>methods</b> which are actually decorated with the <b>@authenticate</b> decorator. See [Method Injection](../Dependency-injection.md#method-injection), [Constructor Injection](../Dependency-injection.md#constructor-injection) and [Optional Dependencies](../Dependency-injection.md#optional-dependencies) for details.
 " %}
 
 For more information on authentication with LoopBack, visit

--- a/docs/site/tutorials/authentication/Authentication-Tutorial.md
+++ b/docs/site/tutorials/authentication/Authentication-Tutorial.md
@@ -259,7 +259,7 @@ a user can print out his/her user profile by performing a `GET` request on the
   // ...
 ```
 
-{% include note.html content="Since this controller method is obtaining CURRENT_USER via [method injection](../../Dependency-injection.md#method-injection) (instead of [constructor injection](../../Dependency-injection.md#constructor-injection)) and this method is decorated with the <b>@authenticate</b> decorator, there is no need to specify <b>@inject(SecurityBindings.USER, {optional:true})</b>. See [Using the Authentication Decorator](../../Loopback-component-authentication.md#using-the-authentication-decorator) for details.
+{% include note.html content="Since this controller method is obtaining SecurityBindings.USER via [method injection](../../Dependency-injection.md#method-injection) (instead of [constructor injection](../../Dependency-injection.md#constructor-injection)) and this method is decorated with the <b>@authenticate</b> decorator, there is no need to specify <b>@inject(SecurityBindings.USER, {optional:true})</b>. See [Using the Authentication Decorator](../../Loopback-component-authentication.md#using-the-authentication-decorator) for details.
 " %}
 
 The `/users/me` endpoint is decorated with

--- a/extensions/authentication-passport/README.md
+++ b/extensions/authentication-passport/README.md
@@ -101,7 +101,7 @@ import {AUTH_STRATEGY_NAME} from './my-basic-auth-strategy';
 
 class MyController {
   constructor(
-    @inject(AuthenticationBindings.CURRENT_USER, {optional: true})
+    @inject(SecurityBindings.USER, {optional: true})
     private user: UserProfile,
   ) {}
 
@@ -223,9 +223,7 @@ function like:
 import {AUTH_STRATEGY_NAME} from './my-basic-auth-strategy';
 
 class MyController {
-  constructor(
-    @inject(AuthenticationBindings.CURRENT_USER) private user: UserProfile,
-  ) {}
+  constructor(@inject(SecurityBindings.USER) private user: UserProfile) {}
 
   // Define your strategy name as a constant so that
   // it is consistent with the name you provide in the adapter

--- a/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
+++ b/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
@@ -11,7 +11,6 @@ import {
   AUTHENTICATION_STRATEGY_NOT_FOUND,
   USER_PROFILE_NOT_FOUND,
 } from '@loopback/authentication';
-import {UserProfile, securityId} from '@loopback/security';
 import {inject} from '@loopback/context';
 import {Application, CoreTags} from '@loopback/core';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
@@ -28,6 +27,7 @@ import {
   Send,
   SequenceHandler,
 } from '@loopback/rest';
+import {SecurityBindings, securityId, UserProfile} from '@loopback/security';
 import {Client, createClientForHandler} from '@loopback/testlab';
 import {BasicStrategy} from 'passport-http';
 import {StrategyAdapter} from '../../strategy-adapter';
@@ -136,9 +136,7 @@ describe('Basic Authentication', () => {
 
     @api(apispec)
     class MyController {
-      constructor(
-        @inject(AuthenticationBindings.CURRENT_USER) private user: UserProfile,
-      ) {}
+      constructor(@inject(SecurityBindings.USER) private user: UserProfile) {}
 
       @authenticate(AUTH_STRATEGY_NAME)
       async whoAmI(): Promise<string> {

--- a/packages/authentication/docs/controller-functions.md
+++ b/packages/authentication/docs/controller-functions.md
@@ -44,7 +44,7 @@ const RESPONSE_SPEC_FOR_JWT_LOGIN = {
 
 class LoginController{
   constructor(
-    @inject(AuthenticationBindings.CURRENT_USER) userProfile: UserProfile,
+    @inject(SecurityBindings.USER) userProfile: UserProfile,
     @inject(AuthenticationBindings.SERVICES.JWT_TOKEN) JWTtokenService: TokenService,
   ) {}
 

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -98,7 +98,7 @@ export namespace AuthenticationBindings {
   export const AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME =
     'authentication.strategies';
 
-  // Make `CURRENT_USER` the alias of the security bindings
+  // Make `CURRENT_USER` the alias of SecurityBindings.USER for backward compatibility
   export const CURRENT_USER = SecurityBindings.USER;
 }
 


### PR DESCRIPTION
There are still a few places where we need to
replace AuthenticationBindings.CURRENT_USER from `authentication` package with SecurityBindings.USER from `security` package in documentation, mocha tests, and the passport adapter code/docs.

In `authentication` package,

const AuthenticationBindings.CURRENT_USER = SecurityBindings.USER

is being kept for backward compatibility but we should use
SecurityBindings.USER everywhere else.

Shopping Cart application no longer has any usage of AuthenticationBindings.CURRENT_USER; so that's good. Nothing to do there.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
