### PR TITLE
fix(repository): make the navigational property err msg more clear

### DIFF
--- a/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
@@ -221,7 +221,7 @@ export function hasManyRelationAcceptance(
           ],
         }),
       ).to.be.rejectedWith(
-        'Navigational properties are not allowed in model data (model "Customer" property "orders")',
+        'Navigational properties are not allowed in model data (model "Customer" property "orders"), please remove it.',
       );
     });
 
@@ -238,7 +238,7 @@ export function hasManyRelationAcceptance(
           },
         ]),
       ).to.be.rejectedWith(
-        'Navigational properties are not allowed in model data (model "Customer" property "orders")',
+        'Navigational properties are not allowed in model data (model "Customer" property "orders"), please remove it.',
       );
     });
 
@@ -296,7 +296,7 @@ export function hasManyRelationAcceptance(
       });
 
       await expect(customerRepo.delete(found)).to.be.rejectedWith(
-        'Navigational properties are not allowed in model data (model "Customer" property "orders")',
+        'Navigational properties are not allowed in model data (model "Customer" property "orders"), please remove it.',
       );
     });
 

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -573,17 +573,23 @@ export class DefaultCrudRepository<
       typeof entity.toJSON === 'function' ? entity.toJSON() : {...entity};
     */
 
-    // proposal solution from agnes: delete the id property in the
-    // target data when runs replaceById
-
     const data: AnyObject = new this.entityClass(entity);
 
     const def = this.entityClass.definition;
+    const props = def.properties;
     for (const r in def.relations) {
       const relName = def.relations[r].name;
       if (relName in data) {
+        let invalidNameMsg = '';
+        if (relName in props) {
+          invalidNameMsg =
+            ` The error might be invoked by belongsTo relations, please make sure the relation name is not the same as` +
+            ` the property name.`;
+        }
         throw new Error(
-          `Navigational properties are not allowed in model data (model "${this.entityClass.modelName}" property "${relName}")`,
+          `Navigational properties are not allowed in model data (model "${this.entityClass.modelName}"` +
+            ` property "${relName}"), please remove it.` +
+            invalidNameMsg,
         );
       }
     }


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
related https://github.com/strongloop/loopback-next/issues/4392,  [stackoverflow](https://stackoverflow.com/questions/59468329/unhandled-error-in-post-order-products-500-error-navigational-properties-are)

The `belongsTo` generator generates the default relation name by taking the `@belongsTo` decorated name then removing `Id` from it. **Idealy**, the default fk name is expected to be `customerId`, and the ideal relation name will be `customer` ([code]( https://github.com/strongloop/loopback-next/blob/master/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts#L45)).

However, lots of users would come up with their own customized name, `customer_id` for example.  And the default relation name generated by the belongsTo will be `customer_id` according to the code. This is problematic because in CRUD operations, it recognize `customer_id` as _a navigational property_ instead of a model property. As a result, operations like
```
orderRepo.create({id: 1, name: 'LoopBack', customer_id: 1})
```
will be rejected with error `500 Error: Navigational properties are not allowed in model data`.

Currently I couldn't find a good way to improve the way it generates the default relation name. So I am proposing to make the error message more clear and also update the site before we come up a better way for generating the default relation name.

Example new error message.
`Navigational properties are not allowed in model data (model "Order" property "customer_id"). Please remove it or make sure the relation name is not the same as the property name in belongsTo relation.`

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
