### PR TITLE
feat(repository): add title property to Count schema definition

### DIFF
--- a/packages/repository/src/common-types.ts
+++ b/packages/repository/src/common-types.ts
@@ -98,5 +98,6 @@ export interface Count {
  */
 export const CountSchema = {
   type: 'object',
+  title: 'loopback.count',
   properties: {count: {type: 'number'}},
 };


### PR DESCRIPTION
Add title property to Count schema definition under common types in order to enable better model
generation by third party tools such as https://github.com/OpenAPITools/openapi-generator

Without a title property the generator would simply name the count response as InlineObject<n>.  By adding the title property, the tooling can produce a model named after the object title.

## Checklist

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
