### PR TITLE
feat(cli): update controller template to enable filter for findById endpoint

### DIFF
--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -202,12 +202,19 @@ export class TodoController {
     responses: {
       '200': {
         description: 'Todo model instance',
-        content: {'application/json': {schema: getModelSchemaRef(Todo)}},
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Todo, {includeRelations: true}),
+          },
+        },
       },
     },
   })
-  async findById(@param.path.number('id') id: number): Promise<Todo> {
-    return this.todoRepository.findById(id);
+  async findById(
+    @param.path.number('id') id: number,
+    @param.query.object('filter', getFilterSchemaFor(Todo)) filter?: Filter<Todo>
+  ): Promise<Todo> {
+    return this.todoRepository.findById(id, filter);
   }
 
   @patch('/todos/{id}', {

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -231,14 +231,24 @@ from the path object.
   responses: {
     '200': {
       description: 'Note model instance',
-      content: {'application/json': {schema: getModelSchemaRef(Note)}},
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Note, {includeRelations: true}),
+        },
+      },
     },
   },
 })
-async findById(@param.path.string('id') id: string): Promise<Note> {
-  return this.noteRepository.findById(id);
+async findById(
+  @param.path.string('id') id: string,
+  @param.query.object('filter', getFilterSchemaFor(Note)) filter?: Filter<Note>
+): Promise<Note> {
+  return this.noteRepository.findById(id, filter);
 }
 ```
+
+(Notice: the filter for `findById()` method only supports the `include` clause
+for now.)
 
 You can also specify a parameter which is an object value encoded as a JSON
 string or in multiple nested keys. For a JSON string, a sample value would be
@@ -378,7 +388,7 @@ details.
   ```
 
 During development and testing, it may be useful to see all error details in the
-HTTP responsed returned by the server. This behavior can be enabled by enabling
+HTTP response returned by the server. This behavior can be enabled by enabling
 the `debug` flag in error-handler configuration as shown in the code example
 below. See strong-error-handler
 [docs](https://github.com/strongloop/strong-error-handler#options) for a list of

--- a/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-rest-template.ts.ejs
@@ -70,7 +70,10 @@ export class <%= className %>Controller {
         description: 'Array of <%= modelName %> model instances',
         content: {
           'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(<%= modelName %>)},
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(<%= modelName %>, {includeRelations: true}),
+            },
           },
         },
       },
@@ -108,12 +111,19 @@ export class <%= className %>Controller {
     responses: {
       '200': {
         description: '<%= modelName %> model instance',
-        content: {'application/json': {schema: getModelSchemaRef(<%= modelName %>)}},
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(<%= modelName %>, {includeRelations: true}),
+          },
+        },
       },
     },
   })
-  async findById(@param.path.<%= idType %>('id') id: <%= idType %>): Promise<<%= modelName %>> {
-    return this.<%= repositoryNameCamel %>.findById(id);
+  async findById(
+    @param.path.<%= idType %>('id') id: <%= idType %>,
+    @param.query.object('filter', getFilterSchemaFor(<%= modelName %>)) filter?: Filter<<%= modelName %>>
+  ): Promise<<%= modelName %>> {
+    return this.<%= repositoryNameCamel %>.findById(id, filter);
   }
 
   @patch('<%= httpPathName %>/{id}', {

--- a/packages/cli/snapshots/integration/generators/controller.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/controller.integration.snapshots.js
@@ -80,7 +80,10 @@ export class ProductReviewController {
         description: 'Array of ProductReview model instances',
         content: {
           'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(ProductReview)},
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(ProductReview, {includeRelations: true}),
+            },
           },
         },
       },
@@ -118,12 +121,19 @@ export class ProductReviewController {
     responses: {
       '200': {
         description: 'ProductReview model instance',
-        content: {'application/json': {schema: getModelSchemaRef(ProductReview)}},
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(ProductReview, {includeRelations: true}),
+          },
+        },
       },
     },
   })
-  async findById(@param.path.number('id') id: number): Promise<ProductReview> {
-    return this.barRepository.findById(id);
+  async findById(
+    @param.path.number('id') id: number,
+    @param.query.object('filter', getFilterSchemaFor(ProductReview)) filter?: Filter<ProductReview>
+  ): Promise<ProductReview> {
+    return this.barRepository.findById(id, filter);
   }
 
   @patch('/product-reviews/{id}', {
@@ -249,7 +259,10 @@ export class ProductReviewController {
         description: 'Array of ProductReview model instances',
         content: {
           'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(ProductReview)},
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(ProductReview, {includeRelations: true}),
+            },
           },
         },
       },
@@ -287,12 +300,19 @@ export class ProductReviewController {
     responses: {
       '200': {
         description: 'ProductReview model instance',
-        content: {'application/json': {schema: getModelSchemaRef(ProductReview)}},
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(ProductReview, {includeRelations: true}),
+          },
+        },
       },
     },
   })
-  async findById(@param.path.number('id') id: number): Promise<ProductReview> {
-    return this.barRepository.findById(id);
+  async findById(
+    @param.path.number('id') id: number,
+    @param.query.object('filter', getFilterSchemaFor(ProductReview)) filter?: Filter<ProductReview>
+  ): Promise<ProductReview> {
+    return this.barRepository.findById(id, filter);
   }
 
   @patch('/product-reviews/{id}', {


### PR DESCRIPTION
As LB4 supports inclusion, I think it's fair to allow users to traverse related models with `findById()` endpoint with CLI generated controllers.

Also, the [todoList example](https://github.com/strongloop/loopback-next/blob/master/examples/todo-list/src/controllers/todo-list.controller.ts#L129) enables such filters. I think they should be consistent as we have a note in [the site](https://loopback.io/doc/en/lb4/todo-list-tutorial.html):
```
This page was generated from the loopback-next/examples/todo-list/README.md
``` 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
