### PR TITLE
Preserve custom type of auto-generated id property

### DIFF
--- a/packages/repository-tests/src/crud/create-retrieve.suite.ts
+++ b/packages/repository-tests/src/crud/create-retrieve.suite.ts
@@ -12,9 +12,9 @@ import {
   property,
 } from '@loopback/repository';
 import {expect, toJSON} from '@loopback/testlab';
-import {MixedIdType} from '../helpers.repository-tests';
 import {
   deleteAllModelsInDefaultDataSource,
+  MixedIdType,
   withCrudCtx,
 } from '../helpers.repository-tests';
 import {
@@ -89,7 +89,7 @@ export function createRetrieveSuite(
       const pens = await repo.create({name: 'Pens', categoryId: 1});
       const pencils = await repo.create({name: 'Pencils', categoryId: 2});
       const products = await findByForeignKeys(repo, 'categoryId', [1]);
-      expect(products).deepEqual([pens]);
+      expect(toJSON(products)).deepEqual(toJSON([pens]));
       expect(products).to.not.containDeep(pencils);
     });
 
@@ -97,7 +97,7 @@ export function createRetrieveSuite(
       const pens = await repo.create({name: 'Pens', categoryId: 1});
       const pencils = await repo.create({name: 'Pencils', categoryId: 2});
       const products = await findByForeignKeys(repo, 'categoryId', [1, 2]);
-      expect(products).deepEqual([pens, pencils]);
+      expect(toJSON(products)).deepEqual(toJSON([pens, pencils]));
     });
   });
 }

--- a/packages/repository-tests/src/crud/nested-model-properties.suite.ts
+++ b/packages/repository-tests/src/crud/nested-model-properties.suite.ts
@@ -14,8 +14,8 @@ import {
 import {expect, toJSON} from '@loopback/testlab';
 import {
   deleteAllModelsInDefaultDataSource,
-  withCrudCtx,
   MixedIdType,
+  withCrudCtx,
 } from '../helpers.repository-tests';
 import {
   CrudFeatures,
@@ -91,6 +91,7 @@ export function nestedModelsPropertiesSuite(
       @property({
         id: true,
         generated: true,
+        useDefaultIdType: true,
       })
       id: MixedIdType;
 

--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
@@ -91,7 +91,7 @@ export function belongsToRelationAcceptance(
         description: 'Order that is shipped Tuesday morning',
       });
       const result = await orderRepo.shipment(order.id);
-      expect(result).to.deepEqual(shipment);
+      expect(toJSON(result)).to.deepEqual(toJSON(shipment));
     });
 
     it('returns undefined if the source instance does not have the foreign key', async () => {

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
@@ -310,7 +310,7 @@ export function hasManyRelationAcceptance(
         });
         const childsParent = await getParentCustomer(child.id);
         expect(_.pick(childsParent, ['id', 'name'])).to.eql(
-          _.pick(parent, ['id', 'name']),
+          toJSON(_.pick(parent, ['id', 'name'])),
         );
       });
 

--- a/packages/repository-tests/src/crud/relations/fixtures/models/address.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/address.model.ts
@@ -19,6 +19,7 @@ export class Address extends Entity {
   @property({
     id: true,
     generated: true,
+    useDefaltIdType: true,
   })
   id: MixedIdType;
   @property({

--- a/packages/repository-tests/src/crud/relations/fixtures/models/customer.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/customer.model.ts
@@ -24,6 +24,7 @@ export class Customer extends Entity {
   @property({
     id: true,
     generated: true,
+    useDefaltIdType: true,
   })
   id: MixedIdType;
 

--- a/packages/repository-tests/src/crud/relations/fixtures/models/order.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/order.model.ts
@@ -20,6 +20,7 @@ export class Order extends Entity {
   @property({
     id: true,
     generated: true,
+    useDefaultIdType: true,
   })
   id: MixedIdType;
 

--- a/packages/repository-tests/src/crud/relations/fixtures/models/shipment.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/shipment.model.ts
@@ -19,6 +19,7 @@ export class Shipment extends Entity {
   @property({
     id: true,
     generated: true,
+    useDefaltIdType: true,
   })
   id: MixedIdType;
 

--- a/packages/repository-tests/src/crud/replace-by-id.suite.ts
+++ b/packages/repository-tests/src/crud/replace-by-id.suite.ts
@@ -35,6 +35,7 @@ export function createSuiteForReplaceById(
       type: features.idType,
       id: true,
       generated: true,
+      useDefaultIdType: true,
       description: 'The unique identifier for a product',
     })
     id: MixedIdType;

--- a/packages/repository/src/__tests__/unit/decorator/model-and-relation.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/model-and-relation.decorator.unit.ts
@@ -192,7 +192,12 @@ describe('model decorator', () => {
         column: 'QTY',
       },
     });
-    expect(meta.id).to.eql({type: 'string', id: true, generated: true});
+    expect(meta.id).to.eql({
+      type: 'string',
+      id: true,
+      generated: true,
+      useDefaultIdType: false,
+    });
     expect(meta.isShipped).to.eql({type: Boolean});
   });
 

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -106,6 +106,16 @@ export class ModelDefinition {
     const definition = (definitionOrType as PropertyDefinition).type
       ? (definitionOrType as PropertyDefinition)
       : {type: definitionOrType};
+
+    if (
+      definition.id === true &&
+      definition.generated === true &&
+      definition.type !== undefined &&
+      definition.useDefaultIdType === undefined
+    ) {
+      definition.useDefaultIdType = false;
+    }
+
     this.properties[name] = definition;
     return this;
   }


### PR DESCRIPTION
Implements #3602 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or **existing tests modified to cover all changes**
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
