### PR TITLE
feat(cli): allow different naming convention for discover

### DIFF
--- a/docs/site/Discovering-models.md
+++ b/docs/site/Discovering-models.md
@@ -43,3 +43,19 @@ placed. Default is `src/models`
 
 `--schema`: Specify the schema which the datasource will find the models to
 discover
+
+### Interactive Prompts
+
+Based on the option, the tool may prompt you for:
+
+- **Name of the connector to discover**: Prompts a list of available
+  connectors(datasources) to choose.
+- **Name of the models to discover**: Prompts choices of available models. The
+  answer can be multiple.
+- **Database column naming convention**: By default, LoopBack converts
+  discovered model properties to `camelCase`. This is recommended. You can
+  choose to keep them the same as the database column names. However, we
+  recommend to use LoopBack default convention. You might need to specify the
+  discovered property names in relation definition later. Check the
+  [Relation Metadata](HasMany-relation.md#relation-metadata) section in each
+  relation for details of customizing names.

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -60,6 +60,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
    * @returns {*}
    */
   setOptions() {
+    /* istanbul ignore next */
     if (this.options.dataSource) {
       debug(`Data source specified: ${this.options.dataSource}`);
       this.artifactInfo.dataSource = modelMaker.loadDataSourceByName(
@@ -74,6 +75,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
    * Ensure CLI is being run in a LoopBack 4 project.
    */
   checkLoopBackProject() {
+    /* istanbul ignore next */
     if (this.shouldExit()) return;
     return super.checkLoopBackProject();
   }
@@ -83,6 +85,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
    */
   async loadAllDatasources() {
     // If we have a dataSourcePath then it is already loaded for us, we don't need load any
+    /* istanbul ignore next */
     if (this.artifactInfo.dataSource) {
       return;
     }
@@ -106,6 +109,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
    * Ask the user to select the data source from which to discover
    */
   promptDataSource() {
+    /* istanbul ignore next */
     if (this.shouldExit()) return;
     const prompts = [
       {
@@ -120,6 +124,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     ];
 
     return this.prompt(prompts).then(answer => {
+      /* istanbul ignore next */
       if (!answer.dataSource) return;
       debug(`Datasource answer: ${JSON.stringify(answer)}`);
 
@@ -133,12 +138,16 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
    * Puts all discoverable models in this.modelChoices
    */
   async discoverModelInfos() {
+    /* istanbul ignore if */
     if (this.artifactInfo.modelDefinitions) return;
     debug(`Getting all models from ${this.artifactInfo.dataSource.name}`);
 
     this.modelChoices = await modelMaker.discoverModelNames(
       this.artifactInfo.dataSource,
-      {views: this.options.views, schema: this.options.schema},
+      {
+        views: this.options.views,
+        schema: this.options.schema,
+      },
     );
     debug(
       `Got ${this.modelChoices.length} models from ${this.artifactInfo.dataSource.name}`,
@@ -151,6 +160,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
    */
   promptModelChoices() {
     // If we are discovering all we don't need to prompt
+    /* istanbul ignore next */
     if (this.options.all) {
       this.discoveringModels = this.modelChoices;
     }
@@ -172,6 +182,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     ];
 
     return this.prompt(prompts).then(answers => {
+      /* istanbul ignore next */
       if (!answers.discoveringModels) return;
       debug(`Models chosen: ${JSON.stringify(answers)}`);
       this.discoveringModels = [];
@@ -204,6 +215,7 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
         default: false,
       },
     ]).then(props => {
+      /* istanbul ignore next */
       if (!props.disableCamelCase) return;
       props.disableCamelCase = props.disableCamelCase !== 'camelCase';
 

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -57,6 +57,53 @@ export type ViewWithRelations = View & ViewRelations;
 `;
 
 
+exports[`lb4 discover integration model discovery keeps model property names the same as the db column names 1`] = `
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Naming extends Entity {
+  @property({
+    type: 'number',
+    id: 1,
+    required: true,
+  })
+  ID: number;
+
+  @property({
+    type: 'number',
+  })
+  snake_case?: number;
+
+  @property({
+    type: 'boolean',
+  })
+  lowercase?: boolean;
+
+  @property({
+    type: 'number',
+  })
+  camelCase?: number;
+
+  // Define well-known properties here
+
+  // Indexer property to allow additional data
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [prop: string]: any;
+
+  constructor(data?: Partial<Naming>) {
+    super(data);
+  }
+}
+
+export interface NamingRelations {
+  // describe navigational properties here
+}
+
+export type NamingWithRelations = Naming & NamingRelations;
+
+`;
+
+
 exports[`lb4 discover integration model discovery uses a different --outDir if provided 1`] = `
 import {Entity, model, property} from '@loopback/repository';
 

--- a/packages/cli/test/fixtures/discover/mem.datasource.js.txt
+++ b/packages/cli/test/fixtures/discover/mem.datasource.js.txt
@@ -15,6 +15,11 @@ const modelList = [
     name:'View',
     view: true,
     schema: ''
+  },
+    {
+    name:'Naming',
+    view: true,
+    schema: 'Naming'
   }
 ];
 // In real model definitions, the schema is contained in options->connectorName->schema
@@ -68,6 +73,41 @@ const fullDefinitions = [
         'precision': null,
         'scale': 0,
         'id': 1,
+      },
+    },
+  },
+    {
+    'name': 'Naming',
+    'schema': 'Naming',
+    'properties': {
+      'ID': {
+        'type': 'Number',
+        'id': 1,
+        'required': true,
+        'length': null,
+        'precision': null,
+        'scale': null,
+      },
+      'snake_case': {
+        'type': 'Number',
+        'required': false,
+        'length': null,
+        'precision': null,
+        'scale': null,
+      },
+      'lowercase': {
+        'type': 'Boolean',
+        'required': false,
+        'length': null,
+        'precision': null,
+        'scale': null,
+      },
+      'camelCase': {
+        'type': 'Number',
+        'required': false,
+        'length': null,
+        'precision': null,
+        'scale': null,
       },
     },
   },

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -43,6 +43,11 @@ const schemaViewsOptions = {
   schema: 'aSchema',
   views: false,
 };
+const disableCamelCaseOptions = {
+  ...baseOptions,
+  schema: 'Naming',
+  disableCamelCase: true,
+};
 const missingDataSourceOptions = {
   dataSource: 'foo',
 };
@@ -59,6 +64,10 @@ const defaultExpectedSchemaModel = path.join(
 const defaultExpectedViewModel = path.join(
   SANDBOX_PATH,
   'src/models/view.model.ts',
+);
+const defaultExpectedNamingModel = path.join(
+  SANDBOX_PATH,
+  'src/models/naming.model.ts',
 );
 
 const defaultExpectedIndexFile = path.join(SANDBOX_PATH, 'src/models/index.ts');
@@ -120,6 +129,20 @@ describe('lb4 discover integration', () => {
       assert.noFile(defaultExpectedViewModel);
       assert.noFile(defaultExpectedTestModel);
       assert.file(defaultExpectedSchemaModel);
+    });
+
+    it('keeps model property names the same as the db column names', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withOptions(disableCamelCaseOptions);
+
+      assert.file(defaultExpectedNamingModel);
+      expectFileToMatchSnapshot(defaultExpectedNamingModel);
     });
 
     it('will fail gracefully if you specify a --dataSource which does not exist', async () => {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
connects to #3343 

Add 2 prompts:
- asking naming convention for db column names: **UPDATED**
```
? Select a convention to convert db column names(EXAMPLE_COLUMN) to model property names:
    ❯ Camel case (exampleColumn) (Recommend) 
    No conversion (EXAMPLE_COLUMN) 
```
If the user pick `keep the same as db`, prompt:
```
? You might need to specify these customized names in relation 
definition. Would you like to continue?
  ❯ Yes 
  No (back to the previous step) 
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
