### PR TITLE
docs(extension-health): add function call-order note

### DIFF
--- a/extensions/health/README.md
+++ b/extensions/health/README.md
@@ -11,6 +11,8 @@ npm install --save @loopback/extension-health
 
 ## Basic use
 
+{% include note.html content="*this.configure()* must be called before *this.component()* to take effect. This is a [known limitation](https://github.com/strongloop/loopback-next/issues/4289#issuecomment-564617263)." %}
+
 The component should be loaded in the constructor of your custom Application
 class.
 


### PR DESCRIPTION
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

See also #4289 

Adds a notice to inform users of the mandatory function calling order of `this.component()` and `this.configure()` to prevent a 404 HTTP error.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
