### PR TITLE
feat: spike on API Explorer supporting complex objects in query param

### DIFF
--- a/examples/todo-list/src/__tests__/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list.acceptance.ts
@@ -204,6 +204,17 @@ describe('TodoListApplication', () => {
     });
   });
 
+  it('exploded filter conditions work', async () => {
+    const list = await givenTodoListInstance(todoListRepo);
+    await givenTodoInstance(todoRepo, {title: 'todo1', todoListId: list.id});
+    await givenTodoInstance(todoRepo, {title: 'todo2', todoListId: list.id});
+    await givenTodoInstance(todoRepo, {title: 'todo3', todoListId: list.id});
+
+    const response = await client.get('/todos').query('filter[limit]=2');
+
+    expect(response.body).to.have.length(2);
+  });
+
   /*
    ============================================================================
    TEST HELPERS

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
@@ -235,6 +235,11 @@ describe('Routing metadata for parameters', () => {
           type: 'object',
           additionalProperties: true,
         },
+        content: {
+          'application/json': {
+            schema: {type: 'object', additionalProperties: true},
+          },
+        },
       };
       expectSpecToBeEqual(MyController, expectedParamSpec);
     });
@@ -258,6 +263,17 @@ describe('Routing metadata for parameters', () => {
         in: 'query',
         style: 'deepObject',
         explode: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                where: {type: 'object', additionalProperties: true},
+                limit: {type: 'number'},
+              },
+            },
+          },
+        },
         schema: {
           type: 'object',
           properties: {
@@ -305,6 +321,11 @@ describe('Routing metadata for parameters', () => {
       schema: {
         type: 'object',
         additionalProperties: true,
+      },
+      content: {
+        'application/json': {
+          schema: {type: 'object', additionalProperties: true},
+        },
       },
     };
     expectSpecToBeEqual(MyController, expectedParamSpec);

--- a/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/param/param-query.decorator.unit.ts
@@ -229,12 +229,6 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec = <ParameterObject>{
         name: 'filter',
         in: 'query',
-        style: 'deepObject',
-        explode: true,
-        schema: {
-          type: 'object',
-          additionalProperties: true,
-        },
         content: {
           'application/json': {
             schema: {type: 'object', additionalProperties: true},
@@ -261,8 +255,6 @@ describe('Routing metadata for parameters', () => {
       const expectedParamSpec: ParameterObject = {
         name: 'filter',
         in: 'query',
-        style: 'deepObject',
-        explode: true,
         content: {
           'application/json': {
             schema: {
@@ -272,13 +264,6 @@ describe('Routing metadata for parameters', () => {
                 limit: {type: 'number'},
               },
             },
-          },
-        },
-        schema: {
-          type: 'object',
-          properties: {
-            where: {type: 'object', additionalProperties: true},
-            limit: {type: 'number'},
           },
         },
       };
@@ -316,12 +301,6 @@ describe('Routing metadata for parameters', () => {
       name: 'filter',
       in: 'query',
       description: 'Search criteria',
-      style: 'deepObject',
-      explode: true,
-      schema: {
-        type: 'object',
-        additionalProperties: true,
-      },
       content: {
         'application/json': {
           schema: {type: 'object', additionalProperties: true},

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -214,6 +214,11 @@ export namespace param {
         in: 'query',
         style: 'deepObject',
         explode: true,
+        content: {
+          'application/json': {
+            schema,
+          },
+        },
         schema,
         ...spec,
       });

--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -50,8 +50,11 @@ export function param(paramSpec: ParameterObject) {
         // generate schema if `paramSpec` has `schema` but without `type`
         (isSchemaObject(paramSpec.schema) && !paramSpec.schema.type)
       ) {
-        // please note `resolveSchema` only adds `type` and `format` for `schema`
-        paramSpec.schema = resolveSchema(paramType, paramSpec.schema);
+        // If content explicitly mentioned do not resolve schema
+        if (!paramSpec.content) {
+          // please note `resolveSchema` only adds `type` and `format` for `schema`
+          paramSpec.schema = resolveSchema(paramType, paramSpec.schema);
+        }
       }
     }
 
@@ -212,14 +215,11 @@ export namespace param {
       return param({
         name,
         in: 'query',
-        style: 'deepObject',
-        explode: true,
         content: {
           'application/json': {
             schema,
           },
         },
-        schema,
         ...spec,
       });
     },

--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -32,7 +32,14 @@ export function coerceParameter(
   data: string | undefined | object,
   spec: ParameterObject,
 ) {
+  if (!spec.schema && spec.content) {
+    const content = spec.content;
+    const jsonSpec = content['application/json'];
+    spec.schema = jsonSpec.schema;
+  }
+
   const schema = spec.schema;
+
   if (!schema || isReferenceObject(schema)) {
     debug(
       'The parameter with schema %s is not coerced since schema' +
@@ -172,7 +179,7 @@ function parseJsonIfNeeded(
 ): string | object | undefined {
   if (typeof data !== 'string') return data;
 
-  if (spec.in !== 'query' || spec.style !== 'deepObject') {
+  if (spec.in !== 'query' || (spec.style !== 'deepObject' && !spec.content)) {
     debug(
       'Skipping JSON.parse, argument %s is not in:query style:deepObject',
       spec.name,


### PR DESCRIPTION
https://github.com/strongloop/loopback-next/issues/3770

## Scope:  
Currently loopback supports both exploded and uri encoded complex objects in query params, even without the changes suggested in this PR. The purpose of this PR is to ONLY fix API Explorer to support complex objects in query params.


To test this spike, 
1. Install an example app (eg: todoList)
2. change the param decorators for the filter query in a controller method to @param.query.jsonObject
3. run npm build and copy the installed example app into this PR branch -> loopback-next/sandbox directory
4. run npm i under loopback-next , to create symlinks 
5. cd sandbox/loopback4-example-todoList && npm run start
6. goto API Explorer http://localhost:3000/explorer
7. check invoking controller method that has @param.query.jsonObject works when a filter object is passed