### PR TITLE
fix(cli): reject datasources with no name property for service generator

### DIFF
--- a/examples/todo/src/datasources/geocoder.datasource.config.json
+++ b/examples/todo/src/datasources/geocoder.datasource.config.json
@@ -1,4 +1,5 @@
 {
+  "name": "geocoder",
   "connector": "rest",
   "options": {
     "headers": {

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -233,6 +233,10 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
           this.artifactInfo.dataSourceClass,
         );
 
+        if (!this.artifactInfo.dataSourceName) {
+          throw new Error('Datasource config does not have `name` property');
+        }
+
         this.artifactInfo.dataSourceClassName =
           utils.toClassName(this.artifactInfo.dataSourceName) + 'DataSource';
 

--- a/packages/cli/test/fixtures/service/index.js
+++ b/packages/cli/test/fixtures/service/index.js
@@ -71,4 +71,16 @@ exports.SANDBOX_FILES = [
     file: 'restdb.datasource.ts',
     content: DUMMY_CONTENT,
   },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'no-name.datasource.config.json',
+    content: JSON.stringify({
+      connector: 'rest',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'no-name.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
 ];

--- a/packages/cli/test/integration/generators/remote-service.integration.js
+++ b/packages/cli/test/integration/generators/remote-service.integration.js
@@ -33,6 +33,19 @@ describe('lb4 service (remote)', () => {
           .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
       ).to.be.rejectedWith(/No datasources found/);
     });
+
+    it('does not accept a datasource file with no name property', async () => {
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(SANDBOX_PATH, () =>
+            testUtils.givenLBProject(SANDBOX_PATH, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withArguments('myService --datasource no-name'),
+      ).to.be.rejectedWith(/Datasource config does not have `name` property/);
+    });
   });
 
   describe('valid generation of services', () => {


### PR DESCRIPTION
When generating a service using `lb4 service`, the generator would look for a `name` property in the config file of the datasource and if it didn't include it, it would still generate the service with errors.

For example:

```ts
import {getService} from '@loopback/service-proxy';
import {inject, Provider} from '@loopback/core';
import {Error: bad inputDataSource} from '../datasources'; // notice this import statement

export interface Geocoder {
  // this is where you define the Node.js methods that will be
  // mapped to REST/SOAP/gRPC operations as stated in the datasource
  // json file.
}

export class GeocoderProvider implements Provider<Geocoder> {
  constructor(
    //  must match the name property in the datasource json file

   // **SEE THE FOLLOWING TWO LINES**
    @inject('datasources.')
    protected dataSource: Error: bad inputDataSource = new Error: bad inputDataSource(),
  ) {}

  value(): Promise<Geocoder> {
    return getService(this.dataSource);
  }
}

```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
