### PR TITLE
fix(docs): add import authentication component

### DIFF
--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -64,6 +64,8 @@ To utilize `authentication` in an application `application.ts`, you must load
 the authentication component named `AuthenticationComponent`.
 
 ```ts
+import {AuthenticationComponent} from '@loopback/authentication';
+//...
 export class MyApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
 ) {


### PR DESCRIPTION
The example snippet fails to work correctly without the following proposed added line.
```
import {AuthenticationComponent} from '@loopback/authentication';
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [Y] `npm test` passes on your machine
- [N ] New tests added or existing tests modified to cover all changes
- [N] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [N] API Documentation in code was updated
- [Y] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [N] Affected artifact templates in `packages/cli` were updated
- [N] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
