### PR TITLE
feat: add title property to ping response schema definition

### DIFF
--- a/examples/express-composition/src/controllers/ping.controller.ts
+++ b/examples/express-composition/src/controllers/ping.controller.ts
@@ -15,6 +15,7 @@ const PING_RESPONSE: ResponseObject = {
     'application/json': {
       schema: {
         type: 'object',
+        title: 'PingResponse',
         properties: {
           greeting: {type: 'string'},
           date: {type: 'string'},

--- a/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
+++ b/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
@@ -10,6 +10,7 @@ const PING_RESPONSE: ResponseObject = {
     'application/json': {
       schema: {
         type: 'object',
+        title: 'PingResponse',
         properties: {
           greeting: {type: 'string'},
           date: {type: 'string'},


### PR DESCRIPTION
Add title property to ping response schema definition in order to enable better model
generation by third party tools such as https://github.com/OpenAPITools/openapi-generator .

Without a title property the generator would simply name the ping response as `InlineResponse200`. By adding the title property, the tooling can produce a model named after the object title.

Similar to #4240

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
