### PR TITLE
fix(cli): discard changes if lb4 `relation` fails. Allow customized relation name for belongsTo

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -43,6 +43,11 @@ related routes, you need to perform the following steps:
 This section describes how to define a `belongsTo` relation at the model level
 using the `@belongsTo` decorator to define the constraining foreign key.
 
+LB4 also provides an CLI tool `lb4 relation` to generate `belongsTo` relation
+for you. Before you check out the
+[`Relation Generator`](https://loopback.io/doc/en/lb4/Relation-generator.html)
+page, read on to learn how you can define relations to meet your requirements.
+
 ### Relation Metadata
 
 LB4 uses three `keyFrom`, `keyTo` and `name` fields in the `belongsTo` relation

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -181,6 +181,11 @@ export interface OrderRelations {
 export type OrderWithRelations = Order & OrderRelations;
 ```
 
+LB4 also provides an CLI tool `lb4 relation` to generate `hasMany` relation for
+you. Before you check out the
+[`Relation Generator`](https://loopback.io/doc/en/lb4/Relation-generator.html)
+page, read on to learn how you can define relations to meet your requirements.
+
 ### Relation Metadata
 
 LB4 uses three `keyFrom`, `keyTo` and `name` fields in the `hasMany` relation

--- a/docs/site/Relation-generator.md
+++ b/docs/site/Relation-generator.md
@@ -32,7 +32,8 @@ lb4 relation [options]
 - `--relationType`: Relation type.
 - `--sourceModel`: Source model.
 - `--destinationModel`: Destination model.
-- `--foreignKeyName`: Destination model foreign key name.
+- `--foreignKeyName`: Destination/Source model foreign key name for
+  HasMany/BelongsTo relation, respectively.
 - `--relationName`: Relation name.
 - `-c`, `--config`: JSON file name or value to configure options.
 - `-y`, `--yes`: Skip all confirmation prompts with default or provided value.
@@ -88,18 +89,31 @@ The tool will prompt you for:
 - **Name of the `target` model.** _(targetModel)_ Prompts a list of available
   models to choose from as the target model of the relation.
 
-- **Name of the `Source property`.** _(relationName)_ Prompts for the Source
-  property name. Note: Leave blank to use the default.
+- **Name of the `foreign key`.** _(relationName)_ Prompts a property name that
+  references the primary key property of the another model. Note: Leave blank to
+  use the default.
+
+  Default values: `<foreignKeyName>` + `Id` in camelCase, e.g `categoryId`
+
+- **Name of the `relation`.** _(relationName)_ Prompts for the Source property
+  name. Note: Leave blank to use the default.
 
   Default values:
 
-  - `<targetModel><targetModelPrimaryKey>` for `belongsTo` relations, e.g.
-    `categoryId`
   - plural form of `<targetModel>` for `hasMany` relations, e.g. `products`
+  - Based on the foreign key for `belongsTo` relations, e.g. when the foreign
+    key is the default name, e.g `categoryId`, the default relation name is
+    `category`.
 
-- **Name of Foreign key** _(foreignKeyName)_ to be created in target model. For
-  hasMany relation type only, default: `<sourceModel><sourceModelPrimaryKey>`.
-  Note: Leave blank to use the default.
+{% include warning.html content="Based on your input, the default foreign key name might be the same as the default relation name, especially for belongsTo relation. Please name them differently to avoid a known issue [Navigational Property Error](https://github.com/strongloop/loopback-next/issues/4392)
+" lang=page.lang %}
+
+The generator has some limitations. It only asks the most basic factors for
+generating relations. For example, it uses the id property as the source key.
+LB4 allows you customize the source key name, the foreign key name, the relation
+name, and even the DB column name. Check the
+[Relation Metadata](HasMany-relation.md#relation-metadata) section in each
+relation to learn how you can define relations.
 
 ### Output
 

--- a/packages/cli/generators/relation/base-relation.generator.js
+++ b/packages/cli/generators/relation/base-relation.generator.js
@@ -40,11 +40,11 @@ module.exports = class BaseRelationGenerator extends ArtifactGenerator {
 
   async generateAll(options) {
     this._setupGenerator();
-    await this.generateControllers(options);
-    this._setupGenerator();
     await this.generateModels(options);
     this._setupGenerator();
     await this.generateRepositories(options);
+    this._setupGenerator();
+    await this.generateControllers(options);
   }
 
   async generateControllers(options) {
@@ -98,13 +98,8 @@ module.exports = class BaseRelationGenerator extends ArtifactGenerator {
       type: this._getRepositoryRelationPropertyType(),
     };
 
-    if (relationUtils.doesPropertyExist(classDeclaration, property.name)) {
-      throw new Error(
-        'property ' + property.name + ' already exist in the repository.',
-      );
-    } else {
-      relationUtils.addProperty(classDeclaration, property);
-    }
+    // already checked the existence of property before
+    relationUtils.addProperty(classDeclaration, property);
   }
 
   _addParametersToRepositoryConstructor(classConstructor) {
@@ -112,9 +107,8 @@ module.exports = class BaseRelationGenerator extends ArtifactGenerator {
       utils.camelCase(this.artifactInfo.dstRepositoryClassName) + 'Getter';
 
     if (relationUtils.doesParameterExist(classConstructor, parameterName)) {
-      throw new Error(
-        'Parameter ' + parameterName + ' already exist in the constructor.',
-      );
+      // no need to check if the getter already exists
+      return;
     }
 
     classConstructor.addParameter({

--- a/packages/cli/generators/relation/has-many-relation.generator.js
+++ b/packages/cli/generators/relation/has-many-relation.generator.js
@@ -74,6 +74,8 @@ module.exports = class HasManyRelationGenerator extends BaseRelationGenerator {
   }
 
   async generateModels(options) {
+    // for repo to generate relation name
+    this.artifactInfo.relationName = options.relationName;
     const modelDir = this.artifactInfo.modelDir;
     const sourceModel = options.sourceModel;
 
@@ -166,7 +168,7 @@ module.exports = class HasManyRelationGenerator extends BaseRelationGenerator {
   }
 
   _getRepositoryRelationPropertyName() {
-    return utils.pluralize(utils.camelCase(this.artifactInfo.dstModelClass));
+    return this.artifactInfo.relationName;
   }
 
   _getRepositoryRelationPropertyType() {

--- a/packages/cli/generators/relation/index.js
+++ b/packages/cli/generators/relation/index.js
@@ -23,14 +23,19 @@ const ERROR_SOURCE_MODEL_PRIMARY_KEY_DOES_NOT_EXIST =
   'Source model primary key does not exist.';
 const ERROR_DESTINATION_MODEL_PRIMARY_KEY_DOES_NOT_EXIST =
   'Target model primary key does not exist.';
+const ERROR_REPOSITORY_DOES_NOT_EXIST =
+  'class does not exist. Please create repository first with "lb4 repository" command.';
 
 const PROMPT_BASE_RELATION_CLASS = 'Please select the relation type';
 const PROMPT_MESSAGE_SOURCE_MODEL = 'Please select source model';
 const PROMPT_MESSAGE_TARGET_MODEL = 'Please select target model';
 const PROMPT_MESSAGE_PROPERTY_NAME =
-  'Source property name for the relation getter';
+  'Source property name for the relation getter (will be the relation name)';
+const PROMPT_MESSAGE_RELATION_NAME = 'Relation name';
 const PROMPT_MESSAGE_FOREIGN_KEY_NAME =
   'Foreign key name to define on the target model';
+const PROMPT_MESSAGE_FOREIGN_KEY_NAME_BELONGSTO =
+  'Foreign key name to define on the source model';
 
 module.exports = class RelationGenerator extends ArtifactGenerator {
   constructor(args, opts) {
@@ -62,6 +67,12 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
       description: 'Destination model',
     });
 
+    this.option('defaultForeignKeyName', {
+      type: String,
+      required: false,
+      description: 'default foreign key name',
+    });
+
     this.option('foreignKeyName', {
       type: String,
       required: false,
@@ -72,6 +83,11 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
       type: String,
       required: false,
       description: 'Relation name',
+    });
+    this.option('defaultRelationName', {
+      type: String,
+      required: false,
+      description: 'Default relation name',
     });
 
     this.option('registerInclusionResolver', {
@@ -85,9 +101,14 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
       rootDir: utils.sourceRootDir,
       outDir: utils.sourceRootDir,
     };
+    // to check if model and repo exist
     this.artifactInfo.modelDir = path.resolve(
       this.artifactInfo.rootDir,
       utils.modelsDir,
+    );
+    this.artifactInfo.repoDir = path.resolve(
+      this.artifactInfo.rootDir,
+      utils.repositoriesDir,
     );
 
     super._setupGenerator();
@@ -109,9 +130,11 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
     let defaultRelationName;
     switch (this.artifactInfo.relationType) {
       case relationUtils.relationType.belongsTo:
-        defaultRelationName =
-          utils.camelCase(this.artifactInfo.destinationModel) +
-          utils.toClassName(this.artifactInfo.destinationModelPrimaryKey);
+        // this is how the belongsToAccessor generates the default relation name
+        defaultRelationName = this.artifactInfo.foreignKeyName.replace(
+          /Id$/,
+          '',
+        );
         break;
       case relationUtils.relationType.hasMany:
         defaultRelationName = utils.pluralize(
@@ -132,10 +155,23 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
         'model',
       );
     } catch (err) {
+      /* istanbul ignore next */
+      return this.exit(err);
+    }
+    let repoList;
+    try {
+      debug(`repository list dir ${this.artifactInfo.repoDir}`);
+      repoList = await utils.getArtifactList(
+        this.artifactInfo.repoDir,
+        'repository',
+      );
+    } catch (err) {
+      /* istanbul ignore next */
       return this.exit(err);
     }
 
     if (modelList.length === 0) {
+      /* istanbul ignore next */
       return this.exit(
         new Error(
           `${ERROR_NO_MODELS_FOUND} ${this.artifactInfo.modelDir}.
@@ -149,6 +185,7 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
     if (this.options[parameter]) {
       this.isChecked[parameter] = true;
       if (!modelList.includes(this.options[parameter])) {
+        /* istanbul ignore next */
         return this.exit(
           new Error(
             `"${this.options[parameter]}" ${ERROR_MODEL_DOES_NOT_EXIST}`,
@@ -175,8 +212,18 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
     ]).then(props => {
       if (this.isChecked[parameter]) return;
       if (!modelList.includes(props[parameter])) {
-        this.exit(
+        /* istanbul ignore next */
+        return this.exit(
           new Error(`"${props[parameter]}" ${ERROR_MODEL_DOES_NOT_EXIST}`),
+        );
+      }
+      // checks if the corresponding repository exists
+      if (!repoList.includes(props[parameter])) {
+        /* istanbul ignore next */
+        return this.exit(
+          new Error(
+            `${props[parameter]}Repository ${ERROR_REPOSITORY_DOES_NOT_EXIST}`,
+          ),
         );
       }
 
@@ -197,6 +244,7 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
         `Relation type received from command line: ${this.options.relationType}`,
       );
       if (!relationTypeChoices.includes(this.options.relationType)) {
+        /* istanbul ignore next */
         return this.exit(new Error(ERROR_INCORRECT_RELATION_TYPE));
       }
 
@@ -216,6 +264,7 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
     ]).then(props => {
       if (this.isChecked.relationType) return;
       if (!relationTypeChoices.includes(props.relationType)) {
+        /* istanbul ignore next */
         this.exit(new Error(ERROR_INCORRECT_RELATION_TYPE));
       }
       Object.assign(this.artifactInfo, props);
@@ -249,6 +298,8 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
    *  3. Generate foreign key (camelCase source class Name + primary key name).
    *  4. Check is foreign key exist in destination model. If not - prompt.
    *  Error - if type is not the same.
+   *
+   * For belongsTo this is getting source key not fk.
    */
   async promptForeignKey() {
     if (this.shouldExit()) return false;
@@ -258,6 +309,12 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
       this.artifactInfo.modelDir,
       this.artifactInfo.sourceModel,
     );
+    if (!this.artifactInfo.sourceModelPrimaryKey) {
+      /* istanbul ignore next */
+      return this.exit(
+        new Error(ERROR_SOURCE_MODEL_PRIMARY_KEY_DOES_NOT_EXIST),
+      );
+    }
 
     if (this.artifactInfo.sourceModelPrimaryKey) {
       this.artifactInfo.sourceModelPrimaryKeyType = relationUtils.getModelPropertyType(
@@ -267,91 +324,19 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
       );
     }
 
-    if (
-      this.artifactInfo.relationType === relationUtils.relationType.belongsTo
-    ) {
-      return;
-    }
-
-    this.artifactInfo.targetModelPrimaryKey = await relationUtils.getModelPrimaryKeyProperty(
+    this.artifactInfo.destinationModelPrimaryKey = await relationUtils.getModelPrimaryKeyProperty(
       this.fs,
       this.artifactInfo.modelDir,
       this.artifactInfo.destinationModel,
     );
-
-    if (this.artifactInfo.sourceModelPrimaryKey == null) {
+    if (!this.artifactInfo.destinationModelPrimaryKey) {
+      /* istanbul ignore next */
       return this.exit(
-        new Error(ERROR_SOURCE_MODEL_PRIMARY_KEY_DOES_NOT_EXIST),
+        new Error(ERROR_DESTINATION_MODEL_PRIMARY_KEY_DOES_NOT_EXIST),
       );
     }
 
-    this.artifactInfo.defaultForeignKeyName =
-      utils.camelCase(this.artifactInfo.sourceModel) +
-      utils.toClassName(this.artifactInfo.sourceModelPrimaryKey);
-
-    const project = new relationUtils.AstLoopBackProject();
-
-    const destinationFile = path.join(
-      this.artifactInfo.modelDir,
-      utils.getModelFileName(this.artifactInfo.destinationModel),
-    );
-    const df = project.addSourceFileAtPath(destinationFile);
-    const cl = relationUtils.getClassObj(
-      df,
-      this.artifactInfo.destinationModel,
-    );
-    this.artifactInfo.doesForeignKeyExist = relationUtils.doesPropertyExist(
-      cl,
-      this.artifactInfo.defaultForeignKeyName,
-    );
-
-    if (!this.artifactInfo.doesForeignKeyExist) {
-      if (this.options.foreignKeyName) {
-        debug(
-          `Foreign key name received from command line: ${this.options.foreignKeyName}`,
-        );
-        this.artifactInfo.foreignKeyName = this.options.foreignKeyName;
-      }
-
-      return this.prompt([
-        {
-          type: 'string',
-          name: 'foreignKeyName',
-          message: PROMPT_MESSAGE_FOREIGN_KEY_NAME,
-          default: this.artifactInfo.defaultForeignKeyName,
-          when: this.artifactInfo.foreignKeyName === undefined,
-        },
-      ]).then(props => {
-        debug(`props after foreign key name prompt: ${inspect(props)}`);
-        Object.assign(this.artifactInfo, props);
-        this.artifactInfo.doesForeignKeyExist = relationUtils.doesPropertyExist(
-          cl,
-          this.artifactInfo.foreignKeyName,
-        );
-
-        return props;
-      });
-    } else {
-      this.artifactInfo.foreignKeyName = this.artifactInfo.defaultForeignKeyName;
-    }
-  }
-
-  async promptRelationName() {
-    if (this.shouldExit()) return false;
-    if (
-      this.artifactInfo.relationType === relationUtils.relationType.belongsTo
-    ) {
-      this.artifactInfo.destinationModelPrimaryKey = await relationUtils.getModelPrimaryKeyProperty(
-        this.fs,
-        this.artifactInfo.modelDir,
-        this.artifactInfo.destinationModel,
-      );
-      if (this.artifactInfo.destinationModelPrimaryKey == null) {
-        return this.exit(
-          new Error(ERROR_DESTINATION_MODEL_PRIMARY_KEY_DOES_NOT_EXIST),
-        );
-      }
-
+    if (this.artifactInfo.destinationModelPrimaryKey) {
       this.artifactInfo.destinationModelPrimaryKeyType = relationUtils.getModelPropertyType(
         this.artifactInfo.modelDir,
         this.artifactInfo.destinationModel,
@@ -359,29 +344,141 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
       );
     }
 
+    // for controller usage;
+    this.artifactInfo.targetModelPrimaryKey = await relationUtils.getModelPrimaryKeyProperty(
+      this.fs,
+      this.artifactInfo.modelDir,
+      this.artifactInfo.destinationModel,
+    );
+
+    if (this.options.foreignKeyName) {
+      debug(
+        `Foreign key name received from command line: ${this.options.foreignKeyName}`,
+      );
+      this.artifactInfo.foreignKeyName = this.options.foreignKeyName;
+    }
+
+    this.artifactInfo.defaultForeignKeyName =
+      this.artifactInfo.relationType === 'belongsTo'
+        ? utils.camelCase(this.artifactInfo.destinationModel) + 'Id'
+        : utils.camelCase(this.artifactInfo.sourceModel) + 'Id';
+
+    const msg =
+      this.artifactInfo.relationType === 'belongsTo'
+        ? PROMPT_MESSAGE_FOREIGN_KEY_NAME_BELONGSTO
+        : PROMPT_MESSAGE_FOREIGN_KEY_NAME;
+    const foreignKeyModel =
+      this.artifactInfo.relationType === 'belongsTo'
+        ? this.artifactInfo.sourceModel
+        : this.artifactInfo.destinationModel;
+
+    const project = new relationUtils.AstLoopBackProject();
+    const fkFile = path.join(
+      this.artifactInfo.modelDir,
+      utils.getModelFileName(foreignKeyModel),
+    );
+    const df = project.addSourceFileAtPath(fkFile);
+    const cl = relationUtils.getClassObj(df, foreignKeyModel);
+
+    return this.prompt([
+      {
+        type: 'string',
+        name: 'foreignKeyName',
+        message: msg,
+        default: this.artifactInfo.defaultForeignKeyName,
+        when: !this.artifactInfo.foreignKeyName,
+        validate: utils.validateKeyName,
+      },
+    ]).then(props => {
+      debug(`props after foreign key name prompt: ${inspect(props)}`);
+      Object.assign(this.artifactInfo, props);
+      this.artifactInfo.doesForeignKeyExist = relationUtils.doesPropertyExist(
+        cl,
+        this.artifactInfo.foreignKeyName,
+      );
+      // checks if its the case that the fk already exists in source model and decorated by @belongsTo, which should be aborted
+      if (
+        this.artifactInfo.doesForeignKeyExist &&
+        this.artifactInfo.relationType === 'belongsTo'
+      ) {
+        try {
+          relationUtils.doesRelationExist(cl, this.artifactInfo.foreignKeyName);
+        } catch (err) {
+          /* istanbul ignore next */
+          this.exit(err);
+        }
+      }
+      return props;
+    });
+  }
+
+  async promptRelationName() {
+    if (this.shouldExit()) return false;
     if (this.options.relationName) {
       debug(
         `Relation name received from command line: ${this.options.relationName}`,
       );
       this.artifactInfo.relationName = this.options.relationName;
     }
+    this.artifactInfo.defaultRelationName = this._getDefaultRelationName();
+    // for hasMany && hasOne, the source key is the same as the relation name
+    const msg =
+      this.artifactInfo.relationType === 'belongsTo'
+        ? PROMPT_MESSAGE_RELATION_NAME
+        : PROMPT_MESSAGE_PROPERTY_NAME;
 
     return this.prompt([
       {
         type: 'string',
         name: 'relationName',
-        message: PROMPT_MESSAGE_PROPERTY_NAME,
-        when: this.artifactInfo.relationName === undefined,
-        default: this._getDefaultRelationName(),
+        message: msg,
+        when: !this.artifactInfo.relationName,
+        default: this.artifactInfo.defaultRelationName,
+        validate: inputName =>
+          utils.validateRelationName(
+            inputName,
+            this.artifactInfo.relationType,
+            this.artifactInfo.foreignKeyName,
+          ),
       },
     ]).then(props => {
       debug(`props after relation name prompt: ${inspect(props)}`);
+      // checks if the relation name already exists
+      this.artifactInfo.srcRepositoryFile = path.resolve(
+        this.artifactInfo.repoDir,
+        utils.getRepositoryFileName(this.artifactInfo.sourceModel),
+      );
+      this.artifactInfo.srcRepositoryClassName =
+        utils.toClassName(this.artifactInfo.sourceModel) + 'Repository';
+      this.artifactInfo.srcRepositoryFileObj = new relationUtils.AstLoopBackProject().addSourceFileAtPath(
+        this.artifactInfo.srcRepositoryFile,
+      );
+
+      const repoClassDeclaration = this.artifactInfo.srcRepositoryFileObj.getClassOrThrow(
+        this.artifactInfo.srcRepositoryClassName,
+      );
+      // checks if the relation name already exists in repo
+      if (
+        relationUtils.doesPropertyExist(
+          repoClassDeclaration,
+          props.relationName,
+        )
+      ) {
+        /* istanbul ignore next */
+        return this.exit(
+          new Error(
+            `relation ${props.relationName} already exists in the repository ${this.artifactInfo.srcRepositoryClassName}.`,
+          ),
+        );
+      }
+
       Object.assign(this.artifactInfo, props);
       return props;
     });
   }
 
   async promptRegisterInclusionResolver() {
+    if (this.shouldExit()) return false;
     const props = await this.prompt([
       {
         type: 'confirm',
@@ -423,6 +520,7 @@ module.exports = class RelationGenerator extends ArtifactGenerator {
     try {
       await relationGenerator.generateAll(this.artifactInfo);
     } catch (error) {
+      /* istanbul ignore next */
       this.exit(error);
     }
   }

--- a/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
+++ b/packages/cli/generators/relation/templates/controller-relation-template-has-many.ts.ejs
@@ -29,7 +29,7 @@ export class <%= controllerClassName %> {
   @get('/<%= sourceModelPath %>/{id}/<%= targetModelPath %>', {
     responses: {
       '200': {
-        description: 'Array of <%= targetModelClassName %>\'s belonging to <%= sourceModelClassName %>',
+        description: 'Array of <%= sourceModelClassName %> has many <%= targetModelClassName %>',
         content: {
           'application/json': {
             schema: {type: 'array', items: getModelSchemaRef(<%= targetModelClassName %>)},

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -141,6 +141,71 @@ exports.validateNotExisting = function(projDir) {
 };
 
 /**
+ * validate source key or foreign key for relations
+ */
+/* istanbul ignore next */
+exports.validateKeyName = function(name) {
+  if (!name || name === '') {
+    return 'Key name cannot be empty';
+  }
+  if (!isNaN(name.charAt(0))) {
+    return util.format('Key name cannot start with a number: %s', name);
+  }
+  if (name.includes('.')) {
+    return util.format('Key name cannot contain .: %s', name);
+  }
+  if (name.includes(' ')) {
+    return util.format('Key name cannot contain spaces: %s', name);
+  }
+  if (name.includes('-')) {
+    return util.format('Key name cannot contain hyphens: %s', name);
+  }
+  if (name.match(/[\/@\s\+%:]/)) {
+    return util.format(
+      'Key name cannot contain special characters (/@+%: ): %s',
+      name,
+    );
+  }
+  return true;
+};
+
+/**
+ * checks if the belongsTo relation has the same relation name and source key name,
+ * which is an invalid case.
+ */
+/* istanbul ignore next */
+exports.validateRelationName = function(name, type, foreignKeyName) {
+  if (!name || name === '') {
+    return 'Relation name cannot be empty';
+  }
+  if (type === 'belongsTo' && name === foreignKeyName) {
+    return util.format(
+      'Relation name cannot be the same as the source key name: %s',
+      name,
+    );
+  }
+  if (!isNaN(name.charAt(0))) {
+    return util.format('Relation name cannot start with a number: %s', name);
+  }
+  if (name.includes('.')) {
+    return util.format('Relation name cannot contain .: %s', name);
+  }
+  if (name.includes(' ')) {
+    return util.format('Relation name cannot contain spaces: %s', name);
+  }
+  if (name.includes('-')) {
+    return util.format('Relation name cannot contain hyphens: %s', name);
+  }
+  if (name.match(/[\/@\s\+%:]/)) {
+    return util.format(
+      'Relation name cannot contain special characters (/@+%: ): %s',
+      name,
+    );
+  }
+  return true;
+};
+
+/**
  * Converts a name to class name after validation
  */
 exports.toClassName = function(name) {

--- a/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.belongs-to.integration.snapshots.js
@@ -10,7 +10,7 @@
 exports[
   `lb4 relation checks generated source class repository  answers {"relationType":"belongsTo","sourceModel":"Order","destinationModel":"Customer"} generates Order repository file with different inputs 1`
 ] = `
-import {DefaultCrudRepository, repository, BelongsToAccessor} from '@loopback/repository';
+import {DefaultCrudRepository, BelongsToAccessor, repository} from '@loopback/repository';
 import {Order, Customer} from '../models';
 import {DbDataSource} from '../datasources';
 import {inject, Getter} from '@loopback/core';
@@ -20,6 +20,10 @@ export class OrderRepository extends DefaultCrudRepository<
   Order,
   typeof Order.prototype.id
 > {
+  public readonly myCustomer: BelongsToAccessor<
+    Customer,
+    typeof Order.prototype.id
+  >;
 
   public readonly customer: BelongsToAccessor<Customer, typeof Order.prototype.id>;
 
@@ -33,7 +37,7 @@ export class OrderRepository extends DefaultCrudRepository<
 `;
 
 exports[
-  `lb4 relation checks generated source class repository  answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass","registerInclusionResolver":true} generates OrderClass repository file with different inputs 1`
+  `lb4 relation checks generated source class repository  answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass","relationName":"customer","registerInclusionResolver":true} generates OrderClass repository file with different inputs 1`
 ] = `
 import {DefaultCrudRepository, repository, BelongsToAccessor} from '@loopback/repository';
 import {OrderClass, CustomerClass} from '../models';
@@ -46,19 +50,19 @@ export class OrderClassRepository extends DefaultCrudRepository<
   typeof OrderClass.prototype.orderNumber
 > {
 
-  public readonly customerClass: BelongsToAccessor<CustomerClass, typeof OrderClass.prototype.orderNumber>;
+  public readonly customer: BelongsToAccessor<CustomerClass, typeof OrderClass.prototype.orderNumber>;
 
   constructor(@inject('datasources.myDB') dataSource: MyDBDataSource, @repository.getter('CustomerClassRepository') protected customerClassRepositoryGetter: Getter<CustomerClassRepository>,) {
     super(OrderClass, dataSource);
-    this.customerClass = this.createBelongsToAccessorFor('customerClassCustNumber', customerClassRepositoryGetter,);
-    this.registerInclusionResolver('customerClass', this.customerClass.inclusionResolver);
+    this.customer = this.createBelongsToAccessorFor('customer', customerClassRepositoryGetter,);
+    this.registerInclusionResolver('customer', this.customer.inclusionResolver);
   }
 }
 
 `;
 
 exports[
-  `lb4 relation checks generated source class repository  answers {"relationType":"belongsTo","sourceModel":"OrderClassType","destinationModel":"CustomerClassType","registerInclusionResolver":false} generates OrderClassType repository file with different inputs 1`
+  `lb4 relation checks generated source class repository  answers {"relationType":"belongsTo","sourceModel":"OrderClassType","destinationModel":"CustomerClassType","relationName":"customer","registerInclusionResolver":false} generates OrderClassType repository file with different inputs 1`
 ] = `
 import {DefaultCrudRepository, repository, BelongsToAccessor} from '@loopback/repository';
 import {OrderClassType, CustomerClassType} from '../models';
@@ -71,11 +75,11 @@ export class OrderClassTypeRepository extends DefaultCrudRepository<
   typeof OrderClassType.prototype.orderString
 > {
 
-  public readonly customerClassType: BelongsToAccessor<CustomerClassType, typeof OrderClassType.prototype.orderString>;
+  public readonly customer: BelongsToAccessor<CustomerClassType, typeof OrderClassType.prototype.orderString>;
 
   constructor(@inject('datasources.myDB') dataSource: MyDBDataSource, @repository.getter('CustomerClassTypeRepository') protected customerClassTypeRepositoryGetter: Getter<CustomerClassTypeRepository>,) {
     super(OrderClassType, dataSource);
-    this.customerClassType = this.createBelongsToAccessorFor('customerClassTypeCustNumber', customerClassTypeRepositoryGetter,);
+    this.customer = this.createBelongsToAccessorFor('customer', customerClassTypeRepositoryGetter,);
   }
 }
 
@@ -133,7 +137,7 @@ export * from './order-customer.controller';
 `;
 
 exports[
-  `lb4 relation checks if the controller file created  answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass"} checks controller content with belongsTo relation 1`
+  `lb4 relation checks if the controller file created  answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass","relationName":"my_customer"} checks controller content with belongsTo relation 1`
 ] = `
 import {
   repository,
@@ -177,60 +181,9 @@ export class OrderClassCustomerClassController {
 `;
 
 exports[
-  `lb4 relation checks if the controller file created  answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass"} the new controller file added to index.ts file 1`
+  `lb4 relation checks if the controller file created  answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass","relationName":"my_customer"} the new controller file added to index.ts file 1`
 ] = `
 export * from './order-class-customer-class.controller';
-
-`;
-
-exports[
-  `lb4 relation checks if the controller file created  answers {"relationType":"belongsTo","sourceModel":"OrderClassType","destinationModel":"CustomerClassType"} checks controller content with belongsTo relation 1`
-] = `
-import {
-  repository,
-} from '@loopback/repository';
-import {
-  param,
-  get,
-  getModelSchemaRef,
-} from '@loopback/rest';
-import {
-  OrderClassType,
-  CustomerClassType,
-} from '../models';
-import {OrderClassTypeRepository} from '../repositories';
-
-export class OrderClassTypeCustomerClassTypeController {
-  constructor(
-    @repository(OrderClassTypeRepository)
-    public orderClassTypeRepository: OrderClassTypeRepository,
-  ) { }
-
-  @get('/order-class-types/{id}/customer-class-type', {
-    responses: {
-      '200': {
-        description: 'CustomerClassType belonging to OrderClassType',
-        content: {
-          'application/json': {
-            schema: {type: 'array', items: getModelSchemaRef(CustomerClassType)},
-          },
-        },
-      },
-    },
-  })
-  async getCustomerClassType(
-    @param.path.string('id') id: typeof OrderClassType.prototype.orderString,
-  ): Promise<CustomerClassType> {
-    return this.orderClassTypeRepository.customerClassType(id);
-  }
-}
-
-`;
-
-exports[
-  `lb4 relation checks if the controller file created  answers {"relationType":"belongsTo","sourceModel":"OrderClassType","destinationModel":"CustomerClassType"} the new controller file added to index.ts file 1`
-] = `
-export * from './order-class-type-customer-class-type.controller';
 
 `;
 
@@ -255,7 +208,7 @@ export class Order extends Entity {
   name?: string;
 
   @belongsTo(() => Customer)
-  myRelation: number;
+  customerId: number;
 
   constructor(data?: Partial<Order>) {
     super(data);
@@ -265,7 +218,7 @@ export class Order extends Entity {
 `;
 
 exports[
-  `lb4 relation generates model relation with custom relation name answers {"relationType":"belongsTo","sourceModel":"Order","destinationModel":"Customer","relationName":"customerPK"} relation name should be customerPK 1`
+  `lb4 relation generates model relation with custom relation name answers {"relationType":"belongsTo","sourceModel":"Order","destinationModel":"Customer","foreignKeyName":"customerId","relationName":"my_customer"} relation name should be my_customer 1`
 ] = `
 import {Entity, model, property, belongsTo} from '@loopback/repository';
 import {Customer} from './customer.model';
@@ -284,8 +237,8 @@ export class Order extends Entity {
   })
   name?: string;
 
-  @belongsTo(() => Customer)
-  customerPK: number;
+  @belongsTo(() => Customer, {name: 'my_customer'})
+  customerId: number;
 
   constructor(data?: Partial<Order>) {
     super(data);
@@ -295,7 +248,7 @@ export class Order extends Entity {
 `;
 
 exports[
-  `lb4 relation generates model relation with custom relation name answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass","relationName":"customerPK"} relation name should be customerPK 1`
+  `lb4 relation generates model relation with custom relation name answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass","relationName":"my_customer"} relation name should be my_customer 1`
 ] = `
 import {Entity, model, property, belongsTo} from '@loopback/repository';
 import {CustomerClass} from './customer-class.model';
@@ -313,39 +266,10 @@ export class OrderClass extends Entity {
   })
   name?: string;
 
-  @belongsTo(() => CustomerClass)
-  customerPK: number;
+  @belongsTo(() => CustomerClass, {name: 'my_customer'})
+  customerClassId: number;
 
   constructor(data?: Partial<OrderClass>) {
-    super(data);
-  }
-}
-
-`;
-
-exports[
-  `lb4 relation generates model relation with custom relation name answers {"relationType":"belongsTo","sourceModel":"OrderClassType","destinationModel":"CustomerClassType","relationName":"customerPK"} relation name should be customerPK 1`
-] = `
-import {Entity, model, property, belongsTo} from '@loopback/repository';
-import {CustomerClassType} from './customer-class-type.model';
-
-@model()
-export class OrderClassType extends Entity {
-  @property({
-    type: 'string',
-    id: true,
-  })
-  orderString: string;
-
-  @property({
-    type: 'string',
-  })
-  name?: string;
-
-  @belongsTo(() => CustomerClassType)
-  customerPK: number;
-
-  constructor(data?: Partial<OrderClassType>) {
     super(data);
   }
 }
@@ -376,64 +300,6 @@ export class Order extends Entity {
   customerId: number;
 
   constructor(data?: Partial<Order>) {
-    super(data);
-  }
-}
-
-`;
-
-exports[
-  `lb4 relation generates model relation with default values answers {"relationType":"belongsTo","sourceModel":"OrderClass","destinationModel":"CustomerClass"} has correct default imports 1`
-] = `
-import {Entity, model, property, belongsTo} from '@loopback/repository';
-import {CustomerClass} from './customer-class.model';
-
-@model()
-export class OrderClass extends Entity {
-  @property({
-    type: 'number',
-    id: true,
-  })
-  orderNumber?: number;
-
-  @property({
-    type: 'string',
-  })
-  name?: string;
-
-  @belongsTo(() => CustomerClass)
-  customerClassCustNumber: number;
-
-  constructor(data?: Partial<OrderClass>) {
-    super(data);
-  }
-}
-
-`;
-
-exports[
-  `lb4 relation generates model relation with default values answers {"relationType":"belongsTo","sourceModel":"OrderClassType","destinationModel":"CustomerClassType"} has correct default imports 1`
-] = `
-import {Entity, model, property, belongsTo} from '@loopback/repository';
-import {CustomerClassType} from './customer-class-type.model';
-
-@model()
-export class OrderClassType extends Entity {
-  @property({
-    type: 'string',
-    id: true,
-  })
-  orderString: string;
-
-  @property({
-    type: 'string',
-  })
-  name?: string;
-
-  @belongsTo(() => CustomerClassType)
-  customerClassTypeCustNumber: number;
-
-  constructor(data?: Partial<OrderClassType>) {
     super(data);
   }
 }

--- a/packages/cli/snapshots/integration/generators/relation.has-many.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.has-many.integration.snapshots.js
@@ -263,7 +263,7 @@ export class CustomerClassOrderClassController {
           schema: getModelSchemaRef(OrderClass, {
             title: 'NewOrderClassInCustomerClass',
             exclude: ['orderNumber'],
-            optional: ['customerClassCustNumber']
+            optional: ['customerClassId']
           }),
         },
       },
@@ -379,7 +379,7 @@ export class CustomerClassTypeOrderClassTypeController {
           schema: getModelSchemaRef(OrderClassType, {
             title: 'NewOrderClassTypeInCustomerClassType',
             exclude: ['orderString'],
-            optional: ['customerClassTypeCustNumber']
+            optional: ['customerClassTypeId']
           }),
         },
       },
@@ -688,7 +688,7 @@ export class CustomerClass extends Entity {
   })
   name?: string;
 
-  @hasMany(() => OrderClass, {keyTo: 'customerClassCustNumber'})
+  @hasMany(() => OrderClass)
   myOrders: OrderClass[];
 
   constructor(data?: Partial<CustomerClass>) {
@@ -719,7 +719,7 @@ export class OrderClass extends Entity {
   @property({
     type: 'number',
   })
-  customerClassCustNumber?: number;
+  customerClassId?: number;
 
   constructor(data?: Partial<OrderClass>) {
     super(data);
@@ -747,7 +747,7 @@ export class CustomerClassType extends Entity {
   })
   name?: string;
 
-  @hasMany(() => OrderClassType, {keyTo: 'customerClassTypeCustNumber'})
+  @hasMany(() => OrderClassType)
   myOrders: OrderClassType[];
 
   constructor(data?: Partial<CustomerClassType>) {
@@ -778,7 +778,7 @@ export class OrderClassType extends Entity {
   @property({
     type: 'number',
   })
-  customerClassTypeCustNumber?: number;
+  customerClassTypeId?: number;
 
   constructor(data?: Partial<OrderClassType>) {
     super(data);
@@ -836,7 +836,7 @@ export class CustomerClass extends Entity {
   })
   name?: string;
 
-  @hasMany(() => OrderClass, {keyTo: 'customerClassCustNumber'})
+  @hasMany(() => OrderClass)
   orderClasses: OrderClass[];
 
   constructor(data?: Partial<CustomerClass>) {
@@ -865,7 +865,7 @@ export class CustomerClassType extends Entity {
   })
   name?: string;
 
-  @hasMany(() => OrderClassType, {keyTo: 'customerClassTypeCustNumber'})
+  @hasMany(() => OrderClassType)
   orderClassTypes: OrderClassType[];
 
   constructor(data?: Partial<CustomerClassType>) {

--- a/packages/cli/snapshots/integration/generators/relation.has-many.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/relation.has-many.integration.snapshots.js
@@ -115,7 +115,7 @@ export class CustomerOrderController {
   @get('/customers/{id}/orders', {
     responses: {
       '200': {
-        description: 'Array of Order\\'s belonging to Customer',
+        description: 'Array of Customer has many Order',
         content: {
           'application/json': {
             schema: {type: 'array', items: getModelSchemaRef(Order)},
@@ -231,7 +231,7 @@ export class CustomerClassOrderClassController {
   @get('/customer-classes/{id}/order-classes', {
     responses: {
       '200': {
-        description: 'Array of OrderClass\\'s belonging to CustomerClass',
+        description: 'Array of CustomerClass has many OrderClass',
         content: {
           'application/json': {
             schema: {type: 'array', items: getModelSchemaRef(OrderClass)},
@@ -347,7 +347,7 @@ export class CustomerClassTypeOrderClassTypeController {
   @get('/customer-class-types/{id}/order-class-types', {
     responses: {
       '200': {
-        description: 'Array of OrderClassType\\'s belonging to CustomerClassType',
+        description: 'Array of CustomerClassType has many OrderClassType',
         content: {
           'application/json': {
             schema: {type: 'array', items: getModelSchemaRef(OrderClassType)},

--- a/packages/cli/test/fixtures/relation/index.js
+++ b/packages/cli/test/fixtures/relation/index.js
@@ -85,8 +85,20 @@ const SourceEntries = {
 
   NoKeyModel: {
     path: MODEL_APP_PATH,
-    file: 'nokey.model.ts',
-    content: readSourceFile('./models/nokey.model.ts'),
+    file: 'no-key.model.ts',
+    content: readSourceFile('./models/no-key.model.ts'),
+  },
+
+  NoKeyRepository: {
+    path: REPOSITORY_APP_PATH,
+    file: 'no-key.repository.ts',
+    content: readSourceFile('./repositories/no-key.repository.ts'),
+  },
+
+  NoRepoModel: {
+    path: MODEL_APP_PATH,
+    file: 'no-repo.model.ts',
+    content: readSourceFile('./models/no-repo.model.ts'),
   },
 
   IndexOfControllers: {
@@ -167,6 +179,7 @@ exports.SANDBOX_FILES = [
   SourceEntries.OrderClassRepository,
   SourceEntries.CustomerClassTypeRepository,
   SourceEntries.OrderClassTypeRepository,
+  SourceEntries.NoKeyRepository,
   {
     path: DATASOURCE_APP_PATH,
     file: 'restdb.datasource.ts',
@@ -175,6 +188,7 @@ exports.SANDBOX_FILES = [
   SourceEntries.CustomerModel,
   SourceEntries.OrderModel,
   SourceEntries.NoKeyModel,
+  SourceEntries.NoRepoModel,
   SourceEntries.CustomerClassModel,
   SourceEntries.OrderClassModel,
   SourceEntries.CustomerClassTypeModel,
@@ -188,6 +202,7 @@ exports.SANDBOX_FILES2 = [
   SourceEntries.OrderClassRepository,
   SourceEntries.CustomerClassTypeRepository,
   SourceEntries.OrderClassTypeRepository,
+  SourceEntries.NoKeyRepository,
 
   {
     path: DATASOURCE_APP_PATH,
@@ -198,6 +213,7 @@ exports.SANDBOX_FILES2 = [
   SourceEntries.CustomerModel,
   SourceEntries.OrderModel,
   SourceEntries.NoKeyModel,
+  SourceEntries.NoRepoModel,
   SourceEntries.CustomerClassModel,
   SourceEntries.OrderClassModel,
   SourceEntries.CustomerClassTypeModel,

--- a/packages/cli/test/fixtures/relation/models/no-key.model.ts
+++ b/packages/cli/test/fixtures/relation/models/no-key.model.ts
@@ -1,7 +1,7 @@
 import {Entity, model, property} from '@loopback/repository';
 
 @model()
-export class Nokey extends Entity {
+export class NoKey extends Entity {
   @property({
     type: 'number',
     default: 0,
@@ -13,7 +13,7 @@ export class Nokey extends Entity {
   })
   name?: string;
 
-  constructor(data?: Partial<nokey>) {
+  constructor(data?: Partial<NoKey>) {
     super(data);
   }
 }

--- a/packages/cli/test/fixtures/relation/models/no-repo.model.ts
+++ b/packages/cli/test/fixtures/relation/models/no-repo.model.ts
@@ -1,0 +1,20 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class NoRepo extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  name?: string;
+
+  constructor(data?: Partial<NoRepo>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/relation/repositories/no-key.repository.ts
+++ b/packages/cli/test/fixtures/relation/repositories/no-key.repository.ts
@@ -1,0 +1,13 @@
+import {DefaultCrudRepository} from '@loopback/repository';
+import {NoKey} from '../models';
+import {DbDataSource} from '../datasources';
+import {inject} from '@loopback/core';
+
+export class NoKeyRepository extends DefaultCrudRepository<
+  NoKey,
+  typeof NoKey.prototype.id
+> {
+  constructor(@inject('datasources.db') dataSource: DbDataSource) {
+    super(NoKey, dataSource);
+  }
+}

--- a/packages/cli/test/fixtures/relation/repositories/order.repository.ts
+++ b/packages/cli/test/fixtures/relation/repositories/order.repository.ts
@@ -1,5 +1,5 @@
-import {DefaultCrudRepository} from '@loopback/repository';
-import {Order} from '../models';
+import {DefaultCrudRepository, BelongsToAccessor} from '@loopback/repository';
+import {Order, Customer} from '../models';
 import {DbDataSource} from '../datasources';
 import {inject} from '@loopback/core';
 
@@ -7,6 +7,10 @@ export class OrderRepository extends DefaultCrudRepository<
   Order,
   typeof Order.prototype.id
 > {
+  public readonly myCustomer: BelongsToAccessor<
+    Customer,
+    typeof Order.prototype.id
+  >;
   constructor(@inject('datasources.db') dataSource: DbDataSource) {
     super(Order, dataSource);
   }

--- a/packages/cli/test/integration/generators/relation.belongs-to.integration.js
+++ b/packages/cli/test/integration/generators/relation.belongs-to.integration.js
@@ -46,7 +46,7 @@ describe('lb4 relation', function() {
     const prompt = {
       relationType: 'belongsTo',
       sourceModel: 'Customer',
-      destinationModel: 'Nokey',
+      destinationModel: 'NoKey',
     };
 
     return expect(
@@ -66,7 +66,7 @@ describe('lb4 relation', function() {
     const prompt = {
       relationType: 'belongsTo',
       sourceModel: 'Customer',
-      destinationModel: 'Nokey',
+      destinationModel: 'NoKey',
     };
 
     return expect(
@@ -122,16 +122,6 @@ describe('lb4 relation', function() {
         sourceModel: 'Order',
         destinationModel: 'Customer',
       },
-      {
-        relationType: 'belongsTo',
-        sourceModel: 'OrderClass',
-        destinationModel: 'CustomerClass',
-      },
-      {
-        relationType: 'belongsTo',
-        sourceModel: 'OrderClassType',
-        destinationModel: 'CustomerClassType',
-      },
     ];
 
     promptArray.forEach(function(multiItemPrompt, i) {
@@ -172,24 +162,28 @@ describe('lb4 relation', function() {
         relationType: 'belongsTo',
         sourceModel: 'Order',
         destinationModel: 'Customer',
-        relationName: 'myRelation',
+        foreignKeyName: 'customerId',
       },
       {
-        relationType: 'belongsTo',
-        sourceModel: 'OrderClass',
-        destinationModel: 'CustomerClass',
-        relationName: 'myRelation',
-      },
-      {
-        relationType: 'belongsTo',
-        sourceModel: 'OrderClassType',
-        destinationModel: 'CustomerClassType',
-        relationName: 'myRelation',
+        relationType: 'hasMany',
+        sourceModel: 'Customer',
+        destinationModel: 'Order',
+        foreignKeyName: 'customerId',
+        relationName: 'orders',
       },
     ];
 
     it('verifies that a preexisting property will be overwritten', async () => {
       await sandbox.reset();
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(promptList[1]);
+
       await testUtils
         .executeGenerator(generator)
         .inDir(SANDBOX_PATH, () =>
@@ -216,19 +210,14 @@ describe('lb4 relation', function() {
         relationType: 'belongsTo',
         sourceModel: 'Order',
         destinationModel: 'Customer',
-        relationName: 'customerPK',
+        foreignKeyName: 'customerId',
+        relationName: 'my_customer',
       },
       {
         relationType: 'belongsTo',
         sourceModel: 'OrderClass',
         destinationModel: 'CustomerClass',
-        relationName: 'customerPK',
-      },
-      {
-        relationType: 'belongsTo',
-        sourceModel: 'OrderClassType',
-        destinationModel: 'CustomerClassType',
-        relationName: 'customerPK',
+        relationName: 'my_customer',
       },
     ];
     promptArray.forEach(function(multiItemPrompt, i) {
@@ -250,7 +239,7 @@ describe('lb4 relation', function() {
           .withPrompts(multiItemPrompt);
       });
 
-      it('relation name should be customerPK', async () => {
+      it('relation name should be my_customer', async () => {
         const sourceFilePath = path.join(
           SANDBOX_PATH,
           MODEL_APP_PATH,
@@ -274,11 +263,7 @@ describe('lb4 relation', function() {
         relationType: 'belongsTo',
         sourceModel: 'OrderClass',
         destinationModel: 'CustomerClass',
-      },
-      {
-        relationType: 'belongsTo',
-        sourceModel: 'OrderClassType',
-        destinationModel: 'CustomerClassType',
+        relationName: 'my_customer',
       },
     ];
 
@@ -343,12 +328,14 @@ describe('lb4 relation', function() {
         relationType: 'belongsTo',
         sourceModel: 'OrderClass',
         destinationModel: 'CustomerClass',
+        relationName: 'customer',
         registerInclusionResolver: true,
       },
       {
         relationType: 'belongsTo',
         sourceModel: 'OrderClassType',
         destinationModel: 'CustomerClassType',
+        relationName: 'customer',
         registerInclusionResolver: false,
       },
     ];

--- a/packages/cli/test/integration/generators/relation.has-many.integration.js
+++ b/packages/cli/test/integration/generators/relation.has-many.integration.js
@@ -47,12 +47,12 @@ describe('lb4 relation HasMany', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(30000);
 
-  it("rejects relation when source model doesn't have primary Key", async () => {
+  it('rejects relation when the corresponding repository does not exist', async () => {
     await sandbox.reset();
 
     const prompt = {
       relationType: 'hasMany',
-      sourceModel: 'Nokey',
+      sourceModel: 'NoRepo',
       destinationModel: 'Customer',
     };
 
@@ -65,10 +65,12 @@ describe('lb4 relation HasMany', function() {
           }),
         )
         .withPrompts(prompt),
-    ).to.be.rejectedWith(/Source model primary key does not exist\./);
+    ).to.be.rejectedWith(
+      /NoRepoRepository class does not exist\. Please create repository first with \"lb4 repository\" command\./,
+    );
   });
 
-  it('rejects relation when relation already exist in the model', async () => {
+  it('rejects relation when source key already exist in the model', async () => {
     await sandbox.reset();
 
     const prompt = {
@@ -94,6 +96,37 @@ describe('lb4 relation HasMany', function() {
     ).to.be.rejectedWith(
       /relational property orders already exist in the model Customer/,
     );
+  });
+
+  context('Execute relation with existing relation name', () => {
+    it('rejects if the relation name already exists in the repository', async () => {
+      await sandbox.reset();
+
+      const prompt = {
+        relationType: 'hasMany',
+        sourceModel: 'Order',
+        destinationModel: 'Customer',
+        relationName: 'myCustomer',
+      };
+
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(SANDBOX_PATH, () =>
+            testUtils.givenLBProject(SANDBOX_PATH, {
+              additionalFiles: [
+                SourceEntries.CustomerModel,
+                SourceEntries.OrderModel,
+                SourceEntries.CustomerRepository,
+                SourceEntries.OrderRepository,
+              ],
+            }),
+          )
+          .withPrompts(prompt),
+      ).to.be.rejectedWith(
+        `relation myCustomer already exists in the repository OrderRepository.`,
+      );
+    });
   });
 
   // special cases regardless of the repository type


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Fixes https://github.com/strongloop/loopback-next/issues/3287 and https://github.com/strongloop/loopback-next/issues/4209

1st commit: code changes
2nd commit: tests

## Before
#### Example: 

- **hasMany**
? SourceModel: `Customer`
? DestModel: `Order`,
? Foreign key to define on the target model: `customerId`
? Source property name for the relation getter: `orders
? Allow Order queries to include data from related Customer instances? Yes
==> issues:
  - if generation gets aborted, part of code still gets generated in Model and Repository 
  - the default value doesn't match with the code in `/repository/relation`


- **belongTo**
? SourceModel: `Order`
? DestModel: `Customer`,
? Source property name for the relation getter: `customerId`
? Allow ..inclusion? Yes
==> issues:
  - if generation gets aborted, part of code still gets generated in Model and Repository
  - the default value doesn't match with the code in `/repository/relation` 
  - generated code failed if the foreign key name is not the default value
  - generator doesn't respect custom relation name, the only relation it generates is `targetModelName` (e.g `customer`)

## New changes

- checks if corresponding repository exists
- checks if pk exists and validates the name
- checks if fk exists and validates the name
- asks fk for both hasMany and belongsTo
- asks relation name for both hasMany and belongsTo
- checks if the relation name exists
- allow custom relation name for belongsTo
  - This fixes https://github.com/strongloop/loopback-next/issues/4209
  - customized relation name will be specified in the relation metadata

#### Examples of new prompt:

- **hasMany**
? Please select the relation type `hasMany`
? Please select source model `Customer`
? Please select target model `Order`
? Foreign key name to define on the _target_ model `c_id` // not default value
? Source property name for the relation getter (will be the relation name) `orders`
? Allow Customer queries to include data from related Review instances? Yes

=>
```
// Customer property:
  @hasMany(() => Order, {keyTo: 'c_id'})  // custom fk
  orders: Order[];

// Order fk:
  @property({
    type: 'number',
  })
  c_id?: number;  // custom fk
```

- **belongsTo**
? Please select the relation type `belongsTo`
? Please select source model `Order`
? Please select target model `Customer`
? Foreign key name to define on the _source_ model `c_id`
? Relation name my_customer   // not default name
? Allow Customer queries to include data from related Review instances? Yes

=> 
```
//Order fk:
  @belongsTo(() => Customer, {name: 'my_customer'}) . // allow custom relation name
  c_id: number;    // allow custom fk name
```

For belongsTo, if the fk name is the same as the relation name, the prompt would ask the user to re-enter a new name to avoid a known issue: [Relations with custom names not working ](https://github.com/strongloop/loopback-next/issues/4392)

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
