### PR TITLE
feat(eslint-config): enable return-await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,10 @@ matrix:
       os: linux
       env: TASK=code-lint
       # Running Code Linter -- Requires @loopback/build so it's bootstrapped
+      # We actually need to bootstrap all packages, otherwise typescript-eslint
+      # is not able to access type information for dependencies
       script:
-        - lerna bootstrap --scope @loopback/build --include-dependencies
+        - lerna bootstrap
         - npm run lint
     - node_js: "8"
       os: linux

--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -152,6 +152,7 @@ module.exports = {
     '@typescript-eslint/prefer-optional-chain': 'error',
     '@typescript-eslint/prefer-nullish-coalescing': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',
+    '@typescript-eslint/return-await': 'error',
   },
 
   overrides: [


### PR DESCRIPTION
Require users to await a promise before returning the result inside a `try` block. Otherwise the errors won't be caught by the catch block.

Require users to NOT await a promise when the result is immediately returned outside of a `try` block. This is a (micro)performance optimization to avoid unnecessary allocation of an extra Promise instance.

Rule docs: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/return-await.md

~~At the moment (2019-11-28), eslint reports false positives, they should be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/1270. This pull request cannot be landed until that patch is released & our package-lock files are updated with the new version of the eslint plugin.~~ 
The eslint fix was released in [v2.10.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v2.10.0).

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
