### PR TITLE
feat(cli): improve UX of multi-item selection

### DIFF
--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -161,6 +161,10 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         when:
           this.discoveringModels === undefined &&
           !this.artifactInfo.modelDefinitions,
+        // Require at least one model to be selected
+        // This prevents users from accidentally pressing ENTER instead of SPACE
+        // to select a model from the list
+        validate: result => !!result.length,
       },
     ];
 

--- a/packages/cli/generators/import-lb3-models/index.js
+++ b/packages/cli/generators/import-lb3-models/index.js
@@ -80,6 +80,9 @@ Learn more at https://loopback.io/doc/en/lb4/Importing-LB3-models.html
         message: 'Select models to import:',
         type: 'checkbox',
         choices: modelNames,
+        // Require at least one model to be selected
+        // This prevents users from accidentally pressing ENTER instead of SPACE
+        // to select a model from the list
         validate: result => !!result.length,
         // TODO: add a CLI flag to supply these names programmatically
       },

--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -102,6 +102,10 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
         message: 'Select controllers to be generated:',
         type: 'checkbox',
         choices: choices,
+        // Require at least one item to be selected
+        // This prevents users from accidentally pressing ENTER instead of SPACE
+        // to select an item from the list
+        validate: result => !!result.length,
       },
     ];
     const selections =

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -354,6 +354,10 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
         message: PROMPT_MESSAGE_MODEL,
         choices: modelList,
         when: this.artifactInfo.modelNameList === undefined,
+        // Require at least one model to be selected
+        // This prevents users from accidentally pressing ENTER instead of SPACE
+        // to select a model from the list
+        validate: result => !!result.length,
       },
     ])
       .then(props => {


### PR DESCRIPTION
When asking the user to select 1 or more items, e.g. models to import, require at least one item to be selected.

This prevents users from accidentally pressing ENTER instead of SPACE to select an item from the list, in which case the prompt is resolved with an empty list and thus the CLI command ends prematurely.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
