### PR TITLE
feat(context): make it possible to set source information for interceptions

### DIFF
--- a/docs/site/Interceptors.md
+++ b/docs/site/Interceptors.md
@@ -586,6 +586,32 @@ The implementation of an interceptor can check `source` to decide if its logic
 should apply. For example, a global interceptor that provides caching for REST
 APIs should only run if the source is from a REST Route.
 
+A global interceptor can also be tagged with
+`ContextTags.GLOBAL_INTERCEPTOR_SOURCE` using a value of string or string array
+to indicate if it should be applied to source types of invocations. If the tag
+is not present, the interceptor applies to invocations of any source type. For
+example:
+
+```ts
+ctx
+  .bind('globalInterceptors.authInterceptor')
+  .to(authInterceptor)
+  .apply(asGlobalInterceptor('auth'))
+  // Do not apply for `proxy` source type
+  .tag({[ContextTags.GLOBAL_INTERCEPTOR_SOURCE]: 'route'});
+```
+
+The tag can also be declared for the provider class.
+
+```ts
+@globalInterceptor('log', {
+  tags: {[ContextTags.GLOBAL_INTERCEPTOR_SOURCE]: ['proxy']},
+})
+export class LogInterceptor implements Provider<Interceptor> {
+  // ...
+}
+```
+
 ### Logic around `next`
 
 An interceptor will receive the `next` parameter, which is a function to execute

--- a/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
@@ -11,6 +11,7 @@ import {
   inject,
   intercept,
   Interceptor,
+  ResolutionSession,
   ValueOrPromise,
 } from '../..';
 
@@ -156,8 +157,8 @@ describe('Interception proxy', () => {
     expect(msg).to.equal('Hello, JOHN');
     expect(events).to.eql([
       'convertName: before-greet',
-      'log: before-greet',
-      'log: after-greet',
+      'log: [my-controller] before-greet',
+      'log: [my-controller] after-greet',
       'convertName: after-greet',
     ]);
   });
@@ -198,8 +199,8 @@ describe('Interception proxy', () => {
     expect(msg).to.equal('Hello, JOHN');
     expect(events).to.eql([
       'convertName: before-greet',
-      'log: before-greet',
-      'log: after-greet',
+      'log: [dummy-controller --> my-controller] before-greet',
+      'log: [dummy-controller --> my-controller] after-greet',
       'convertName: after-greet',
     ]);
   });
@@ -207,9 +208,15 @@ describe('Interception proxy', () => {
   let events: string[];
 
   const log: Interceptor = async (invocationCtx, next) => {
-    events.push('log: before-' + invocationCtx.methodName);
+    let source: string;
+    if (invocationCtx.source instanceof ResolutionSession) {
+      source = `[${invocationCtx.source.getBindingPath()}] `;
+    } else {
+      source = invocationCtx.source ? `[${invocationCtx.source}] ` : '';
+    }
+    events.push(`log: ${source}before-${invocationCtx.methodName}`);
     const result = await next();
-    events.push('log: after-' + invocationCtx.methodName);
+    events.push(`log: ${source}after-${invocationCtx.methodName}`);
     return result;
   };
 

--- a/packages/context/src/__tests__/unit/resolution-session.unit.ts
+++ b/packages/context/src/__tests__/unit/resolution-session.unit.ts
@@ -78,6 +78,10 @@ describe('ResolutionSession', () => {
       'a --> @MyController.constructor[0] --> b',
     );
 
+    expect(session.toString()).to.eql(
+      'a --> @MyController.constructor[0] --> b',
+    );
+
     expect(session.popBinding()).to.be.exactly(bindingB);
     expect(session.popInjection()).to.be.exactly(injection);
     expect(session.popBinding()).to.be.exactly(bindingA);

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -532,7 +532,11 @@ export class Binding<T = BoundValue> {
     this._setValueGetter((ctx, options) => {
       const instOrPromise = instantiateClass(ctor, ctx, options.session);
       if (!options.asProxyWithInterceptors) return instOrPromise;
-      return createInterceptionProxyFromInstance(instOrPromise, ctx);
+      return createInterceptionProxyFromInstance(
+        instOrPromise,
+        ctx,
+        options.session,
+      );
     });
     this._valueConstructor = ctor;
     return this;
@@ -640,6 +644,7 @@ export class Binding<T = BoundValue> {
 function createInterceptionProxyFromInstance<T>(
   instOrPromise: ValueOrPromise<T>,
   context: Context,
+  session?: ResolutionSession,
 ) {
   return transformValueOrPromise(instOrPromise, inst => {
     if (typeof inst !== 'object') return inst;
@@ -647,6 +652,7 @@ function createInterceptionProxyFromInstance<T>(
       // Cast inst from `T` to `object`
       (inst as unknown) as object,
       context,
+      session,
     ) as unknown) as T;
   });
 }

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -305,6 +305,7 @@ export function invokeMethodWithInterceptors(
     target,
     methodName,
     args,
+    options.source,
   );
 
   invocationCtx.assertMethodExists();

--- a/packages/context/src/invocation.ts
+++ b/packages/context/src/invocation.ts
@@ -27,6 +27,20 @@ export type InvocationResult = any;
 export type InvocationArgs = any[];
 
 /**
+ * An interface to represent the caller of the invocation
+ */
+export interface InvocationSource<T = unknown> {
+  /**
+   * Type of the invoker, such as `proxy` and `route`
+   */
+  readonly type: string;
+  /**
+   * Metadata for the source, such as `ResolutionSession`
+   */
+  readonly value: T;
+}
+
+/**
  * InvocationContext represents the context to invoke interceptors for a method.
  * The context can be used to access metadata about the invocation as well as
  * other dependencies.
@@ -47,6 +61,7 @@ export class InvocationContext extends Context {
     public readonly target: object,
     public readonly methodName: string,
     public readonly args: InvocationArgs,
+    public readonly source?: InvocationSource,
   ) {
     super(parent);
   }
@@ -71,7 +86,8 @@ export class InvocationContext extends Context {
    * Description of the invocation
    */
   get description() {
-    return `InvocationContext(${this.name}): ${this.targetName}`;
+    const source = this.source == null ? '' : `${this.source} => `;
+    return `InvocationContext(${this.name}): ${source}${this.targetName}`;
   }
 
   toString() {
@@ -129,6 +145,11 @@ export type InvocationOptions = {
    * Skip invocation of interceptors
    */
   skipInterceptors?: boolean;
+  /**
+   * Information about the source object that makes the invocation. For REST,
+   * it's a `Route`. For injected proxies, it's a `Binding`.
+   */
+  source?: InvocationSource;
 };
 
 /**

--- a/packages/context/src/keys.ts
+++ b/packages/context/src/keys.ts
@@ -41,6 +41,13 @@ export namespace ContextTags {
   export const GLOBAL_INTERCEPTOR = 'globalInterceptor';
 
   /**
+   * Binding tag for global interceptors to specify sources of invocations that
+   * the interceptor should apply. The tag value can be a string or string[], such
+   * as `'route'` or `['route', 'proxy']`.
+   */
+  export const GLOBAL_INTERCEPTOR_SOURCE = 'globalInterceptorSource';
+
+  /**
    * Binding tag for group name of global interceptors
    */
   export const GLOBAL_INTERCEPTOR_GROUP = 'globalInterceptorGroup';

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -321,6 +321,10 @@ export class ResolutionSession {
   getResolutionPath() {
     return this.stack.map(i => ResolutionSession.describe(i)).join(' --> ');
   }
+
+  toString() {
+    return this.getResolutionPath();
+  }
 }
 
 /**

--- a/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.ts
+++ b/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.ts
@@ -10,7 +10,7 @@ import {
   Provider,
   ValueOrPromise,
 } from '@loopback/context';
-import {Request, RestBindings} from '../../..';
+import {Request, RestBindings, RouteSource} from '../../..';
 
 /**
  * Execution status
@@ -61,6 +61,12 @@ export async function cache<T>(
   next: () => ValueOrPromise<T>,
 ) {
   status.returnFromCache = false;
+  if (
+    invocationCtx.source == null ||
+    !(invocationCtx.source instanceof RouteSource)
+  ) {
+    return next();
+  }
   const req = await invocationCtx.get(RestBindings.Http.REQUEST, {
     optional: true,
   });

--- a/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
@@ -12,6 +12,7 @@ import {
   createControllerFactoryForBinding,
   createControllerFactoryForClass,
   RestBindings,
+  RouteSource,
 } from '../../..';
 
 describe('ControllerRoute', () => {
@@ -85,6 +86,20 @@ describe('ControllerRoute', () => {
     );
 
     expect(route._controllerName).to.eql('my-controller');
+  });
+
+  it('implements toString', () => {
+    const spec = anOperationSpec().build();
+    const route = new MyRoute(
+      'get',
+      '/greet',
+      spec,
+      MyController,
+      myControllerFactory,
+      'greet',
+    );
+    expect(route.toString()).to.equal('MyRoute - get /greet');
+    expect(new RouteSource(route).toString()).to.equal('get /greet');
   });
 
   describe('updateBindings()', () => {

--- a/packages/rest/src/__tests__/unit/router/handler-route.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/handler-route.unit.ts
@@ -6,7 +6,7 @@
 import {Context} from '@loopback/core';
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
 import {expect} from '@loopback/testlab';
-import {RestBindings, Route} from '../../..';
+import {RestBindings, Route, RouteSource} from '../../..';
 
 describe('HandlerRoute', () => {
   describe('updateBindings()', () => {
@@ -30,5 +30,14 @@ describe('HandlerRoute', () => {
       requestCtx = new Context(appCtx, 'request');
       route.updateBindings(requestCtx);
     }
+  });
+
+  describe('toString', () => {
+    it('implements toString', () => {
+      const spec = anOperationSpec().build();
+      const route = new Route('get', '/greet', spec, () => {});
+      expect(route.toString()).to.equal('Route - get /greet');
+      expect(new RouteSource(route).toString()).to.equal('get /greet');
+    });
   });
 });

--- a/packages/rest/src/router/base-route.ts
+++ b/packages/rest/src/router/base-route.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context, InvocationSource} from '@loopback/context';
 import {OperationObject} from '@loopback/openapi-v3';
 import {OperationArgs, OperationRetval} from '../types';
 import {RouteEntry} from './route-entry';
@@ -37,5 +37,17 @@ export abstract class BaseRoute implements RouteEntry {
 
   describe(): string {
     return `"${this.verb} ${this.path}"`;
+  }
+
+  toString() {
+    return `${this.constructor.name} - ${this.verb} ${this.path}`;
+  }
+}
+
+export class RouteSource implements InvocationSource<RouteEntry> {
+  type = 'route';
+  constructor(readonly value: RouteEntry) {}
+  toString() {
+    return `${this.value.verb} ${this.value.path}`;
   }
 }

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -16,7 +16,7 @@ import {OperationObject} from '@loopback/openapi-v3';
 import * as HttpErrors from 'http-errors';
 import {RestBindings} from '../keys';
 import {OperationArgs, OperationRetval} from '../types';
-import {BaseRoute} from './base-route';
+import {BaseRoute, RouteSource} from './base-route';
 
 /*
  * A controller instance with open properties/methods
@@ -138,7 +138,9 @@ export class ControllerRoute<T> extends BaseRoute {
       );
     }
     // Invoke the method with dependency injection
-    return invokeMethod(controller, this._methodName, requestContext, args);
+    return invokeMethod(controller, this._methodName, requestContext, args, {
+      source: new RouteSource(this),
+    });
   }
 }
 

--- a/packages/rest/src/router/handler-route.ts
+++ b/packages/rest/src/router/handler-route.ts
@@ -7,7 +7,7 @@ import {Context, invokeMethodWithInterceptors} from '@loopback/context';
 import {OperationObject} from '@loopback/openapi-v3';
 import {RestBindings} from '../keys';
 import {OperationArgs, OperationRetval} from '../types';
-import {BaseRoute} from './base-route';
+import {BaseRoute, RouteSource} from './base-route';
 
 export class Route extends BaseRoute {
   constructor(
@@ -33,6 +33,12 @@ export class Route extends BaseRoute {
   ): Promise<OperationRetval> {
     // Use `invokeMethodWithInterceptors` to invoke the handler function so
     // that global interceptors are applied
-    return invokeMethodWithInterceptors(requestContext, this, '_handler', args);
+    return invokeMethodWithInterceptors(
+      requestContext,
+      this,
+      '_handler',
+      args,
+      {source: new RouteSource(this)},
+    );
   }
 }


### PR DESCRIPTION
Interceptors can be invoked in the following cases:

1. A route to a controller method
2. A controller to a repository/service with injected proxy
3. A repository/service method invoked explicitly with `invokeMethod/invokeMethodWithInterceptors`

Some interceptors want to check invocationContext.source to decide if its logic should be applied. For example, an http access logger only cares about invocations from the rest layer to the first controller.

This is also useful for metrics, tracing and logging.

This PR sets `source` as follows:
- the ResolutionSession in `ProxySource` for injected proxies. 
- the Rest Route in `RouteSource` for REST

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
