### PR TITLE
docs: remove @loopback/passport-authentication experimental warning

### DIFF
--- a/docs/site/Understanding-the-differences.md
+++ b/docs/site/Understanding-the-differences.md
@@ -255,7 +255,6 @@ separated from the code responsible for implementing client side APIs.
   <td><a href="/doc/en/lb3/Third-party-login-using-Passport.html"><code>loopback-component-passport</code></a>
   </td>
   <td><a href="https://github.com/strongloop/loopback-next/tree/master/extensions/authentication-passport"><code>@loopback/authentication-passport</code></a>
-    <br>(EXPERIMENTAL)
   </td>
 </tr>
 


### PR DESCRIPTION
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

Loosely related: #4036

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
