### PR TITLE
feat(repository): rejects create/update operations for navigational  properties

### DIFF
--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
@@ -187,9 +187,142 @@ export function hasManyInclusionResolverAcceptance(
       expect(toJSON(result)).to.deepEqual(toJSON(expected));
     });
 
-    it('throws when navigational properties are present when updating model instance', async () => {
-      const created = await customerRepo.create({name: 'customer'});
-      const customerId = created.id;
+    skipIf(
+      features.hasRevisionToken,
+      it,
+      'returns inclusions after running save() operation',
+      async () => {
+        // this shows save() works well with func ensurePersistable and ObjectId
+        // the test skips for Cloudant as it needs the _rev property for replacement.
+        // see replace-by-id.suite.ts
+        const thor = await customerRepo.create({name: 'Thor'});
+        const odin = await customerRepo.create({name: 'Odin'});
+
+        const thorOrder = await orderRepo.create({
+          customerId: thor.id,
+          description: 'Pizza',
+        });
+
+        const pizza = await orderRepo.findById(thorOrder.id);
+        pizza.customerId = odin.id;
+
+        await orderRepo.save(pizza);
+        const odinPizza = await orderRepo.findById(thorOrder.id);
+
+        const result = await customerRepo.findById(odin.id, {
+          include: [{relation: 'orders'}],
+        });
+        const expected = {
+          ...odin,
+          parentId: features.emptyValue,
+          orders: [
+            {
+              ...odinPizza,
+              isShipped: features.emptyValue,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              shipment_id: features.emptyValue,
+            },
+          ],
+        };
+        expect(toJSON(result)).to.containEql(toJSON(expected));
+      },
+    );
+
+    skipIf(
+      features.hasRevisionToken,
+      it,
+      'returns inclusions after running replaceById() operation',
+      async () => {
+        // this shows replaceById() works well with func ensurePersistable and ObjectId
+        // the test skips for Cloudant as it needs the _rev property for replacement.
+        // see replace-by-id.suite.ts
+        const thor = await customerRepo.create({name: 'Thor'});
+        const odin = await customerRepo.create({name: 'Odin'});
+
+        const thorOrder = await orderRepo.create({
+          customerId: thor.id,
+          description: 'Pizza',
+        });
+
+        const pizza = await orderRepo.findById(thorOrder.id.toString());
+        pizza.customerId = odin.id;
+        // FIXME: [mongo] if pizza obj is converted to JSON obj, it would get an error
+        // because it tries to convert ObjectId to string type.
+        // should test with JSON obj once it's fixed.
+
+        await orderRepo.replaceById(pizza.id, pizza);
+        const odinPizza = await orderRepo.findById(thorOrder.id);
+
+        const result = await customerRepo.find({
+          include: [{relation: 'orders'}],
+        });
+        const expected = [
+          {
+            ...thor,
+            parentId: features.emptyValue,
+          },
+          {
+            ...odin,
+            parentId: features.emptyValue,
+            orders: [
+              {
+                ...odinPizza,
+                isShipped: features.emptyValue,
+                // eslint-disable-next-line @typescript-eslint/camelcase
+                shipment_id: features.emptyValue,
+              },
+            ],
+          },
+        ];
+        expect(toJSON(result)).to.deepEqual(toJSON(expected));
+      },
+    );
+
+    it('returns inclusions after running updateById() operation', async () => {
+      const thor = await customerRepo.create({name: 'Thor'});
+      const odin = await customerRepo.create({name: 'Odin'});
+
+      const thorOrder = await orderRepo.create({
+        customerId: thor.id,
+        description: 'Pizza',
+      });
+
+      const pizza = await orderRepo.findById(thorOrder.id.toString());
+      pizza.customerId = odin.id;
+      const reheatedPizza = toJSON(pizza);
+
+      await orderRepo.updateById(pizza.id, reheatedPizza);
+      const odinPizza = await orderRepo.findById(thorOrder.id);
+
+      const result = await customerRepo.find({
+        include: [{relation: 'orders'}],
+      });
+      const expected = [
+        {
+          ...thor,
+          parentId: features.emptyValue,
+        },
+        {
+          ...odin,
+          parentId: features.emptyValue,
+          orders: [
+            {
+              ...odinPizza,
+              isShipped: features.emptyValue,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              shipment_id: features.emptyValue,
+            },
+          ],
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('throws when navigational properties are present when updating model instance with save()', async () => {
+      // save() calls replaceById so the result will be the same for replaceById
+      const customer = await customerRepo.create({name: 'customer'});
+      const anotherCus = await customerRepo.create({name: 'another customer'});
+      const customerId = customer.id;
 
       await orderRepo.create({
         description: 'pizza',
@@ -201,11 +334,19 @@ export function hasManyInclusionResolverAcceptance(
       });
       expect(found.orders).to.have.lengthOf(1);
 
+      const wrongOrder = await orderRepo.create({
+        description: 'wrong order',
+        customerId: anotherCus.id,
+      });
+
       found.name = 'updated name';
+      found.orders.push(wrongOrder);
+
       await expect(customerRepo.save(found)).to.be.rejectedWith(
-        'The `Customer` instance is not valid. Details: `orders` is not defined in the model (value: undefined).',
+        /Navigational properties are not allowed.*"orders"/,
       );
     });
+
     // scope for inclusion is not supported yet
     it('throws error if the inclusion query contains a non-empty scope', async () => {
       const customer = await customerRepo.create({name: 'customer'});

--- a/packages/repository-tests/src/crud/relations/acceptance/has-one.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-one.relation.acceptance.ts
@@ -49,6 +49,7 @@ export function hasOneRelationAcceptance(
     );
 
     beforeEach(async () => {
+      await customerRepo.deleteAll();
       await addressRepo.deleteAll();
       existingCustomerId = (await givenPersistedCustomerInstance()).id;
     });

--- a/packages/repository-tests/src/crud/relations/helpers.ts
+++ b/packages/repository-tests/src/crud/relations/helpers.ts
@@ -8,9 +8,11 @@ import {CrudFeatures, CrudRepositoryCtor} from '../..';
 import {
   Address,
   AddressRepository,
+  Customer,
   CustomerRepository,
   Order,
   OrderRepository,
+  Shipment,
   ShipmentRepository,
 } from './fixtures/models';
 import {
@@ -25,6 +27,10 @@ export function givenBoundCrudRepositories(
   repositoryClass: CrudRepositoryCtor,
   features: CrudFeatures,
 ) {
+  Order.definition.properties.id.type = features.idType;
+  Address.definition.properties.id.type = features.idType;
+  Customer.definition.properties.id.type = features.idType;
+  Shipment.definition.properties.id.type = features.idType;
   // when running the test suite on MongoDB, we don't really need to setup
   // this config for mongo connector to pass the test.
   // however real-world applications might have such config for MongoDB

--- a/packages/repository-tests/src/crud/replace-by-id.suite.ts
+++ b/packages/repository-tests/src/crud/replace-by-id.suite.ts
@@ -3,12 +3,17 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property} from '@loopback/repository';
-import {AnyObject, EntityCrudRepository} from '@loopback/repository';
+import {
+  AnyObject,
+  Entity,
+  EntityCrudRepository,
+  model,
+  property,
+} from '@loopback/repository';
 import {expect, toJSON} from '@loopback/testlab';
-import {MixedIdType} from '../helpers.repository-tests';
 import {
   deleteAllModelsInDefaultDataSource,
+  MixedIdType,
   withCrudCtx,
 } from '../helpers.repository-tests';
 import {
@@ -72,7 +77,6 @@ export function createSuiteForReplaceById(
       // This important! Not all databases allow `patchById` to set
       // properties to "undefined", `replaceById` must always work.
       created.description = undefined;
-
       await repo.replaceById(created.id, created);
 
       const found = await repo.findById(created.id);
@@ -112,7 +116,6 @@ export function createSuiteForReplaceById(
       // This important! Not all databases allow `patchById` to set
       // properties to "undefined", `replaceById` must always work.
       created.description = undefined;
-
       await repo.replaceById(created.id, created);
 
       const found = await repo.findById(created.id);


### PR DESCRIPTION
implements https://github.com/strongloop/loopback-next/issues/3439.

### **_please review it with "Hide whitespace changes"_**

Add two new protected methods:
`DefaultCrudRepository.ensurePersistable` and `DefaultCrudRepository.entityToData`.

This new function checks `create*(), update*(), save(), delete*(), and replaceById()` methods. Throws when the target data ( the one we are going to create, update) contains navigational properties: 
```
target data: {id: 1, name: 'cusotmer', orders: [{id: 1...}]}
```

- in the `ensurePersistable`, the `//FIXME` from @bajtos says mongoDB would break `replaceById` with ObjectID issue if we apply `ensurePersistable` to `replaceIdBy`. 
By debugging, I think it's caused by replacing the **id project** (`ObjectID` type) to a **string type id**. ~So in my proposal, I remove the id property from the target data for `replaceById` method in `ensurePersistable` since we don't need it anyway~.
I decide to open a follow up issue to handle the issue cause it relates to `dao.js` and `mongo.js` files, which is not a easy fix for me according to my knowledge of the code base :no_mouth:

- tests for create/update with nav properties are added to 
[`legacy-juggler-bridge.unit.ts`](https://github.com/strongloop/loopback-next/pull/4148/files?utf8=%E2%9C%93&diff=unified&w=1#diff-73f3835db4f07793d68c31ec97c55d19R507) (for basic functionality) and
 [`has-many.relation.acceptance.ts `](https://github.com/strongloop/loopback-next/pull/4148/files#diff-11ce87c51444cd7183f671fc75716321R177) ( against real DBs).
- tests for replacement(`save`, `replaceById`) are added to 
[`has-many-inclusion-resolver.relation.acceptance.ts`](https://github.com/strongloop/loopback-next/pull/4148/files#diff-cfaa21cba5e38026c57f793615b06846R190) to check if the new instance can be found with inclusion ( these tests are skip for **Cloudant** as it needs `_rev` token).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈

### Followups 
Commented the `objectId` issue in #3456 
Simplify fixtures and tests #4249
Enable replaceById + inclusion tests run on Cloudant https://github.com/strongloop/loopback-next/issues/4251
