### PR TITLE
docs: update default external explorer URL

### DIFF
--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -109,7 +109,7 @@ LoopBack allows externally hosted API Explorer UI to render the OpenAPI
 endpoints for a REST server. Such URLs can be specified with `rest.apiExplorer`:
 
 - url: URL for the hosted API Explorer UI, default to
-  `https://loopback.io/api-explorer`.
+  `https://explorer.loopback.io`.
 - httpUrl: URL for the API explorer served over plain http to deal with mixed
   content security imposed by browsers as the spec is exposed over `http` by
   default. See https://github.com/strongloop/loopback-next/issues/1603. Default


### PR DESCRIPTION
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

The `@loopback/rest` package now defaults `rest.url` to `https://explorer.loopback.io`. This PR is to update the docs to reflect these changes.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
