### PR TITLE
fix(docs): replace emoji markup with an emoji glyph

### DIFF
--- a/extensions/metrics/README.md
+++ b/extensions/metrics/README.md
@@ -3,7 +3,7 @@
 This module contains a component that reports metrics of Node.js, LoopBack
 framework, and your application to [Prometheus](https://prometheus.io/).
 
-## Stability: :warning:Experimental:warning:
+## Stability: ⚠️Experimental⚠️
 
 > Experimental packages provide early access to advanced or experimental
 > functionality to get community feedback. Such modules are published to npm


### PR DESCRIPTION
Jekyll does not interpret markup like `:warning:` and as a result, the Metrics page was showing the following heading:

<img width="863" alt="Screen Shot 2019-12-12 at 13 50 23" src="https://user-images.githubusercontent.com/1140553/70713475-5e65b100-1ce6-11ea-9c7f-231b6e01305e.png">

In this patch, I am replacing `:warning:` with the actual emoji glyph, i.e. `⚠️`. This fixes the rendered page, see the screenshot from `npm run docs:start`:

<img width="851" alt="Screen Shot 2019-12-12 at 13 51 38" src="https://user-images.githubusercontent.com/1140553/70713541-89500500-1ce6-11ea-949f-bd2007a35536.png">

/cc @raymondfeng 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
