### PR TITLE
Use stringifyObject instead of JSON.stringify for connector metadata

### DIFF
--- a/packages/cli/lib/model-discoverer.js
+++ b/packages/cli/lib/model-discoverer.js
@@ -1,6 +1,7 @@
 const debug = require('./debug')('model-discoverer');
 const fs = require('fs');
 const path = require('path');
+const {stringifyObject} = require('../lib/utils');
 
 /**
  * Given a datasource and discovery options,
@@ -85,8 +86,11 @@ const sanitizeProperty = function(o) {
     }
 
     // If you are an object or array, stringify so you don't appear as [object [object]
-    if (v === Object(v)) {
-      o[k] = JSON.stringify(o[k]);
+    if (typeof v === 'object' && v !== null) {
+      o[k] = stringifyObject(o[k], {
+        // don't break lines to avoid formatting problems in the model template
+        inlineCharacterLimit: Infinity,
+      });
     }
   });
 

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -565,16 +565,18 @@ exports.dataSourceToJSONFileName = function(dataSourceClass) {
   );
 };
 
+exports.stringifyObject = function(data, options = {}) {
+  return stringifyObject(data, {
+    indent: '  ', // two spaces
+    singleQuotes: true,
+    inlineCharacterLimit: 80,
+    ...options,
+  });
+};
+
 exports.stringifyModelSettings = function(modelSettings) {
   if (!modelSettings || !Object.keys(modelSettings).length) return '';
-  return stringifyObject(
-    {settings: modelSettings},
-    {
-      indent: '  ', // two spaces
-      singleQuotes: true,
-      inlineCharacterLimit: 80,
-    },
-  );
+  return exports.stringifyObject({settings: modelSettings});
 };
 
 // literal strings with artifacts directory locations

--- a/packages/cli/test/unit/discover/import-discovered-model.test.js
+++ b/packages/cli/test/unit/discover/import-discovered-model.test.js
@@ -145,4 +145,33 @@ describe('importDiscoveredModel', () => {
         id: 1,
       });
   });
+
+  it('converts connector metadata to TypeScript object', () => {
+    const discoveredModel = {
+      name: 'TestModel',
+      properties: {
+        title: {
+          type: 'String',
+          required: false,
+          postgresql: {
+            columnName: 'title',
+            dataType: 'text',
+            dataLength: null,
+            dataPrecision: null,
+            dataScale: null,
+            nullable: 'NO',
+          },
+        },
+      },
+    };
+
+    const modelData = importDiscoveredModel(discoveredModel);
+    expect(modelData.properties)
+      .to.have.property('title')
+      .deepEqual({
+        type: `'string'`,
+        tsType: 'string',
+        postgresql: `{columnName: 'title', dataType: 'text', dataLength: null, dataPrecision: null, dataScale: null, nullable: 'NO'}`,
+      });
+  });
 });


### PR DESCRIPTION
Rework the code handling object-like property metadata (typically connector-specific conciguration) to use `stringifyObject` instead of `JSON.parse`. Resolve #3806.

Before this change, a model property discovered from a database could
look as follows:

```ts
  @property({
    type: String,
    postgresql: {"columnName":"title","dataType":"text"},
  })
  title: String;
```

With this commit in place, the property definition is generated
in TypeScript style:

```ts
  @property({
    type: String,
    postgresql: {columnName: 'title', dataType: 'text'},
  })
  title: String;
```

Please note that in a typical case, connector metadata won't fit into a single line. Ideally, we would like to split the object into multiple lines. Unfortunately, that requires more complex changes in the way how we are generating property definitions, which is something I don't have bandwidth for right now. Users can use tools like Prettier and/or `eslint --fix .` to reformat the code as they like.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
