### PR TITLE
feat(repository): add interface for hasManyThrough

### DIFF
--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -68,6 +68,50 @@ export interface HasManyDefinition extends RelationDefinitionBase {
   keyTo?: string;
 }
 
+/**
+ * A `hasManyThrough` relation defines a many-to-many connection with another model.
+ * This relation indicates that the declaring model can be matched with zero or more
+ * instances of another model by proceeding through a third model.
+ *
+ * Warning: The hasManyThrough interface is experimental and is subject to change.
+ * If backwards-incompatible changes are made, a new major version may not be
+ * released.
+ */
+export interface HasManyThroughDefinition extends RelationDefinitionBase {
+  type: RelationType.hasMany;
+  targetsMany: true;
+
+  /**
+   * The foreign key in the source model, e.g. Customer#id.
+   */
+  keyFrom: string;
+
+  /**
+   * The primary key of the target model, e.g Seller#id.
+   */
+  keyTo: string;
+
+  through: {
+    /**
+     * The through model of this relation.
+     *
+     * E.g. when a Customer has many Order instances and a Seller has many Order instances,
+     * then Order is through.
+     */
+    model: TypeResolver<Entity, typeof Entity>;
+
+    /**
+     * The foreign key of the source model defined in the through model, e.g. Order#customerId
+     */
+    keyFrom: string;
+
+    /**
+     * The foreign key of the target model defined in the through model, e.g. Order#sellerId
+     */
+    keyTo: string;
+  };
+}
+
 export interface BelongsToDefinition extends RelationDefinitionBase {
   type: RelationType.belongsTo;
   targetsMany: false;
@@ -102,6 +146,7 @@ export interface HasOneDefinition extends RelationDefinitionBase {
  */
 export type RelationMetadata =
   | HasManyDefinition
+  | HasManyThroughDefinition
   | BelongsToDefinition
   | HasOneDefinition
   // TODO(bajtos) add other relation types and remove RelationDefinitionBase once


### PR DESCRIPTION
Adds interface for the new relation type "hasManyThrough" to support many-to-many model relations.

This PR is a continuation of #2359 and implements the first change described in https://github.com/strongloop/loopback-next/pull/2359#issuecomment-559719080.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
