### PR TITLE
RFC: enable no-untyped-public-signature

### DIFF
--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -150,6 +150,7 @@ module.exports = {
     '@typescript-eslint/no-misused-promises': 'error',
 
     '@typescript-eslint/prefer-optional-chain': 'error',
+    '@typescript-eslint/no-untyped-public-signature': 'error',
   },
 
   overrides: [
@@ -157,6 +158,13 @@ module.exports = {
       files: ['**/*.js'],
       rules: {
         '@typescript-eslint/prefer-optional-chain': 'off',
+        '@typescript-eslint/no-untyped-public-signature': 'off',
+      },
+    },
+    {
+      files: ['**/__tests__/**/*.ts'],
+      rules: {
+        '@typescript-eslint/no-untyped-public-signature': 'off',
       },
     },
   ],

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -149,7 +149,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      * app.component(ProductComponent);
      * ```
      */
-    public component(component: Class<unknown>, name?: string) {
+    public component(component: Class<unknown>, name?: string): void {
       super.component(component, name);
       this.mountComponentRepositories(component);
     }
@@ -161,7 +161,7 @@ export function RepositoryMixin<T extends Class<any>>(superClass: T) {
      *
      * @param component - The component to mount repositories of
      */
-    mountComponentRepositories(component: Class<unknown>) {
+    mountComponentRepositories(component: Class<unknown>): void {
       const componentKey = `components.${component.name}`;
       const compInstance = this.getSync(componentKey);
 

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -508,7 +508,7 @@ export class DefaultCrudRepository<
   registerInclusionResolver(
     relationName: string,
     resolver: InclusionResolver<T, Entity>,
-  ) {
+  ): void {
     this.inclusionResolvers.set(relationName, resolver);
   }
 

--- a/packages/repository/src/types/date.ts
+++ b/packages/repository/src/types/date.ts
@@ -14,7 +14,7 @@ import {Type} from './type';
 export class DateType implements Type<Date> {
   readonly name = 'date';
 
-  isInstance(value: any) {
+  isInstance(value: any): boolean {
     return value == null || value instanceof Date;
   }
 

--- a/packages/repository/src/types/model.ts
+++ b/packages/repository/src/types/model.ts
@@ -17,7 +17,7 @@ export class ModelType<T extends Model> extends ObjectType<T> {
     super(modelClass);
   }
 
-  serialize(value: T | null | undefined) {
+  serialize(value: T | null | undefined): object | null | undefined {
     if (value == null) return value;
     return value.toJSON();
   }

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -5,6 +5,7 @@
 
 import {inject} from '@loopback/context';
 import {
+  OpenApiSpec,
   OpenApiSpecForm,
   RequestContext,
   RestBindings,
@@ -45,7 +46,7 @@ export class ExplorerController {
     this.openApiSpecUrl = this.getOpenApiSpecUrl(restConfig);
   }
 
-  indexRedirect() {
+  indexRedirect(): void {
     const {request, response} = this.requestContext;
     let url = request.originalUrl || request.url;
     // be safe against path-modifying reverse proxies by generating the redirect
@@ -57,7 +58,7 @@ export class ExplorerController {
     response.redirect(301, url);
   }
 
-  index() {
+  index(): void {
     let openApiSpecUrl = this.openApiSpecUrl;
 
     // if using self-hosted openapi spec, then the path to use is always the
@@ -89,7 +90,7 @@ export class ExplorerController {
       .send(homePage);
   }
 
-  spec() {
+  spec(): OpenApiSpec {
     return this.restServer.getApiSpec(this.requestContext);
   }
 

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -280,7 +280,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param path Path at which to host the copy of the OpenAPI
    * @param form Form that should be renedered from that path
    */
-  addOpenApiSpecEndpoint(path: string, form: OpenApiSpecForm) {
+  addOpenApiSpecEndpoint(path: string, form: OpenApiSpecForm): void {
     if (this._expressApp) {
       // if the app is already started, try to hot-add it
       // this only actually "works" mid-startup, once this._handleHttpRequest
@@ -658,7 +658,11 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param rootDir - The root directory from which to serve static assets
    * @param options - Options for serve-static
    */
-  static(path: PathParams, rootDir: string, options?: ServeStaticOptions) {
+  static(
+    path: PathParams,
+    rootDir: string,
+    options?: ServeStaticOptions,
+  ): void {
     this._externalRoutes.registerAssets(path, rootDir, options);
   }
 
@@ -767,7 +771,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    *
    * @param value - The sequence to invoke for each incoming request.
    */
-  public sequence(value: Constructor<SequenceHandler>) {
+  public sequence(value: Constructor<SequenceHandler>): void {
     this.bind(RestBindings.SEQUENCE).toClass(value);
   }
 
@@ -783,7 +787,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    *
    * @param handlerFn - The handler to invoke for each incoming request.
    */
-  public handler(handlerFn: SequenceFunction) {
+  public handler(handlerFn: SequenceFunction): void {
     class SequenceFromFunction extends DefaultSequence {
       // NOTE(bajtos) Unfortunately, we have to duplicate the constructor
       // in order for our DI/IoC framework to inject constructor arguments
@@ -824,7 +828,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * Configure the `basePath` for the rest server
    * @param path - Base path
    */
-  basePath(path = '') {
+  basePath(path = ''): void {
     if (this._requestHandler != null) {
       throw new Error(
         'Base path cannot be set as the request handler has been created',
@@ -877,7 +881,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
   /**
    * Stop this REST API's HTTP/HTTPS server.
    */
-  async stop() {
+  async stop(): Promise<void> {
     // Kill the server instance.
     if (!this._httpServer) return;
     await this._httpServer.stop();

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -100,7 +100,7 @@ export class ControllerRoute<T> extends BaseRoute {
     return `${this._controllerName}.${this._methodName}`;
   }
 
-  updateBindings(requestContext: Context) {
+  updateBindings(requestContext: Context): void {
     /*
      * Bind current controller to the request context in `SINGLETON` scope.
      * Within the same request, we always get the same instance of the

--- a/packages/rest/src/router/external-express-routes.ts
+++ b/packages/rest/src/router/external-express-routes.ts
@@ -49,7 +49,7 @@ export class ExternalExpressRoutes {
     path: PathParams,
     rootDir: string,
     options?: ServeStaticOptions,
-  ) {
+  ): void {
     this._staticRoutes.use(path, express.static(rootDir, options));
   }
 
@@ -57,7 +57,7 @@ export class ExternalExpressRoutes {
     basePath: string,
     router: ExpressRequestHandler,
     spec: RouterSpec = {paths: {}},
-  ) {
+  ): void {
     this._externalRoutes.use(basePath, router);
 
     spec = rebaseOpenApiSpec(spec, basePath);

--- a/packages/rest/src/router/handler-route.ts
+++ b/packages/rest/src/router/handler-route.ts
@@ -23,7 +23,7 @@ export class Route extends BaseRoute {
     return this._handler.name || super.describe();
   }
 
-  updateBindings(requestContext: Context) {
+  updateBindings(requestContext: Context): void {
     requestContext.bind(RestBindings.OPERATION_SPEC_CURRENT).to(this.spec);
   }
 

--- a/packages/rest/src/router/redirect-route.ts
+++ b/packages/rest/src/router/redirect-route.ts
@@ -37,7 +37,7 @@ export class RedirectRoute implements RouteEntry, ResolvedRoute {
     response.redirect(this.statusCode, this.targetLocation);
   }
 
-  updateBindings(requestContext: RequestContext) {
+  updateBindings(requestContext: RequestContext): void {
     // no-op
   }
 

--- a/packages/rest/src/router/router-base.ts
+++ b/packages/rest/src/router/router-base.ts
@@ -5,9 +5,9 @@
 
 import {Request} from '../types';
 import {getPathVariables} from './openapi-path';
+import {RestRouter, RestRouterOptions} from './rest-router';
 import {createResolvedRoute, ResolvedRoute, RouteEntry} from './route-entry';
 import {compareRoute} from './route-sort';
-import {RestRouter, RestRouterOptions} from './rest-router';
 
 /**
  * Base router implementation that only handles path without variables
@@ -24,7 +24,7 @@ export abstract class BaseRouter implements RestRouter {
     return this.getKey(route.verb, route.path);
   }
 
-  add(route: RouteEntry) {
+  add(route: RouteEntry): void {
     if (!getPathVariables(route.path)) {
       const key = this.getKeyForRoute(route);
       this.routesWithoutPathVars[key] = route;
@@ -37,7 +37,7 @@ export abstract class BaseRouter implements RestRouter {
     return this.getKey(request.method, request.path);
   }
 
-  find(request: Request) {
+  find(request: Request): ResolvedRoute | undefined {
     if (this.options.strict) {
       return this.findRoute(request.method, request.path);
     }
@@ -63,7 +63,7 @@ export abstract class BaseRouter implements RestRouter {
     else return this.findRouteWithPathVars(verb, path);
   }
 
-  list() {
+  list(): RouteEntry[] {
     let routes = Object.values(this.routesWithoutPathVars);
     routes = routes.concat(this.listRoutesWithPathVars());
     // Sort the routes so that they show up in OpenAPI spec in order

--- a/packages/rest/src/router/routing-table.ts
+++ b/packages/rest/src/router/routing-table.ts
@@ -46,7 +46,7 @@ export class RoutingTable {
     spec: ControllerSpec,
     controllerCtor: ControllerClass<T>,
     controllerFactory?: ControllerFactory<T>,
-  ) {
+  ): void {
     assert(
       typeof spec === 'object' && !!spec,
       'API specification must be a non-null object',
@@ -74,7 +74,7 @@ export class RoutingTable {
     }
   }
 
-  static joinPath(basePath: string, path: string) {
+  static joinPath(basePath: string, path: string): string {
     const fullPath = [basePath, path]
       .join('/') // Join by /
       .replace(/(\/){2,}/g, '/') // Remove extra /
@@ -87,7 +87,7 @@ export class RoutingTable {
    * Register a route
    * @param route - A route entry
    */
-  registerRoute(route: RouteEntry) {
+  registerRoute(route: RouteEntry): void {
     // TODO(bajtos) handle the case where opSpec.parameters contains $ref
     // See https://github.com/strongloop/loopback-next/issues/435
     /* istanbul ignore if */

--- a/packages/rest/src/router/trie.ts
+++ b/packages/rest/src/router/trie.ts
@@ -53,7 +53,7 @@ export class Trie<T> {
    * @param pathTemplate - The path template,
    * @param value - Value of the route
    */
-  create(routeTemplate: string, value: T) {
+  create(routeTemplate: string, value: T): Node<T> {
     const keys = routeTemplate.split('/').filter(Boolean);
     return createNode(keys, 0, value, this.root);
   }

--- a/packages/security/src/types.ts
+++ b/packages/security/src/types.ts
@@ -26,7 +26,7 @@ export class TypedPrincipal implements Principal {
     public readonly principal: Principal,
     public readonly type: string,
   ) {}
-  get [securityId]() {
+  get [securityId](): string {
     return `${this.type}:${this.principal[securityId]}`;
   }
 }
@@ -94,7 +94,7 @@ export class Permission {
    */
   resourceId?: string;
 
-  get [securityId]() {
+  get [securityId](): string {
     const resIds: string[] = [];
     resIds.push(this.resourceType);
     if (this.resourceProperty) {
@@ -161,29 +161,29 @@ export class DefaultSubject implements Subject {
   readonly authorities = new Set<Permission>();
   readonly credentials = new Set<Credential>();
 
-  addUser(...users: UserProfile[]) {
+  addUser(...users: UserProfile[]): void {
     for (const user of users) {
       this.principals.add(new TypedPrincipal(user, 'USER'));
     }
   }
 
-  addApplication(app: ClientApplication) {
+  addApplication(app: ClientApplication): void {
     this.principals.add(new TypedPrincipal(app, 'APPLICATION'));
   }
 
-  addAuthority(...authorities: Permission[]) {
+  addAuthority(...authorities: Permission[]): void {
     for (const authority of authorities) {
       this.authorities.add(authority);
     }
   }
 
-  addCredential(...credentials: Credential[]) {
+  addCredential(...credentials: Credential[]): void {
     for (const credential of credentials) {
       this.credentials.add(credential);
     }
   }
 
-  getPrincipal(type: string) {
+  getPrincipal(type: string): Principal | undefined {
     let principal: Principal | undefined;
     for (const p of this.principals) {
       if (p.type === type) {
@@ -194,7 +194,7 @@ export class DefaultSubject implements Subject {
     return principal;
   }
 
-  get user() {
+  get user(): UserProfile | undefined {
     return this.getPrincipal('USER') as UserProfile | undefined;
   }
 }

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -87,7 +87,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      * app.component(ProductComponent);
      * ```
      */
-    public component(component: Class<unknown>, name?: string) {
+    public component(component: Class<unknown>, name?: string): void {
       super.component(component, name);
       this.mountComponentServices(component);
     }
@@ -99,7 +99,7 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      *
      * @param component - The component to mount services of
      */
-    mountComponentServices(component: Class<unknown>) {
+    mountComponentServices(component: Class<unknown>): void {
       const componentKey = `components.${component.name}`;
       const compInstance = this.getSync(componentKey);
 
@@ -197,5 +197,5 @@ export class ServiceMixinDoc {
    *
    * @param component - The component to mount services of
    */
-  mountComponentServices(component: Class<unknown>) {}
+  mountComponentServices(component: Class<unknown>): void {}
 }

--- a/packages/tsdocs/fixtures/monorepo/packages/pkg1/src/index.ts
+++ b/packages/tsdocs/fixtures/monorepo/packages/pkg1/src/index.ts
@@ -18,7 +18,7 @@ export class Pet {
    * @param msg - Message for the greeting
    * @returns The description
    */
-  greet(msg: string) {
+  greet(msg: string): string {
     return `[${msg}] ${this.name}:${this.kind}`;
   }
 }


### PR DESCRIPTION
eslint-typescript recently introduced a new rule [no-untyped-public-signature](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-untyped-public-signature.md).

I'd like to discuss whether we want to enable it. We have more than 200 violations of this rule in our current code base and unfortunately there is not automatic fixer available. Before I go ahead and manually fix all violations, I'd like to get consensus that we want to enable the rule.

Why would we want to enable it? In my experience, code with missing type information is difficult to read. When LB users are trying to learn about our public API from our code, they have difficult times figuring out what are the methods and functions returning when the return type is not explicitly described.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
