### PR TITLE
fix(cli): updated OAS 'date' type mapping to JS 'string'

### DIFF
--- a/packages/cli/generators/openapi/schema-helper.js
+++ b/packages/cli/generators/openapi/schema-helper.js
@@ -244,6 +244,8 @@ function mapPrimitiveType(schema, options) {
     case 'string':
       switch (schema.format) {
         case 'date':
+          jsType = 'string';
+          break;
         case 'date-time':
           jsType = 'Date';
           break;

--- a/packages/cli/test/unit/openapi/schema-helper.unit.js
+++ b/packages/cli/test/unit/openapi/schema-helper.unit.js
@@ -41,11 +41,11 @@ describe('primitive types', () => {
   });
 
   it('maps date', () => {
-    expectMapping({type: 'string', format: 'date'}, 'Date');
+    expectMapping({type: 'string', format: 'date'}, 'string');
   });
 
   it('maps date-time', () => {
-    expectMapping({type: 'string', format: 'date'}, 'Date');
+    expectMapping({type: 'string', format: 'date-time'}, 'Date');
   });
 
   it('maps password', () => {


### PR DESCRIPTION
Fixes #4085

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
