### PR TITLE
improvement(repository): add support for custom json keys in Model.toJSON()

### DIFF
--- a/packages/repository/src/__tests__/unit/model/model.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/model.unit.ts
@@ -428,4 +428,45 @@ describe('model', () => {
       firstName: 'Test User',
     });
   });
+
+  it('converts to json using custom json keys', () => {
+    const accountDef = new ModelDefinition('Account');
+    accountDef
+      .addProperty('accountId', {type: 'number', json: {name: 'account_id'}})
+      .addProperty('isActive', {type: 'number', json: {name: 'is_active'}})
+      .addProperty('createdAt', {type: 'string', json: {name: 'created_at'}})
+      .addProperty('updatedAt', {type: 'string', json: {name: 'updated-at'}});
+
+    class Account extends Entity {
+      static definition = accountDef;
+      accountId: number;
+      isActive: number;
+      createdAt: string;
+      updatedAt: string;
+
+      constructor(data?: Partial<Account>) {
+        super(data);
+      }
+    }
+
+    function createAccount() {
+      const account = new Account();
+      account.accountId = 1;
+      account.isActive = 0;
+      account.createdAt = '2018-09-28T10:55:51.603Z';
+      account.updatedAt = '2018-09-29T10:55:51.603Z';
+      return account;
+    }
+
+    const account = createAccount();
+    expect(account.toJSON()).to.eql({
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      account_id: 1,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      is_active: 0,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      created_at: '2018-09-28T10:55:51.603Z',
+      'updated-at': '2018-09-29T10:55:51.603Z',
+    });
+  });
 });

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -207,7 +207,8 @@ export abstract class Model {
     }
 
     const copyPropertyAsJson = (key: string) => {
-      json[key] = asJSON((this as AnyObject)[key]);
+      const jsonKey = def.properties[key]?.json?.name ?? key;
+      json[jsonKey] = asJSON((this as AnyObject)[key]);
     };
 
     const json: AnyObject = {};


### PR DESCRIPTION

* PropertyDefinition already [contains](https://loopback.io/doc/en/lb4/apidocs.repository.propertydefinition.html) a `json` field but it was not used
* If the name is defined in PropertyForm then take it into account
when forming the json in Model.toJSON(). If not defined fallback
to the key
* Needed because sometimes the json we want to return from the REST
endpoints must adhere to different conventions (snake-case or
kebab-case)
* It fixes https://github.com/strongloop/loopback-datasource-juggler/issues/432 which is linked in the loopback documentation on [PropertyForm](https://loopback.io/doc/en/lb4/apidocs.repository.propertyform.html) 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated