### PR TITLE
fix(cli): ignore stdin when config is provided via CLI args

### DIFF
--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -99,7 +99,10 @@ module.exports = class BaseGenerator extends Generator {
         : ['Config:', this.options.config]),
     );
     try {
-      if (jsonFileOrValue === 'stdin' || !process.stdin.isTTY) {
+      if (
+        jsonFileOrValue === 'stdin' ||
+        (!jsonFileOrValue && !process.stdin.isTTY)
+      ) {
         debug('  enabling --yes and reading config from stdin');
         this.options['yes'] = true;
         opts = await this._readJSONFromStdin();


### PR DESCRIPTION
Before this change, the following command did not work:

    $ lb4 --yes --config '{}' < /dev/null
    Generation is aborted: SyntaxError: Unexpected end of JSON input

In this change, I am tweaking the condition detecting when we need to read config from stdin to use data from CLI arg `--config` when it's available and don't try to read from stdin.

See also https://github.com/strongloop/loopback-next/issues/4425

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
