### PR TITLE
feat(repository): enable inclusion with custom scope

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -43,6 +43,8 @@ related routes, you need to perform the following steps:
 This section describes how to define a `belongsTo` relation at the model level
 using the `@belongsTo` decorator to define the constraining foreign key.
 
+### Relation Metadata
+
 The definition of the `belongsTo` relation is inferred by using the `@belongsTo`
 decorator. The decorator takes in a function resolving the target model class
 constructor and designates the relation type. It also calls `property()` to
@@ -356,7 +358,7 @@ or use APIs with controllers:
 GET http://localhost:3000/orders?filter[include][][relation]=customer
 ```
 
-### Enable/disable the inclusion resolvers:
+### Enable/disable the inclusion resolvers
 
 - Base repository classes have a public property `inclusionResolvers`, which
   maintains a map containing inclusion resolvers for each relation.
@@ -442,17 +444,22 @@ export class OrderRepository extends DefaultCrudRepository {
   ];
   ```
 
-  Here is a diagram to make this more intuitive:
+{% include note.html content="The query syntax is a slightly different from LB3. We are also thinking about simplifying the query syntax. Check our GitHub issue for more information: [Simpler Syntax for Inclusion](https://github.com/strongloop/loopback-next/issues/3205)" %}
 
-  ![Graph](./imgs/belongsTo-relation-graph.png)
+Here is a diagram to make this more intuitive:
+
+![Graph](./imgs/belongsTo-relation-graph.png)
 
 - You can delete a relation from `inclusionResolvers` to disable the inclusion
   for a certain relation. e.g
   `orderRepository.inclusionResolvers.delete('customer')`
 
-{% include note.html content="
-Inclusion with custom scope:
-Besides specifying the relation name to include, it's also possible to specify additional scope constraints.
-However, this feature is not supported yet. Check our GitHub issue for more information:
-[Include related models with a custom scope](https://github.com/strongloop/loopback-next/issues/3453).
+### Query multiple relations
+
+It is possible to query several relations or nested include relations with
+custom scope once you have the inclusion resolver of each relation set up.
+Check[HasMany - Query multiple relations](HasMany-relation.md#query-multiple-relations)
+for the usage and examples.
+
+{% include important.html content="There are some limitations of inclusion:. <br/><br/> We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/><br/> It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/><br/> It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
 " %}

--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -399,7 +399,7 @@ or use APIs with controllers:
 GET http://localhost:3000/suppliers?filter[include][][relation]=account
 ```
 
-### Enable/disable the inclusion resolvers:
+### Enable/disable the inclusion resolvers
 
 - Base repository classes have a public property `inclusionResolvers`, which
   maintains a map containing inclusion resolvers for each relation.
@@ -465,17 +465,22 @@ export class SupplierRepository extends DefaultCrudRepository {
   ];
   ```
 
-  Here is a diagram to make this more intuitive:
+{% include note.html content="The query syntax is a slightly different from LB3. We are also thinking about simplifying the query syntax. Check our GitHub issue for more information: [Simpler Syntax for Inclusion](https://github.com/strongloop/loopback-next/issues/3205)" %}
 
-  ![Graph](./imgs/hasOne-relation-graph.png)
+Here is a diagram to make this more intuitive:
+
+![Graph](./imgs/hasOne-relation-graph.png)
 
 - You can delete a relation from `inclusionResolvers` to disable the inclusion
   for a certain relation. e.g
   `supplierRepository.inclusionResolvers.delete('account')`
 
-{% include note.html content="
-Inclusion with custom scope:
-Besides specifying the relation name to include, it's also possible to specify additional scope constraints.
-However, this feature is not supported yet. Check our GitHub issue for more information:
-[Include related models with a custom scope](https://github.com/strongloop/loopback-next/issues/3453).
+### Query multiple relations
+
+It is possible to query several relations or nested include relations with
+custom scope once you have the inclusion resolver of each relation set up.
+Check[HasMany - Query multiple relations](HasMany-relation.md#query-multiple-relations)
+for the usage and examples.
+
+{% include important.html content="There are some limitations of inclusion:. <br/><br/> We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/><br/> It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/><br/> It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
 " %}

--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
@@ -163,19 +163,6 @@ export function belongsToInclusionResolverAcceptance(
       };
       expect(toJSON(result)).to.deepEqual(toJSON(expected));
     });
-    // scope for inclusion is not supported yet
-    it('throws error if the inclusion query contains a non-empty scope', async () => {
-      const customer = await customerRepo.create({name: 'customer'});
-      await orderRepo.create({
-        description: 'an order',
-        customerId: customer.id,
-      });
-      await expect(
-        orderRepo.find({
-          include: [{relation: 'customer', scope: {limit: 1}}],
-        }),
-      ).to.be.rejectedWith(`scope is not supported`);
-    });
 
     it('throws error if the target repository does not have the registered resolver', async () => {
       const customer = await customerRepo.create({name: 'customer'});

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
@@ -347,20 +347,6 @@ export function hasManyInclusionResolverAcceptance(
       );
     });
 
-    // scope for inclusion is not supported yet
-    it('throws error if the inclusion query contains a non-empty scope', async () => {
-      const customer = await customerRepo.create({name: 'customer'});
-      await orderRepo.create({
-        description: 'an order',
-        customerId: customer.id,
-      });
-      await expect(
-        customerRepo.find({
-          include: [{relation: 'orders', scope: {limit: 1}}],
-        }),
-      ).to.be.rejectedWith(`scope is not supported`);
-    });
-
     it('throws error if the target repository does not have the registered resolver', async () => {
       const customer = await customerRepo.create({name: 'customer'});
       await orderRepo.create({

--- a/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
@@ -162,23 +162,6 @@ export function hasOneInclusionResolverAcceptance(
       expect(toJSON(result)).to.deepEqual(toJSON(expected));
     });
 
-    // scope field for inclusion is not supported yet
-    it('throws error if the inclusion query contains a non-empty scope', async () => {
-      const customer = await customerRepo.create({name: 'customer'});
-      await addressRepo.create({
-        street: 'home of Thor Rd.',
-        city: 'Thrudheim',
-        province: 'Asgard',
-        zipcode: '8200',
-        customerId: customer.id,
-      });
-      await expect(
-        customerRepo.find({
-          include: [{relation: 'address', scope: {limit: 1}}],
-        }),
-      ).to.be.rejectedWith(`scope is not supported`);
-    });
-
     it('throws error if the target repository does not have the registered resolver', async () => {
       const customer = await customerRepo.create({name: 'customer'});
       await addressRepo.create({

--- a/packages/repository-tests/src/crud/relations/acceptance/multi-relations-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/multi-relations-inclusion-resolver.relation.acceptance.ts
@@ -1,0 +1,189 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository-tests
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect, skipIf, toJSON} from '@loopback/testlab';
+import {Suite} from 'mocha';
+import {
+  CrudFeatures,
+  CrudRepositoryCtor,
+  CrudTestContext,
+  DataSourceOptions,
+} from '../../..';
+import {
+  deleteAllModelsInDefaultDataSource,
+  withCrudCtx,
+} from '../../../helpers.repository-tests';
+import {
+  Customer,
+  CustomerRepository,
+  Order,
+  OrderRepository,
+} from '../fixtures/models';
+import {givenBoundCrudRepositories} from '../helpers';
+
+export function hasManyInclusionResolverAcceptance(
+  dataSourceOptions: DataSourceOptions,
+  repositoryClass: CrudRepositoryCtor,
+  features: CrudFeatures,
+) {
+  skipIf<[(this: Suite) => void], void>(
+    !features.supportsInclusionResolvers,
+    describe,
+    'Multi relations inclusion resolvers - acceptance',
+    suite,
+  );
+  function suite() {
+    before(deleteAllModelsInDefaultDataSource);
+    let customerRepo: CustomerRepository;
+    let orderRepo: OrderRepository;
+
+    before(
+      withCrudCtx(async function setupRepository(ctx: CrudTestContext) {
+        // this helper should create the inclusion resolvers and also
+        // register inclusion resolvers for us
+        ({customerRepo, orderRepo} = givenBoundCrudRepositories(
+          ctx.dataSource,
+          repositoryClass,
+          features,
+        ));
+        expect(customerRepo.orders.inclusionResolver).to.be.Function();
+
+        await ctx.dataSource.automigrate([Customer.name, Order.name]);
+      }),
+    );
+
+    beforeEach(async () => {
+      await customerRepo.deleteAll();
+      await orderRepo.deleteAll();
+    });
+
+    it('include multiple relations', async () => {
+      const parent = await customerRepo.create({name: 'parent'});
+      const customer = await customerRepo.create({
+        name: 'customer',
+        parentId: parent.id,
+      });
+      const order = await orderRepo.create({
+        description: 'an order',
+        customerId: parent.id,
+      });
+
+      const result = await customerRepo.find({
+        include: [{relation: 'orders'}, {relation: 'customers'}],
+      });
+      const expected = [
+        {
+          ...parent,
+          parentId: features.emptyValue,
+          orders: [
+            {
+              ...order,
+              isShipped: features.emptyValue,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              shipment_id: features.emptyValue,
+            },
+          ],
+          customers: [
+            {
+              ...customer,
+              parentId: parent.id,
+            },
+          ],
+        },
+        {
+          ...customer,
+          parentId: parent.id, // doesn't have any related models
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('custom scope with `where` clause', async () => {
+      const customer = await customerRepo.create({name: 'customer'});
+      await orderRepo.create({
+        description: 'to be excluded',
+        customerId: customer.id,
+      });
+      const o2 = await orderRepo.create({
+        description: 'to be included',
+        customerId: customer.id,
+      });
+      const result = await customerRepo.find({
+        include: [{relation: 'orders', scope: {where: {id: o2.id}}}],
+      });
+      const expected = [
+        {
+          ...customer,
+          parentId: features.emptyValue,
+          orders: [
+            {
+              ...o2,
+              isShipped: features.emptyValue,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              shipment_id: features.emptyValue,
+            },
+          ],
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('custom scope with nested inclusion and where clause', async () => {
+      const customer = await customerRepo.create({name: 'customer'});
+      await orderRepo.create({
+        description: 'to be excluded',
+        customerId: customer.id,
+      });
+      const o2 = await orderRepo.create({
+        description: 'to be included',
+        customerId: customer.id,
+      });
+      const result = await customerRepo.find({
+        include: [
+          {
+            relation: 'orders',
+            scope: {where: {id: o2.id}, include: [{relation: 'customer'}]},
+          },
+        ],
+      });
+      const expected = [
+        {
+          ...customer,
+          parentId: features.emptyValue,
+          orders: [
+            {
+              ...o2,
+              isShipped: features.emptyValue,
+              // eslint-disable-next-line @typescript-eslint/camelcase
+              shipment_id: features.emptyValue,
+              customer: {...customer, parentId: features.emptyValue},
+            },
+          ],
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('throws if the custom scope contains nonexists relation name', async () => {
+      const customer = await customerRepo.create({name: 'customer'});
+      await orderRepo.create({
+        description: 'order',
+        customerId: customer.id,
+      });
+      await expect(
+        customerRepo.find({
+          include: [
+            {
+              relation: 'orders',
+              scope: {include: [{relation: 'random'}]},
+            },
+          ],
+        }),
+      ).to.be.rejectedWith(
+        `Invalid "filter.include" entries: {"relation":"random"}`,
+      );
+    });
+  }
+}

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/find-by-foreign-keys.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/find-by-foreign-keys.unit.ts
@@ -118,16 +118,6 @@ describe('findByForeignKeys', () => {
     });
   });
 
-  // update the test when scope is supported
-  it('throws error if scope is passed in and is non-empty', async () => {
-    productRepo.stubs.find.resolves([]);
-    await expect(
-      findByForeignKeys(productRepo, 'categoryId', [1], {limit: 1}),
-    ).to.be.rejectedWith('scope is not supported');
-    sinon.assert.notCalled(productRepo.stubs.find);
-  });
-
-  // update the test when scope is supported
   it('does not throw an error if scope is passed in and is undefined or empty', async () => {
     const find = productRepo.stubs.find;
     find.resolves([]);
@@ -143,5 +133,24 @@ describe('findByForeignKeys', () => {
     products = await findByForeignKeys(productRepo, 'categoryId', 1, {}, {});
     expect(products).to.be.empty();
     sinon.assert.calledWithMatch(find, {});
+  });
+
+  it('checks if the custom scope is handled properly', async () => {
+    const find = productRepo.stubs.find;
+    find.resolves([]);
+    await productRepo.create({id: 1, name: 'product', categoryId: 1});
+    await productRepo.create({id: 2, name: 'product', categoryId: 1});
+    await findByForeignKeys(productRepo, 'categoryId', 1, {
+      where: {id: 2},
+      include: [{relation: 'nested inclusion'}],
+    });
+
+    sinon.assert.calledWithMatch(find, {
+      where: {
+        categoryId: 1,
+        id: 2,
+      },
+      include: [{relation: 'nested inclusion'}],
+    });
   });
 });


### PR DESCRIPTION
Implements https://github.com/strongloop/loopback-next/issues/3453

This will allow using custom scope in inclusion. Example:
```
Order: [{id: 1, customerId: 1, name: "to be excluded"}, {id: 2, customerId: 1, name: "to be included"}]
result = await customerRepo.find({
     include: [
       {
         relation: 'orders',
         scope: {where: {id: 2}, include: [{relation: 'customer'}]},
       },
     ],
   });
```
the result should be:
```
[{ id: 1, 
   name: 'IBM', 
   orders:[
      {id: 2, 
       customerId: 1, 
       name: "to be included",
       customer: {id: 1, name: 'IBM'}
      }
   ]
 }]
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
