### PR TITLE
repository: Add `defineModelClass` helper and fix `DeepPartial<AnyObject>`

### DIFF
--- a/packages/repository/src/__tests__/unit/common-types.unit.ts
+++ b/packages/repository/src/__tests__/unit/common-types.unit.ts
@@ -1,0 +1,38 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {AnyObject, DeepPartial} from '../../common-types';
+
+describe('common types', () => {
+  describe('DeepPartial<T>', () => {
+    it('works for strict models', () => {
+      class Product {
+        name: string;
+      }
+      check<Product>({name: 'a name'});
+      // the test passes when the compiler is happy
+    });
+
+    it('works for free-form models', () => {
+      class FreeForm {
+        id: number;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        [key: string]: any;
+      }
+      check<FreeForm>({id: 1, name: 'a name'});
+      // the test passes when the compiler is happy
+    });
+
+    it('works for AnyObject', () => {
+      check<AnyObject>({id: 'some id', name: 'a name'});
+      // the test passes when the compiler is happy
+    });
+  });
+});
+
+function check<T extends object>(data?: DeepPartial<T>) {
+  // dummy function to run compile-time checks
+  return data;
+}

--- a/packages/repository/src/__tests__/unit/model/define-model-class.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/define-model-class.unit.ts
@@ -1,0 +1,91 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {defineModelClass, Entity, Model, ModelDefinition} from '../../..';
+import {AnyObject} from '../../../common-types';
+
+describe('defineModelClass', () => {
+  it('creates a Model class', () => {
+    const definition = new ModelDefinition(
+      'DataTransferObject',
+    ).addProperty('title', {type: 'string'});
+
+    const DataTransferObject = defineModelClass<typeof Model, {title: string}>(
+      Model,
+      definition,
+    );
+    expect(DataTransferObject.prototype).instanceof(Model);
+
+    // Verify that typedefs allows us to access static Model properties
+    expect(DataTransferObject.modelName).to.equal('DataTransferObject');
+    expect(DataTransferObject.definition).to.equal(definition);
+
+    // Verify that typedefs allows us to create new model instances
+    const instance = new DataTransferObject({title: 'a title'});
+    // Verify that typedefs allows us to call Model methods
+    expect(instance.toJSON()).to.deepEqual({title: 'a title'});
+    // Verify that typedefs allows us to access known properties
+    expect(instance.title).to.equal('a title');
+  });
+
+  it('creates an Entity class', () => {
+    const definition = new ModelDefinition('Product')
+      .addProperty('id', {type: 'number', id: true})
+      .addProperty('name', {
+        type: 'string',
+      });
+
+    const Product = defineModelClass<typeof Entity, {id: number; name: string}>(
+      Entity,
+      definition,
+    );
+    expect(Product.prototype).instanceof(Entity);
+
+    // Verify that typedefs allows us to access static Model properties
+    expect(Product.modelName).to.equal('Product');
+    expect(Product.definition).to.equal(definition);
+
+    // Verify that typedefs allows us to access static Entity properties
+    expect(Product.getIdProperties()).to.deepEqual(['id']);
+
+    // Verify that typedefs allows us to create new model instances
+    const instance = new Product({id: 1, name: 'a name'});
+    // Verify that typedefs allows us to call Entity methods
+    expect(instance.getId()).to.equal(1);
+    // Verify that typedefs allows us to call Model methods
+    expect(instance.toJSON()).to.deepEqual({id: 1, name: 'a name'});
+    // Verify that typedefs allows us to access known properties
+    expect(instance.name).to.equal('a name');
+  });
+
+  it('creates a free-form Entity', () => {
+    const definition = new ModelDefinition('FreeForm')
+      .addProperty('id', {type: 'number', id: true})
+      .addSetting('strict', false);
+
+    const FreeForm = defineModelClass<typeof Entity, AnyObject>(
+      Entity,
+      definition,
+    );
+    expect(FreeForm.prototype).instanceof(Entity);
+
+    // Verify that typedefs allows us to access static Model properties
+    expect(FreeForm.modelName).to.equal('FreeForm');
+    expect(FreeForm.definition).to.equal(definition);
+
+    // Verify that typedefs allows us to access static Entity properties
+    expect(FreeForm.getIdProperties()).to.deepEqual(['id']);
+
+    // Verify that typedefs allows us to create new model instances
+    const instance = new FreeForm({id: 1, name: 'a name'});
+    // Verify that typedefs allows us to call Entity methods
+    expect(instance.getId()).to.equal(1);
+    // Verify that typedefs allows us to call Model methods
+    expect(instance.toJSON()).to.deepEqual({id: 1, name: 'a name'});
+    // Verify that typedefs allows us to access free-form properties
+    expect(instance.name).to.equal('a name');
+  });
+});

--- a/packages/repository/src/common-types.ts
+++ b/packages/repository/src/common-types.ts
@@ -103,3 +103,14 @@ export const CountSchema = {
   title: 'loopback.count',
   properties: {count: {type: 'number'}},
 };
+
+/**
+ * Type helper to infer prototype from a constructor function.
+ *
+ * Example: `PrototypeOf<typeof Entity>` is resolved to `Entity`.
+ */
+export type PrototypeOf<Ctor extends Function> = Ctor extends {
+  prototype: infer Proto;
+}
+  ? Proto
+  : never;

--- a/packages/repository/src/common-types.ts
+++ b/packages/repository/src/common-types.ts
@@ -49,7 +49,9 @@ export interface AnyObject {
  * An extension of the built-in Partial<T> type which allows partial values
  * in deeply nested properties too.
  */
-export type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
+export type DeepPartial<T> =
+  | Partial<T> // handle free-form properties, e.g. DeepPartial<AnyObject>
+  | {[P in keyof T]?: DeepPartial<T[P]>};
 
 /**
  * Type alias for strongly or weakly typed objects of T

--- a/packages/repository/src/define-model-class.ts
+++ b/packages/repository/src/define-model-class.ts
@@ -1,0 +1,88 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import * as assert from 'assert';
+import {DataObject, PrototypeOf} from './common-types';
+import {Model, ModelDefinition} from './model';
+
+/**
+ * Create (define) a new model class with the given name and definition.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * const Product = defineModelClass(Entity, new ModelDefinition('Product'));
+ * ```
+ *
+ * To enable type safety, you should describe properties of your model:
+ *
+ * ```ts
+ * const Product = defineModelClass<
+ *  typeof Entity,
+ *  {id: number, name: string}
+ * >(Entity, new ModelDefinition('Product'));
+ * ```
+ *
+ * If your model allows arbitrary (free-form) properties, then add `AnyObject`
+ * to the type describing model properties.
+ *
+ * ```ts
+ * const Product = defineModelClass<
+ *  typeof Entity,
+ *  AnyObject & {id: number},
+ * >(Entity, new ModelDefinition('Product'));
+ * ```
+ *
+ * @param base The base model to extend, typically Model or Entity.
+ *  You can also use your own base class, e.g. `User`.
+ * @param definition Definition of the model to create.
+ * @template BaseCtor Constructor type of the base class,
+ *   e.g `typeof Model` or `typeof Entity`
+ * @template Props Interface describing model properties,
+ *   e.g. `{title: string}` or `AnyObject & {id: number}`.
+ */
+export function defineModelClass<
+  BaseCtor extends typeof Model,
+  Props extends object = {}
+>(
+  base: BaseCtor /* Model or Entity */,
+  definition: ModelDefinition,
+): DynamicModelCtor<BaseCtor, Props> {
+  const modelName = definition.name;
+  const defineNamedModelClass = new Function(
+    base.name,
+    `return class ${modelName} extends ${base.name} {}`,
+  );
+  const modelClass = defineNamedModelClass(base) as DynamicModelCtor<
+    BaseCtor,
+    Props
+  >;
+  assert.equal(modelClass.name, modelName);
+  modelClass.definition = definition;
+  return modelClass;
+}
+
+/**
+ * A type describing a model class created via `defineModelClass`.
+ *
+ * Assuming template arguments `BaseCtor` and `Props`, this type describes
+ * a class constructor with the following properties:
+ * - a constructor function accepting `DataObject<Props>` as the only argument,
+ *   this argument is optional
+ * - all static fields (properties, methods) from `BaseCtor` are inherited and
+ *   available as static fields on the dynamic class
+ * - all prototype fields from `BaseCtor` prototype are inherited and available
+ *   as prototype fields on the dynamic class
+ */
+export type DynamicModelCtor<
+  BaseCtor extends typeof Model,
+  Props extends object
+> = BaseCtor & {
+  /** Model constructor accepting partial model data. */
+  new (data?: DataObject<PrototypeOf<BaseCtor> & Props>): PrototypeOf<
+    BaseCtor
+  > &
+    Props;
+};

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -7,6 +7,7 @@ export * from './common-types';
 export * from './connectors';
 export * from './datasource';
 export * from './decorators';
+export * from './define-model-class';
 export * from './errors';
 export * from './mixins';
 export * from './model';


### PR DESCRIPTION
_See #4235 for background context._

Implement a new helper function that allows LB4 users to create
model classes dynamically at runtime. This is similar functionality
as offered by LB3, but with the benefit of compile-time type checks.

Example use:

```ts
const definition = new ModelDefinition('Product')
  .addProperty('id', {type: 'number', id: true})
  .addProperty('name', {
    type: 'string',
  });

const Product = defineModelClass<
  typeof Entity,
  {id: number; name: string}
>(
  Entity,
  definition,
);
```

While testing this code, I found a bug in `DeepPartial<T>` that I have experienced before. This time I could not ignore it because one of my tests would fail, so I am finally fixing it (see the first commit). Consider the following code:

```ts
function create<T extends object>(data?: DeepPartial<T>) {
  // ...
}
```

Before this change, `create<AnyObject>({key: 'value'})` is rejected by the compiler, becase "No overload matches this call."

With this change in place, the compiler no longer complains.




## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
