### PR TITLE
chore: add frbuceta and agnes to maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,6 +5,7 @@ on particular package, please see the [CODEOWNERS file](CODEOWNERS).
 
 Core maintainers:
 
+- Agnes Lin ([@agnes512](https://github.com/agnes512))
 - Deepak Rajamohan ([@deepakrkris](https://github.com/deepakrkris))
 - Diana Lau ([@dhmlau](https://github.com/dhmlau))
 - Dominique Emond ([@emonddr](https://github.com/emonddr))
@@ -16,9 +17,10 @@ Core maintainers:
 
 Community maintainers:
 
-- Hugo Da Roit ([@Yaty](https://github.com/Yaty))
-- Mario Estrada ([@marioestradarosa](https://github.com/marioestradarosa))
-- TN ([@thinusn](https://github.com/thinusn))
 - Denny Bartelt ([@derdeka](https://github.com/derdeka))
 - Douglas McConnachie ([@dougal83](https://github.com/dougal83))
+- Francisco Buceta ([@frbuceta](https://github.com/frbuceta))
+- Hugo Da Roit ([@Yaty](https://github.com/Yaty))
+- Mario Estrada ([@marioestradarosa](https://github.com/marioestradarosa))
 - Rifa Achrinza ([@achrinza](https://github.com/achrinza))
+- TN ([@thinusn](https://github.com/thinusn))


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
