### PR TITLE
feat(context): improve context name with the subclass name as prefix

### DIFF
--- a/packages/context/src/__tests__/unit/context.unit.ts
+++ b/packages/context/src/__tests__/unit/context.unit.ts
@@ -47,6 +47,13 @@ describe('Context constructor', () => {
     );
   });
 
+  it('adds subclass name as the prefix', () => {
+    const ctx = new TestContext();
+    expect(ctx.name).to.match(
+      /^TestContext-[0-9A-F]{8}-[0-9A-F]{4}-[1][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+    );
+  });
+
   it('generates unique names for different instances', () => {
     const ctx1 = new Context();
     const ctx2 = new Context();

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -108,9 +108,16 @@ export class Context extends EventEmitter {
       _parent = undefined;
     }
     this._parent = _parent;
-    this.name = name ?? uuidv1();
+    this.name = name ?? this.generateName();
     this.tagIndexer = new ContextTagIndexer(this);
     this.subscriptionManager = new ContextSubscriptionManager(this);
+  }
+
+  private generateName() {
+    const id = uuidv1();
+    let prefix = `${this.constructor.name}-`;
+    if (prefix === 'Context-') prefix = '';
+    return `${prefix}${id}`;
   }
 
   /**


### PR DESCRIPTION
context.inspect() or other debug statements will have more meaningful
context names to understand if the context is an Application, RestServer,
or RequestContext.

For example, the context name for `TestContext` will be prefixed with `TestContext-`:

`TestContext-f859c8c1-4444-11ea-b8e7-f93bb3eeab9e`

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
