### PR TITLE
[Very Small] Update API Documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ by using it for your next project. Start by having a look at
 [Getting Started](https://loopback.io/doc/en/lb4/Getting-started.html).
 
 Check the
-[API documentation](https://apidocs.loopback.io/@loopback%2fdocs/apidocs.html)
+[API documentation](https://loopback.io/doc/en/lb4/apidocs.index.html)
 for all the API usages in each package.
 
 [LoopBack 3](https://loopback.io/doc/en/lb3/) became active LTS version, and


### PR DESCRIPTION
This is such an insignificant change I figure I wouldn't need to jump through the hoops needed for submitting an actual PR.

Updated a link in the Readme because when I tried to access it would bring me to a page giving a 404 and saying `Cannot GET /@loopback%2fdocs/apidocs.html`.