### PR TITLE
fix: replace `open` with `open-cli`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3749,6 +3749,12 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-type": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
+      "integrity": "sha512-rM0UO7Qm9K7TWTtA6AShI/t7H5BPjDeGVDaNyg9BjHAj3PysKy7+8C8D137R88jnR3rFJZQB/tFgydl5sN5m7g==",
+      "dev": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -5140,6 +5146,12 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -6067,6 +6079,58 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
+    "open-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/open-cli/-/open-cli-5.0.0.tgz",
+      "integrity": "sha512-Y2KQDS6NqNtk+PSXzSgwH41vTDMRndwFgVWsfgMhXv7lNe1cImLCe19Vo8oKwMsL7WeNsGmmbX7Ml74Ydj61Cg==",
+      "dev": true,
+      "requires": {
+        "file-type": "^11.0.0",
+        "get-stdin": "^7.0.0",
+        "meow": "^5.0.0",
+        "open": "^6.3.0",
+        "temp-write": "^4.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "temp-write": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-4.0.0.tgz",
+          "integrity": "sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "is-stream": "^2.0.0",
+            "make-dir": "^3.0.0",
+            "temp-dir": "^1.0.0",
+            "uuid": "^3.3.2"
+          }
+        }
       }
     },
     "opencollective-postinstall": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "fs-extra": "^8.1.0",
     "husky": "^3.1.0",
     "lerna": "^3.20.2",
+    "open-cli": "^5.0.0",
     "typescript": "~3.7.5"
   },
   "scripts": {
@@ -42,7 +43,7 @@
     "tsdocs": "lerna run --scope @loopback/tsdocs build:tsdocs",
     "coverage:ci": "node packages/build/bin/run-nyc report --reporter=text-lcov | coveralls",
     "precoverage": "npm test",
-    "coverage": "open coverage/index.html",
+    "coverage": "open-cli coverage/index.html",
     "lint": "npm run prettier:check && npm run eslint && node bin/check-package-locks",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "eslint": "node packages/build/bin/run-eslint --report-unused-disable-directives --cache .",


### PR DESCRIPTION
The npm script `npm run coverage` invokes `open coverage/index.html`, which is invalid on both Linux and Windows.  This pr adds `open-cli` as a dependency, which is a cross-platform `open`, and uses it instead.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
