### PR TITLE
feat(tsdocs): fix package url and add editurl to page metadata

### DIFF
--- a/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
+++ b/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
@@ -123,6 +123,7 @@ lang: en
 title: 'API docs: index'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
+editurl: https://github.com/strongloop/loopback-next
 permalink: /doc/en/lb4/apidocs.index.html
 ---`);
 
@@ -141,6 +142,9 @@ permalink: /doc/en/lb4/apidocs.index.html
       'utf-8',
     );
     expect(constructorDoc).to.not.match(/\.\(constructor\)\.md/);
+    expect(constructorDoc).to.match(
+      /editurl\: https\:\/\/github\.com\/strongloop\/loopback\-next\/tree\/master\/packages\/pkg1/,
+    );
 
     const pkgDoc = await fs.readFile(
       path.join(SITE_APIDOCS_ROOT, 'pkg1.md'),
@@ -148,6 +152,9 @@ permalink: /doc/en/lb4/apidocs.index.html
     );
     expect(pkgDoc).to.match(
       /\[pkg1\]\(https\:\/\/github\.com\/strongloop\/loopback\-next\/tree\/master\/packages\/pkg1\)/,
+    );
+    expect(pkgDoc).to.match(
+      /editurl\: https\:\/\/github\.com\/strongloop\/loopback\-next\/tree\/master\/packages\/pkg1/,
     );
   });
 });

--- a/packages/tsdocs/src/helper.ts
+++ b/packages/tsdocs/src/helper.ts
@@ -139,6 +139,11 @@ export interface ApiDocsOptions {
    * A flag to generate default package documentation
    */
   generateDefaultPackageDoc?: boolean;
+
+  /**
+   * Package metadata
+   */
+  lernaPackages?: Record<string, LernaPackage>;
 }
 
 /**


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/issues/4467

This is the 1st step to fix #4467. The generated md files now have `editurl` metadata.

The next step is to fix https://github.com/strongloop/loopback.io/blob/gh-pages/_layouts/page.html#L15 to allow `editurl` to customize the default calculation.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
