### PR TITLE
fix(repository): belongsTo accessor should return undefined if foreign key is not included

### DIFF
--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.relation.acceptance.ts
@@ -93,6 +93,18 @@ export function belongsToRelationAcceptance(
       expect(result).to.deepEqual(shipment);
     });
 
+    it('returns undefined if the source instance does not have the foreign key', async () => {
+      await shipmentRepo.create({
+        name: 'Tuesday morning shipment',
+      });
+      const order = await orderRepo.create({
+        // doesn't have the foreign key
+        description: 'Order that is shipped Tuesday morning',
+      });
+      const result = await orderRepo.shipment(order.id);
+      expect(result).to.be.undefined();
+    });
+
     it('throws EntityNotFound error when the related model does not exist', async () => {
       const deletedCustomer = await customerRepo.create({
         name: 'Order McForder',

--- a/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to-accessor.ts
@@ -53,6 +53,12 @@ export function createBelongsToAccessor<
     const primaryKey = meta.keyTo;
     const sourceModel = await sourceRepository.findById(sourceId);
     const foreignKeyValue = sourceModel[foreignKey as keyof Source];
+    // workaround to check referential integrity.
+    // should be removed once the memory connector ref integrity is done
+    // GH issue: https://github.com/strongloop/loopback-next/issues/2333
+    if (!foreignKeyValue) {
+      return (undefined as unknown) as Target;
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const constraint: any = {[primaryKey]: foreignKeyValue};
     const constrainedRepo = new DefaultBelongsToRepository(


### PR DESCRIPTION
fixes https://github.com/strongloop/loopback-next/issues/4147

Relates to https://github.com/strongloop/loopback-next/issues/2333

## Current behavior
For instances:
```
Customer {
  id: 1,
  name: 'exists'
}

Order {
  id: 1,
  name: 'has fk',
  customerId: 1
}
Order {
  id: 2,
  name: 'customer doesn't exist',
  customerId: 999
}
Order {
  id: 3,
  name: 'no fk',
}
```
The result of await `orderRepo.customer(order.id = 3);` returns the first customer in the database even it doesn't have the foreign [key](url)

## Proposal

**After reading through #2333, this is only a workaround.**
~Should check the foreign key value of the source instance.
Since different databases use different empty value, we check both `undefined` and `null`.~

I think this issue can be closed as duplicate.. 
- when user uses lb4, the memory connector is mostly for tutorials. The priority is relatively low.
- the goal of #2333 is to set referential integrity instead of returning `[]` in this case. 
- this workaround changes the result of other connectors. They are able to throw error `with id "constraint {\"id\":null}"`. With the change, they return `[]`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
