### PR TITLE
feat: improve context/binding inspection

### DIFF
--- a/packages/context/src/binding-filter.ts
+++ b/packages/context/src/binding-filter.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Binding, BindingTag} from './binding';
-import {BindingAddress} from './binding-key';
+import {BindingAddress, BindingKey} from './binding-key';
 import {MapObject} from './value-promise';
 
 /**
@@ -52,12 +52,14 @@ export type BindingSelector<ValueType = unknown> =
 
 /**
  * Type guard for binding address
- * @param bindingSelector
+ * @param bindingSelector - Binding key or filter function
  */
 export function isBindingAddress(
   bindingSelector: BindingSelector,
 ): bindingSelector is BindingAddress {
-  return typeof bindingSelector !== 'function';
+  return (
+    typeof bindingSelector === 'string' || bindingSelector instanceof BindingKey
+  );
 }
 
 /**

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -7,7 +7,9 @@ import debugFactory from 'debug';
 import {EventEmitter} from 'events';
 import {BindingAddress, BindingKey} from './binding-key';
 import {Context} from './context';
+import {inspectInjections} from './inject';
 import {createProxyWithInterceptors} from './interception-proxy';
+import {JSONObject} from './json-types';
 import {ContextTags} from './keys';
 import {Provider} from './provider';
 import {
@@ -635,8 +637,8 @@ export class Binding<T = BoundValue> extends EventEmitter {
   /**
    * Convert to a plain JSON object
    */
-  toJSON(): object {
-    const json: Record<string, unknown> = {
+  toJSON(): JSONObject {
+    const json: JSONObject = {
       key: this.key,
       scope: this.scope,
       tags: this.tagMap,
@@ -653,6 +655,23 @@ export class Binding<T = BoundValue> extends EventEmitter {
     }
     if (this._alias != null) {
       json.alias = this._alias.toString();
+    }
+    return json;
+  }
+
+  /**
+   * Inspect the binding to return a json representation of the binding information
+   * @param options - Options to control what information should be included
+   */
+  inspect(options: BindingInspectOptions = {}): JSONObject {
+    options = {
+      includeInjections: false,
+      ...options,
+    };
+    const json = this.toJSON();
+    if (options.includeInjections) {
+      const injections = inspectInjections(this);
+      if (Object.keys(injections).length) json.injections = injections;
     }
     return json;
   }
@@ -686,6 +705,16 @@ export class Binding<T = BoundValue> extends EventEmitter {
       [ContextTags.CONFIGURATION_FOR]: key.toString(),
     });
   }
+}
+
+/**
+ * Options for binding.inspect()
+ */
+export interface BindingInspectOptions {
+  /**
+   * The flag to control if injections should be inspected
+   */
+  includeInjections?: boolean;
 }
 
 function createInterceptionProxyFromInstance<T>(

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -210,6 +210,7 @@ export class Binding<T = BoundValue> extends EventEmitter {
 
   private _valueConstructor?: Constructor<T>;
   private _providerConstructor?: Constructor<Provider<T>>;
+  private _alias?: BindingAddress<T>;
 
   /**
    * For bindings bound via `toClass()`, this property contains the constructor
@@ -595,6 +596,7 @@ export class Binding<T = BoundValue> extends EventEmitter {
       debug('Bind %s to alias %s', this.key, keyWithPath);
     }
     this._type = BindingType.ALIAS;
+    this._alias = keyWithPath;
     this._setValueGetter((ctx, options) => {
       return ctx.getValueOrPromise(keyWithPath, options);
     });
@@ -648,6 +650,9 @@ export class Binding<T = BoundValue> extends EventEmitter {
     }
     if (this._providerConstructor != null) {
       json.providerConstructor = this._providerConstructor.name;
+    }
+    if (this._alias != null) {
+      json.alias = this._alias.toString();
     }
     return json;
   }

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -27,3 +27,4 @@ export * from './provider';
 export * from './resolution-session';
 export * from './resolver';
 export * from './value-promise';
+export * from './json-types';

--- a/packages/context/src/json-types.ts
+++ b/packages/context/src/json-types.ts
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/context
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/**
+ * Type definition for JSON types
+ */
+
+/**
+ * JSON primitive types:
+ * - string
+ * - number
+ * - boolean
+ * - null
+ */
+export type JSONPrimitive = string | number | boolean | null;
+
+/**
+ * JSON values
+ * - primitive
+ * - object
+ * - array
+ */
+export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+
+/**
+ * JSON object
+ */
+export interface JSONObject extends Record<string, JSONValue> {}
+
+/**
+ * JSON array
+ */
+export interface JSONArray extends Array<JSONValue> {}

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -155,9 +155,7 @@ export class ResolutionSession {
    * Describe the injection for debugging purpose
    * @param injection - Injection object
    */
-  static describeInjection(injection?: Readonly<Injection>) {
-    /* istanbul ignore if */
-    if (injection == null) return {};
+  static describeInjection(injection: Readonly<Injection>) {
     const name = getTargetName(
       injection.target,
       injection.member,
@@ -166,8 +164,7 @@ export class ResolutionSession {
     return {
       targetName: name,
       bindingSelector: injection.bindingSelector,
-      // Cast to Object so that we don't have to expose InjectionMetadata
-      metadata: injection.metadata as object,
+      metadata: injection.metadata,
     };
   }
 
@@ -300,14 +297,14 @@ export class ResolutionSession {
    */
   getInjectionPath() {
     return this.injectionStack
-      .map(i => ResolutionSession.describeInjection(i)!.targetName)
+      .map(i => ResolutionSession.describeInjection(i).targetName)
       .join(' --> ');
   }
 
   private static describe(e: ResolutionElement) {
     switch (e.type) {
       case 'injection':
-        return '@' + ResolutionSession.describeInjection(e.value)!.targetName;
+        return '@' + ResolutionSession.describeInjection(e.value).targetName;
       case 'binding':
         return e.value.key;
     }

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -9,11 +9,12 @@ import {
   Constructor,
   Context,
   createBindingFromClass,
+  JSONObject,
   Provider,
 } from '@loopback/context';
 import assert from 'assert';
-import pEvent from 'p-event';
 import debugFactory from 'debug';
+import pEvent from 'p-event';
 import {Component, mountComponent} from './component';
 import {CoreBindings, CoreTags} from './keys';
 import {
@@ -483,16 +484,6 @@ export interface ApplicationConfig {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ControllerClass = Constructor<any>;
-
-/**
- * Type definition for JSON
- */
-export type JSONPrimitive = string | number | boolean | null;
-export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
-export interface JSONObject {
-  [property: string]: JSONValue;
-}
-export interface JSONArray extends Array<JSONValue> {}
 
 /**
  * Type description for `package.json`


### PR DESCRIPTION
The PR improves context/binding inspection APIs with more options and information:

At binding level, there is one flag:

- includeInjections: control if injections should be inspected

At context level, there are two flags:

- includeInjections: control if binding injections should be inspected
- includeParent: control if parent context should be inspected

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
