### PR TITLE
chore: update vscode settings for eslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,9 +32,6 @@
   "eslint.nodePath": "./packages/build/node_modules",
   "eslint.validate": [
     "javascript",
-    {
-        "language": "typescript",
-        "autoFix": true
-    }
+    "typescript"
   ]
 }

--- a/packages/cli/generators/project/templates/.vscode/settings.json
+++ b/packages/cli/generators/project/templates/.vscode/settings.json
@@ -17,14 +17,13 @@
   "files.trimTrailingWhitespace": true,
 
   "typescript.tsdk": "./node_modules/typescript/lib",
-  "eslint.autoFixOnSave": true,
   "eslint.run": "onSave",
   "eslint.nodePath": "./node_modules",
   "eslint.validate": [
     "javascript",
-    {
-        "language": "typescript",
-        "autoFix": true
-    }
-  ]
+    "typescript"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }


### PR DESCRIPTION
Latest version of vscode prompts us to update deprecated settings.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
