### PR TITLE
docs: update belongsTo relation metadata

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -45,30 +45,48 @@ using the `@belongsTo` decorator to define the constraining foreign key.
 
 ### Relation Metadata
 
-The definition of the `belongsTo` relation is inferred by using the `@belongsTo`
-decorator. The decorator takes in a function resolving the target model class
-constructor and designates the relation type. It also calls `property()` to
-ensure that the decorated property is correctly defined.
+LB4 uses three `keyFrom`, `keyTo` and `name` fields in the `belongsTo` relation
+metadata to configure relations. The relation metadata has its own default
+values for these three fields:
 
-The `@belongsTo` decorator takes three parameters:
+<table>
+  <thead>
+    <tr>
+      <th width="95">Field Name</th>
+      <th width="260">Description</th>
+      <th width="260">Default Value</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>keyFrom</code></td>
+      <td>the foreign key of the source model</td>
+      <td>the target model name appended with `Id` in camel case</td>
+      <td><code>Order.customerId</code></td>
+    </tr>
+    <tr>
+      <td><code>keyTo</code></td>
+      <td>the source key of the target model</td>
+      <td>the primary key in the target model</td>
+      <td><code>Customer.id</code></td>
+    </tr>
+    <tr>
+      <td><code>name</code></td>
+      <td>the name of the relation</td>
+      <td>@belongsTo decorated property name without <code>Id</code></td>
+      <td><code>customer</code></td>
+    </tr>
 
-- `target model class` (required)
-- `relation definition` (optional) - has three attributes, keyFrom, keyTo, name
-  - `keyFrom` is the property name of the foreign key on the "source" model. It
-    is always set to the decorated property name (in the given example it is,
-    "customerId" property on Order model).
-  - `keyTo` is the property name of the foreign key on the "target" model, it is
-    typically the primary key of the "target" model. `keyTo` attribute defaults
-    to the id property on the target model (in the given example, "id" property
-    on Customer).
-  - `name` is the name of the relation as defined in the repository. The
-    relation name is used in the repository constructor to define a
-    [BelongsToAccessor](#configuring-a-belongsto-relation) and map it to the
-    relation using a
-    [inclusion resolver](#enabledisable-the-inclusion-resolvers).
-- `property definition` (optional) - creates a property decorator implicitly.
-  The name attribute in the definition can be used to customize datasource
-  column name.
+  </tbody>
+</table>
+
+We recommend to use default values. If you'd like to customize the foreign key
+name or the relation name, you'll need to specify some fields through the
+relation decorator.
+
+The standard naming convention for the foreign key property in the source model
+is `relation name` + `Id` (for example, Order.customerId).
 
 {% include code-caption.html content="/src/models/order.model.ts" %}
 
@@ -85,7 +103,7 @@ export class Order extends Entity {
   id: number;
 
   @belongsTo(() => Customer)
-  customerId: number;
+  customerId: number; // relation name will default to `customer`
 
   @property({type: 'number'})
   quantity: number;
@@ -102,34 +120,65 @@ export interface OrderRelations {
 export type OrderWithRelations = Order & OrderRelations;
 ```
 
-The standard naming convention for the foreign key property in the source model
-is `relation name` + `Id` (for example, Order.customerId).
+If the foreign key property name in the source model has to be customized
+(`customer_id` instead of `customerId` for example), the relation name has to be
+explicitly specified in the `name` attribute of the relation definition.
+Otherwise the _default relation name_ generates by LB4 (`customer_id` in this
+case) will be the same as the customized foreign key name, which is invalid.
 
-- If the foreign key property name in the source model has to be customized, the
-  relation name has to be explicitly specified in the `name` attribute of the
-  relation definition. In addition, if you have a corresponding `hasMany` or
-  `hasOne` relation in the target model (for example, a Customer has many
-  Orders), the `keyTo` attribute of that corresponding relation needs to be
-  stated explicitly. Check the relation metadata in
-  [hasMany](https://loopback.io/doc/en/lb4/HasMany-relation.html#relation-metadata)
-  and
-  [hasOne](https://loopback.io/doc/en/lb4/hasOne-relation.html#relation-metadata)
-  for more details.
-- In the following example, the foreign key property name is customized as
-  `cust_Id` instead of `customerId`. so the relation definition in the second
-  argument is explicitly passed to the `belongsTo` decorator.
+{% include warning.html content="Make sure that you have different names for the foreign key and the relation name in BelongsTo relations."%}
 
 ```ts
-class Order extends Entity {
-  // constructor, properties, etc.
-  @belongsTo(() => Customer, {keyFrom: 'cust_Id', name: 'customer'})
-  cust_Id: number;
+// import statements
+@model()
+export class Order extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+  })
+  id: number;
+
+  @belongsTo(() => Customer, {name: 'customer'}) // specify the relation name if fk is customized
+  customer_id: number; // customized fk
+
+  // other properties, constructor, etc.
 }
 ```
 
-In the following example, the db column name of the foreign key is customized by
-passing the property definition in the third argument to the `belongsTo`
-decorator.
+In addition, if you have a corresponding `hasMany` or `hasOne` relation in the
+target model (for example, a Customer has many Orders), the `keyTo` attribute of
+that corresponding relation needs to be stated explicitly:
+
+```ts
+// import statements
+@model()
+export class Order extends Entity {
+  // constructor, properties, etc.
+
+  @belongsTo(() => Customer, {name: 'customer'})
+  customer_id: number; // customized foreign key name
+}
+```
+
+```ts
+@model()
+export class Customer extends Entity {
+  // constructor, properties, etc.
+  @hasMany(() => Order, {keyTo: 'customer_id'})
+  orders: Order[];
+}
+```
+
+Check the relation metadata in
+[hasMany](https://loopback.io/doc/en/lb4/HasMany-relation.html#relation-metadata)
+and
+[hasOne](https://loopback.io/doc/en/lb4/hasOne-relation.html#relation-metadata)
+for more details.
+
+If you need to use _different names for models and database columns_, to use
+`customer_id` as db column name other than `customerId` for example, passing the
+column name in the third argument to the `belongsTo` decorator would allow you
+to do so:
 
 ```ts
 class Order extends Entity {
@@ -139,9 +188,9 @@ class Order extends Entity {
 }
 ```
 
-The `keyTo` attribute in the relation definition has to be stated explicitly,
-when the property of the target model for the belongsTo relation is not the id
-property in the target model.
+If you need to use another attribute other than the id property to be the source
+key of the target model (joining two tables on non-primary attribute), the
+`keyTo` attribute in the relation definition has to be stated explicitly.
 
 ```ts
 class Order extends Entity {

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -80,7 +80,7 @@ decorator. The decorator takes in a function resolving the target model class
 constructor and optionally a custom foreign key to store the relation metadata.
 The decorator logic also designates the relation type and tries to infer the
 foreign key on the target model (`keyTo` in the relation metadata) to a default
-value (source model name appended with `id` in camel case, same as LoopBack 3).
+value (source model name appended with `Id` in camel case, same as LoopBack 3).
 It also calls `property.array()` to ensure that the type of the property is
 inferred properly as an array of the target model instances.
 
@@ -206,7 +206,7 @@ values for these three fields:
     <tr>
       <td><code>keyTo</code></td>
       <td>the foreign key of the target model</td>
-      <td>the source model name appended with `id` in camel case</td>
+      <td>the source model name appended with `Id` in camel case</td>
       <td><code>Order.customerId</code></td>
     </tr>
     <tr>
@@ -219,8 +219,8 @@ values for these three fields:
   </tbody>
 </table>
 
-We recommend to use default values. If you'd like to customize foreign key name,
-you'll need to specify some fields through the relation decorator.
+We recommend to use default values. If you'd like to customize the foreign key
+name, you'll need to specify some fields through the relation decorator.
 
 For customizing the foreign key name, `keyTo` field needs to be specified via
 `@hasMany` decorator. The following example shows how to customize the foreign
@@ -231,6 +231,7 @@ key name as `my_customer_id` instead of `customerId`:
 @model()
 export class Customer extends Entity {
   // constructor, properties, etc.
+
   @hasMany(() => Order, {keyTo: 'my_customer_id'})
   orders: Order[];
 }
@@ -241,6 +242,7 @@ export class Customer extends Entity {
 @model()
 export class Order extends Entity {
   // constructor, properties, etc.
+
   @property({
     type: 'number',
   })

--- a/docs/site/hasOne-relation.md
+++ b/docs/site/hasOne-relation.md
@@ -154,7 +154,7 @@ values for these three fields:
     <tr>
       <td><code>keyTo</code></td>
       <td>the foreign key of the target model</td>
-      <td>the source model name appended with `id` in camel case</td>
+      <td>the source model name appended with `Id` in camel case</td>
       <td><code>Account.supplierId</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
Related https://github.com/strongloop/loopback-next/issues/4392,  [stackoverflow](https://stackoverflow.com/questions/59468329/unhandled-error-in-post-order-products-500-error-navigational-properties-are)

The `belongsTo` generator generates the default relation name by taking the `@belongsTo` decorated name then removing `Id` from it. **Idealy**, the default fk name is expected to be `customerId`, and the ideal relation name will be `customer` ([code]( https://github.com/strongloop/loopback-next/blob/master/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts#L45)).

However, lots of users would come up with their own customized name, `customer_id` for example.  And the default relation name generated by the belongsTo will be `customer_id` according to the code. This is problematic because in CRUD operations, it recognize `customer_id` as _a navigational property_ instead of a model property. As a result, operations like
```
orderRepo.create({id: 1, name: 'LoopBack', customer_id: 1})
```
will be rejected with error `500 Error: Navigational properties are not allowed in model data`.

Currently I couldn't find a good way to improve the way it generates the default relation name. Updating the site before we come up a better way for generating the default relation name.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
