### PR TITLE
fix(context): relax checking on instances of BindingKey class

### DIFF
--- a/packages/context/src/__tests__/unit/binding-filter.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-filter.unit.ts
@@ -4,7 +4,15 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Binding, filterByKey, filterByTag, isBindingTagFilter} from '../..';
+import {
+  Binding,
+  BindingFilter,
+  BindingKey,
+  filterByKey,
+  filterByTag,
+  isBindingAddress,
+  isBindingTagFilter,
+} from '../..';
 
 const key = 'foo';
 
@@ -69,6 +77,33 @@ describe('BindingFilter', () => {
       binding.tag({controller: 'my-controller'});
       binding.tag({name: 'my-controller'});
       expect(filter(binding)).to.be.false();
+    });
+  });
+
+  describe('isBindingAddress', () => {
+    it('allows binding selector to be a string', () => {
+      expect(isBindingAddress('controllers.MyController')).to.be.true();
+    });
+
+    it('allows binding selector to be a BindingKey', () => {
+      expect(
+        isBindingAddress(BindingKey.create('controllers.MyController')),
+      ).to.be.true();
+    });
+
+    it('does not allow binding selector to be an object', () => {
+      const filter: BindingFilter = () => true;
+      expect(isBindingAddress(filter)).to.be.false();
+    });
+
+    it('allows binding selector to be a BindingKey by duck-typing', () => {
+      // Please note that TypeScript checks types by duck-typing
+      // See https://www.typescriptlang.org/docs/handbook/interfaces.html#introduction
+      const selector: BindingKey<unknown> = {
+        key: 'x',
+        deepProperty: () => BindingKey.create('y'),
+      };
+      expect(isBindingAddress(selector)).to.be.true();
     });
   });
 

--- a/packages/context/src/binding-filter.ts
+++ b/packages/context/src/binding-filter.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Binding, BindingTag} from './binding';
-import {BindingAddress, BindingKey} from './binding-key';
+import {BindingAddress} from './binding-key';
 import {MapObject} from './value-promise';
 
 /**
@@ -51,6 +51,18 @@ export type BindingSelector<ValueType = unknown> =
   | BindingFilter<ValueType>;
 
 /**
+ * Check if an object is a `BindingKey` by duck typing
+ * @param selector Binding selector
+ */
+function isBindingKey(selector: BindingSelector) {
+  if (selector == null || typeof selector !== 'object') return false;
+  return (
+    typeof selector.key === 'string' &&
+    typeof selector.deepProperty === 'function'
+  );
+}
+
+/**
  * Type guard for binding address
  * @param bindingSelector - Binding key or filter function
  */
@@ -58,7 +70,13 @@ export function isBindingAddress(
   bindingSelector: BindingSelector,
 ): bindingSelector is BindingAddress {
   return (
-    typeof bindingSelector === 'string' || bindingSelector instanceof BindingKey
+    typeof bindingSelector !== 'function' &&
+    (typeof bindingSelector === 'string' ||
+      // See https://github.com/strongloop/loopback-next/issues/4570
+      // `bindingSelector instanceof BindingKey` is not always reliable as the
+      // `@loopback/context` module might be loaded from multiple locations if
+      // `npm install` does not dedupe or there are mixed versions in the tree
+      isBindingKey(bindingSelector))
   );
 }
 


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/4570


Please note that `bindingSelector instanceof BindingKey` is not always
reliable as the `@loopback/context` module might be loaded from multiple
locations if `npm install` does not dedupe or there are mixed versions in
the tree.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
