### PR TITLE
feat(context): improve context/binding with inspect/toJSON for metadata dumping

### DIFF
--- a/packages/context/src/__tests__/unit/binding.unit.ts
+++ b/packages/context/src/__tests__/unit/binding.unit.ts
@@ -189,6 +189,12 @@ describe('Binding', () => {
       const b = ctx.bind('provider_key').toProvider(MyProvider);
       expect(b.type).to.equal(BindingType.PROVIDER);
     });
+
+    it('sets the providerConstructor', () => {
+      ctx.bind('msg').to('hello');
+      const b = ctx.bind('provider_key').toProvider(MyProvider);
+      expect(b.providerConstructor).to.equal(MyProvider);
+    });
   });
 
   describe('toAlias(bindingKeyWithPath)', () => {

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -180,12 +180,22 @@ export class Binding<T = BoundValue> {
   private _getValue: ValueGetter<T>;
 
   private _valueConstructor?: Constructor<T>;
+  private _providerConstructor?: Constructor<Provider<T>>;
+
   /**
-   * For bindings bound via toClass, this property contains the constructor
-   * function
+   * For bindings bound via `toClass()`, this property contains the constructor
+   * function of the class
    */
   public get valueConstructor(): Constructor<T> | undefined {
     return this._valueConstructor;
+  }
+
+  /**
+   * For bindings bound via `toProvider()`, this property contains the
+   * constructor function of the provider class
+   */
+  public get providerConstructor(): Constructor<Provider<T>> | undefined {
+    return this._providerConstructor;
   }
 
   constructor(key: BindingAddress<T>, public isLocked: boolean = false) {
@@ -494,6 +504,7 @@ export class Binding<T = BoundValue> {
       debug('Bind %s to provider %s', this.key, providerClass.name);
     }
     this._type = BindingType.PROVIDER;
+    this._providerConstructor = providerClass;
     this._setValueGetter((ctx, options) => {
       const providerOrPromise = instantiateClass<Provider<T>>(
         providerClass,
@@ -576,9 +587,8 @@ export class Binding<T = BoundValue> {
   /**
    * Convert to a plain JSON object
    */
-  toJSON(): Object {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const json: {[name: string]: any} = {
+  toJSON(): object {
+    const json: Record<string, unknown> = {
       key: this.key,
       scope: this.scope,
       tags: this.tagMap,
@@ -586,6 +596,12 @@ export class Binding<T = BoundValue> {
     };
     if (this.type != null) {
       json.type = this.type;
+    }
+    if (this._valueConstructor != null) {
+      json.valueConstructor = this._valueConstructor.name;
+    }
+    if (this._providerConstructor != null) {
+      json.providerConstructor = this._providerConstructor.name;
     }
     return json;
   }

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -968,10 +968,26 @@ export class Context extends EventEmitter {
   /**
    * Create a plain JSON object for the context
    */
-  toJSON(): Object {
-    const json: {[key: string]: Object} = {};
+  toJSON(): object {
+    const bindings: Record<string, object> = {};
     for (const [k, v] of this.registry) {
-      json[k] = v.toJSON();
+      bindings[k] = v.toJSON();
+    }
+    return bindings;
+  }
+
+  /**
+   * Inspect the context and dump out a JSON object representing the context
+   * hierarchy
+   */
+  // TODO(rfeng): Evaluate https://nodejs.org/api/util.html#util_custom_inspection_functions_on_objects
+  inspect(): object {
+    const json: Record<string, unknown> = {
+      name: this.name,
+      bindings: this.toJSON(),
+    };
+    if (this._parent) {
+      json.parent = this._parent.inspect();
     }
     return json;
   }


### PR DESCRIPTION
I was trying to expose json metadata for the context hierarchy to REST as follows and realized that there are deficiencies in ctx.toJSON():

```ts
export class PingController {

  @get('/metadata')
  metadata(
    @inject(CoreBindings.APPLICATION_INSTANCE) application: Context,
    @inject(RestBindings.SERVER) server: Context,
    @inject(RestBindings.Http.CONTEXT) request: Context,
  ): object {
    return {
      application,
      server,
      request,
    };
  }
}
```

ctx.inspect() can be now used to print out the context hierarchy in JSON.
This is useful for troubeshooting and rendering in UI.

With this PR, I can simplify the implementation:

```ts
@get('/metadata')
  metadata(
    @inject(RestBindings.Http.CONTEXT) request: Context,
  ): object {
  return request.inspect();
}
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
