### PR TITLE
docs: fix link to src/application.ts in @loopback/example-hello-world

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -5,8 +5,10 @@ A simple hello-world application using LoopBack 4!
 ## Summary
 
 This project shows how to write the simplest LoopBack 4 application possible.
-Check out [src/application.ts](src/application.ts) to learn how we configured
-our application to always respond with "Hello World!".
+Check out
+[src/application.ts](https://github.com/strongloop/loopback-next/blob/master/examples/hello-world/src/application.ts)
+to learn how we configured our application to always respond with "Hello
+World!".
 
 ## Prerequisites
 


### PR DESCRIPTION
The link to `src/application.ts` mentioned in

https://www.npmjs.com/package/@loopback/example-hello-world

![image](https://user-images.githubusercontent.com/6864736/69985005-66fd0100-1508-11ea-96f9-79e77e7169d1.png)

was giving a 404.

Update the underlying link to be : https://github.com/strongloop/loopback-next/blob/master/examples/hello-world/src/application.ts   

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
