### PR TITLE
fix(docs): fix formatting for datasource migrations

### DIFF
--- a/docs/site/migration/datasources.md
+++ b/docs/site/migration/datasources.md
@@ -45,7 +45,7 @@ steps:
    your LoopBack 4 application with the datasource configuration from
    `server/datasources.json` in your LoopBack 3 application.
 
-   {% include code-caption.html content="server/datasources.json" %}
+   For example, if your `server/datasources.json` file contains:
 
    ```json
    {
@@ -61,7 +61,8 @@ steps:
    }
    ```
 
-   {% include code-caption.html content="src/datasources/mysql-ds.datasource.config.json" %}
+   Move it to `src/datasources/mysql-ds.datasource.config.json`, so that it
+   looks as follows:
 
    ```json
    {


### PR DESCRIPTION
Before:

<img width="910" alt="Screen Shot 2020-01-08 at 10 00 41 PM" src="https://user-images.githubusercontent.com/42985749/72034186-51df6480-3262-11ea-9a30-480200af04d3.png">

After:

<img width="860" alt="Screen Shot 2020-01-08 at 10 01 00 PM" src="https://user-images.githubusercontent.com/42985749/72034205-5c99f980-3262-11ea-93b4-e3ad50c5f8c0.png">

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
