### PR TITLE
fix(cli): openAPI generator should update index files. Add relation interfaces to model template.

### DIFF
--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -12,6 +12,8 @@ const {validateUrlOrFile, escapeComment} = require('./utils');
 const {getControllerFileName} = require('./spec-helper');
 
 const updateIndex = require('../../lib/update-index');
+const MODEL = 'models';
+const CONTROLLER = 'controllers';
 
 module.exports = class OpenApiGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.
@@ -122,8 +124,9 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
   async scaffold() {
     if (this.shouldExit()) return false;
     this._generateModels();
+    await this._updateIndex(MODEL);
     this._generateControllers();
-    await this._updateIndex();
+    await this._updateIndex(CONTROLLER);
   }
 
   _generateControllers() {
@@ -161,13 +164,26 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
     }
   }
 
-  async _updateIndex() {
-    const targetDir = this.destinationPath(`src/controllers`);
-    for (const c of this.selectedControllers) {
-      // Check all files being generated to ensure they succeeded
-      const status = this.conflicter.generationStatus[c.fileName];
-      if (status !== 'skip' && status !== 'identical') {
-        await updateIndex(targetDir, c.fileName);
+  // update index file for models and controllers
+  async _updateIndex(dir) {
+    if (dir === MODEL) {
+      const targetDir = this.destinationPath(`src/${MODEL}`);
+      for (const m of this.modelSpecs) {
+        // Check all files being generated to ensure they succeeded
+        const status = this.conflicter.generationStatus[m.fileName];
+        if (status !== 'skip' && status !== 'identical') {
+          await updateIndex(targetDir, m.fileName);
+        }
+      }
+    }
+    if (dir === CONTROLLER) {
+      const targetDir = this.destinationPath(`src/${CONTROLLER}`);
+      for (const c of this.selectedControllers) {
+        // Check all files being generated to ensure they succeeded
+        const status = this.conflicter.generationStatus[c.fileName];
+        if (status !== 'skip' && status !== 'identical') {
+          await updateIndex(targetDir, c.fileName);
+        }
       }
     }
   }

--- a/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
@@ -40,3 +40,10 @@ export class <%- className %> {
   <%_ } -%>
 }
 
+export interface <%= className %>Relations {
+  // describe navigational properties here
+}
+
+export type <%= className %>WithRelations = <%= className %> & <%= className %>Relations;
+
+

--- a/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
@@ -1,0 +1,168 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`openapi-generator specific files generates all the proper files 1`] = `
+export * from './open-api.controller';
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 2`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+import {Pet} from '../models/pet.model';
+import {NewPet} from '../models/new-pet.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by 
+ * 
+ */
+export class OpenApiController {
+  constructor() {}
+
+  /**
+   * Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+
+   * 
+
+   * @param tags tags to filter by
+   * @param limit maximum number of results to return
+   * @returns pet response
+   */
+  @operation('get', '/pets')
+  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Creates a new pet in the store.  Duplicates are allowed
+   * 
+
+   * @param _requestBody Pet to add to the store
+   * @returns pet response
+   */
+  @operation('post', '/pets')
+  async addPet(@requestBody() _requestBody: NewPet): Promise<Pet> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns a user based on a single ID, if the user does not have access to the pet
+   * 
+
+   * @param id ID of pet to fetch
+   * @returns pet response
+   */
+  @operation('get', '/pets/{id}')
+  async findPetById(@param({name: 'id', in: 'path'}) id: number): Promise<Pet> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * deletes a single pet based on the ID supplied
+   * 
+
+   * @param id ID of pet to delete
+   */
+  @operation('delete', '/pets/{id}')
+  async deletePet(@param({name: 'id', in: 'path'}) id: number): Promise<any> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 3`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {NewPet} from './new-pet.model';
+/**
+ * The model type is generated from OpenAPI schema - Pet
+ * Pet
+ */
+export type Pet = NewPet & {
+  id: number;
+};
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 4`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - NewPet
+ * NewPet
+ */
+@model({name: 'NewPet'})
+export class NewPet {
+  constructor(data?: Partial<NewPet>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   * 
+   */
+  @property({required: true})
+  name: string;
+
+  /**
+   * 
+   */
+  @property()
+  tag?: string;
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 5`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - Error
+ * Error
+ */
+@model({name: 'Error'})
+export class Error {
+  constructor(data?: Partial<Error>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   * 
+   */
+  @property({required: true})
+  code: number;
+
+  /**
+   * 
+   */
+  @property({required: true})
+  message: string;
+
+}
+
+
+`;

--- a/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
@@ -8,12 +8,20 @@
 'use strict';
 
 exports[`openapi-generator specific files generates all the proper files 1`] = `
-export * from './open-api.controller';
+export * from './pet.model';
+export * from './new-pet.model';
+export * from './error.model';
 
 `;
 
 
 exports[`openapi-generator specific files generates all the proper files 2`] = `
+export * from './open-api.controller';
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 3`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {operation, param, requestBody} from '@loopback/rest';
 import {Pet} from '../models/pet.model';
@@ -85,7 +93,7 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 3`] = `
+exports[`openapi-generator specific files generates all the proper files 4`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {NewPet} from './new-pet.model';
 /**
@@ -100,7 +108,7 @@ export type Pet = NewPet & {
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 4`] = `
+exports[`openapi-generator specific files generates all the proper files 5`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {model, property} from '@loopback/repository';
 
@@ -130,11 +138,18 @@ export class NewPet {
 
 }
 
+export interface NewPetRelations {
+  // describe navigational properties here
+}
+
+export type NewPetWithRelations = NewPet & NewPetRelations;
+
+
 
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 5`] = `
+exports[`openapi-generator specific files generates all the proper files 6`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {model, property} from '@loopback/repository';
 
@@ -163,6 +178,13 @@ export class Error {
   message: string;
 
 }
+
+export interface ErrorRelations {
+  // describe navigational properties here
+}
+
+export type ErrorWithRelations = Error & ErrorRelations;
+
 
 
 `;

--- a/packages/cli/snapshots/integration/generators/openapi-uspto-with-anonymous.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-uspto-with-anonymous.integration.snapshots.js
@@ -1,0 +1,151 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`openapi-generator specific files generates all the proper files 1`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+import {PerformSearchRequestBody} from '../models/perform-search-request-body.model';
+import {PerformSearchResponseBody} from '../models/perform-search-response-body.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by search
+ * Search a data set
+ */
+export class SearchController {
+  constructor() {}
+
+  /**
+   * This API is based on Solr/Lucense Search. The data is indexed using SOLR. This GET API returns the list of all the searchable field names that are in the Solr Index. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the Solr/Lucene Syntax. Please refer https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the query syntax. List of field names that are searchable can be determined using above GET api.
+   * 
+
+   * @param _requestBody 
+   * @param version Version of the dataset.
+   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * @returns successful operation
+   */
+  @operation('post', '/{dataset}/{version}/records')
+  async performSearch(@requestBody() _requestBody: PerformSearchRequestBody, @param({name: 'version', in: 'path'}) version: string, @param({name: 'dataset', in: 'path'}) dataset: string): Promise<PerformSearchResponseBody> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 2`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+import {DataSetList} from '../models/data-set-list.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by metadata
+ * Find out about the data sets
+ */
+export class MetadataController {
+  constructor() {}
+
+  /**
+   * 
+   * 
+
+   * @returns Returns a list of data sets
+   */
+  @operation('get', '/')
+  async listDataSets(): Promise<DataSetList> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
+   * 
+
+   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * @param version Version of the dataset.
+   * @returns The dataset api for the given version is found and it is accessible to consume.
+   */
+  @operation('get', '/{dataset}/{version}/fields')
+  async listSearchableFields(@param({name: 'dataset', in: 'path'}) dataset: string, @param({name: 'version', in: 'path'}) version: string): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 3`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - performSearchRequestBody
+ * performSearchRequestBody
+ */
+@model({name: 'performSearchRequestBody'})
+export class PerformSearchRequestBody {
+  constructor(data?: Partial<PerformSearchRequestBody>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   * Uses Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format: propertyName:[yyyyMMdd TO yyyyMMdd]. In the response please see the 'docs' element which has the list of record objects. Each record structure would consist of all the fields and their corresponding values.
+   */
+  @property({required: true})
+  criteria: string = '*:*';
+
+  /**
+   * Starting record number. Default value is 0.
+   */
+  @property()
+  start?: number = 0;
+
+  /**
+   * Specify number of rows to be returned. If you run the search with default values, in the response you will see 'numFound' attribute which will tell the number of records available in the dataset.
+   */
+  @property()
+  rows?: number = 100;
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 4`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * The model type is generated from OpenAPI schema - {
+  [additionalProperty: string]: {
+  
+};
+}[]
+ * performSearchResponseBody
+ */
+export type PerformSearchResponseBody = {
+  [additionalProperty: string]: {
+  
+};
+}[];
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 5`] = `
+export * from './metadata.controller';
+export * from './search.controller';
+
+`;

--- a/packages/cli/snapshots/integration/generators/openapi-uspto-with-anonymous.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-uspto-with-anonymous.integration.snapshots.js
@@ -120,6 +120,13 @@ export class PerformSearchRequestBody {
 
 }
 
+export interface PerformSearchRequestBodyRelations {
+  // describe navigational properties here
+}
+
+export type PerformSearchRequestBodyWithRelations = PerformSearchRequestBody & PerformSearchRequestBodyRelations;
+
+
 
 `;
 
@@ -145,6 +152,14 @@ export type PerformSearchResponseBody = {
 
 
 exports[`openapi-generator specific files generates all the proper files 5`] = `
+export * from './data-set-list.model';
+export * from './perform-search-request-body.model';
+export * from './perform-search-response-body.model';
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 6`] = `
 export * from './metadata.controller';
 export * from './search.controller';
 

--- a/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
@@ -1,0 +1,146 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`openapi-generator specific files generates all the proper files 1`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by search
+ * Search a data set
+ */
+export class SearchController {
+  constructor() {}
+
+  /**
+   * This API is based on Solr/Lucense Search. The data is indexed using SOLR. This GET API returns the list of all the searchable field names that are in the Solr Index. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the Solr/Lucene Syntax. Please refer https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the query syntax. List of field names that are searchable can be determined using above GET api.
+   * 
+
+   * @param _requestBody 
+   * @param version Version of the dataset.
+   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * @returns successful operation
+   */
+  @operation('post', '/{dataset}/{version}/records')
+  async performSearch(@requestBody() _requestBody: {
+  criteria: string;
+  start?: number;
+  rows?: number;
+}, @param({name: 'version', in: 'path'}) version: string, @param({name: 'dataset', in: 'path'}) dataset: string): Promise<{
+  [additionalProperty: string]: {
+  
+};
+}[]> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 2`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+import {DataSetList} from '../models/data-set-list.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by metadata
+ * Find out about the data sets
+ */
+export class MetadataController {
+  constructor() {}
+
+  /**
+   * 
+   * 
+
+   * @returns Returns a list of data sets
+   */
+  @operation('get', '/')
+  async listDataSets(): Promise<DataSetList> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
+   * 
+
+   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * @param version Version of the dataset.
+   * @returns The dataset api for the given version is found and it is accessible to consume.
+   */
+  @operation('get', '/{dataset}/{version}/fields')
+  async listSearchableFields(@param({name: 'dataset', in: 'path'}) dataset: string, @param({name: 'version', in: 'path'}) version: string): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 3`] = `
+export * from './metadata.controller';
+export * from './search.controller';
+
+`;
+
+
+exports[`openapi-generator specific files skips controllers not selected 1`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+import {DataSetList} from '../models/data-set-list.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by metadata
+ * Find out about the data sets
+ */
+export class MetadataController {
+  constructor() {}
+
+  /**
+   * 
+   * 
+
+   * @returns Returns a list of data sets
+   */
+  @operation('get', '/')
+  async listDataSets(): Promise<DataSetList> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
+   * 
+
+   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * @param version Version of the dataset.
+   * @returns The dataset api for the given version is found and it is accessible to consume.
+   */
+  @operation('get', '/{dataset}/{version}/fields')
+  async listSearchableFields(@param({name: 'dataset', in: 'path'}) dataset: string, @param({name: 'version', in: 'path'}) version: string): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator specific files skips controllers not selected 2`] = `
+export * from './metadata.controller';
+
+`;

--- a/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
@@ -91,6 +91,12 @@ export class MetadataController {
 
 
 exports[`openapi-generator specific files generates all the proper files 3`] = `
+export * from './data-set-list.model';
+
+`;
+
+
+exports[`openapi-generator specific files generates all the proper files 4`] = `
 export * from './metadata.controller';
 export * from './search.controller';
 
@@ -141,6 +147,12 @@ export class MetadataController {
 
 
 exports[`openapi-generator specific files skips controllers not selected 2`] = `
+export * from './data-set-list.model';
+
+`;
+
+
+exports[`openapi-generator specific files skips controllers not selected 3`] = `
 export * from './metadata.controller';
 
 `;

--- a/packages/cli/test/integration/generators/openapi-petstore.integration.js
+++ b/packages/cli/test/integration/generators/openapi-petstore.integration.js
@@ -30,6 +30,7 @@ describe('openapi-generator specific files', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
+  const modelIndex = path.resolve(SANDBOX_PATH, 'src/models/index.ts');
   const controIndex = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
   const controller = path.resolve(
     SANDBOX_PATH,
@@ -48,6 +49,9 @@ describe('openapi-generator specific files', function() {
       .executeGenerator(generator)
       .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
       .withPrompts(props);
+
+    assert.file(modelIndex);
+    expectFileToMatchSnapshot(modelIndex);
 
     assert.file(controIndex);
     expectFileToMatchSnapshot(controIndex);

--- a/packages/cli/test/integration/generators/openapi-petstore.integration.js
+++ b/packages/cli/test/integration/generators/openapi-petstore.integration.js
@@ -7,14 +7,14 @@
 
 const path = require('path');
 const assert = require('yeoman-assert');
+const {TestSandbox} = require('@loopback/testlab');
+const {expectFileToMatchSnapshot} = require('../../snapshots');
+
 const generator = path.join(__dirname, '../../../generators/openapi');
 const specPath = path.join(
   __dirname,
   '../../fixtures/openapi/3.0/petstore-expanded.yaml',
 );
-
-const testlab = require('@loopback/testlab');
-const TestSandbox = testlab.TestSandbox;
 
 // Test Sandbox
 const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
@@ -30,12 +30,11 @@ describe('openapi-generator specific files', function() {
   // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
-  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const controIndex = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
   const controller = path.resolve(
     SANDBOX_PATH,
     'src/controllers/open-api.controller.ts',
   );
-
   const petModel = path.resolve(SANDBOX_PATH, 'src/models/pet.model.ts');
   const newPetModel = path.resolve(SANDBOX_PATH, 'src/models/new-pet.model.ts');
   const errorModel = path.resolve(SANDBOX_PATH, 'src/models/error.model.ts');
@@ -49,33 +48,20 @@ describe('openapi-generator specific files', function() {
       .executeGenerator(generator)
       .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
       .withPrompts(props);
+
+    assert.file(controIndex);
+    expectFileToMatchSnapshot(controIndex);
+
     assert.file(controller);
-
-    assert.fileContent(controller, 'export class OpenApiController {');
-    assert.fileContent(controller, `@operation('get', '/pets')`);
-    assert.fileContent(
-      controller,
-      `async findPets(@param({name: 'tags', in: 'query'}) tags: string[], ` +
-        `@param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]>`,
-    );
-
-    assert.fileContent(index, `export * from './open-api.controller';`);
+    expectFileToMatchSnapshot(controller);
 
     assert.file(petModel);
-    assert.fileContent(petModel, `import {NewPet} from './new-pet.model';`);
-    assert.fileContent(
-      petModel,
-      `export type Pet = NewPet & {
-  id: number;
-};`,
-    );
+    expectFileToMatchSnapshot(petModel);
+
     assert.file(newPetModel);
-    assert.fileContent(newPetModel, `export class NewPet {`);
-    assert.fileContent(newPetModel, `@model({name: 'NewPet'})`);
-    assert.fileContent(newPetModel, `@property({required: true})`);
-    assert.fileContent(newPetModel, `name: string;`);
-    assert.fileContent(newPetModel, `@property()`);
-    assert.fileContent(newPetModel, `tag?: string`);
+    expectFileToMatchSnapshot(newPetModel);
+
     assert.file(errorModel);
+    expectFileToMatchSnapshot(errorModel);
   });
 });

--- a/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
@@ -23,7 +23,8 @@ const props = {
 };
 
 describe('openapi-generator specific files', () => {
-  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const modelIndex = path.resolve(SANDBOX_PATH, 'src/models/index.ts');
+  const controIndex = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
   const searchController = path.resolve(
     SANDBOX_PATH,
     'src/controllers/search.controller.ts',
@@ -63,7 +64,10 @@ describe('openapi-generator specific files', () => {
     assert.file(performSearchResponseBodyModel);
     expectFileToMatchSnapshot(performSearchResponseBodyModel);
 
-    assert.file(index);
-    expectFileToMatchSnapshot(index);
+    assert.file(modelIndex);
+    expectFileToMatchSnapshot(modelIndex);
+
+    assert.file(controIndex);
+    expectFileToMatchSnapshot(controIndex);
   });
 });

--- a/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
@@ -7,11 +7,11 @@
 
 const path = require('path');
 const assert = require('yeoman-assert');
+const {TestSandbox} = require('@loopback/testlab');
+const {expectFileToMatchSnapshot} = require('../../snapshots');
+
 const generator = path.join(__dirname, '../../../generators/openapi');
 const specPath = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
-
-const testlab = require('@loopback/testlab');
-const TestSandbox = testlab.TestSandbox;
 
 // Test Sandbox
 const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
@@ -51,32 +51,19 @@ describe('openapi-generator specific files', () => {
       .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
       .withArguments('--promote-anonymous-schemas')
       .withPrompts(props);
+    assert.file(searchController);
+    expectFileToMatchSnapshot(searchController);
+
     assert.file(metadataController);
+    expectFileToMatchSnapshot(metadataController);
 
-    assert.fileContent(
-      searchController,
-      `async performSearch(@requestBody() _requestBody: PerformSearchRequestBody, ` +
-        `@param({name: 'version', in: 'path'}) version: string, ` +
-        `@param({name: 'dataset', in: 'path'}) dataset: string): ` +
-        `Promise<PerformSearchResponseBody> {`,
-    );
+    assert.file(performSearchRequestBodyModel);
+    expectFileToMatchSnapshot(performSearchRequestBodyModel);
 
-    assert.fileContent(
-      performSearchRequestBodyModel,
-      'export class PerformSearchRequestBody {',
-    );
+    assert.file(performSearchResponseBodyModel);
+    expectFileToMatchSnapshot(performSearchResponseBodyModel);
 
-    assert.fileContent(
-      performSearchResponseBodyModel,
-      'export type PerformSearchResponseBody = {',
-    );
-
-    assert.fileContent(
-      performSearchResponseBodyModel,
-      '[additionalProperty: string]: {',
-    );
-
-    assert.fileContent(index, `export * from './search.controller';`);
-    assert.fileContent(index, `export * from './metadata.controller';`);
+    assert.file(index);
+    expectFileToMatchSnapshot(index);
   });
 });

--- a/packages/cli/test/integration/generators/openapi-uspto.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto.integration.js
@@ -23,7 +23,8 @@ const props = {
 };
 
 describe('openapi-generator specific files', () => {
-  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const modelIndex = path.resolve(SANDBOX_PATH, 'src/models/index.ts');
+  const controIndex = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
   const searchController = path.resolve(
     SANDBOX_PATH,
     'src/controllers/search.controller.ts',
@@ -32,7 +33,7 @@ describe('openapi-generator specific files', () => {
     SANDBOX_PATH,
     'src/controllers/metadata.controller.ts',
   );
-  before('reset sandbox', async () => {
+  after('reset sandbox', async () => {
     await sandbox.reset();
   });
 
@@ -47,8 +48,11 @@ describe('openapi-generator specific files', () => {
     assert.file(metadataController);
     expectFileToMatchSnapshot(metadataController);
 
-    assert.file(index);
-    expectFileToMatchSnapshot(index);
+    assert.file(modelIndex);
+    expectFileToMatchSnapshot(modelIndex);
+
+    assert.file(controIndex);
+    expectFileToMatchSnapshot(controIndex);
   });
 
   it('skips controllers not selected', async () => {
@@ -64,7 +68,10 @@ describe('openapi-generator specific files', () => {
 
     assert.noFile(searchController);
 
-    assert.file(index);
-    expectFileToMatchSnapshot(index);
+    assert.file(modelIndex);
+    expectFileToMatchSnapshot(modelIndex);
+
+    assert.file(controIndex);
+    expectFileToMatchSnapshot(controIndex);
   });
 });

--- a/packages/cli/test/integration/generators/openapi-uspto.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto.integration.js
@@ -7,11 +7,11 @@
 
 const path = require('path');
 const assert = require('yeoman-assert');
+const {TestSandbox} = require('@loopback/testlab');
+const {expectFileToMatchSnapshot} = require('../../snapshots');
+
 const generator = path.join(__dirname, '../../../generators/openapi');
 const specPath = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
-
-const testlab = require('@loopback/testlab');
-const TestSandbox = testlab.TestSandbox;
 
 // Test Sandbox
 const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
@@ -32,7 +32,7 @@ describe('openapi-generator specific files', () => {
     SANDBOX_PATH,
     'src/controllers/metadata.controller.ts',
   );
-  after('reset sandbox', async () => {
+  before('reset sandbox', async () => {
     await sandbox.reset();
   });
 
@@ -42,26 +42,13 @@ describe('openapi-generator specific files', () => {
       .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
       .withPrompts(props);
     assert.file(searchController);
+    expectFileToMatchSnapshot(searchController);
 
-    assert.fileContent(metadataController, 'export class MetadataController {');
-    assert.fileContent(metadataController, `@operation('get', '/')`);
-    assert.fileContent(
-      metadataController,
-      'async listDataSets(): Promise<DataSetList> {',
-    );
-    assert.fileContent(
-      metadataController,
-      `@operation('get', '/{dataset}/{version}/fields')`,
-    );
-    assert.fileContent(
-      metadataController,
-      `async listSearchableFields(@param({name: 'dataset', in: 'path'}) ` +
-        `dataset: string, @param({name: 'version', in: 'path'}) ` +
-        `version: string): Promise<string> {`,
-    );
+    assert.file(metadataController);
+    expectFileToMatchSnapshot(metadataController);
 
-    assert.fileContent(index, `export * from './search.controller';`);
-    assert.fileContent(index, `export * from './metadata.controller';`);
+    assert.file(index);
+    expectFileToMatchSnapshot(index);
   });
 
   it('skips controllers not selected', async () => {
@@ -73,8 +60,11 @@ describe('openapi-generator specific files', () => {
         controllerSelections: ['MetadataController'],
       });
     assert.file(metadataController);
+    expectFileToMatchSnapshot(metadataController);
+
     assert.noFile(searchController);
-    assert.noFileContent(index, `export * from './search.controller';`);
-    assert.fileContent(index, `export * from './metadata.controller';`);
+
+    assert.file(index);
+    expectFileToMatchSnapshot(index);
   });
 });


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

fixes: https://github.com/strongloop/loopback-next/issues/4135

- The first commit refactors openapi cli tests with snapshot
- The second commit fixes the generator so that the index files get updated correctly. Also adds relation interface to the openAPI model template so that when it generates repositories from these models, it won't complain that `xxxRelations` doesn't exist.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
