### PR TITLE
chore: make sure *.tsbuildinfo is removed with `npm run clean` to force a clean build

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "lb-tsc",
-    "clean": "lb-clean dist",
+    "clean": "lb-clean dist *.tsbuildinfo",
     "pretest": "npm run clean && npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "prestart": "npm run build",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean dist",
+    "clean": "lb-clean *example-rcp-server-*.tgz dist tsconfig.build.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",


### PR DESCRIPTION
Without this change, `npm run clean` leaves `examples/rpc-server` in a state that `dist` is not re-populated with `npm run build` as there is a stale `tsbuildinfo` file.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
