### PR TITLE
chore(core): fix the assertion for parallel run of observers within the same group

### DIFF
--- a/packages/core/src/__tests__/unit/lifecycle-registry.unit.ts
+++ b/packages/core/src/__tests__/unit/lifecycle-registry.unit.ts
@@ -104,12 +104,14 @@ describe('LifeCycleRegistry', () => {
     registry.setParallel(true);
     await registry.start();
     expect(events.length).to.equal(4);
-    expect(events).to.eql([
-      'g1-2-start',
-      'g1-1-start',
-      'g2-2-start',
-      'g2-1-start',
-    ]);
+
+    // 1st group: g1-1, g1-2
+    const group1 = events.slice(0, 2);
+    expect(group1.sort()).to.eql(['g1-1-start', 'g1-2-start']);
+
+    // 2nd group: g2-1, g2-2
+    const group2 = events.slice(2, 4);
+    expect(group2.sort()).to.eql(['g2-1-start', 'g2-2-start']);
   });
 
   it('runs all registered observers within the same group in serial', async () => {


### PR DESCRIPTION
The timeout based assumption is not always reliable in CI.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
