### PR TITLE
Discussion: some OAS Enhancer additions for discussion

### DIFF
--- a/examples/lb3-application/src/__tests__/acceptance/lb3app.acceptance.ts
+++ b/examples/lb3-application/src/__tests__/acceptance/lb3app.acceptance.ts
@@ -138,7 +138,7 @@ describe('CoffeeShopApplication', () => {
     let apiSpec: OpenApiSpec;
 
     before(async () => {
-      apiSpec = app.lbApp.restServer.getApiSpec();
+      apiSpec = await app.lbApp.restServer.getApiSpec();
     });
 
     it('has the same properties in both the LB3 and LB4 specs', () => {

--- a/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
+++ b/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
@@ -41,8 +41,8 @@ describe('booter-lb3app', () => {
   });
 
   context('generated OpenAPI spec', () => {
-    it('uses different request-body schema for "create" operation', () => {
-      const spec = app.restServer.getApiSpec();
+    it('uses different request-body schema for "create" operation', async () => {
+      const spec = await app.restServer.getApiSpec();
       const createOp: OperationObject = spec.paths['/api/CoffeeShops'].post;
       expect(createOp.requestBody).to.containDeep({
         content: {
@@ -66,8 +66,8 @@ describe('booter-lb3app', () => {
         });
     });
 
-    it('includes the target model as a property of the source model in a relation', () => {
-      const spec = app.restServer.getApiSpec();
+    it('includes the target model as a property of the source model in a relation', async () => {
+      const spec = await app.restServer.getApiSpec();
       const schemas = (spec.components ?? {}).schemas ?? {};
 
       expect(schemas.CoffeeShop)
@@ -118,8 +118,8 @@ describe('booter-lb3app', () => {
       }
     });
 
-    it('includes LoopBack 3 endpoints with `/api` base in OpenApiSpec', () => {
-      const apiSpec = app.restServer.getApiSpec();
+    it('includes LoopBack 3 endpoints with `/api` base in OpenApiSpec', async () => {
+      const apiSpec = await app.restServer.getApiSpec();
       const paths = Object.keys(apiSpec.paths);
       expect(paths).to.containDeep([
         '/api/CoffeeShops/{id}',
@@ -219,8 +219,8 @@ describe('booter-lb3app', () => {
       }));
     });
 
-    it('does apply the spec modification', () => {
-      const spec = app.restServer.getApiSpec();
+    it('does apply the spec modification', async () => {
+      const spec = await app.restServer.getApiSpec();
       const createOp: OperationObject = spec.paths['/api/CoffeeShops'].post;
       expect(createOp.summary).to.eql('just a very simple modification');
     });

--- a/packages/openapi-v3/package-lock.json
+++ b/packages/openapi-v3/package-lock.json
@@ -10,6 +10,27 @@
 			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
 			"dev": true
 		},
+		"@types/json-merge-patch": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@types/json-merge-patch/-/json-merge-patch-0.0.4.tgz",
+			"integrity": "sha1-pSgtqWkKgSpiEoo0cIr0dqMI2UE=",
+			"dev": true
+		},
+		"@types/json-schema": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+			"dev": true
+		},
+		"@types/json-schema-compare": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@types/json-schema-compare/-/json-schema-compare-0.2.0.tgz",
+			"integrity": "sha512-TtCXQjsCQi+fcandEbzDJhqyztpVM9c5mtGuk7Hf8yQsdaBpfjEkOicfydAEWB684wGCzUrV5ttvt9hCyDCoxA==",
+			"dev": true,
+			"requires": {
+				"@types/json-schema": "*"
+			}
+		},
 		"@types/lodash": {
 			"version": "4.14.149",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
@@ -134,6 +155,14 @@
 			"integrity": "sha1-+ixrWvh9p3uuKWalidUuI+2B/kA=",
 			"requires": {
 				"deep-equal": "^1.0.0"
+			}
+		},
+		"json-schema-compare": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+			"integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+			"requires": {
+				"lodash": "^4.17.4"
 			}
 		},
 		"lodash": {

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -10,6 +10,7 @@
     "@loopback/repository-json-schema": "^1.12.0",
     "debug": "^4.1.1",
     "json-merge-patch": "^0.2.3",
+    "json-schema-compare": "^0.2.2",
     "lodash": "^4.17.15",
     "openapi3-ts": "^1.3.0"
   },
@@ -20,6 +21,8 @@
     "@loopback/repository": "^1.18.0",
     "@loopback/testlab": "^1.10.2",
     "@types/debug": "^4.1.5",
+    "@types/json-merge-patch": "0.0.4",
+    "@types/json-schema-compare": "^0.2.0",
     "@types/lodash": "^4.14.149",
     "@types/node": "^10.17.14"
   },

--- a/packages/openapi-v3/src/__tests__/unit/enhancers/consolidate-schema.enhancer.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/enhancers/consolidate-schema.enhancer.unit.ts
@@ -9,9 +9,9 @@ import {
   OperationSpecBuilder,
 } from '@loopback/openapi-spec-builder';
 import {expect} from '@loopback/testlab';
-import {ConsolidationEnhancer} from '../../..';
+import {ConsolidateSpecEnhancer} from '../../..';
 
-const consolidationEnhancer = new ConsolidationEnhancer();
+const specEnhancer = new ConsolidateSpecEnhancer();
 
 describe('consolidateSchemaObjects', () => {
   it('moves schema with title to component.schemas, replace with reference', () => {
@@ -64,7 +64,7 @@ describe('consolidateSchemaObjects', () => {
       )
       .build();
 
-    expect(consolidationEnhancer.modifySpec(inputSpec)).to.eql(expectedSpec);
+    expect(specEnhancer.modifySpec(inputSpec)).to.eql(expectedSpec);
   });
 
   it('ignores schema without title property', () => {
@@ -89,7 +89,7 @@ describe('consolidateSchemaObjects', () => {
       )
       .build();
 
-    expect(consolidationEnhancer.modifySpec(inputSpec)).to.eql(inputSpec);
+    expect(specEnhancer.modifySpec(inputSpec)).to.eql(inputSpec);
   });
 
   it('Avoids naming collision', () => {
@@ -161,6 +161,6 @@ describe('consolidateSchemaObjects', () => {
       )
       .build();
 
-    expect(consolidationEnhancer.modifySpec(inputSpec)).to.eql(expectedSpec);
+    expect(specEnhancer.modifySpec(inputSpec)).to.eql(expectedSpec);
   });
 });

--- a/packages/openapi-v3/src/__tests__/unit/enhancers/consolidate-schema.enhancer.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/enhancers/consolidate-schema.enhancer.unit.ts
@@ -1,0 +1,166 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  ComponentsSpecBuilder,
+  OpenApiSpecBuilder,
+  OperationSpecBuilder,
+} from '@loopback/openapi-spec-builder';
+import {expect} from '@loopback/testlab';
+import {ConsolidationEnhancer} from '../../..';
+
+const consolidationEnhancer = new ConsolidationEnhancer();
+
+describe('consolidateSchemaObjects', () => {
+  it('moves schema with title to component.schemas, replace with reference', () => {
+    const inputSpec = new OpenApiSpecBuilder()
+      .withOperation(
+        'get',
+        '/',
+        new OperationSpecBuilder().withResponse(200, {
+          description: 'Example',
+          content: {
+            'application/json': {
+              schema: {
+                title: 'loopback.example',
+                properties: {
+                  test: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+      .build();
+
+    const expectedSpec = new OpenApiSpecBuilder()
+      .withOperation(
+        'get',
+        '/',
+        new OperationSpecBuilder().withResponse(200, {
+          description: 'Example',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/loopback.example',
+              },
+            },
+          },
+        }),
+      )
+      .withComponents(
+        new ComponentsSpecBuilder().withSchema('loopback.example', {
+          title: 'loopback.example',
+          properties: {
+            test: {
+              type: 'string',
+            },
+          },
+        }),
+      )
+      .build();
+
+    expect(consolidationEnhancer.modifySpec(inputSpec)).to.eql(expectedSpec);
+  });
+
+  it('ignores schema without title property', () => {
+    const inputSpec = new OpenApiSpecBuilder()
+      .withOperation(
+        'get',
+        '/',
+        new OperationSpecBuilder().withResponse(200, {
+          description: 'Example',
+          content: {
+            'application/json': {
+              schema: {
+                properties: {
+                  test: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+      .build();
+
+    expect(consolidationEnhancer.modifySpec(inputSpec)).to.eql(inputSpec);
+  });
+
+  it('Avoids naming collision', () => {
+    const inputSpec = new OpenApiSpecBuilder()
+      .withOperation(
+        'get',
+        '/',
+        new OperationSpecBuilder().withResponse(200, {
+          description: 'Example',
+          content: {
+            'application/json': {
+              schema: {
+                title: 'loopback.example',
+                properties: {
+                  test: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+      .withComponents(
+        new ComponentsSpecBuilder().withSchema('loopback.example', {
+          title: 'Different loopback.example exists',
+          properties: {
+            testDiff: {
+              type: 'string',
+            },
+          },
+        }),
+      )
+      .build();
+
+    const expectedSpec = new OpenApiSpecBuilder()
+      .withOperation(
+        'get',
+        '/',
+        new OperationSpecBuilder().withResponse(200, {
+          description: 'Example',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/loopback.example1',
+              },
+            },
+          },
+        }),
+      )
+      .withComponents(
+        new ComponentsSpecBuilder()
+          .withSchema('loopback.example', {
+            title: 'Different loopback.example exists',
+            properties: {
+              testDiff: {
+                type: 'string',
+              },
+            },
+          })
+          .withSchema('loopback.example1', {
+            title: 'loopback.example',
+            properties: {
+              test: {
+                type: 'string',
+              },
+            },
+          }),
+      )
+      .build();
+
+    expect(consolidationEnhancer.modifySpec(inputSpec)).to.eql(expectedSpec);
+  });
+});

--- a/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/application.ts
+++ b/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/application.ts
@@ -5,8 +5,8 @@
 
 import {Application, createBindingFromClass} from '@loopback/core';
 import {OASEnhancerService, OAS_ENHANCER_SERVICE} from '../../../..';
+import {SecuritySpecEnhancer} from '../../../../enhancers/extensions/security.spec.extension';
 import {InfoSpecEnhancer} from './info.spec.extension';
-import {SecuritySpecEnhancer} from './security.spec.extension';
 
 export class SpecServiceApplication extends Application {
   constructor() {

--- a/packages/openapi-v3/src/__tests__/unit/enhancers/spec-enhancer.extensions.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/enhancers/spec-enhancer.extensions.unit.ts
@@ -34,7 +34,7 @@ describe('spec-enhancer-extension-point', () => {
       // the security scheme entry is added by the security enhancer
       components: {
         securitySchemes: {
-          bearerAuth: {
+          jwt: {
             type: 'http',
             scheme: 'bearer',
             bearerFormat: 'JWT',

--- a/packages/openapi-v3/src/enhancers/consolidate-schema.enhancer.ts
+++ b/packages/openapi-v3/src/enhancers/consolidate-schema.enhancer.ts
@@ -1,0 +1,130 @@
+import {bind} from '@loopback/core';
+import compare from 'json-schema-compare';
+import _ from 'lodash';
+import {
+  ISpecificationExtension,
+  isSchemaObject,
+  OpenApiSpec,
+  ReferenceObject,
+  SchemaObject,
+} from '../types';
+import {asSpecEnhancer, OASEnhancer} from './types';
+
+/**
+ * A spec enhancer to consolidate OpenAPI specs
+ *
+ */
+@bind(asSpecEnhancer)
+export class ConsolidationEnhancer implements OASEnhancer {
+  name = 'consolidate';
+
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    return this.consolidateSchemaObjects(spec);
+  }
+
+  /**
+   *  Recursively search OpenApiSpec PathsObject for SchemaObjects with title property.
+   *  Move reusable schema bodies to #/components/schemas and replace with json pointer.
+   *  Handles title collisions with schema body comparision.
+   *
+   */
+  private consolidateSchemaObjects(spec: OpenApiSpec): OpenApiSpec {
+    // use 'paths' as crawl root
+    this.recursiveWalk(spec.paths, ['paths'], spec);
+
+    return spec;
+  }
+
+  private recursiveWalk(
+    rootSchema: ISpecificationExtension,
+    parentPath: Array<string>,
+    spec: OpenApiSpec,
+  ) {
+    if (this.isTraversable(rootSchema)) {
+      Object.entries(rootSchema).forEach(([key, subSchema]) => {
+        if (subSchema) {
+          this.recursiveWalk(subSchema, parentPath.concat(key), spec);
+          this.processSchema(subSchema, parentPath.concat(key), spec);
+        }
+      });
+    }
+  }
+
+  /**
+   * Carry out schema consolidation after tree traversal. If 'title' property
+   * set then we consider current schema for consolidation. SchemaObjects with
+   * properties (and title set) are moved to #/components/schemas/<title> and
+   * replaced with ReferenceObject.
+   *
+   * Features:
+   *  - name collision protection
+   *
+   * @param schema - current schema element to process
+   * @param parentPath - path object to parent
+   * @param spec - subject OpenApi specification
+   *
+   */
+  private processSchema(
+    schema: SchemaObject | ReferenceObject,
+    parentPath: Array<string>,
+    spec: OpenApiSpec,
+  ) {
+    const schemaObj = this.ifConsolidationCandidate(schema);
+    if (schemaObj) {
+      // name collison protection
+      let instanceNo = 1;
+      let title = schemaObj.title!;
+      let refSchema = this.getRefSchema(title, spec);
+      while (
+        refSchema &&
+        !compare(schemaObj as ISpecificationExtension, refSchema, {
+          ignore: ['description'],
+        })
+      ) {
+        title = `${schemaObj.title}${instanceNo++}`;
+        refSchema = this.getRefSchema(title, spec);
+      }
+      if (!refSchema) {
+        this.patchRef(title, schema, spec);
+      }
+      this.patchPath(title, parentPath, spec);
+    }
+  }
+
+  private getRefSchema(
+    name: string,
+    spec: OpenApiSpec,
+  ): ISpecificationExtension | undefined {
+    const schema = _.get(spec, ['components', 'schemas', name]);
+
+    return schema;
+  }
+
+  private patchRef(
+    name: string,
+    value: ISpecificationExtension,
+    spec: OpenApiSpec,
+  ) {
+    _.set(spec, ['components', 'schemas', name], value);
+  }
+
+  private patchPath(name: string, path: Array<string>, spec: OpenApiSpec) {
+    const patch = {
+      $ref: `#/components/schemas/${name}`,
+    };
+    _.set(spec, path, patch);
+  }
+
+  private ifConsolidationCandidate(
+    schema: SchemaObject | ReferenceObject,
+  ): SchemaObject | undefined {
+    // use title to discriminate references
+    return isSchemaObject(schema) && schema.properties && schema.title
+      ? schema
+      : undefined;
+  }
+
+  private isTraversable(schema: ISpecificationExtension): boolean {
+    return schema && typeof schema === 'object' ? true : false;
+  }
+}

--- a/packages/openapi-v3/src/enhancers/extensions/consolidate.spec.extension.ts
+++ b/packages/openapi-v3/src/enhancers/extensions/consolidate.spec.extension.ts
@@ -7,15 +7,15 @@ import {
   OpenApiSpec,
   ReferenceObject,
   SchemaObject,
-} from '../types';
-import {asSpecEnhancer, OASEnhancer} from './types';
+} from '../../types';
+import {asSpecEnhancer, OASEnhancer} from '../types';
 
 /**
  * A spec enhancer to consolidate OpenAPI specs
  *
  */
 @bind(asSpecEnhancer)
-export class ConsolidationEnhancer implements OASEnhancer {
+export class ConsolidateSpecEnhancer implements OASEnhancer {
   name = 'consolidate';
 
   modifySpec(spec: OpenApiSpec): OpenApiSpec {

--- a/packages/openapi-v3/src/enhancers/extensions/deprecate.spec.extension.ts
+++ b/packages/openapi-v3/src/enhancers/extensions/deprecate.spec.extension.ts
@@ -1,0 +1,37 @@
+import {bind} from '@loopback/core';
+import {OperationObject} from 'openapi3-ts';
+import {OpenApiSpec} from '../../types';
+import {asSpecEnhancer, OASEnhancer} from '../types';
+
+/**
+ * A spec enhancer to add verbose deprecation status to OperationObjects
+ *
+ */
+@bind(asSpecEnhancer)
+export class DeprecateSpecEnhancer implements OASEnhancer {
+  name = 'deprecate';
+
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    try {
+      return this.defaultDeprecate(spec);
+    } catch {
+      console.log('Default Deprecate Enhancer failed, returned original spec.');
+      return spec;
+    }
+  }
+
+  /**
+   *  add verbose deprecation status to OperationObjects if not set
+   *
+   */
+  private defaultDeprecate(spec: OpenApiSpec): OpenApiSpec {
+    Object.keys(spec.paths).forEach(path =>
+      Object.keys(spec.paths[path]).forEach(op => {
+        const OpObj = spec.paths[path][op] as OperationObject;
+        if (!OpObj.deprecated) OpObj.deprecated = false;
+      }),
+    );
+
+    return spec;
+  }
+}

--- a/packages/openapi-v3/src/enhancers/extensions/prune.spec.extension.ts
+++ b/packages/openapi-v3/src/enhancers/extensions/prune.spec.extension.ts
@@ -1,0 +1,103 @@
+import {bind} from '@loopback/core';
+import _ from 'lodash';
+import {ISpecificationExtension, OpenApiSpec} from '../..';
+import {asSpecEnhancer, OASEnhancer} from '../types';
+
+/**
+ * A spec enhancer to remove unneccesary properties from the OpenAPI spec
+ *
+ */
+@bind(asSpecEnhancer)
+export class PruneSpecEnhancer implements OASEnhancer {
+  name = 'prune';
+
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    try {
+      // note, title is valid but pruning as not needed atm
+      const values = ['x-', 'title'];
+      return this.pruneSchemas({spec, values});
+    } catch {
+      console.log('Prune Enhancer failed, returned original spec.');
+      return spec;
+    }
+  }
+
+  /**
+   *  Recursively walk OpenApiSpec and prune excess properties
+   *
+   */
+  private pruneSchemas(ctx: PruneContext): OpenApiSpec {
+    // use 'paths' as crawl root
+    this.recursiveWalk(ctx.spec.paths, ['paths'], ctx);
+    // use 'components.schemas' as crawl root
+    if (ctx.spec.components && ctx.spec.components.schemas) {
+      this.recursiveWalk(
+        ctx.spec.components.schemas,
+        ['components', 'schemas'],
+        ctx,
+      );
+    }
+
+    return ctx.spec;
+  }
+
+  private recursiveWalk(
+    rootSchema: ISpecificationExtension,
+    parentPath: Array<string>,
+    ctx: PruneContext,
+  ) {
+    if (this.isTraversable(rootSchema)) {
+      Object.entries(rootSchema).forEach(([key, subSchema]) => {
+        if (subSchema) {
+          this.recursiveWalk(subSchema, parentPath.concat(key), ctx);
+          if (!this.isTraversable(subSchema)) {
+            this.processSchema(rootSchema, parentPath, ctx);
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Carry out schema pruning after tree traversal. If key starts with any of
+   * the propsToRemove then unset.
+   *
+   * @param schema - current schema element to process
+   * @param parentPath - path object to parent
+   * @param ctx - prune context object
+   *
+   */
+  private async processSchema(
+    schema: ISpecificationExtension,
+    parentPath: Array<string>,
+    ctx: PruneContext,
+  ) {
+    Object.keys(schema).forEach(key => {
+      ctx.values.forEach(name => {
+        if (key.startsWith(name)) {
+          this.patchRemove(parentPath.concat(key), ctx);
+        }
+      });
+    });
+  }
+
+  patchRemove(path: Array<string>, ctx: PruneContext) {
+    _.unset(ctx.spec, path);
+  }
+
+  private isTraversable(schema: ISpecificationExtension): boolean {
+    return schema && typeof schema === 'object' ? true : false;
+  }
+}
+
+/**
+ * Prune context
+ *
+ * @param spec - subject openapi specification
+ * @param values - array of properties to remove
+ *
+ */
+interface PruneContext {
+  spec: OpenApiSpec;
+  values: Array<string>;
+}

--- a/packages/openapi-v3/src/enhancers/extensions/security.spec.extension.ts
+++ b/packages/openapi-v3/src/enhancers/extensions/security.spec.extension.ts
@@ -6,13 +6,9 @@
 import {bind} from '@loopback/core';
 import debugModule from 'debug';
 import {inspect} from 'util';
-import {
-  mergeOpenAPISpec,
-  ReferenceObject,
-  SecuritySchemeObject,
-} from '../../../..';
-import {asSpecEnhancer, OASEnhancer} from '../../../../enhancers/types';
-import {OpenApiSpec} from '../../../../types';
+import {mergeOpenAPISpec, ReferenceObject, SecuritySchemeObject} from '../..';
+import {OpenApiSpec} from '../../types';
+import {asSpecEnhancer, OASEnhancer} from '../types';
 const debug = debugModule('loopback:openapi:spec-enhancer');
 
 export type SecuritySchemeObjects = {
@@ -20,7 +16,7 @@ export type SecuritySchemeObjects = {
 };
 
 export const SECURITY_SCHEME_SPEC: SecuritySchemeObjects = {
-  bearerAuth: {
+  jwt: {
     type: 'http',
     scheme: 'bearer',
     bearerFormat: 'JWT',
@@ -28,7 +24,7 @@ export const SECURITY_SCHEME_SPEC: SecuritySchemeObjects = {
 };
 
 /**
- * A spec enhancer to add bearer token OpenAPI security entry to
+ * A spec enhancer to add jwt bearer token OpenAPI security entry to
  * `spec.component.securitySchemes`
  */
 @bind(asSpecEnhancer)
@@ -36,7 +32,10 @@ export class SecuritySpecEnhancer implements OASEnhancer {
   name = 'security';
 
   modifySpec(spec: OpenApiSpec): OpenApiSpec {
-    const patchSpec = {components: {securitySchemes: SECURITY_SCHEME_SPEC}};
+    if (spec?.components?.securitySchemes?.jwt) return spec;
+    const patchSpec = {
+      components: {securitySchemes: SECURITY_SCHEME_SPEC},
+    };
     const mergedSpec = mergeOpenAPISpec(spec, patchSpec);
     debug(`security spec extension, merged spec: ${inspect(mergedSpec)}`);
     return mergedSpec;

--- a/packages/openapi-v3/src/enhancers/extensions/structure.spec.extension.ts
+++ b/packages/openapi-v3/src/enhancers/extensions/structure.spec.extension.ts
@@ -1,0 +1,59 @@
+import {bind} from '@loopback/core';
+import {OpenApiSpec} from '../../types';
+import {asSpecEnhancer, OASEnhancer} from '../types';
+
+/**
+ * A spec enhancer to restructure the OpenAPI spec in an opinionated manner.
+ * (dougal83)
+ *
+ */
+@bind(asSpecEnhancer)
+export class StructureSpecEnhancer implements OASEnhancer {
+  name = 'structure';
+
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    try {
+      return this.restructureSpec(spec);
+    } catch {
+      console.log('Restructure Enhancer failed, returned original spec.');
+      return spec;
+    }
+  }
+
+  /**
+   *  Structure OpenApiSpec in an opinionated manner
+   *
+   */
+  private restructureSpec(spec: OpenApiSpec): OpenApiSpec {
+    spec = Object.assign(
+      {
+        openapi: undefined,
+        info: undefined,
+        servers: undefined,
+        paths: undefined,
+        components: undefined,
+        tags: undefined,
+      },
+      spec,
+    );
+
+    Object.keys(spec.paths).forEach(path =>
+      Object.keys(spec.paths[path]).forEach(op => {
+        spec.paths[path][op] = Object.assign(
+          {
+            tags: undefined,
+            summary: undefined,
+            description: undefined,
+            operationId: undefined,
+            parameters: undefined,
+            responses: undefined,
+            depreciated: undefined,
+          },
+          spec.paths[path][op],
+        );
+      }),
+    );
+
+    return spec;
+  }
+}

--- a/packages/openapi-v3/src/enhancers/extensions/tags.spec.extension.ts
+++ b/packages/openapi-v3/src/enhancers/extensions/tags.spec.extension.ts
@@ -1,0 +1,48 @@
+import {bind} from '@loopback/core';
+import {OperationObject} from 'openapi3-ts';
+import {OpenApiSpec} from '../../types';
+import {asSpecEnhancer, OASEnhancer} from '../types';
+
+/**
+ * A spec enhancer to combine OperationObject Tags OpenApiSpec into spec.tags
+ *
+ */
+@bind(asSpecEnhancer)
+export class TagsSpecEnhancer implements OASEnhancer {
+  name = 'tags';
+
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    try {
+      return this.tagsConsolidate(spec);
+    } catch {
+      console.log('Tags Enhancer failed, returned original spec.');
+      return spec;
+    }
+  }
+
+  /**
+   *  Combine OperationObject Tags OpenApiSpec into spec.tags
+   *
+   */
+  private tagsConsolidate(spec: OpenApiSpec): OpenApiSpec {
+    Object.keys(spec.paths).forEach(path =>
+      Object.keys(spec.paths[path]).forEach(op => {
+        const OpObj = spec.paths[path][op] as OperationObject;
+        if (OpObj.tags) this.patchTags(OpObj.tags, spec);
+      }),
+    );
+
+    return spec;
+  }
+
+  // TODO(dougal83) desc. resolution
+  private patchTags(tags: Array<string>, spec: OpenApiSpec) {
+    if (!spec.tags) {
+      spec.tags = [];
+    }
+    tags.forEach(name => {
+      if (spec.tags!.findIndex(tag => tag.name === name) <= 0)
+        spec.tags!.push({name, description: ''});
+    });
+  }
+}

--- a/packages/openapi-v3/src/enhancers/index.ts
+++ b/packages/openapi-v3/src/enhancers/index.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+export * from './consolidate-schema.enhancer';
 export * from './extensions/security.spec.extension';
 export * from './keys';
 export * from './spec-enhancer.service';

--- a/packages/openapi-v3/src/enhancers/index.ts
+++ b/packages/openapi-v3/src/enhancers/index.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+export * from './extensions/security.spec.extension';
 export * from './keys';
 export * from './spec-enhancer.service';
 export * from './types';

--- a/packages/openapi-v3/src/enhancers/index.ts
+++ b/packages/openapi-v3/src/enhancers/index.ts
@@ -3,8 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-export * from './consolidate-schema.enhancer';
+export * from './extensions/consolidate.spec.extension';
+export * from './extensions/deprecate.spec.extension';
+export * from './extensions/prune.spec.extension';
 export * from './extensions/security.spec.extension';
+export * from './extensions/structure.spec.extension';
+export * from './extensions/tags.spec.extension';
 export * from './keys';
 export * from './spec-enhancer.service';
 export * from './types';

--- a/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
+++ b/packages/rest-crud/src/__tests__/acceptance/default-model-crud-rest.acceptance.ts
@@ -126,7 +126,7 @@ describe('CrudRestController for a simple Product model', () => {
     // a new test suite that will configure a PK with a different name
     // and type, e.g. `pk: string` instead of `id: number`.
     it('uses correct schema for the id parameter', async () => {
-      const spec = app.restServer.getApiSpec();
+      const spec = await app.restServer.getApiSpec();
       const findByIdOp = spec.paths['/products/{id}'].get;
       expect(findByIdOp).to.containDeep({
         parameters: [
@@ -210,7 +210,7 @@ describe('CrudRestController for a simple Product model', () => {
     // a new test suite that will configure a PK with a different name
     // and type, e.g. `pk: string` instead of `id: number`.
     it('uses correct schema for the id parameter', async () => {
-      const spec = app.restServer.getApiSpec();
+      const spec = await app.restServer.getApiSpec();
       const findByIdOp = spec.paths['/products/{id}'].patch;
       expect(findByIdOp).to.containDeep({
         parameters: [
@@ -245,7 +245,7 @@ describe('CrudRestController for a simple Product model', () => {
     // a new test suite that will configure a PK with a different name
     // and type, e.g. `pk: string` instead of `id: number`.
     it('uses correct schema for the id parameter', async () => {
-      const spec = app.restServer.getApiSpec();
+      const spec = await app.restServer.getApiSpec();
       const findByIdOp = spec.paths['/products/{id}']['patch'];
       expect(findByIdOp).to.containDeep({
         parameters: [
@@ -278,7 +278,7 @@ describe('CrudRestController for a simple Product model', () => {
     // a new test suite that will configure a PK with a different name
     // and type, e.g. `pk: string` instead of `id: number`.
     it('uses correct schema for the id parameter', async () => {
-      const spec = app.restServer.getApiSpec();
+      const spec = await app.restServer.getApiSpec();
       const findByIdOp = spec.paths['/products/{id}']['delete'];
       expect(findByIdOp).to.containDeep({
         parameters: [

--- a/packages/rest/src/__tests__/integration/rest.application.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.application.integration.ts
@@ -139,7 +139,7 @@ describe('RestApplication (integration)', () => {
       'x-foo': 'bar',
     });
 
-    const spec = restApp.restServer.getApiSpec();
+    const spec = await restApp.restServer.getApiSpec();
     expect(spec).to.deepEqual({
       openapi: '3.0.0',
       info: {
@@ -231,7 +231,7 @@ describe('RestApplication (integration)', () => {
       restApp.mountExpressRouter('/dogs', router, spec);
       await client.get('/dogs/hello').expect(200, 'Hello dogs!');
 
-      const openApiSpec = restApp.restServer.getApiSpec();
+      const openApiSpec = await restApp.restServer.getApiSpec();
       expect(openApiSpec.paths).to.deepEqual({
         '/dogs/hello': {
           get: {

--- a/packages/rest/src/__tests__/integration/rest.application.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.application.integration.ts
@@ -149,6 +149,15 @@ describe('RestApplication (integration)', () => {
       servers: [{url: 'example.com:8080/api'}],
       paths: {},
       'x-foo': 'bar',
+      components: {
+        securitySchemes: {
+          jwt: {
+            bearerFormat: 'JWT',
+            scheme: 'bearer',
+            type: 'http',
+          },
+        },
+      },
     });
   });
 

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -20,10 +20,10 @@ describe('RestServer.getApiSpec()', () => {
   beforeEach(givenApplication);
 
   it('comes with a valid default spec', async () => {
-    await validateApiSpec(server.getApiSpec());
+    await validateApiSpec(await server.getApiSpec());
   });
 
-  it('honours API defined via app.api()', () => {
+  it('honours API defined via app.api()', async () => {
     server.api({
       openapi: '3.0.0',
       info: {
@@ -35,7 +35,7 @@ describe('RestServer.getApiSpec()', () => {
       'x-foo': 'bar',
     });
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec).to.deepEqual({
       openapi: '3.0.0',
       info: {
@@ -72,11 +72,11 @@ describe('RestServer.getApiSpec()', () => {
     expect(binding.tagNames).containEql('route');
   });
 
-  it('returns routes registered via app.route(route)', () => {
+  it('returns routes registered via app.route(route)', async () => {
     function greet() {}
     server.route('get', '/greet', {responses: {}}, greet);
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths).to.eql({
       '/greet': {
         get: {
@@ -86,7 +86,7 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
-  it('ignores routes marked as "x-visibility" via app.route(route)', () => {
+  it('ignores routes marked as "x-visibility" via app.route(route)', async () => {
     function greet() {}
     function meet() {}
     server.route(
@@ -96,7 +96,7 @@ describe('RestServer.getApiSpec()', () => {
       greet,
     );
     server.route('get', '/meet', {responses: {}, spec: {}}, meet);
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths).to.eql({
       '/meet': {
         get: {
@@ -107,7 +107,7 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
-  it('returns routes registered via app.route(..., Controller, method)', () => {
+  it('returns routes registered via app.route(..., Controller, method)', async () => {
     class MyController {
       greet() {}
     }
@@ -121,7 +121,7 @@ describe('RestServer.getApiSpec()', () => {
       'greet',
     );
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths).to.eql({
       '/greet': {
         get: {
@@ -134,7 +134,7 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
-  it('ignores routes marked as "x-visibility" via app.route(..., Controller, method)', () => {
+  it('ignores routes marked as "x-visibility" via app.route(..., Controller, method)', async () => {
     class GreetController {
       greet() {}
     }
@@ -161,7 +161,7 @@ describe('RestServer.getApiSpec()', () => {
       'meet',
     );
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths).to.eql({
       '/meet': {
         get: {
@@ -174,14 +174,14 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
-  it('honors tags in the operation spec', () => {
+  it('honors tags in the operation spec', async () => {
     class MyController {
       @get('/greet', {responses: {'200': {description: ''}}, tags: ['MyTag']})
       greet() {}
     }
     app.controller(MyController);
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths).to.eql({
       '/greet': {
         get: {
@@ -195,7 +195,7 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
-  it('emits all media types for request body', () => {
+  it('emits all media types for request body', async () => {
     const expectedOpSpec = anOperationSpec()
       .withRequestBody({
         description: 'Any object value.',
@@ -229,18 +229,18 @@ describe('RestServer.getApiSpec()', () => {
     }
     app.controller(MyController);
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths['/show-body'].post).to.containDeep(expectedOpSpec);
   });
 
-  it('returns routes registered via app.controller()', () => {
+  it('returns routes registered via app.controller()', async () => {
     class MyController {
       @get('/greet')
       greet() {}
     }
     app.controller(MyController);
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths).to.eql({
       '/greet': {
         get: {
@@ -256,7 +256,7 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
-  it('returns definitions inferred via app.controller()', () => {
+  it('returns definitions inferred via app.controller()', async () => {
     @model()
     class MyModel {
       @property()
@@ -268,7 +268,7 @@ describe('RestServer.getApiSpec()', () => {
     }
     app.controller(MyController);
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.components && spec.components.schemas).to.deepEqual({
       MyModel: {
         title: 'MyModel',
@@ -282,7 +282,7 @@ describe('RestServer.getApiSpec()', () => {
     });
   });
 
-  it('preserves routes specified in app.api()', () => {
+  it('preserves routes specified in app.api()', async () => {
     function status() {}
     server.api(
       anOpenApiSpec()
@@ -296,7 +296,7 @@ describe('RestServer.getApiSpec()', () => {
     function greet() {}
     server.route('get', '/greet', {responses: {}}, greet);
 
-    const spec = server.getApiSpec();
+    const spec = await server.getApiSpec();
     expect(spec.paths).to.eql({
       '/greet': {
         get: {

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -45,6 +45,15 @@ describe('RestServer.getApiSpec()', () => {
       servers: [{url: 'example.com:8080/api'}],
       paths: {},
       'x-foo': 'bar',
+      components: {
+        securitySchemes: {
+          jwt: {
+            bearerFormat: 'JWT',
+            scheme: 'bearer',
+            type: 'http',
+          },
+        },
+      },
     });
   });
 

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -425,7 +425,7 @@ export class RestServer extends Context implements Server, HttpServerLike {
     );
 
     specForm = specForm ?? {version: '3.0.0', format: 'json'};
-    const specObj = this.getApiSpec(requestContext);
+    const specObj = await this.getApiSpec(requestContext);
 
     if (specForm.format === 'json') {
       const spec = JSON.stringify(specObj, null, 2);
@@ -699,8 +699,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param requestContext - Optional context to update the `servers` list
    * in the returned spec
    */
-  getApiSpec(requestContext?: RequestContext): OpenApiSpec {
-    let spec = this.getSync<OpenApiSpec>(RestBindings.API_SPEC);
+  async getApiSpec(requestContext?: RequestContext): Promise<OpenApiSpec> {
+    let spec = await this.get<OpenApiSpec>(RestBindings.API_SPEC);
     const defs = this.httpHandler.getApiDefinitions();
 
     // Apply deep clone to prevent getApiSpec() callers from

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -15,6 +15,7 @@ import {
 import {Application, CoreBindings, Server} from '@loopback/core';
 import {HttpServer, HttpServerOptions} from '@loopback/http-server';
 import {
+  ConsolidationEnhancer,
   getControllerSpec,
   OASEnhancerService,
   OAS_ENHANCER_SERVICE,
@@ -741,6 +742,8 @@ export class RestServer extends Context implements Server, HttpServerLike {
     if (requestContext) {
       spec = this.updateSpecFromRequest(spec, requestContext);
     }
+    const consolidationEnhancer = new ConsolidationEnhancer();
+    spec = consolidationEnhancer.modifySpec(spec);
 
     // Apply OAS enhancers to the OpenAPI specification
     this.OASEnhancer.spec = spec;

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -9,15 +9,19 @@ import {
   BindingScope,
   Constructor,
   Context,
+  createBindingFromClass,
   inject,
 } from '@loopback/context';
 import {Application, CoreBindings, Server} from '@loopback/core';
 import {HttpServer, HttpServerOptions} from '@loopback/http-server';
 import {
   getControllerSpec,
+  OASEnhancerService,
+  OAS_ENHANCER_SERVICE,
   OpenAPIObject,
   OpenApiSpec,
   OperationObject,
+  SecuritySpecEnhancer,
   ServerObject,
 } from '@loopback/openapi-v3';
 import {AssertionError} from 'assert';
@@ -128,6 +132,12 @@ export class RestServer extends Context implements Server, HttpServerLike {
    * @param res - The response.
    */
 
+  protected _OASEnhancer: OASEnhancerService;
+  public get OASEnhancer(): OASEnhancerService {
+    this._setupOASEnhancerIfNeeded();
+    return this._OASEnhancer;
+  }
+
   protected _requestHandler: HttpRequestListener;
   public get requestHandler(): HttpRequestListener {
     if (this._requestHandler == null) {
@@ -215,6 +225,21 @@ export class RestServer extends Context implements Server, HttpServerLike {
 
     this.bind(RestBindings.BASE_PATH).toDynamicValue(() => this._basePath);
     this.bind(RestBindings.HANDLER).toDynamicValue(() => this.httpHandler);
+  }
+
+  protected _setupOASEnhancerIfNeeded() {
+    if (this._OASEnhancer != null) return;
+    this.add(
+      createBindingFromClass(OASEnhancerService, {
+        key: OAS_ENHANCER_SERVICE,
+      }).inScope(BindingScope.SINGLETON),
+    );
+    this._registerCoreSpecEnhancers();
+    this._OASEnhancer = this.getSync(OAS_ENHANCER_SERVICE);
+  }
+
+  private _registerCoreSpecEnhancers() {
+    this.add(createBindingFromClass(SecuritySpecEnhancer));
   }
 
   protected _setupRequestHandlerIfNeeded() {
@@ -716,6 +741,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
     if (requestContext) {
       spec = this.updateSpecFromRequest(spec, requestContext);
     }
+
+    // Apply OAS enhancers to the OpenAPI specification
+    this.OASEnhancer.spec = spec;
+    spec = await this.OASEnhancer.applyEnhancerByName('security');
 
     return spec;
   }


### PR DESCRIPTION
I've put together some OAS Enhancer additions for discussion if any are of interest to create a PR. I'm just looking at tidying the output, removing unnecessary spec pollution, reorder in a way that I see as more logical and others, see commits.

- **feat(rest): add openapi schema consolidation** ... consolidate schemas to components for reuse
- feat: add prune enhancer … remove pollution "x-...", "title" properties
- feat: add default deprecate enhancer … add deprecated: "false" by default to be verbose
- feat: add tags enhancer … copy tags to global tags, can add description tbd
- feat: add restructure enhancer … rearrange spec to more logical order (IMO)

(Core in bold, others could be optional community addons)

Can look at others on suggestion.  Might need @jannyHou to help integrate properly on rest server. :)

Please take a look at the [resultant openapi.json spec](https://gist.github.com/dougal83/e6f0a96f878bf98cf530cf93fe309250) from these enhancers.