### PR TITLE
feat(openapi-v3): add support for `anyOf` and `oneOf` on the `jsonToSchemaObject` utility

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/json-to-schema.unit.ts
@@ -19,8 +19,6 @@ describe('jsonToSchemaObject', () => {
 
   it('ignores non-compatible JSON schema properties', () => {
     const nonCompatibleDef = {
-      anyOf: [],
-      oneOf: [],
       additionalItems: {
         anyOf: [],
       },
@@ -39,6 +37,26 @@ describe('jsonToSchemaObject', () => {
       allOf: [expectedType, expectedType],
     };
     propertyConversionTest(allOfDef, expectedAllOf);
+  });
+
+  it('converts anyOf', () => {
+    const anyOfDef: JsonSchema = {
+      anyOf: [typeDef, typeDef],
+    };
+    const expectedAnyOf: SchemaObject = {
+      anyOf: [expectedType, expectedType],
+    };
+    propertyConversionTest(anyOfDef, expectedAnyOf);
+  });
+
+  it('converts oneOf', () => {
+    const oneOfDef: JsonSchema = {
+      oneOf: [typeDef, typeDef],
+    };
+    const expectedOneOf: SchemaObject = {
+      oneOf: [expectedType, expectedType],
+    };
+    propertyConversionTest(oneOfDef, expectedOneOf);
   });
 
   it('converts definitions', () => {

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -56,13 +56,7 @@ export function jsonToSchemaObject(
     [converted]: false,
   };
   visited.set(json, result);
-  const propsToIgnore = [
-    'anyOf',
-    'oneOf',
-    'additionalItems',
-    'defaultProperties',
-    'typeof',
-  ];
+  const propsToIgnore = ['additionalItems', 'defaultProperties', 'typeof'];
   for (const property in json) {
     if (propsToIgnore.includes(property)) {
       continue;
@@ -79,6 +73,18 @@ export function jsonToSchemaObject(
       }
       case 'allOf': {
         result.allOf = _.map(json.allOf, item =>
+          jsonToSchemaObject(item as JsonSchema, visited),
+        );
+        break;
+      }
+      case 'anyOf': {
+        result.anyOf = _.map(json.anyOf, item =>
+          jsonToSchemaObject(item as JsonSchema, visited),
+        );
+        break;
+      }
+      case 'oneOf': {
+        result.oneOf = _.map(json.oneOf, item =>
           jsonToSchemaObject(item as JsonSchema, visited),
         );
         break;


### PR DESCRIPTION
fix #3524

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
