### PR TITLE
fix(docs): add import authentication component

### DIFF
--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -64,6 +64,10 @@ To utilize `authentication` in an application `application.ts`, you must load
 the authentication component named `AuthenticationComponent`.
 
 ```ts
+import {AuthenticationComponent} from '@loopback/authentication';
+
+//...
+
 export class MyApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
 ) {

--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -66,7 +66,7 @@ the authentication component named `AuthenticationComponent`.
 ```ts
 import {AuthenticationComponent} from '@loopback/authentication';
 
-//...
+//....
 
 export class MyApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),


### PR DESCRIPTION
Add import `AuthenticationComponent` to application.ts

Without the line
```
import {AuthenticationComponent} from '@loopback/authentication';
```
the example fails because the interpretor cannot find `AuthenticationComponent`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
