### PR TITLE
docs: update auth options

### DIFF
--- a/docs/site/Loopback-component-authorization.md
+++ b/docs/site/Loopback-component-authorization.md
@@ -99,8 +99,8 @@ class.
     defaultDecision: AuthorizationDecision.DENY,
   };
 
-  const binding = app.component(AuthorizationComponent);
-  app.configure(binding.key).to(options);
+  app.configure(AuthorizationBindings.COMPONENT).to(options);
+  app.component(AuthorizationComponent);
   ```
 
 - The authorization `options` are provided specifically for enforcing the


### PR DESCRIPTION
Fixes: https://github.com/strongloop/loopback-next/issues/4576

Copy from ^

I verified with an app in PR https://github.com/strongloop/loopback-next/pull/4571

```ts
const auth_options: AuthorizationOptions = {
      defaultDecision: AuthorizationDecision.ALLOW,
      precedence: AuthorizationDecision.ALLOW,
    }
    
this.configure(AuthorizationBindings.COMPONENT).to(auth_options);
```
works.
The debug log:
```
loopback:authorization:interceptor Authorization options { defaultDecision: 'Allow', precedence: 'Allow' } +272ms
```
And according to the code in
https://github.com/strongloop/loopback-next/blob/6eea5e428b145cafb84a998bd53979da8c8fba07/packages/authorization/src/authorize-interceptor.ts#L38

Your solution is the correct fix. Submitting a PR to update the doc

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
