### PR TITLE
feat(cli): add static BINDING_KEY prop to non-global interceptors 

### DIFF
--- a/docs/site/Interceptor-generator.md
+++ b/docs/site/Interceptor-generator.md
@@ -121,8 +121,10 @@ import {
  * This class will be bound to the application as a global `Interceptor` during
  * `boot`
  */
-@bind({tags: {namespace: 'interceptors', name: 'test'}})
+@bind({tags: {key: TestInterceptor.BINDING_KEY}})
 export class TestInterceptor implements Provider<Interceptor> {
+  static readonly BINDING_KEY = `interceptors.${TestInterceptor.name}`;
+
   /*
   constructor() {}
   */

--- a/packages/cli/generators/interceptor/templates/interceptor-template.ts.ejs
+++ b/packages/cli/generators/interceptor/templates/interceptor-template.ts.ejs
@@ -19,9 +19,13 @@ import {
 <% if (isGlobal) { -%>
 @globalInterceptor('<%= group %>', {tags: {name: '<%= name %>'}})
 <% } else { -%>
-@bind({tags: {namespace: 'interceptors', name: '<%= name %>'}})
+@bind({tags: {key: <%= className %>.BINDING_KEY}})
 <% } -%>
 export class <%= className %> implements Provider<Interceptor> {
+<% if (!isGlobal) { -%>
+  static readonly BINDING_KEY = `interceptors.${<%= className %>.name}`;
+
+<% } -%>
   /*
   constructor() {}
   */

--- a/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
@@ -1,0 +1,312 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`lb4 interceptor valid generation of interceptors generates a basic interceptor from CLI with group 1`] = `
+import {
+  /* inject, */
+  globalInterceptor,
+  Interceptor,
+  InvocationContext,
+  InvocationResult,
+  Provider,
+  ValueOrPromise,
+} from '@loopback/context';
+
+/**
+ * This class will be bound to the application as an \`Interceptor\` during
+ * \`boot\`
+ */
+@globalInterceptor('myGroup', {tags: {name: 'myInterceptor'}})
+export class MyInterceptorInterceptor implements Provider<Interceptor> {
+  /*
+  constructor() {}
+  */
+
+  /**
+   * This method is used by LoopBack context to produce an interceptor function
+   * for the binding.
+   *
+   * @returns An interceptor function
+   */
+  value() {
+    return this.intercept.bind(this);
+  }
+
+  /**
+   * The logic to intercept an invocation
+   * @param invocationCtx - Invocation context
+   * @param next - A function to invoke next interceptor or the target method
+   */
+  async intercept(
+    invocationCtx: InvocationContext,
+    next: () => ValueOrPromise<InvocationResult>,
+  ) {
+    try {
+      // Add pre-invocation logic here
+      const result = await next();
+      // Add post-invocation logic here
+      return result;
+    } catch (err) {
+      // Add error handling logic here
+      throw err;
+    }
+  }
+}
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a basic interceptor from CLI with group 2`] = `
+export * from './my-interceptor.interceptor';
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a basic interceptor from command line arguments 1`] = `
+import {
+  /* inject, */
+  globalInterceptor,
+  Interceptor,
+  InvocationContext,
+  InvocationResult,
+  Provider,
+  ValueOrPromise,
+} from '@loopback/context';
+
+/**
+ * This class will be bound to the application as an \`Interceptor\` during
+ * \`boot\`
+ */
+@globalInterceptor('', {tags: {name: 'myInterceptor'}})
+export class MyInterceptorInterceptor implements Provider<Interceptor> {
+  /*
+  constructor() {}
+  */
+
+  /**
+   * This method is used by LoopBack context to produce an interceptor function
+   * for the binding.
+   *
+   * @returns An interceptor function
+   */
+  value() {
+    return this.intercept.bind(this);
+  }
+
+  /**
+   * The logic to intercept an invocation
+   * @param invocationCtx - Invocation context
+   * @param next - A function to invoke next interceptor or the target method
+   */
+  async intercept(
+    invocationCtx: InvocationContext,
+    next: () => ValueOrPromise<InvocationResult>,
+  ) {
+    try {
+      // Add pre-invocation logic here
+      const result = await next();
+      // Add post-invocation logic here
+      return result;
+    } catch (err) {
+      // Add error handling logic here
+      throw err;
+    }
+  }
+}
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a basic interceptor from command line arguments 2`] = `
+export * from './my-interceptor.interceptor';
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a interceptor from a config file 1`] = `
+import {
+  /* inject, */
+  globalInterceptor,
+  Interceptor,
+  InvocationContext,
+  InvocationResult,
+  Provider,
+  ValueOrPromise,
+} from '@loopback/context';
+
+/**
+ * This class will be bound to the application as an \`Interceptor\` during
+ * \`boot\`
+ */
+@globalInterceptor('', {tags: {name: 'myInterceptor'}})
+export class MyInterceptorInterceptor implements Provider<Interceptor> {
+  /*
+  constructor() {}
+  */
+
+  /**
+   * This method is used by LoopBack context to produce an interceptor function
+   * for the binding.
+   *
+   * @returns An interceptor function
+   */
+  value() {
+    return this.intercept.bind(this);
+  }
+
+  /**
+   * The logic to intercept an invocation
+   * @param invocationCtx - Invocation context
+   * @param next - A function to invoke next interceptor or the target method
+   */
+  async intercept(
+    invocationCtx: InvocationContext,
+    next: () => ValueOrPromise<InvocationResult>,
+  ) {
+    try {
+      // Add pre-invocation logic here
+      const result = await next();
+      // Add post-invocation logic here
+      return result;
+    } catch (err) {
+      // Add error handling logic here
+      throw err;
+    }
+  }
+}
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a interceptor from a config file 2`] = `
+export * from './my-interceptor.interceptor';
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a non-global interceptor from CLI 1`] = `
+import {
+  /* inject, */
+  bind,
+  Interceptor,
+  InvocationContext,
+  InvocationResult,
+  Provider,
+  ValueOrPromise,
+} from '@loopback/context';
+
+/**
+ * This class will be bound to the application as an \`Interceptor\` during
+ * \`boot\`
+ */
+@bind({tags: {namespace: 'interceptors', name: 'myInterceptor'}})
+export class MyInterceptorInterceptor implements Provider<Interceptor> {
+  /*
+  constructor() {}
+  */
+
+  /**
+   * This method is used by LoopBack context to produce an interceptor function
+   * for the binding.
+   *
+   * @returns An interceptor function
+   */
+  value() {
+    return this.intercept.bind(this);
+  }
+
+  /**
+   * The logic to intercept an invocation
+   * @param invocationCtx - Invocation context
+   * @param next - A function to invoke next interceptor or the target method
+   */
+  async intercept(
+    invocationCtx: InvocationContext,
+    next: () => ValueOrPromise<InvocationResult>,
+  ) {
+    try {
+      // Add pre-invocation logic here
+      const result = await next();
+      // Add post-invocation logic here
+      return result;
+    } catch (err) {
+      // Add error handling logic here
+      throw err;
+    }
+  }
+}
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a non-global interceptor from CLI 2`] = `
+export * from './my-interceptor.interceptor';
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a non-global interceptor with prompts 1`] = `
+import {
+  /* inject, */
+  bind,
+  Interceptor,
+  InvocationContext,
+  InvocationResult,
+  Provider,
+  ValueOrPromise,
+} from '@loopback/context';
+
+/**
+ * This class will be bound to the application as an \`Interceptor\` during
+ * \`boot\`
+ */
+@bind({tags: {namespace: 'interceptors', name: 'myInterceptor'}})
+export class MyInterceptorInterceptor implements Provider<Interceptor> {
+  /*
+  constructor() {}
+  */
+
+  /**
+   * This method is used by LoopBack context to produce an interceptor function
+   * for the binding.
+   *
+   * @returns An interceptor function
+   */
+  value() {
+    return this.intercept.bind(this);
+  }
+
+  /**
+   * The logic to intercept an invocation
+   * @param invocationCtx - Invocation context
+   * @param next - A function to invoke next interceptor or the target method
+   */
+  async intercept(
+    invocationCtx: InvocationContext,
+    next: () => ValueOrPromise<InvocationResult>,
+  ) {
+    try {
+      // Add pre-invocation logic here
+      const result = await next();
+      // Add post-invocation logic here
+      return result;
+    } catch (err) {
+      // Add error handling logic here
+      throw err;
+    }
+  }
+}
+
+`;
+
+
+exports[`lb4 interceptor valid generation of interceptors generates a non-global interceptor with prompts 2`] = `
+export * from './my-interceptor.interceptor';
+
+`;

--- a/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
@@ -205,8 +205,10 @@ import {
  * This class will be bound to the application as an \`Interceptor\` during
  * \`boot\`
  */
-@bind({tags: {namespace: 'interceptors', name: 'myInterceptor'}})
+@bind({tags: {key: MyInterceptorInterceptor.BINDING_KEY}})
 export class MyInterceptorInterceptor implements Provider<Interceptor> {
+  static readonly BINDING_KEY = \`interceptors.\${MyInterceptorInterceptor.name}\`;
+
   /*
   constructor() {}
   */
@@ -266,8 +268,10 @@ import {
  * This class will be bound to the application as an \`Interceptor\` during
  * \`boot\`
  */
-@bind({tags: {namespace: 'interceptors', name: 'myInterceptor'}})
+@bind({tags: {key: MyInterceptorInterceptor.BINDING_KEY}})
 export class MyInterceptorInterceptor implements Provider<Interceptor> {
+  static readonly BINDING_KEY = \`interceptors.\${MyInterceptorInterceptor.name}\`;
+
   /*
   constructor() {}
   */


### PR DESCRIPTION
While working on #3950, I discovered that non-global interceptors are difficult to use via `@intercept` when they are implemented as provider classes. In this pull request, I am improving the CLI templates to add a static property `BINDING_KEY` when generating a new non-global interceptor.

At the moment, we have to use a magic string to reference an interceptor:

```ts
@inject('interceptors.FooBarInterceptor')
```

With my change in place, we can use the new static variable instead:

```ts
@inject(FooBarInterceptor.BINDING_KEY)
```

The pull request has two commits:
1. The first commit reworks interceptor tests to use snapshot-based assertions, no changes in the actual functionality as made.
2. The second commit modifies the template per the feature description above.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
