### PR TITLE
docs: update documentation to reflect any/all/oneOf

### DIFF
--- a/docs/site/decorators/Decorators_openapi.md
+++ b/docs/site/decorators/Decorators_openapi.md
@@ -427,6 +427,52 @@ export class SomeController {
 }
 ```
 
+#### anyOf, allOf, oneOf, not
+
+The `x-ts-type` extention is also valid as a value in `allOf`, `anyOf`, `oneOf`,
+and `not` schema keys.
+
+```ts
+@model
+class FooModel extends Model {
+  @property()
+  foo: string;
+}
+
+@model
+class BarModel extends Model {
+  @property()
+  bar: string;
+}
+
+@model
+class BazModel extends Model {
+  @property()
+  baz: string;
+}
+
+class MyController {
+  @get('/some-value', {
+    responses: {
+      '200': {
+        description: 'returns a union of two values',
+        content: {
+          'application/json': {
+            schema: {
+              not: {'x-ts-type': BazModel},
+              allOf: [{'x-ts-type': FooModel}, {'x-ts-type': BarModel}],
+            },
+          },
+        },
+      },
+    },
+  })
+  getSomeValue() {
+    return {foo: 'foo', bar: 'bar'};
+  }
+}
+```
+
 When the OpenAPI spec is generated, the `xs-ts-type` is mapped to
 `{$ref: '#/components/schemas/MyModel'}` and a corresponding schema is added to
 `components.schemas.MyModel` of the spec.


### PR DESCRIPTION
This PR updates the documentation to reflect that `x-ts-type` can be used under the schema keywords `allOf`, `anyOf`, `oneOf`, and `not` - functionality which landed in #4479

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
