### PR TITLE
chore: fix CLI records in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -91,6 +91,14 @@
 /docs/ @agnes512 @bajtos @deepakrkris @emonddr @jannyHou @hacksparrow @nabdelgadir @raymondfeng
 
 #
+# CLI (`lb4` infrastructure, commands not covered by functional areas below)
+#
+# - Issue label: CLI
+# - Primary owner(s): @agnes512
+# - Standby owner(s): @emonddr @nabdelgadir
+/packages/cli/ @agnes512 @emonddr @nabdelgadir
+
+#
 # Dependency Injection, Inversion of Control and related areas
 #
 # - Issue label: IoC/Context
@@ -193,14 +201,6 @@
 # The SOAP Calculator examples is a bit special, we want to preserve
 # Mario as the code owner of this specific subarea only
 /examples/soap-calculator/ @raymondfeng @marioestradarosa
-
-#
-# CLI (`lb4` infrastructure, commands not covered by functional areas above)
-#
-# - Issue label: CLI
-# - Primary owner(s): @agnes512
-# - Standby owner(s): @emonddr @nabdelgadir
-/packages/cli/ @agnes512 @emonddr @nabdelgadir
 
 #
 # `lb4 openapi` (scaffold an LB4 app from the given OpenAPI spec)


### PR DESCRIPTION
While looking up owners of CLI, I noticed that the catch-all CLI entry is after more specific entries for individual generators. Because CODEOWNERS algorithm is picking up the last matching pattern, this setup was effectively invalidating generator-specific configuration.

In this commit, I am fixing the issue by moving the catch-all CLI entry to the top.

See also https://github.com/strongloop/loopback-next/pull/4559
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
