### PR TITLE
fix(cli): handle missing target artifact dir

### DIFF
--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -224,13 +224,21 @@ exports.findArtifactPaths = async function(dir, artifactType, reader) {
   const readdir = reader || readdirAsync;
   debug(`Finding artifact paths at: ${dir}`);
 
-  // Wrapping readdir in case it's not a promise.
-  const files = await readdir(dir);
-  return _.filter(files, f => {
-    return (
-      _.endsWith(f, `${artifactType}.js`) || _.endsWith(f, `${artifactType}.ts`)
+  try {
+    // Wrapping readdir in case it's not a promise.
+    const files = await readdir(dir);
+    return files.filter(
+      f =>
+        _.endsWith(f, `${artifactType}.js`) ||
+        _.endsWith(f, `${artifactType}.ts`),
     );
-  });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      // Target directory was not found (e.g. "src/models" does not exist yet).
+      return [];
+    }
+    throw err;
+  }
 };
 /**
  * Parses the files of the target directory and returns matching JavaScript

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -214,9 +214,7 @@ describe('lb4 controller', () => {
             }),
           )
           .withPrompts(restCLIInputComplete),
-      ).to.be.rejectedWith(
-        /ENOENT: no such file or directory, scandir(.*?)models\b/,
-      );
+      ).to.be.rejectedWith(/No models found in .*[\/\\]models\b/);
     });
 
     it('fails when no repository directory present', () => {
@@ -230,9 +228,7 @@ describe('lb4 controller', () => {
             }),
           )
           .withPrompts(restCLIInputComplete),
-      ).to.be.rejectedWith(
-        /ENOENT: no such file or directory, scandir(.*?)repositories\b/,
-      );
+      ).to.be.rejectedWith(/No repositories found in .*[\/\\]repositories\b/);
     });
   });
 });

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -10,6 +10,7 @@ const path = require('path');
 const assert = require('yeoman-assert');
 const {expect, TestSandbox} = require('@loopback/testlab');
 const {expectFileToMatchSnapshot} = require('../../snapshots');
+const {remove} = require('fs-extra');
 
 const generator = path.join(__dirname, '../../../generators/model');
 const tests = require('../lib/artifact-generator')(generator);
@@ -110,6 +111,21 @@ describe('lb4 model integration', () => {
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .withPrompts({
+          name: 'test',
+          propName: null,
+        });
+
+      basicModelFileChecks(expectedModelFile, expectedIndexFile);
+    });
+
+    it('creates "src/models" directory if it does not exist', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, async () => {
+          testUtils.givenLBProject(SANDBOX_PATH);
+          await remove(path.resolve(SANDBOX_PATH, 'src/models'));
+        })
         .withPrompts({
           name: 'test',
           propName: null,


### PR DESCRIPTION
When creating a new artifact (e.g. Model or Repository) while the target directory does not exist yet (e.g. `src/models` or `src/repositories`), we used to abort CLI with a ENOENT error.

This commit is fixing our CLI to treat the missing directory as if it was empty and continue the operation if possible.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
