### PR TITLE
feat: adds @oas.response decorator

### DIFF
--- a/packages/openapi-v3/package-lock.json
+++ b/packages/openapi-v3/package-lock.json
@@ -10,6 +10,15 @@
 			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
 			"dev": true
 		},
+		"@types/http-status": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/http-status/-/http-status-1.1.2.tgz",
+			"integrity": "sha512-GodZPvF3xPVglUx4q7s0plKu1cdW0mMLADpWi5PMMx3n/2xGB6GoKqQxQxp6A5xuARtZpQ9/6p3WDFwCpPaN8A==",
+			"dev": true,
+			"requires": {
+				"http-status": "*"
+			}
+		},
 		"@types/lodash": {
 			"version": "4.14.149",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
@@ -96,6 +105,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+		},
+		"http-status": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/http-status/-/http-status-1.4.2.tgz",
+			"integrity": "sha512-mBnIohUwRw9NyXMEMMv8/GANnzEYUj0Y8d3uL01zDWFkxUjYyZ6rgCaAI2zZ1Wb34Oqtbx/nFZolPRDc8Xlm5A==",
+			"dev": true
 		},
 		"is-arguments": {
 			"version": "1.0.4",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -9,6 +9,7 @@
     "@loopback/core": "^1.12.4",
     "@loopback/repository-json-schema": "^1.12.2",
     "debug": "^4.1.1",
+    "http-status": "^1.4.2",
     "json-merge-patch": "^0.2.3",
     "lodash": "^4.17.15",
     "openapi3-ts": "^1.3.0"
@@ -20,6 +21,7 @@
     "@loopback/repository": "^1.19.1",
     "@loopback/testlab": "^1.10.3",
     "@types/debug": "^4.1.5",
+    "@types/http-status": "^1.1.2",
     "@types/lodash": "^4.14.149",
     "@types/node": "^10.17.14"
   },

--- a/packages/openapi-v3/src/__tests__/unit/decorators/response.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/response.decorator.unit.ts
@@ -1,0 +1,204 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Model, model, property} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import * as httpStatus from 'http-status';
+import {ResponseObject} from 'openapi3-ts';
+import {get, getControllerSpec, oas} from '../../..';
+
+describe('@oas.response decorator', () => {
+  it('allows a class to not be decorated with @oas.response at all', () => {
+    class MyController {
+      @get('/greet')
+      greet() {
+        return 'Hello world!';
+      }
+    }
+
+    const actualSpec = getControllerSpec(MyController);
+    expect(actualSpec.paths['/greet'].get.responses['200'].description).to.eql(
+      'Return value of MyController.greet',
+    );
+  });
+
+  context('with response models', () => {
+    @model()
+    class SuccessModel extends Model {
+      constructor(err: Partial<SuccessModel>) {
+        super(err);
+      }
+      @property({default: 'ok'})
+      message: string;
+    }
+
+    @model()
+    class FooError extends Model {
+      constructor(err: Partial<FooError>) {
+        super(err);
+      }
+      @property({default: 'foo'})
+      foo: string;
+    }
+
+    @model()
+    class BarError extends Model {
+      constructor(err: Partial<BarError>) {
+        super(err);
+      }
+      @property({default: 'bar'})
+      bar: string;
+    }
+
+    const successSchema: ResponseObject = {
+      description: httpStatus['200'],
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/SuccessModel',
+          },
+        },
+      },
+    };
+
+    const fooBarSchema: ResponseObject = {
+      description: httpStatus['404'],
+      content: {
+        'application/json': {
+          schema: {
+            anyOf: [
+              {$ref: '#/components/schemas/BarError'},
+              {$ref: '#/components/schemas/FooError'},
+            ],
+          },
+        },
+      },
+    };
+
+    it('supports a single @oas.response decorator', () => {
+      class MyController {
+        @get('/greet')
+        @oas.response(200, SuccessModel)
+        greet() {
+          return new SuccessModel({message: 'Hello, world'});
+        }
+      }
+
+      const actualSpec = getControllerSpec(MyController);
+      expect(actualSpec.paths['/greet'].get.responses[200]).to.eql(
+        successSchema,
+      );
+      expect(
+        actualSpec.components?.schemas?.SuccessModel,
+      ).to.not.be.undefined();
+    });
+
+    it('supports multiple @oas.response decorators on a method', () => {
+      class MyController {
+        @get('/greet')
+        @oas.response(200, SuccessModel)
+        @oas.response(404, FooError)
+        @oas.response(404, BarError)
+        greet() {
+          throw new FooError({foo: 'bar'});
+        }
+      }
+
+      const actualSpec = getControllerSpec(MyController);
+      expect(actualSpec.paths['/greet'].get.responses[404]).to.eql(
+        fooBarSchema,
+      );
+      expect(actualSpec.components?.schemas?.FooError).to.not.be.undefined();
+      expect(actualSpec.components?.schemas?.BarError).to.not.be.undefined();
+      expect(
+        actualSpec.components?.schemas?.SuccessModel,
+      ).to.not.be.undefined();
+    });
+    it('supports multiple @oas.response decorators with an array of models', () => {
+      class MyController {
+        @get('/greet')
+        @oas.response(200, SuccessModel)
+        @oas.response(404, BarError, FooError)
+        greet() {
+          throw new BarError({bar: 'baz'});
+        }
+      }
+
+      const actualSpec = getControllerSpec(MyController);
+
+      expect(actualSpec.paths['/greet'].get.responses[404]).to.eql(
+        fooBarSchema,
+      );
+      expect(actualSpec.components?.schemas?.FooError).to.not.be.undefined();
+      expect(actualSpec.components?.schemas?.BarError).to.not.be.undefined();
+      expect(
+        actualSpec.components?.schemas?.SuccessModel,
+      ).to.not.be.undefined();
+    });
+
+    context('with complex responses', () => {
+      const FIRST_SCHEMA = {
+        type: 'object',
+        properties: {
+          x: {
+            type: 'int',
+            default: 1,
+          },
+          y: {
+            type: 'string',
+            default: '2',
+          },
+        },
+      };
+
+      class MyController {
+        @get('/greet', {
+          responses: {
+            200: {
+              description: 'Unknown',
+              content: {
+                'application/jsonc': {schema: FIRST_SCHEMA},
+              },
+            },
+          },
+        })
+        @oas.response(200, SuccessModel, {
+          content: {
+            'application/pdf': {schema: {type: 'string', format: 'base64'}},
+          },
+        })
+        @oas.response(404, FooError, BarError)
+        greet() {
+          return new SuccessModel({message: 'Hello, world!'});
+        }
+      }
+
+      const actualSpec = getControllerSpec(MyController);
+      expect(
+        actualSpec.paths['/greet'].get.responses[200].content[
+          'application/jsonc'
+        ],
+      ).to.not.be.undefined();
+
+      expect(
+        actualSpec.paths['/greet'].get.responses[200].content[
+          'application/json'
+        ],
+      ).to.not.be.undefined();
+
+      expect(
+        actualSpec.paths['/greet'].get.responses[200].content[
+          'application/pdf'
+        ],
+      ).to.not.be.undefined();
+
+      expect(
+        actualSpec.paths['/greet'].get.responses[200].content[
+          'application/json'
+        ].schema,
+      ).to.eql({$ref: '#/components/schemas/SuccessModel'});
+    });
+  });
+});

--- a/packages/openapi-v3/src/build-responses-from-metadata.ts
+++ b/packages/openapi-v3/src/build-responses-from-metadata.ts
@@ -1,0 +1,150 @@
+import {DecoratorFactory} from '@loopback/core';
+import {Model} from '@loopback/repository';
+import {
+  ContentObject,
+  OperationObject,
+  ResponseDecoratorMetadata,
+  ResponseModelOrSpec,
+  ResponseObject,
+} from './types';
+
+declare type ContentMap = Map<string, ResponseModelOrSpec[]>;
+declare type ResponseMap = Map<
+  number,
+  {description: string; content: ContentMap}
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isModel<T extends Model>(c: any): c is T {
+  return c && c.prototype instanceof Model;
+}
+
+/**
+ * Reducer which builds the operation responses
+ */
+function reduceSpecContent(
+  specContents: ContentObject,
+  [contentType, modelOrSpecs]: [string, ResponseModelOrSpec[]],
+): ContentObject {
+  if (Array.isArray(modelOrSpecs) && modelOrSpecs.length > 1) {
+    specContents[contentType] = {
+      schema: {
+        anyOf: modelOrSpecs.map(m => {
+          if (isModel(m)) {
+            return {'x-ts-type': m};
+          } else {
+            return m;
+          }
+        }),
+      },
+    };
+  } else {
+    const modelOrSpec = Array.isArray(modelOrSpecs)
+      ? modelOrSpecs[0]
+      : modelOrSpecs;
+    if (isModel(modelOrSpec)) {
+      specContents[contentType] = {
+        schema: {'x-ts-type': modelOrSpec},
+      };
+    } else {
+      specContents[contentType] = {
+        schema: modelOrSpec,
+      };
+    }
+  }
+  return specContents;
+}
+
+/**
+ * Reducer which builds the content sections of the operation responses
+ */
+function reduceSpecResponses(
+  specResponses: ResponseObject,
+  [responseCode, c]: [number, {description: string; content: ContentMap}],
+): ResponseObject {
+  const responseContent = c.content;
+  // check if there is an existing block, from something like an inhered @op spec
+  if (Object.prototype.hasOwnProperty.call(specResponses, responseCode)) {
+    // we might need to merge
+    const content = Array.from(responseContent).reduce(
+      reduceSpecContent,
+      specResponses[responseCode].content as ContentObject,
+    );
+
+    specResponses[responseCode] = {
+      description: c.description,
+      content,
+    };
+  } else {
+    const content = Array.from(responseContent).reduce(
+      reduceSpecContent,
+      {} as ContentObject,
+    );
+
+    specResponses[responseCode] = {
+      description: c.description,
+      content,
+    };
+  }
+  return specResponses;
+}
+
+/**
+ * This function takes an array of flat-ish data:
+ * ```
+ * [
+ *  { responseCode, contentType, description, modelOrSpec },
+ *  { responseCode, contentType, description, modelOrSpec },
+ * ]
+ * ```
+ * and turns it into a multi-map structure that more closely aligns with
+ * the final json
+ * ```
+ * Map{ [code, Map{[contentType, modelOrSpec], [contentType, modelOrSpec]}]}
+ * ```
+ */
+function buildMapsFromMetadata(
+  metadata: ResponseDecoratorMetadata,
+): ResponseMap {
+  const builder: ResponseMap = new Map();
+  metadata.forEach(r => {
+    if (builder.has(r.responseCode)) {
+      const responseRef = builder.get(r.responseCode);
+      const codeRef = responseRef?.content;
+
+      if (codeRef?.has(r.contentType)) {
+        // eslint-disable-next-line no-unused-expressions
+        codeRef.get(r.contentType)?.push(r.responseModelOrSpec);
+      } else {
+        // eslint-disable-next-line no-unused-expressions
+        codeRef?.set(r.contentType, [r.responseModelOrSpec]);
+      }
+    } else {
+      const codeRef = new Map();
+      codeRef.set(r.contentType, [r.responseModelOrSpec]);
+      builder.set(r.responseCode, {
+        description: r.description,
+        content: codeRef,
+      });
+    }
+  });
+  return builder;
+}
+export function buildResponsesFromMetadata(
+  metadata: ResponseDecoratorMetadata,
+  existingOperation?: OperationObject,
+): OperationObject {
+  const builder = buildMapsFromMetadata(metadata);
+  const base = existingOperation
+    ? DecoratorFactory.cloneDeep(existingOperation.responses)
+    : {};
+  // Now, mega-reduce.
+  const responses: ResponseObject = Array.from(builder).reduce(
+    reduceSpecResponses,
+    base as ResponseObject,
+  );
+
+  return {
+    responses,
+  };
+}

--- a/packages/openapi-v3/src/decorators/index.ts
+++ b/packages/openapi-v3/src/decorators/index.ts
@@ -14,6 +14,7 @@ import {deprecated} from './deprecated.decorator';
 import {del, get, operation, patch, post, put} from './operation.decorator';
 import {param} from './parameter.decorator';
 import {requestBody} from './request-body.decorator';
+import {response} from './response.decorator';
 import {tags} from './tags.decorator';
 
 export const oas = {
@@ -35,5 +36,6 @@ export const oas = {
 
   // oas convenience decorators
   deprecated,
+  response,
   tags,
 };

--- a/packages/openapi-v3/src/decorators/response.decorator.ts
+++ b/packages/openapi-v3/src/decorators/response.decorator.ts
@@ -1,0 +1,83 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: @loopback/openapi-v3
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+import {MethodMultiDecoratorFactory} from '@loopback/core';
+import httpStatus from 'http-status';
+import {
+  ContentObject,
+  ReferenceObject,
+  ResponseObject,
+  SchemaObject,
+} from 'openapi3-ts';
+import {OAI3Keys} from '../keys';
+import {ResponseDecoratorMetadata, ResponseModelOrSpec} from '../types';
+
+// overloading the definition because content cannot be undefined in this case.
+interface ResponseWithContent extends ResponseObject {
+  content: ContentObject;
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isResponseObject(c: any): c is ResponseWithContent {
+  // eslint-disable-next-line no-prototype-builtins
+  return !!c && c.hasOwnProperty('content') && !!c.content;
+}
+
+function buildDecoratorReducer(
+  responseCode: number,
+  description: string,
+  contentType = 'application/json',
+) {
+  const decoratorItemReducer = (
+    r: ResponseDecoratorMetadata,
+    m: ResponseModelOrSpec,
+  ) => {
+    // allow { content: { 'application/json': {...}}}
+    if (isResponseObject(m)) {
+      Object.keys(m.content ?? {}).forEach(ct => {
+        r.push({
+          responseCode,
+          responseModelOrSpec: m.content[ct].schema as
+            | SchemaObject
+            | ReferenceObject,
+          contentType: ct,
+          description,
+        });
+      });
+    } else {
+      r.push({
+        responseCode,
+        responseModelOrSpec: m,
+        // we're defaulting these for convenience for now.
+        contentType,
+        description,
+      });
+    }
+    return r;
+  };
+  return decoratorItemReducer;
+}
+
+/**
+ *  class MyController {
+ *    @oas.response(200, FirstModel)
+ *    @oas.response(404, OneError, { $ref: '#/definition...'})
+ *    @oas.response(403, SecondError, { schema: ... })
+ *  }
+ *
+ */
+export function response(
+  responseCode: number,
+  ...responseModelOrSpec: ResponseModelOrSpec[]
+) {
+  const messageKey = String(responseCode) as keyof httpStatus.HttpStatus;
+
+  return MethodMultiDecoratorFactory.createDecorator(
+    OAI3Keys.RESPONSE_METHOD_KEY,
+    responseModelOrSpec.reduce(
+      buildDecoratorReducer(responseCode, httpStatus[messageKey] as string),
+      [],
+    ),
+    {decoratorName: '@response', allowInheritance: false},
+  );
+}

--- a/packages/openapi-v3/src/keys.ts
+++ b/packages/openapi-v3/src/keys.ts
@@ -5,7 +5,11 @@
 
 import {MetadataAccessor} from '@loopback/core';
 import {ControllerSpec, RestEndpoint} from './controller-spec';
-import {ParameterObject, RequestBodyObject} from './types';
+import {
+  ParameterObject,
+  RequestBodyObject,
+  ResponseDecoratorMetadata,
+} from './types';
 
 export namespace OAI3Keys {
   /**
@@ -31,6 +35,14 @@ export namespace OAI3Keys {
     boolean,
     ClassDecorator
   >('openapi-v3:class:deprecated');
+
+  /*
+   * Metadata key used to add to or retrieve an endpoint's responses
+   */
+  export const RESPONSE_METHOD_KEY = MetadataAccessor.create<
+    ResponseDecoratorMetadata,
+    MethodDecorator
+  >('openapi-v3:methods:response');
 
   /**
    * Metadata key used to set or retrieve `param` decorator metadata

--- a/packages/openapi-v3/src/types.ts
+++ b/packages/openapi-v3/src/types.ts
@@ -2,8 +2,13 @@
 // Node module: @loopback/openapi-v3
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
-
-import {OpenAPIObject} from 'openapi3-ts';
+import {Model} from '@loopback/repository';
+import {
+  OpenAPIObject,
+  ReferenceObject,
+  ResponseObject,
+  SchemaObject,
+} from 'openapi3-ts';
 /*
  * OpenApiSpec - A typescript representation of OpenApi 3.0.0
  */
@@ -32,3 +37,18 @@ export function createEmptyApiSpec(): OpenApiSpec {
 export interface TagsDecoratorMetadata {
   tags: string[];
 }
+
+export type ResponseModelOrSpec =
+  | typeof Model
+  | SchemaObject
+  | ResponseObject
+  | ReferenceObject;
+
+export interface ResponseDecoratorMetadataItem {
+  responseCode: number;
+  contentType: string;
+  responseModelOrSpec: ResponseModelOrSpec;
+  description: string;
+}
+
+export type ResponseDecoratorMetadata = ResponseDecoratorMetadataItem[];


### PR DESCRIPTION
Partially implements: #4300
See: #4406

## Adds
This PR adds the `@oas.response(code: number, ...modelOrSpec: ModelOrSpec[])` decorator.  

### Note
The decorator only affects the OpenAPI specification object that is created, and anything that uses it to verify and validate responses.  **This decorator has no impact on the actual response code**.  It also doesn't add any typings or lint configuration that could force response compliance at compile/lint time (if that's even possible).

### Example
```ts
@model()
class SuccessModel extends Model {
  constructor(err: Partial<SuccessModel>) {
    super(err);
  }
  @property({default: 'Hi there!'})
  message: string;
}

class FooNotFound extends Model {
  @property()
  message: string;
}

class BarNotFound extends Model {
  @property()
  message: string;
}

class BazNotFound extends Model {
  @property()
  message: string;
}

class MyController {
  @oas.get('/greet/{foo}/{bar}',
  @oas.response(200, SuccessModel)
  @oas.response(404, FooNotFound, BarNotFound)
  @oas.response(404, BazNotFound)
  greet() {
    return new SuccessModel({message: 'Hello, world!'});
  }
}
```


## Checklist
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

