### PR TITLE
fix: update clean script for examples to be compatible with `lb4 example`

### DIFF
--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -11,7 +11,7 @@
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-context*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-context*.tgz dist *.tsbuildinfo package",
     "verify": "npm pack && tar xf *example-context*.tgz && tree package && npm run clean",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-express-composition*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-express-composition*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-greeter-extension-*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-greeter-extension-*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-greeting-app-*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-greeting-app-*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -11,7 +11,7 @@
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-hello-world*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-hello-world*.tgz dist *.tsbuildinfo package",
     "verify": "npm pack && tar xf *example-hello-world*.tgz && tree package && npm run clean",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-lb3-application*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-lb3-application*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-log-extension-*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-log-extension-*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -11,7 +11,7 @@
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-metrics-prometheus*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-metrics-prometheus*.tgz dist *.tsbuildinfo package",
     "verify": "npm pack && tar xf *example-metrics-prometheus*.tgz && tree package && npm run clean",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-rpc-server-*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-rpc-server-*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-soap*.tgz dist package api-docs dist tsconfig.build.tsbuildinfo",
+    "clean": "lb-clean *example-soap*.tgz dist package api-docs dist *.tsbuildinfo",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-todo-list*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-todo-list*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-todo*.tgz dist tsconfig.build.tsbuildinfo package",
+    "clean": "lb-clean *example-todo*.tgz dist *.tsbuildinfo package",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\"",


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/4545

Please note that `lb4 example` rename `tsconfig.build.json` to
`tsconfig.json`. As a result, the build cache file is `tsconfig.tsbuildinfo`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
