### PR TITLE
feat: adds utility launch for debugging a single test file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
       "request": "launch",
       "name": "Run Mocha tests",
       "program": "${workspaceRoot}/packages/build/node_modules/mocha/bin/_mocha",
+      "runtimeArgs": ["-r", "${workspaceRoot}/packages/build/node_modules/source-map-support/register"],
       "cwd": "${workspaceRoot}",
       "args": [
         "--config",
@@ -17,6 +18,25 @@
         "-t",
         "0"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current Test File",
+      "program": "${workspaceRoot}/bin/mocha-current-file",
+      "runtimeArgs": ["-r", "${workspaceRoot}/packages/build/node_modules/source-map-support/register"],
+      "cwd": "${workspaceRoot}",
+      "args": [
+        "--config",
+        "${workspaceRoot}/packages/build/config/.mocharc.json",
+        "-t",
+        "0",
+        "${file}"
+      ],
+      // This ensures vscode won't set breakpoints until after sourcemaps
+      // have been loaded for the file.  Important when your tests are compiled
+      // from typescript.
+      "disableOptimisticBPs": true,
     },
     {
       "type": "node",

--- a/bin/mocha-current-file.js
+++ b/bin/mocha-current-file.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/*
+================================================================================
+This is used in the launch.json to enable you to debug a test file written in
+typescript.  This function attempts to convert the passed typescript file to
+the best-guess output javascript file.
+
+It walks up the filesystem from the current file, stops at package.json, and
+looks in `dist`
+
+Ideally, we could somehow use the typescript compiler and tsconfig.json to get
+the explicit output file instead of trying to guess it, but there might be
+overhead.
+
+Ex:
+```jsonc
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current Test File",
+      "program": "${workspaceRoot}/bin/mocha-current-file",
+      "runtimeArgs": ["-r", "${workspaceRoot}/packages/build/node_modules/source-map-support/register"],
+      "cwd": "${workspaceRoot}",
+      "autoAttachChildProcesses": true,
+      "args": [
+        "--config",
+        "${workspaceRoot}/packages/build/config/.mocharc.json",
+        "-t",
+        "0",
+        "${file}"
+      ],
+      "disableOptimisticBPs": true
+    }
+  ]
+}
+```
+================================================================================
+*/
+
+'use strict';
+const path = require('path');
+const fs = require('fs');
+
+function findDistFile(filename) {
+  const absolutePath = path.resolve(filename);
+  const systemRoot = path.parse(absolutePath).root;
+  let currentDir = path.dirname(absolutePath);
+
+  let isPackageRoot = fs.existsSync(path.resolve(currentDir, 'package.json'));
+  while (!isPackageRoot) {
+    if (path.dirname(currentDir) === systemRoot) {
+      throw new Error(
+        `Could not find a package.json file in the path heirarchy of ${absolutePath}`,
+      );
+    }
+    currentDir = path.join(currentDir, '..');
+    isPackageRoot = fs.existsSync(path.resolve(currentDir, 'package.json'));
+  }
+  const base = path.resolve(currentDir);
+  const relative = path.relative(currentDir, absolutePath);
+  const resultPath = relative.replace(/^src/, 'dist').replace(/\.ts$/, '.js');
+  return path.resolve(base, resultPath);
+}
+
+const newFile = findDistFile(process.argv.splice(-1)[0]);
+
+if (newFile) {
+  require('../packages/build/node_modules/mocha/lib/cli').main(
+    [...process.argv, newFile].slice(2),
+  );
+}


### PR DESCRIPTION
Partially implements: #4300
See: #4406

This has been split from #4406 as a more manageable, smaller PR.

This update adds a developer convenience Launch task to allow debugging a single unit test file in Visual Studio Code.  

## Adds
- **`bin/mocha-current-file.js`** - this is a utility script that attempts to determine the dist output of the given test file, and passes it off to mocha in-process.
- **VSCode: Debug Current Test File** launch configuration.  This launch configuration allows you to debug the current unit test file currently focused.  It uses the above helper to determine the correct name and path of the compiled JavaScript file to run.

## Modifies
- The launch for "Run Mocha Tests" so that it also runs on Windows.

## Checklist
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

