### PR TITLE
chore: add new maintainers to README 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ You can join the team by posting a comment to
 | [![nabdelgadir]](https://github.com/nabdelgadir) | [![marioestradarosa]](https://github.com/marioestradarosa) |        [![yaty]](https://github.com/yaty)        |
 |                 Dominique Emond                  |                         Agnes Lin                          |                 Deepak Rajamohan                 |
 |     [![emonddr]](https://github.com/emonddr)     |         [![agnes512]](https://github.com/agnes512)         | [![deepakrkris]](https://github.com/deepakrkris) |
+|                  Denny Bartelt                   |                    Douglas McConnachie                     |                  Rifa Achrinza                   |
+|     [![derdeka]](https://github.com/derdeka)     |         [![dougal83]](https://github.com/dougal83)         |    [![achrinza]](https://github.com/achrinza)    |
 
 See
 [all contributors](https://github.com/strongloop/loopback-next/graphs/contributors).
@@ -115,3 +117,6 @@ See
 [emonddr]: https://avatars0.githubusercontent.com/u/6864736??v=3&s=60
 [agnes512]: https://avatars3.githubusercontent.com/u/50331796?v=3&s=60
 [deepakrkris]: https://avatars0.githubusercontent.com/u/7688315?v=3&s=60
+[derdeka]: https://avatars3.githubusercontent.com/u/13640166?v=3&s=60
+[dougal83]: https://avatars0.githubusercontent.com/u/2735881?v=3&s=60
+[achrinza]: https://avatars3.githubusercontent.com/u/25147899?v=3&s=60


### PR DESCRIPTION
Add @derdeka, @dougal83 and @achrinza to the list of maintainers.

It looks like GitHub is not able to down-scale the auto-generated avatars :(

<img width="884" alt="Screen Shot 2019-12-13 at 15 24 54" src="https://user-images.githubusercontent.com/1140553/70806954-be2e8b80-1dbc-11ea-9879-eb1bc085b854.png">

@derdeka @dougal83 Would you mind updating your profile to set your own avatar? It does not have to be your real picture, any image will do.

I will understand if you don't want to, in which case I am proposing to leave out the auto-generated avatars from the table in the README.

@dhmlau I would like to wait for  @derdeka, @dougal83 and @achrinza to approve this pull request before it's landed. To avoid waiting until I get back from my vacation, can you please take care of this pull request for me?

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
