### PR TITLE
feat(repository): allow custom keyFrom for hasMany and hasOne

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -155,6 +155,8 @@ export interface OrderRelations {
 }
 ```
 
+{% include important.html content="LB4 doesn't support composite keys for now. e.g joining two tables with more than one source key. Related GitHub issue: [Composite primary/foreign keys](https://github.com/strongloop/loopback-next/issues/1830)" %}
+
 ## Configuring a belongsTo relation
 
 The configuration and resolution of a `belongsTo` relation takes place at the
@@ -461,5 +463,5 @@ custom scope once you have the inclusion resolver of each relation set up.
 Check[HasMany - Query multiple relations](HasMany-relation.md#query-multiple-relations)
 for the usage and examples.
 
-{% include important.html content="There are some limitations of inclusion:. <br/><br/> We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/><br/> It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/><br/> It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
+{% include important.html content="There are some limitations of inclusion:. <br/>We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/>It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/>It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
 " %}

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -248,10 +248,10 @@ export class Order extends Entity {
 }
 ```
 
-Notice that if you decorate the corresponding foreign key of the target model
-with `@belongsTo`, you also need to specify the `belongsTo` relation name in the
-`name` field of its relation metadata. See [BelongsTo](BelongsTo-relation.md)
-for more details.
+Notice that if you decorate the corresponding customized foreign key of the
+target model with `@belongsTo`, you also need to specify the `belongsTo`
+relation name in the `name` field of its relation metadata. See
+[BelongsTo](BelongsTo-relation.md) for more details.
 
 ```ts
 // import statements
@@ -264,6 +264,54 @@ export class Order extends Entity {
   my_customer_id: number; // customized foreign key name
 }
 ```
+
+If you need to use another attribute other than the id property to be the source
+key, customizing `keyFrom` field would allow you to do so:
+
+```ts
+export class Customer extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+  })
+  id: number;
+
+  // if you'd like to use this property as the source id
+  // of a certain relation that relates to a model `Foo`
+  @property({
+    type: 'number',
+  })
+  authorId: number; // not primary key
+
+  @hasMany(() => Review, {keyFrom: 'authorId'})
+  reviews?: Review[];
+
+  @hasMany(() => Order)
+  orders?: Order[];
+
+  // ..constructor
+  }
+}
+```
+
+Notice that if you decorate the corresponding foreign key of the target model
+with `@belongsTo`, you also need to specify the `keyTo` field of its relation
+metadata. See [BelongsTo](BelongsTo-relation.md#relation-metadata) for more
+details.
+
+```ts
+// import statements
+@model()
+export class Review extends Entity {
+  // constructor, properties, etc.
+
+  // specify the keyTo if the source key is not the id property
+  @belongsTo(() => Customer, {keyTo: 'authorId'})
+  customerId: number; // default foreign key name
+}
+```
+
+{% include important.html content="LB4 doesn't support composite keys for now. e.g joining two tables with more than one source key. Related GitHub issue: [Composite primary/foreign keys](https://github.com/strongloop/loopback-next/issues/1830)" %}
 
 If you need to use _different names for models and database columns_, to use
 `my_orders` as db column name other than `orders` for example, the following
@@ -664,5 +712,5 @@ The `Where` clause above filters the result of `orders`.
 {% include tip.html content="Make sure that you have all inclusion resolvers that you need REGISTERED, and
 all relation names should be UNIQUE."%}
 
-{% include important.html content="There are some limitations of inclusion:. <br/><br/> We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/><br/> It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/><br/> It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
+{% include important.html content="There are some limitations of inclusion:. <br/>We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/>It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/>It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
 " %}

--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -184,10 +184,10 @@ export class Supplier extends Entity {
 }
 ```
 
-Notice that if you decorate the corresponding foreign key of the target model
-with `@belongsTo`, you also need to specify the `belongTo` relation name in the
-`name` field of its relation metadata. See [BelongsTo](BelongsTo-relation.md)
-for more details.
+Notice that if you decorate the corresponding customized foreign key of the
+target model with `@belongsTo`, you also need to specify the `belongTo` relation
+name in the `name` field of its relation metadata. See
+[BelongsTo](BelongsTo-relation.md) for more details.
 
 ```ts
 // import statements
@@ -200,6 +200,54 @@ export class Account extends Entity {
   suppId: number; // customized foreign key name
 }
 ```
+
+If you need to use another attribute other than the id property to be the source
+key, customizing `keyFrom` field would allow you to do so:
+
+```ts
+export class Supplier extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+  })
+  id: number;
+
+  // if you'd like to use this property as the source id
+  // of a certain relation that relates to a model `Foo`
+  @property({
+    type: 'number',
+  })
+  supplier_id: number; // not primary key
+
+  @hasOne(() => Account)
+  account?: Account;
+
+  @hasOne(() => Manufacturer, {keyFrom: 'supplier_id'})
+  manufacturer ?: Manufacturer;
+
+  // ..constructor
+  }
+}
+```
+
+Notice that if you decorate the corresponding foreign key of the target model
+with `@belongsTo`, you also need to specify the `keyTo` field of its relation
+metadata. See [BelongsTo](BelongsTo-relation.md#relation-metadata) for more
+details.
+
+```ts
+// import statements
+@model()
+export class Manufacturer extends Entity {
+  // constructor, properties, etc.
+
+  // specify the keyTo if the source key is not the id property
+  @belongsTo(() => Supplier, {keyTo: 'supplier_id'})
+  supplierId: number; // default foreign key name
+}
+```
+
+{% include important.html content="LB4 doesn't support composite keys for now. e.g joining two tables with more than one source key. Related GitHub issue: [Composite primary/foreign keys](https://github.com/strongloop/loopback-next/issues/1830)" %}
 
 If you need to use _different names for models and database columns_, to use
 `suppAccount` as db column name instead of `account` for example, the following
@@ -482,5 +530,5 @@ custom scope once you have the inclusion resolver of each relation set up.
 Check[HasMany - Query multiple relations](HasMany-relation.md#query-multiple-relations)
 for the usage and examples.
 
-{% include important.html content="There are some limitations of inclusion:. <br/><br/> We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/><br/> It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/><br/> It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
+{% include important.html content="There are some limitations of inclusion:. <br/>We don’t support recursive inclusion of related models. Related GH issue: [Recursive inclusion of related models](https://github.com/strongloop/loopback-next/issues/3454). <br/>It doesn’t split numbers of queries. Related GH issue: [Support inq splitting](https://github.com/strongloop/loopback-next/issues/3444). <br/>It might not work well with ObjectId of MongoDB. Related GH issue: [Spike: robust handling of ObjectID type for MongoDB](https://github.com/strongloop/loopback-next/issues/3456).
 " %}

--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
@@ -85,8 +85,7 @@ export function belongsToInclusionResolverAcceptance(
       const expected = {
         ...order,
         isShipped: features.emptyValue,
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        shipment_id: features.emptyValue,
+        shipmentInfo: features.emptyValue,
         customer: {
           ...thor,
           parentId: features.emptyValue,
@@ -115,8 +114,7 @@ export function belongsToInclusionResolverAcceptance(
         {
           ...thorOrder,
           isShipped: features.emptyValue,
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          shipment_id: features.emptyValue,
+          shipmentInfo: features.emptyValue,
           customer: {
             ...thor,
             parentId: features.emptyValue,
@@ -125,8 +123,7 @@ export function belongsToInclusionResolverAcceptance(
         {
           ...odinOrder,
           isShipped: features.emptyValue,
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          shipment_id: features.emptyValue,
+          shipmentInfo: features.emptyValue,
           customer: {
             ...odin,
             parentId: features.emptyValue,
@@ -154,8 +151,7 @@ export function belongsToInclusionResolverAcceptance(
       const expected = {
         ...odinOrder,
         isShipped: features.emptyValue,
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        shipment_id: features.emptyValue,
+        shipmentInfo: features.emptyValue,
         customer: {
           ...odin,
           parentId: features.emptyValue,

--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
@@ -83,10 +83,11 @@ export function belongsToRelationAcceptance(
     it('can find shipment of order with a custom foreign key name', async () => {
       const shipment = await shipmentRepo.create({
         name: 'Tuesday morning shipment',
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        shipment_id: 999,
       });
       const order = await orderRepo.create({
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        shipment_id: shipment.id,
+        shipmentInfo: shipment.shipment_id,
         description: 'Order that is shipped Tuesday morning',
       });
       const result = await orderRepo.shipment(order.id);

--- a/packages/repository-tests/src/crud/relations/acceptance/multi-relations-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/multi-relations-inclusion-resolver.relation.acceptance.ts
@@ -81,8 +81,7 @@ export function hasManyInclusionResolverAcceptance(
             {
               ...order,
               isShipped: features.emptyValue,
-              // eslint-disable-next-line @typescript-eslint/camelcase
-              shipment_id: features.emptyValue,
+              shipmentInfo: features.emptyValue,
             },
           ],
           customers: [
@@ -121,8 +120,7 @@ export function hasManyInclusionResolverAcceptance(
             {
               ...o2,
               isShipped: features.emptyValue,
-              // eslint-disable-next-line @typescript-eslint/camelcase
-              shipment_id: features.emptyValue,
+              shipmentInfo: features.emptyValue,
             },
           ],
         },
@@ -156,8 +154,7 @@ export function hasManyInclusionResolverAcceptance(
             {
               ...o2,
               isShipped: features.emptyValue,
-              // eslint-disable-next-line @typescript-eslint/camelcase
-              shipment_id: features.emptyValue,
+              shipmentInfo: features.emptyValue,
               customer: {...customer, parentId: features.emptyValue},
             },
           ],

--- a/packages/repository-tests/src/crud/relations/fixtures/models/order.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/order.model.ts
@@ -38,8 +38,8 @@ export class Order extends Entity {
   @belongsTo(() => Customer)
   customerId: MixedIdType;
 
-  @belongsTo(() => Shipment, {name: 'shipment'})
-  shipment_id: MixedIdType;
+  @belongsTo(() => Shipment, {keyTo: 'shipment_id', name: 'shipment'})
+  shipmentInfo: number;
 }
 
 export interface OrderRelations {

--- a/packages/repository-tests/src/crud/relations/fixtures/models/shipment.model.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/models/shipment.model.ts
@@ -22,10 +22,16 @@ export class Shipment extends Entity {
   })
   id: MixedIdType;
 
+  @property({
+    type: 'number',
+  })
+  shipment_id: number;
+
   @property({type: 'string'})
   name: string;
 
-  @hasMany(() => Order, {keyTo: 'shipment_id'})
+  // keyFrom is not the id property of Shipment
+  @hasMany(() => Order, {keyFrom: 'shipment_id', keyTo: 'shipmentInfo'})
   shipmentOrders: Order[];
 
   constructor(data?: Partial<Shipment>) {
@@ -34,7 +40,7 @@ export class Shipment extends Entity {
 }
 
 export interface ShipmentRelations {
-  orders?: OrderWithRelations[];
+  shipmentOrders?: OrderWithRelations[];
 }
 
 export type ShipmentWithRelations = Shipment & ShipmentRelations;
@@ -42,5 +48,5 @@ export type ShipmentWithRelations = Shipment & ShipmentRelations;
 export interface ShipmentRepository
   extends EntityCrudRepository<Shipment, typeof Shipment.prototype.id> {
   // define additional members like relation methods here
-  orders: HasManyRepositoryFactory<Order, MixedIdType>;
+  shipmentOrders: HasManyRepositoryFactory<Order, MixedIdType>;
 }

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/shipment.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/shipment.repository.ts
@@ -20,7 +20,7 @@ export function createShipmentRepo(repoClass: CrudRepositoryCtor) {
     typeof Shipment.prototype.id,
     ShipmentRelations
   > {
-    public readonly orders: HasManyRepositoryFactory<
+    public readonly shipmentOrders: HasManyRepositoryFactory<
       Order,
       typeof Shipment.prototype.id
     >;
@@ -30,11 +30,11 @@ export function createShipmentRepo(repoClass: CrudRepositoryCtor) {
       orderRepositoryGetter: Getter<typeof repoClass.prototype>,
     ) {
       super(Shipment, db);
-      const ordersMeta = this.entityClass.definition.relations[
+      const shipmentOrdersMeta = this.entityClass.definition.relations[
         'shipmentOrders'
       ];
-      this.orders = createHasManyRepositoryFactory(
-        ordersMeta as HasManyDefinition,
+      this.shipmentOrders = createHasManyRepositoryFactory(
+        shipmentOrdersMeta as HasManyDefinition,
         orderRepositoryGetter,
       );
     }

--- a/packages/repository-tests/src/crud/relations/helpers.ts
+++ b/packages/repository-tests/src/crud/relations/helpers.ts
@@ -83,6 +83,11 @@ export function givenBoundCrudRepositories(
     async () => orderRepo,
   );
 
+  shipmentRepo.inclusionResolvers.set(
+    'shipmentOrders',
+    shipmentRepo.shipmentOrders.inclusionResolver,
+  );
+
   const addressRepoClass = createAddressRepo(repositoryClass);
   const addressRepo: AddressRepository = new addressRepoClass(
     db,

--- a/packages/repository/src/relations/has-many/has-many.helpers.ts
+++ b/packages/repository/src/relations/has-many/has-many.helpers.ts
@@ -50,8 +50,16 @@ export function resolveHasManyMetadata(
     throw new InvalidRelationError(reason, relationMeta);
   }
 
-  const keyFrom = sourceModel.getIdProperties()[0];
-
+  // keyFrom defaults to id property
+  let keyFrom;
+  if (
+    relationMeta.keyFrom &&
+    relationMeta.source.definition.properties[relationMeta.keyFrom]
+  ) {
+    keyFrom = relationMeta.keyFrom;
+  } else {
+    keyFrom = sourceModel.getIdProperties()[0];
+  }
   // Make sure that if it already keys to the foreign key property,
   // the key exists in the target model
   if (relationMeta.keyTo && targetModelProperties[relationMeta.keyTo]) {
@@ -72,5 +80,8 @@ export function resolveHasManyMetadata(
     throw new InvalidRelationError(reason, relationMeta);
   }
 
-  return Object.assign(relationMeta, {keyFrom, keyTo: defaultFkName});
+  return Object.assign(relationMeta, {
+    keyFrom,
+    keyTo: defaultFkName,
+  } as HasManyResolvedDefinition);
 }

--- a/packages/repository/src/relations/has-one/has-one.helpers.ts
+++ b/packages/repository/src/relations/has-one/has-one.helpers.ts
@@ -50,7 +50,16 @@ export function resolveHasOneMetadata(
     throw new InvalidRelationError(reason, relationMeta);
   }
 
-  const keyFrom = sourceModel.getIdProperties()[0];
+  // keyFrom defaults to id property
+  let keyFrom;
+  if (
+    relationMeta.keyFrom &&
+    relationMeta.source.definition.properties[relationMeta.keyFrom]
+  ) {
+    keyFrom = relationMeta.keyFrom;
+  } else {
+    keyFrom = sourceModel.getIdProperties()[0];
+  }
 
   // Make sure that if it already keys to the foreign key property,
   // the key exists in the target model

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -59,13 +59,18 @@ export interface HasManyDefinition extends RelationDefinitionBase {
   targetsMany: true;
 
   /**
-   * The foreign key used by the target model.
+   * keyTo: The foreign key used by the target model for this relation.
+   * keyFrom: The source key used by the source model for this relation.
    *
    * E.g. when a Customer has many Order instances, then keyTo is "customerId".
    * Note that "customerId" is the default FK assumed by the framework, users
    * can provide a custom FK name by setting "keyTo".
+   * And Customer.id is keyFrom. keyFrom defaults to the id property of a model.
+   * Users can provide a custom source key name by setting "keyTo".
+   *
    */
   keyTo?: string;
+  keyFrom?: string;
 }
 
 /**
@@ -132,13 +137,17 @@ export interface HasOneDefinition extends RelationDefinitionBase {
   targetsMany: false;
 
   /**
-   * The foreign key used by the target model.
+   * keyTo: The foreign key used by the target model for this relation.
+   * keyFrom: The source key used by the source model for this relation.
    *
    * E.g. when a Customer has one Address instance, then keyTo is "customerId".
    * Note that "customerId" is the default FK assumed by the framework, users
    * can provide a custom FK name by setting "keyTo".
+   * And Customer.id is keyFrom. keyFrom defaults to the id property of a model.
+   * Users can provide a custom source key name by setting "keyTo".
    */
   keyTo?: string;
+  keyFrom?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

LB4 relation `hasMany` and `hasOne` use the mode id property as the source key. However, there are cases use would like to define a non-id property as their source key in these two relations ( in the other words, join tables on non-id attribute). 

### Example

- `Customer` has many `Order`s. 
- `Customer` has many `Review`s.

<img width="706" alt="Screen Shot 2019-12-16 at 3 40 45 PM" src="https://user-images.githubusercontent.com/50331796/71096405-3a89eb80-217c-11ea-9da4-5ef4b4b23dfa.png">

### Current Behavior

Traditionally, `Order` takes the id property `Customer.customerId` as it's foreign key.

### Expect Behavior

**This feature would allow `Review` to have the non-id property `Customer.articleId` as its foreign key.**

Users could travers order and also reviews with different attributes.

## Implementation

Similar to the `belongTo` relation, this PR enables the custom source key, which is `keyFrom` in lb4 relation metadata. The feature should also work with inclusion.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
