### PR TITLE
chore: update eslint fix on save settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
   },
   "editor.codeActionsOnSave": {
     "source.organizeImports": true,
+    "source.fixAll.eslint": true
   },
   "files.exclude": {
     "**/.DS_Store": true,
@@ -27,7 +28,6 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "typescript.tsdk": "./packages/build/node_modules/typescript/lib",
-  "eslint.autoFixOnSave": true,
   "eslint.run": "onSave",
   "eslint.nodePath": "./packages/build/node_modules",
   "eslint.validate": [


### PR DESCRIPTION
`eslint.autoFixOnSave` has been deprecated and replaced by `source.fixAll.eslint` (see https://github.com/microsoft/vscode-eslint/blob/master/README.md#release-notes - 2.0.4)

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
