### PR TITLE
docs: add instruction to remove api explorer

### DIFF
--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -141,6 +141,9 @@ const app = new RestApplication({
 });
 ```
 
+{% include note.html content="To completely disable API Explorer, we also need
+to [disable the self-hosted REST API Explorer extension](./Self-hosted-REST-API-Explorer.md#disable-self-hosted-api-explorer)." %}
+
 ### Use a self-hosted API Explorer
 
 Hosting the API Explorer at an external URL has a few downsides, for example a

--- a/packages/rest-explorer/README.md
+++ b/packages/rest-explorer/README.md
@@ -90,6 +90,22 @@ Note also that you cannot use a url-relative path for the `servers` entry, as
 the Swagger UI does not support that (yet). You may use a _host_-relative path
 however.
 
+### Disable Self-Hosted API Explorer
+
+To disable the self-hosted API Explorer, remove the component from the
+constructor of your custom Application class. Typically the component will be
+located in `./src/application.ts` and consist of two items, for example:
+
+```ts
+this.bind(RestExplorerBindings.CONFIG).to({
+  path: '/openapi/ui',
+});
+this.component(RestExplorerComponent);
+```
+
+{% include note.html content="To completely disable API Explorer, we also need
+to [disable the redirect to the externally hosted API Explorer](./Server.html#disable-redirect-to-api-explorer)." %}
+
 #### Summary
 
 For some common scenarios, here are recommended configurations to have the


### PR DESCRIPTION
Add instructions to completely disable API explorer for both remote and self-hosted.

See also #4138

## Checklist

- [x] `npm test` passes on your machine
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
