### PR TITLE
feat(docs): expose docs for extension modules

### DIFF
--- a/docs/site/Authentication-passport.md
+++ b/docs/site/Authentication-passport.md
@@ -1,0 +1,10 @@
+---
+lang: en
+title: 'Passport Authentication Strategy Adapter'
+keywords: LoopBack 4.0, LoopBack 4, Authentication, Passport
+layout: readme
+source: loopback-next
+file: extensions/authentication-passport/README.md
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Authentication-passport.html
+---

--- a/docs/site/Metrics.md
+++ b/docs/site/Metrics.md
@@ -1,0 +1,10 @@
+---
+lang: en
+title: 'Metrics collection for Prometheus'
+keywords: LoopBack 4.0, LoopBack 4, Cloud Native, Metrics, Prometheus
+layout: readme
+source: loopback-next
+file: extensions/metrics/README.md
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Metrics.html
+---

--- a/docs/site/Using-extensions.md
+++ b/docs/site/Using-extensions.md
@@ -1,0 +1,18 @@
+---
+lang: en
+title: 'Using extensions'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Using-extensions.html
+---
+
+## Extensions
+
+### Cloud native extensions
+
+- [@loopback/extension-health](Health.md) (Experimental)
+- [@loopback/extension-metrics](Metrics.md) (Experimental)
+
+### Authentication extensions
+
+- [@loopback/authentication-passport](Authentication-passport.md)

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -230,7 +230,7 @@ children:
   output: 'web, pdf'
   children:
 
-  - title: Self-hosted REST API Explorer
+  - title: 'Self-hosted REST API Explorer'
     url: Self-hosted-rest-api-explorer.html
     output: 'web, pdf'
 
@@ -244,6 +244,24 @@ children:
 
   - title: 'Boot and Mount a LoopBack 3 Application'
     url: Boot-and-Mount-a-LoopBack-3-application.html
+    output: 'web, pdf'
+
+- title: 'Using Extensions'
+  url: Using-extensions.html
+  output: 'web, pdf'
+
+  children:
+
+  - title: 'Health check'
+    url: Health.html
+    output: 'web, pdf'
+
+  - title: 'Metrics for Prometheus'
+    url: Metrics.html
+    output: 'web, pdf'
+
+  - title: 'Passport Adapter for Authentication'
+    url: Authentication-passport.html
     output: 'web, pdf'
 
 - title: 'Extending LoopBack 4'


### PR DESCRIPTION

<img width="740" alt="using-extensions" src="https://user-images.githubusercontent.com/540892/70207378-771b0900-16df-11ea-816e-2782468cbc8a.png">


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
