### PR TITLE
fix(docs): fix anchor link in authorization page

### DIFF
--- a/docs/site/Loopback-component-authorization.md
+++ b/docs/site/Loopback-component-authorization.md
@@ -73,16 +73,16 @@ approach authorization.
 
 `Developers` need to,
 
-- mount the authorization component
-  ([see, Registering the Authorization Component](##Registering-the-Authorization-Component))
-- decorate endpoints with authorization metadata
-  ([see, Configuring API Endpoints](##Configuring-API-Endpoints))
-- define `authorizer` and `voter` functions
-  ([see, Programming Access Policies](##Programming-Access-Policies))
-- design security policies as decision matrix
-  ([see, Authorization by decision matrix](##Authorization-by-decision-matrix))
-- plug in external enforcer libraries
-  ([see, Enforcer Libraries](##Enforcer-Libraries))
+- mount the authorization component, see
+  [Registering the Authorization Component](#registering-the-authorization-component)
+- decorate endpoints with authorization metadata, see
+  [Configuring API Endpoints](#configuring-api-endpoints)
+- define `authorizer` and `voter` functions, see
+  [Programming Access Policies](#programming-access-policies)
+- design security policies as decision matrix, see
+  [Authorization by decision matrix](#authorization-by-decision-matrix)
+- plug in external enforcer libraries, see
+  [Enforcer Libraries](#enforcer-libraries)
 
 ## Registering the Authorization Component
 
@@ -125,26 +125,25 @@ The component also declares various
 [types](https://github.com/strongloop/loopback-next/blob/master/packages/authorization/src/types.ts)
 to use in defining necessary classes and inputs by developers.
 
-    - `Authorizer`: A class implementing access policies. Accepts
-      `AuthorizationContext` and `AuthorizationMetadata` as input and returns an
-      `AuthorizationDecision`.
+- `Authorizer`: A class implementing access policies. Accepts
+  `AuthorizationContext` and `AuthorizationMetadata` as input and returns an
+  `AuthorizationDecision`.
 
-    - `AuthorizationDecision`: expected type to be returned by an `Authorizer`
+- `AuthorizationDecision`: expected type to be returned by an `Authorizer`
 
-    - `AuthorizationMetadata`: expected type of the authorization spec passed to
-      the decorator used to annotate a controller method. Also provided as input
-      parameter to the `Authorizer`.
+- `AuthorizationMetadata`: expected type of the authorization spec passed to the
+  decorator used to annotate a controller method. Also provided as input
+  parameter to the `Authorizer`.
 
-    - `AuthorizationContext`: contains current principal invoking an endpoint,
-      request context and expected roles and scopes.
+- `AuthorizationContext`: contains current principal invoking an endpoint,
+  request context and expected roles and scopes.
 
-    - `Enforcer`: type of extension classes that provide authorization services
-      for an `Authorizer`.
+- `Enforcer`: type of extension classes that provide authorization services for
+  an `Authorizer`.
 
-    - `AuthorizationRequest`: type of the input provided to an `Enforcer`.
+- `AuthorizationRequest`: type of the input provided to an `Enforcer`.
 
-    - `AuthorizationError`: expected type of the error thrown by an
-      `Authorizer`.
+- `AuthorizationError`: expected type of the error thrown by an `Authorizer`.
 
 ## Authorization Interceptor
 


### PR DESCRIPTION
The anchor links in the [authorization page](https://loopback.io/doc/en/lb4/Loopback-component-authorization.html) are not working. The links are working as markdown file but not after they get generated with Jekyll. 



## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
