### PR TITLE
chore: upgrade Node to 12.x for Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       os: osx
       # using the default script to build & run the tests
 
-    - node_js: "8"
+    - node_js: "12"
       os: linux
       env: TASK=code-lint
       # Running Code Linter -- Requires @loopback/build so it's bootstrapped
@@ -35,15 +35,15 @@ matrix:
       script:
         - lerna bootstrap
         - npm run lint
-    - node_js: "8"
+    - node_js: "12"
       os: linux
       env: TASK=commit-lint
       script: commitlint-travis
-    - node_js: "8"
+    - node_js: "12"
       os: linux
       env: TASK=verify-docs
       script: ./bin/verify-doc-changes.sh
-    - node_js: "10"
+    - node_js: "12"
       os: linux
       env:
         - TASK=test-repository-mongodb
@@ -53,7 +53,7 @@ matrix:
         - npm run postinstall -- --scope "@loopback/test-repository-mongodb" --include-dependencies
         - npm run build -- --scope "@loopback/test-repository-mongodb" --include-dependencies
         - cd acceptance/repository-mongodb && npm run mocha
-    - node_js: "10"
+    - node_js: "12"
       os: linux
       env:
         - TASK=test-repository-mysql
@@ -70,7 +70,7 @@ matrix:
         - npm run postinstall -- --scope "@loopback/test-repository-mysql" --include-dependencies
         - npm run build -- --scope "@loopback/test-repository-mysql" --include-dependencies
         - cd acceptance/repository-mysql && npm run mocha
-    - node_js: "10"
+    - node_js: "12"
       os: linux
       env:
         - TASK=test-repository-postgresql
@@ -82,7 +82,7 @@ matrix:
         - npm run build -- --scope "@loopback/test-repository-postgresql" --include-dependencies
         - psql -U postgres -a -f acceptance/repository-postgresql/test/schema.sql
         - cd acceptance/repository-postgresql && npm run mocha
-    - node_js: "10"
+    - node_js: "12"
       os: linux
       env:
         - TASK=test-repository-cloudant


### PR DESCRIPTION
With Node.js version 12 already in LTS mode, it's time to upgrade our Travis jobs to use the latest & greatest & fastest! version of Node.

Also note that the version 8 is going end of life soon, it's time to upgrade to a newer one.