### PR TITLE
feat(context): allow current binding to be injected with `@inject.binding`

### DIFF
--- a/docs/site/decorators/Decorators_inject.md
+++ b/docs/site/decorators/Decorators_inject.md
@@ -204,6 +204,20 @@ export class HelloController {
 }
 ```
 
+If the `bindingKey` is not specified, the current binding from the resolution
+session is injected.
+
+```ts
+export class HelloController {
+  @inject.binding() private myBinding: Binding<string>;
+
+  @get('/hello')
+  async greet() {
+    return `Hello from ${this.myBinding.key}`;
+  }
+}
+```
+
 The `@inject.binding` takes an optional `metadata` object which can contain
 `bindingCreation` to control how underlying binding is resolved or created based
 on the following values:

--- a/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
@@ -352,6 +352,16 @@ describe('Context bindings - Injecting dependencies of classes', () => {
       expect(ctx.getSync(HASH_KEY)).to.equal('a-value');
     });
 
+    it('throws error if binding key is empty', async () => {
+      class InvalidStore {
+        constructor(@inject.setter('') public setter: Setter<string>) {}
+      }
+      ctx.bind(STORE_KEY).toClass(InvalidStore);
+      return expect(ctx.get<InvalidStore>(STORE_KEY)).to.be.rejectedWith(
+        /Binding key is not set for @inject\.setter/,
+      );
+    });
+
     it('injects a setter function that uses an existing binding', () => {
       // Create a binding for hash key
       ctx
@@ -561,6 +571,18 @@ describe('Context bindings - Injecting dependencies of classes', () => {
         }
         return StoreWithInjectBindingMetadata;
       }
+    });
+  });
+
+  describe('@inject.binding without binding key', () => {
+    class Store {
+      constructor(@inject.binding() public binding: Binding<string>) {}
+    }
+
+    it('injects a binding', () => {
+      ctx.bind(STORE_KEY).toClass(Store);
+      const store = ctx.getSync<Store>(STORE_KEY);
+      expect(store.binding).to.equal(ctx.getBinding(STORE_KEY));
     });
   });
 


### PR DESCRIPTION
This minor improvement allows a class or provider to receive its own binding information.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
