### PR TITLE
fix(cli): emit correct property definitions for built-in types in discovered models

### DIFF
--- a/packages/cli/generators/discover/import-discovered-model.js
+++ b/packages/cli/generators/discover/import-discovered-model.js
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const {pascalCase, stringifyModelSettings} = require('../../lib/utils');
+const {sanitizeProperty} = require('../../lib/model-discoverer');
+
+module.exports = {
+  importDiscoveredModel,
+};
+
+/**
+ * Convert model definition created by loopback-datasource-juggler discovery
+ * into template data used by LB4 model generator.
+ *
+ * @param {object} discoveredDefinition Model definition as discovered from DB
+ * @returns {object} Template data for model source file template
+ */
+function importDiscoveredModel(discoveredDefinition) {
+  const modelName = discoveredDefinition.name;
+  const templateData = {
+    name: modelName,
+    className: pascalCase(modelName),
+    modelBaseClass: 'Entity',
+    isModelBaseBuiltin: true,
+    settings: importModelSettings(discoveredDefinition.settings),
+    properties: importModelProperties(discoveredDefinition.properties),
+    allowAdditionalProperties: true,
+  };
+
+  templateData.modelSettings = stringifyModelSettings(templateData.settings);
+
+  return templateData;
+}
+
+function importModelSettings(discoveredSettings = {}) {
+  // Currently a no-op, we may want to apply transformation in the future
+  // See migrateModelSettings in ../import-lb3-models/migrate-model.js
+  return {
+    // Shallow-clone to avoid accidental modification of input data
+    ...discoveredSettings,
+  };
+}
+
+function importModelProperties(discoveredProps) {
+  const templateData = {};
+  for (const prop in discoveredProps) {
+    templateData[prop] = importPropertyDefinition(discoveredProps[prop]);
+  }
+  return templateData;
+}
+
+function importPropertyDefinition(discoveredDefinition) {
+  const templateData = {...discoveredDefinition};
+  // TODO: handle String->string typename conversion, etc.
+  sanitizeProperty(templateData);
+  return templateData;
+}

--- a/packages/cli/generators/discover/import-discovered-model.js
+++ b/packages/cli/generators/discover/import-discovered-model.js
@@ -7,6 +7,10 @@
 
 const {pascalCase, stringifyModelSettings} = require('../../lib/utils');
 const {sanitizeProperty} = require('../../lib/model-discoverer');
+const {
+  createPropertyTemplateData,
+  findBuiltinType,
+} = require('../model/property-definition');
 
 module.exports = {
   importDiscoveredModel,
@@ -54,8 +58,13 @@ function importModelProperties(discoveredProps) {
 }
 
 function importPropertyDefinition(discoveredDefinition) {
-  const templateData = {...discoveredDefinition};
-  // TODO: handle String->string typename conversion, etc.
-  sanitizeProperty(templateData);
-  return templateData;
+  const propDef = {
+    ...discoveredDefinition,
+  };
+
+  const builtinType = findBuiltinType(propDef.type);
+  if (builtinType) propDef.type = builtinType;
+
+  sanitizeProperty(propDef);
+  return createPropertyTemplateData(propDef);
 }

--- a/packages/cli/generators/import-lb3-models/migrate-model.js
+++ b/packages/cli/generators/import-lb3-models/migrate-model.js
@@ -14,7 +14,7 @@ const {
 const {sanitizeProperty} = require('../../lib/model-discoverer');
 const {
   createPropertyTemplateData,
-  BUILTIN_TYPES,
+  findBuiltinType,
 } = require('../model/property-definition');
 const chalk = require('chalk');
 
@@ -109,7 +109,7 @@ function migratePropertyType(typeDef) {
     typeDef = typeDef.name.toString();
   }
 
-  const builtin = BUILTIN_TYPES.find(t => t === typeDef.toLowerCase());
+  const builtin = findBuiltinType(typeDef);
   if (builtin) typeDef = builtin;
 
   // TODO: handle anonymous object types (nested properties)

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -161,6 +161,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
         views: true,
       },
     );
+    await this.artifactInfo.dataSource.disconnect();
 
     if (!schemaDef) {
       this.exit(

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -14,7 +14,10 @@ const utils = require('../../lib/utils');
 const chalk = require('chalk');
 const path = require('path');
 
-const {createPropertyTemplateData} = require('./property-definition');
+const {
+  createPropertyTemplateData,
+  findBuiltinType,
+} = require('./property-definition');
 
 const PROMPT_BASE_MODEL_CLASS = 'Please select the model base class';
 const ERROR_NO_MODELS_FOUND = 'Model was not found in';
@@ -466,9 +469,11 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
     debug('scaffolding');
 
-    Object.entries(this.artifactInfo.properties).forEach(([k, v]) =>
-      modelDiscoverer.sanitizeProperty(v),
-    );
+    Object.entries(this.artifactInfo.properties).forEach(([k, v]) => {
+      const builtinType = findBuiltinType(v.type);
+      if (builtinType) v.type = builtinType;
+      modelDiscoverer.sanitizeProperty(v);
+    });
 
     // Data for templates
     this.artifactInfo.outFile = utils.getModelFileName(this.artifactInfo.name);

--- a/packages/cli/generators/model/property-definition.js
+++ b/packages/cli/generators/model/property-definition.js
@@ -11,6 +11,7 @@ const BUILTIN_TYPES = [...TS_TYPES, ...NON_TS_TYPES];
 
 module.exports = {
   createPropertyTemplateData,
+  findBuiltinType,
   BUILTIN_TYPES,
 };
 
@@ -70,4 +71,15 @@ function createPropertyTemplateData(val) {
   }
 
   return val;
+}
+
+/**
+ * Check if the type is a built-in type, return the canonical type name in
+ * such case (e.g. convert 'String' to 'string').
+ *
+ * @param {string} typeName Property type name, e.g. 'String' or 'Address'
+ * @returns {string|undefined}  Built-in type name (e.g. 'string') or undefined
+ */
+function findBuiltinType(typeName) {
+  return BUILTIN_TYPES.find(t => t === typeName.toLowerCase());
 }

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -1,0 +1,114 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`lb4 discover integration model discovery generates all models without prompts using --all --dataSource 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Schema extends Entity {
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Schema>) {
+    super(data);
+  }
+}
+
+export interface SchemaRelations {
+  // describe navigational properties here
+}
+
+export type SchemaWithRelations = Schema & SchemaRelations;
+
+`;
+
+
+exports[`lb4 discover integration model discovery generates all models without prompts using --all --dataSource 2`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class View extends Entity {
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<View>) {
+    super(data);
+  }
+}
+
+export interface ViewRelations {
+  // describe navigational properties here
+}
+
+export type ViewWithRelations = View & ViewRelations;
+
+`;
+
+
+exports[`lb4 discover integration model discovery uses a different --outDir if provided 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Test extends Entity {
+  @property({
+    type: Date,
+    required: false,
+  })
+  dateTest?: Date;
+
+  @property({
+    type: Number,
+    required: false,
+  })
+  numberTest?: Number;
+
+  @property({
+    type: String,
+    required: false,
+  })
+  stringTest?: String;
+
+  @property({
+    type: Boolean,
+    required: false,
+  })
+  booleanText?: Boolean;
+
+  @property({
+    type: Number,
+    required: true,
+    scale: 0,
+    id: 1,
+  })
+  id: Number;
+
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Test>) {
+    super(data);
+  }
+}
+
+export interface TestRelations {
+  // describe navigational properties here
+}
+
+export type TestWithRelations = Test & TestRelations;
+
+`;

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -63,36 +63,32 @@ import {Entity, model, property} from '@loopback/repository';
 @model()
 export class Test extends Entity {
   @property({
-    type: Date,
-    required: false,
+    type: 'date',
   })
-  dateTest?: Date;
+  dateTest?: string;
 
   @property({
-    type: Number,
-    required: false,
+    type: 'number',
   })
-  numberTest?: Number;
+  numberTest?: number;
 
   @property({
-    type: String,
-    required: false,
+    type: 'string',
   })
-  stringTest?: String;
+  stringTest?: string;
 
   @property({
-    type: Boolean,
-    required: false,
+    type: 'boolean',
   })
-  booleanText?: Boolean;
+  booleanText?: boolean;
 
   @property({
-    type: Number,
+    type: 'number',
     required: true,
     scale: 0,
     id: 1,
   })
-  id: Number;
+  id: number;
 
   // Define well-known properties here
 

--- a/packages/cli/snapshots/integration/generators/model.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/model.integration.snapshots.js
@@ -1,0 +1,55 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`lb4 model integration discovers a model from a datasource 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Test extends Entity {
+  @property({
+    type: 'Date',
+  })
+  dateTest?: Date;
+
+  @property({
+    type: 'Number',
+  })
+  numberTest?: Number;
+
+  @property({
+    type: 'String',
+  })
+  stringTest?: String;
+
+  @property({
+    type: 'Boolean',
+  })
+  booleanText?: Boolean;
+
+  @property({
+    type: 'Number',
+    required: true,
+    scale: 0,
+    id: 1,
+  })
+  id: Number;
+
+
+  constructor(data?: Partial<Test>) {
+    super(data);
+  }
+}
+
+export interface TestRelations {
+  // describe navigational properties here
+}
+
+export type TestWithRelations = Test & TestRelations;
+
+`;

--- a/packages/cli/snapshots/integration/generators/model.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/model.integration.snapshots.js
@@ -13,32 +13,32 @@ import {Entity, model, property} from '@loopback/repository';
 @model()
 export class Test extends Entity {
   @property({
-    type: 'Date',
+    type: 'date',
   })
-  dateTest?: Date;
+  dateTest?: string;
 
   @property({
-    type: 'Number',
+    type: 'number',
   })
-  numberTest?: Number;
+  numberTest?: number;
 
   @property({
-    type: 'String',
+    type: 'string',
   })
-  stringTest?: String;
+  stringTest?: string;
 
   @property({
-    type: 'Boolean',
+    type: 'boolean',
   })
-  booleanText?: Boolean;
+  booleanText?: boolean;
 
   @property({
-    type: 'Number',
+    type: 'number',
     required: true,
     scale: 0,
     id: 1,
   })
-  id: Number;
+  id: number;
 
 
   constructor(data?: Partial<Test>) {

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -8,9 +8,8 @@
 // Imports
 const path = require('path');
 const assert = require('yeoman-assert');
-const testlab = require('@loopback/testlab');
-
-const {expect, TestSandbox} = testlab;
+const {expect, TestSandbox} = require('@loopback/testlab');
+const {expectFileToMatchSnapshot} = require('../../snapshots');
 
 const generator = path.join(__dirname, '../../../generators/discover');
 require('../lib/artifact-generator')(generator);
@@ -65,10 +64,10 @@ describe('generator-loopback4:discover', tests);*/
 
 describe('lb4 discover integration', () => {
   describe('model discovery', () => {
-    beforeEach('creates dist/datasources', async () => {
+    beforeEach('reset sandbox', async () => {
+      await sandbox.reset();
       await sandbox.mkdir('dist/datasources');
     });
-    beforeEach('reset sandbox', () => sandbox.reset());
 
     it('generates all models without prompts using --all --dataSource', async function() {
       // eslint-disable-next-line no-invalid-this
@@ -83,9 +82,10 @@ describe('lb4 discover integration', () => {
         .withOptions(baseOptions);
 
       basicModelFileChecks(defaultExpectedTestModel, defaultExpectedIndexFile);
-      assert.file(defaultExpectedSchemaModel);
-      assert.file(defaultExpectedViewModel);
+      expectFileToMatchSnapshot(defaultExpectedSchemaModel);
+      expectFileToMatchSnapshot(defaultExpectedViewModel);
     });
+
     it('uses a different --outDir if provided', async () => {
       await testUtils
         .executeGenerator(generator)
@@ -97,7 +97,9 @@ describe('lb4 discover integration', () => {
         .withOptions(outDirOptions);
 
       basicModelFileChecks(movedExpectedTestModel, movedExpectedIndexFile);
+      expectFileToMatchSnapshot(movedExpectedTestModel);
     });
+
     it('excludes models based on the --views and --schema options', async () => {
       await testUtils
         .executeGenerator(generator)
@@ -112,6 +114,7 @@ describe('lb4 discover integration', () => {
       assert.noFile(defaultExpectedTestModel);
       assert.file(defaultExpectedSchemaModel);
     });
+
     it('will fail gracefully if you specify a --dataSource which does not exist', async () => {
       return expect(
         testUtils

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -17,6 +17,13 @@ require('../lib/base-generator')(generator);
 const testUtils = require('../../test-utils');
 const basicModelFileChecks = require('../lib/file-check').basicModelFileChecks;
 
+// In this test suite we invoke the full generator with mocked prompts
+// and inspect the generated model file(s).
+// Such tests are slow to run, we strive to keep only few of them.
+// Use unit tests to verify the conversion from discovered model schema
+// to LB4 model template data, see
+// tests/unit/discovery/import-discovered-model.test.ts
+
 // Test Sandbox
 const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
 const SANDBOX_FILES = require('../../fixtures/discover').SANDBOX_FILES;

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -8,10 +8,8 @@
 // Imports
 const path = require('path');
 const assert = require('yeoman-assert');
-const testlab = require('@loopback/testlab');
-
-const expect = testlab.expect;
-const TestSandbox = testlab.TestSandbox;
+const {expect, TestSandbox} = require('@loopback/testlab');
+const {expectFileToMatchSnapshot} = require('../../snapshots');
 
 const generator = path.join(__dirname, '../../../generators/model');
 const tests = require('../lib/artifact-generator')(generator);
@@ -82,7 +80,7 @@ describe('lb4 model integration', () => {
     assert.file(expectedModelFile);
   });
 
-  it('will discover a model through a datasource', async () => {
+  it('discovers a model from a datasource', async () => {
     await testUtils
       .executeGenerator(generator)
       .inDir(SANDBOX_PATH, () =>
@@ -91,8 +89,9 @@ describe('lb4 model integration', () => {
         }),
       )
       .withArguments('--dataSource mem --table Test');
-    assert.file(expectedModelFile);
+    expectFileToMatchSnapshot(expectedModelFile);
   });
+
   it('will fail gracefully if datasource discovery does not find the model ', async () => {
     return expect(
       testUtils

--- a/packages/cli/test/unit/discover/import-discovered-model.test.js
+++ b/packages/cli/test/unit/discover/import-discovered-model.test.js
@@ -1,0 +1,154 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const {expect} = require('@loopback/testlab');
+const {
+  importDiscoveredModel,
+} = require('../../../generators/discover/import-discovered-model');
+
+describe('importDiscoveredModel', () => {
+  it('imports empty schema', () => {
+    const modelData = importDiscoveredModel({
+      name: 'Schema',
+      schema: 'aSchema',
+      properties: {},
+    });
+    expect(modelData).to.deepEqual({
+      name: 'Schema',
+      className: 'Schema',
+      modelBaseClass: 'Entity',
+      isModelBaseBuiltin: true,
+
+      settings: {},
+      modelSettings: '',
+
+      properties: {},
+      allowAdditionalProperties: true,
+    });
+  });
+
+  it('imports Date properties', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        createdAt: {
+          type: 'Date',
+          required: false,
+          length: null,
+          precision: null,
+          scale: null,
+        },
+      },
+    };
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties)
+      .to.have.property('createdAt')
+      .deepEqual({
+        type: 'Date',
+        tsType: 'Date',
+        required: false,
+      });
+  });
+
+  it('imports Number properties', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        counter: {
+          type: 'Number',
+          required: false,
+          length: null,
+          precision: null,
+          scale: null,
+        },
+      },
+    };
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties)
+      .to.have.property('counter')
+      .deepEqual({
+        type: 'Number',
+        tsType: 'Number',
+        required: false,
+      });
+  });
+
+  it('imports String properties', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        title: {
+          type: 'String',
+          required: false,
+          length: null,
+          precision: null,
+          scale: null,
+        },
+      },
+    };
+
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties)
+      .to.have.property('title')
+      .deepEqual({
+        type: 'String',
+        tsType: 'String',
+        required: false,
+      });
+  });
+
+  it('imports Boolean properties', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        active: {
+          type: 'Boolean',
+          required: false,
+          length: null,
+          precision: null,
+          scale: null,
+        },
+      },
+    };
+
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties)
+      .to.have.property('active')
+      .deepEqual({
+        type: 'Boolean',
+        tsType: 'Boolean',
+        required: false,
+      });
+  });
+
+  it('imports numeric primary key', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        id: {
+          type: 'Number',
+          required: false,
+          length: null,
+          precision: null,
+          scale: 0,
+          id: 1,
+        },
+      },
+    };
+
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties)
+      .to.have.property('id')
+      .deepEqual({
+        type: 'Number',
+        tsType: 'Number',
+        required: false,
+        scale: 0,
+        id: 1,
+      });
+  });
+});

--- a/packages/cli/test/unit/discover/import-discovered-model.test.js
+++ b/packages/cli/test/unit/discover/import-discovered-model.test.js
@@ -48,9 +48,8 @@ describe('importDiscoveredModel', () => {
     expect(modelData.properties)
       .to.have.property('createdAt')
       .deepEqual({
-        type: 'Date',
-        tsType: 'Date',
-        required: false,
+        type: `'date'`,
+        tsType: 'string',
       });
   });
 
@@ -71,9 +70,8 @@ describe('importDiscoveredModel', () => {
     expect(modelData.properties)
       .to.have.property('counter')
       .deepEqual({
-        type: 'Number',
-        tsType: 'Number',
-        required: false,
+        type: `'number'`,
+        tsType: 'number',
       });
   });
 
@@ -83,7 +81,6 @@ describe('importDiscoveredModel', () => {
       properties: {
         title: {
           type: 'String',
-          required: false,
           length: null,
           precision: null,
           scale: null,
@@ -95,9 +92,8 @@ describe('importDiscoveredModel', () => {
     expect(modelData.properties)
       .to.have.property('title')
       .deepEqual({
-        type: 'String',
-        tsType: 'String',
-        required: false,
+        type: `'string'`,
+        tsType: 'string',
       });
   });
 
@@ -119,9 +115,8 @@ describe('importDiscoveredModel', () => {
     expect(modelData.properties)
       .to.have.property('active')
       .deepEqual({
-        type: 'Boolean',
-        tsType: 'Boolean',
-        required: false,
+        type: `'boolean'`,
+        tsType: 'boolean',
       });
   });
 
@@ -144,9 +139,8 @@ describe('importDiscoveredModel', () => {
     expect(modelData.properties)
       .to.have.property('id')
       .deepEqual({
-        type: 'Number',
-        tsType: 'Number',
-        required: false,
+        type: `'number'`,
+        tsType: 'number',
         scale: 0,
         id: 1,
       });


### PR DESCRIPTION
This pull request fixes model discovery to correctly handle built-in types and convert e.g. `type: String` to `type: 'string'`, see https://github.com/strongloop/loopback-next/issues/3806.

I split the change into several smaller commits:

1. Add snapshots to CLI tests to give us better understanding of what code we are actually scaffolding. This is also needed to have a test that demonstrates the problem!

2. Refactor the current implementation to make the fix easier: extract helper function converting discovered model to template data, extract `findBuiltintType` helper.

These first steps are not changing observable behavior. With the preparations done, we can make the fixes now.

3. Emit correct property definitions for built-in types from `lb4 discover`.

4. Disconnect the datasource after the model was discovered by `lb4 model`.

5. Emit correct property definitions for built-in types from `lb4 model`. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
