### PR TITLE
feat(docs): add 2020Q1 roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,6 +31,13 @@
 - Spike on getting APIs created from LB4 imported into APIC,
   https://github.com/strongloop/loopback-next/issues/4115
 
+#### Create models & REST APIs dynamically at runtime
+
+- Dynamic binding/rebinding of controllers after app start #433
+- How to build models, repositories and controllers dynamically at runtime #4296
+- Docs for exposing REST API of a Model with no custom classes #2740 (stretch
+  goal)
+
 #### Open Issues with `bug` or `developer experience` labels
 
 - Would like to put more time in tackling those. Will plan it as part of the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,3 +1,59 @@
+## Q1 2020 Roadmap
+
+### Overview
+
+- Migration: it will continue to be our focus, including filling up the details
+  to the migration guide and adding tooling to make migration easier.
+- Tackle issues labelled as `bug` or `developer experience`
+- Issue cleanup: take some time to triage open issues and possibly some smaller
+  enhancements that we never get the time to do.
+
+### Scope
+
+#### Migration
+
+- Migration guide https://github.com/strongloop/loopback-next/issues/453
+  - continue the work in Q4 2019 for migrating:
+    - boot scripts
+    - model mixins
+    - remoting hooks
+- Tooling:
+  - improve existing commands like `import-lb3-models`
+  - add new commands (e.g. import datasources).
+
+#### Authentication
+
+- Auth0 example: Create a more realistic example than
+  https://github.com/raymondfeng/loopback4-example-auth0.
+
+#### API Connect / LoopBack 4 Integration
+
+- Spike on getting APIs created from LB4 imported into APIC,
+  https://github.com/strongloop/loopback-next/issues/4115
+
+#### Open Issues with `bug` or `developer experience` labels
+
+- Would like to put more time in tackling those. Will plan it as part of the
+  monthly milestone planning.
+
+### Stretch Goals
+
+#### From model definition to REST API with no custom repository/controller classes https://github.com/strongloop/loopback-next/issues/2036
+
+- Add CrudRestApiBuilder to @loopback/rest-crud #3737
+- Example app showing CrudRestApiBuilder #3738
+
+#### Robust handling of ObjectID type for MongoDB https://github.com/strongloop/loopback-next/issues/3720
+
+- Spike: robust handling of ObjectID type for MongoDB,
+  https://github.com/strongloop/loopback-next/issues/3456
+
+#### Shopping example app
+
+- clean up authentication and authorization
+
+---
+
 ## Q4 2019 Roadmap
 
 ### Overview


### PR DESCRIPTION
Based on our initial discussion in https://ibm.ent.box.com/notes/556759029402, I'm creating this PR to capture the 2020 Q1 roadmap.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
