### PR TITLE
chore: update community maintainers on MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,3 +19,6 @@ Community maintainers:
 - Hugo Da Roit ([@Yaty](https://github.com/Yaty))
 - Mario Estrada ([@marioestradarosa](https://github.com/marioestradarosa))
 - TN ([@thinusn](https://github.com/thinusn))
+- Denny Bartelt ([@derdeka](https://github.com/derdeka))
+- Douglas McConnachie ([@dougal83](https://github.com/dougal83))
+- Rifa Achrinza ([@achrinza](https://github.com/achrinza))


### PR DESCRIPTION
This PR is to update [`MAINTAINERS.md`](https://github.com/strongloop/loopback-next/blob/0ca8cd1840300643958c264b4d79f1bdc3f5a77a/MAINTAINERS.md) to include the new maintainers as per-[`README.md`](https://github.com/strongloop/loopback-next/blob/0ca8cd1840300643958c264b4d79f1bdc3f5a77a/README.md).

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
