### PR TITLE
feat(rest): bind controller routes to the context

### DIFF
--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -21,6 +21,7 @@ import {is} from 'type-is';
 import util from 'util';
 import {
   BodyParser,
+  ControllerRoute,
   get,
   post,
   Request,
@@ -827,6 +828,19 @@ paths:
     serverUrl = server.getSync(RestBindings.URL);
     const res = await httpsGetAsync(serverUrl);
     expect(res.statusCode).to.equal(200);
+    await server.stop();
+  });
+
+  it('register controller routes under routes.*', async () => {
+    const server = await givenAServer();
+    server.controller(DummyController);
+    await server.start();
+    const keys = server.find('routes.*').map(b => b.key);
+    expect(keys).to.eql(['routes.get %2Fhtml', 'routes.get %2Fendpoint']);
+    for (const key of keys) {
+      const controllerRoute = await server.get(key);
+      expect(controllerRoute).to.be.instanceOf(ControllerRoute);
+    }
     await server.stop();
   });
 

--- a/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
@@ -11,9 +11,27 @@ import {
   ControllerRoute,
   createControllerFactoryForBinding,
   createControllerFactoryForClass,
+  joinPath,
   RestBindings,
   RouteSource,
 } from '../../..';
+
+describe('joinPath', () => {
+  it('joins basePath and path', () => {
+    expect(joinPath('', 'a')).to.equal('/a');
+    expect(joinPath('/', '')).to.equal('/');
+    expect(joinPath('/', 'a')).to.equal('/a');
+    expect(joinPath('/root', 'a')).to.equal('/root/a');
+    expect(joinPath('root', 'a')).to.equal('/root/a');
+    expect(joinPath('root/', '/a')).to.equal('/root/a');
+    expect(joinPath('root/', '/a/')).to.equal('/root/a');
+    expect(joinPath('/root/', '/a/')).to.equal('/root/a');
+    expect(joinPath('/root//x', '/a')).to.equal('/root/x/a');
+    expect(joinPath('/root/', '/')).to.equal('/root');
+    expect(joinPath('/root/x', '/a/b')).to.equal('/root/x/a/b');
+    expect(joinPath('//root//x', '//a///b////c')).to.equal('/root/x/a/b/c');
+  });
+});
 
 describe('ControllerRoute', () => {
   it('rejects routes with no methodName', () => {

--- a/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
@@ -20,25 +20,6 @@ import {
   TrieRouter,
 } from '../../..';
 
-describe('RoutingTable', () => {
-  it('joins basePath and path', () => {
-    expect(RoutingTable.joinPath('', 'a')).to.equal('/a');
-    expect(RoutingTable.joinPath('/', '')).to.equal('/');
-    expect(RoutingTable.joinPath('/', 'a')).to.equal('/a');
-    expect(RoutingTable.joinPath('/root', 'a')).to.equal('/root/a');
-    expect(RoutingTable.joinPath('root', 'a')).to.equal('/root/a');
-    expect(RoutingTable.joinPath('root/', '/a')).to.equal('/root/a');
-    expect(RoutingTable.joinPath('root/', '/a/')).to.equal('/root/a');
-    expect(RoutingTable.joinPath('/root/', '/a/')).to.equal('/root/a');
-    expect(RoutingTable.joinPath('/root//x', '/a')).to.equal('/root/x/a');
-    expect(RoutingTable.joinPath('/root/', '/')).to.equal('/root');
-    expect(RoutingTable.joinPath('/root/x', '/a/b')).to.equal('/root/x/a/b');
-    expect(RoutingTable.joinPath('//root//x', '//a///b////c')).to.equal(
-      '/root/x/a/b/c',
-    );
-  });
-});
-
 describe('RoutingTable with RegExpRouter', () => {
   runTestsWithRouter(new RegExpRouter());
 });


### PR DESCRIPTION
This PR makes it consistent for all routes to be bound under `routes.*` namespace. Before the change, controller routes are not bound to the context.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
