### PR TITLE
docs: add lb3 parity warnings

### DIFF
--- a/docs/site/Understanding-the-differences.md
+++ b/docs/site/Understanding-the-differences.md
@@ -42,6 +42,8 @@ model definitions, migrating their application incrementally.
 
 ## Concept/feature mapping
 
+{% include note.html content="See the [GitHub issue](https://github.com/strongloop/loopback-next/issues/1920) for a full list of features that have not been migrated to LoopBack 4." %}
+
 In Loopback 3.x (and earlier), models were responsible for both accessing data
 in other systems (databases, SOAP services, etc.) and providing the
 application's external REST API. This made it easy to quickly build a REST

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -15,6 +15,8 @@ multiple repos, as in v3. However, examples and externally-developed components
 will be in separate repositories.
 '%}
 
+{% include important.html content="Certain features from LoopBack 3 may still be a work in progress or are not planned to be migrated to LoopBack 4. See [Understanding the differences](understanding-the-differences.md)." %}
+
 LoopBack is a highly extensible, open-source Node.js and TypeScript framework
 based on Express that enables you to quickly create APIs and microservices
 composed from backend systems such as databases and SOAP or REST services.


### PR DESCRIPTION
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Currently, LoopBack 4 does not provide full parity of the features from LoopBack 3. This PR is intended to add a warning for existing users of LoopBack 3 on the docs page (see: https://github.com/strongloop/loopback-next/issues/1920#issuecomment-563309178).

While there is a [pinned issue](https://github.com/strongloop/loopback-next/issues/1920) to keep track of this, it may be hidden to the average user. Hence, this PR intends to put forward the pinned issue in more clearly.

This is to prevent users from taking extra time to work around the lack of feature parity that may not have been known to them due to lack of warning in the docs.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
