### PR TITLE
chore: remove support for Node.js v8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
   - "13"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for more details.
 
 Make sure you have the following installed:
 
-- [Node.js](https://nodejs.org/en/download/) >= 8.9.0
+- [Node.js](https://nodejs.org/en/download/) >= 10
 
 Install LoopBack 4 CLI to help create new projects as follows:
 

--- a/acceptance/extension-logging-fluentd/package.json
+++ b/acceptance/extension-logging-fluentd/package.json
@@ -4,7 +4,7 @@
   "description": "Acceptance test for extension-logging with fluentd",
   "private": true,
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-cloudant/package.json
+++ b/acceptance/repository-cloudant/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mongodb/package.json
+++ b/acceptance/repository-mongodb/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mysql/package.json
+++ b/acceptance/repository-mysql/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-postgresql/package.json
+++ b/acceptance/repository-postgresql/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/strongloop/loopback-next/tree/master/docs",
   "author": "IBM Corp.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "files": [
     "**/*"

--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -9,7 +9,7 @@ summary: Write and run a LoopBack 4 "Hello World" project in TypeScript.
 
 ## Prerequisites
 
-Install [Node.js](https://nodejs.org/en/download/) (version 8.9 or higher) if it
+Install [Node.js](https://nodejs.org/en/download/) (version 10 or higher) if it
 is not already installed on your machine.
 
 ## Install LoopBack 4 CLI

--- a/docs/site/deployment/Deploying_to_ibm_cloud_kubernetes.md
+++ b/docs/site/deployment/Deploying_to_ibm_cloud_kubernetes.md
@@ -17,7 +17,7 @@ application onto [Kubernetes](http://kubernetes.io/) on the
 
 You’ll need the following:
 
-1. [Node.js 8.9 or higher](https://nodejs.org)
+1. [Node.js 10 or higher](https://nodejs.org)
 2. [Docker 18.06 or higher](https://docs.docker.com/install/)
 3. [Sign up for an IBM Cloud account](https://cloud.ibm.com/) if you don't have
    one already.

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -4,7 +4,7 @@
   "description": "Standalone examples for @loopback/context",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "scripts": {

--- a/examples/express-composition/README.md
+++ b/examples/express-composition/README.md
@@ -7,7 +7,7 @@ This is an example of how to mount LoopBack 4 REST API on a simple
 
 First, you'll need to install a supported version of Node:
 
-- [Node.js](https://nodejs.org/en/) at v8.9 or greater
+- [Node.js](https://nodejs.org/en/) at v10 or greater
 
 Additionally, this tutorial assumes that you are comfortable with certain
 technologies, languages and concepts.

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -4,7 +4,7 @@
   "description": "An example extension point/extensions for LoopBack 4",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -4,7 +4,7 @@
   "description": "An example greeting application for LoopBack 4",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -14,7 +14,7 @@ World!".
 
 Before we can begin, you'll need to make sure you have some things installed:
 
-- [Node.js](https://nodejs.org/en/) at v8.9 or greater
+- [Node.js](https://nodejs.org/en/) at v10 or greater
 
 Additionally, this tutorial assumes that you are comfortable with certain
 technologies, languages and concepts.

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -4,7 +4,7 @@
   "description": "A simple hello-world Application using LoopBack 4",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "scripts": {

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -4,7 +4,7 @@
   "description": "Tutorial example on how to add existing an LB3 application to a LB4 project",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "scripts": {

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -4,7 +4,7 @@
   "description": "An example extension project for LoopBack 4",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "scripts": {

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -4,7 +4,7 @@
   "description": "Standalone examples for @loopback/metrics",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "scripts": {

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -7,7 +7,7 @@
     "loopback"
   ],
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/soap-calculator/README.md
+++ b/examples/soap-calculator/README.md
@@ -17,7 +17,7 @@ you will be creating in blue.
 
 You'll need to make sure you have some things installed:
 
-- [Node.js](https://nodejs.org/en/) at v8.9 or greater
+- [Node.js](https://nodejs.org/en/) at v10 or greater
 
 Lastly, you'll need to install the LoopBack 4 CLI toolkit:
 

--- a/examples/todo-list/README.md
+++ b/examples/todo-list/README.md
@@ -18,7 +18,7 @@ straight to our first step:
 If not, you'll need to make sure you have a couple of things installed before we
 get started:
 
-- [Node.js](https://nodejs.org/en/) at v8.9 or greater
+- [Node.js](https://nodejs.org/en/) at v10 or greater
 
 Next, you'll need to install the LoopBack 4 CLI toolkit:
 

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -4,7 +4,7 @@
   "description": "Continuation of the todo example using relations in LoopBack 4.",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "scripts": {

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -14,7 +14,7 @@ LoopBack 4. You will experience how you can create REST APIs with just
 
 First, you'll need to install a supported version of Node:
 
-- [Node.js](https://nodejs.org/en/) at v8.9 or greater
+- [Node.js](https://nodejs.org/en/) at v10 or greater
 
 Additionally, this tutorial assumes that you are comfortable with certain
 technologies, languages and concepts.

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -4,7 +4,7 @@
   "description": "Tutorial example on how to build an application with LoopBack 4.",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "scripts": {

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.3",
   "description": "A package creating adapters between the passport module and @loopback/authentication",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.17",
   "description": "LoopBack Health",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "LoopBack Logging for Winston and Fluentd",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.6",
   "description": "LoopBack Metrics for Prometheus",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "version": "0.1.0",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "license": "MIT",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.3",
   "description": "A LoopBack component for authentication support.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.10",
   "description": "A LoopBack component for authorization support.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.4",
   "description": "A collection of Booters for LoopBack 4 Applications",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/boot/src/__tests__/fixtures/package.json
+++ b/packages/boot/src/__tests__/fixtures/package.json
@@ -7,7 +7,7 @@
     "loopback"
   ],
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
   },

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.12",
   "description": "Boot a LoopBack 3 application in a LoopBack 4 project",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -8,7 +8,7 @@
 	},
 	"version": "3.1.1",
 	"engines": {
-		"node": ">=8.9"
+		"node": ">=10"
 	},
 	"author": "IBM Corp.",
 	"main": "index.js",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -8,7 +8,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -8,7 +8,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/strongloop/loopback-next/tree/master/packages/cli",
   "author": "IBM Corp.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "files": [
     "bin",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.1",
   "description": "LoopBack's container for Inversion of Control",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.4",
   "description": "LoopBack 4 core",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.3",
   "description": "Shared configuration for ESLint",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "main": "eslintrc.js",
   "author": "IBM Corp.",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "description": "A caching HTTP proxy for integration tests. NOT SUITABLE FOR PRODUCTION USE!",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.4",
   "description": "A wrapper for creating HTTP/HTTPS servers",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.1",
   "description": "LoopBack's metadata utilities for reflection and decoration",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.4",
   "description": "Types and helpers for packages contributing Model API builders.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "main": "index",
   "publishConfig": {

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.1",
   "description": "Make it easy to create OpenAPI (Swagger) specification documents in your tests using the builder pattern.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Processes openapi v3 related metadata",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "dependencies": {
     "@loopback/core": "^1.12.4",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.2",
   "description": "Converts TS classes into JSON Schemas using TypeScript's reflection API",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -3,7 +3,7 @@
   "version": "0.10.1",
   "description": "Shared test-suite for repository based persistence",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "main": "index",
   "publishConfig": {

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -3,7 +3,7 @@
   "version": "1.19.1",
   "description": "Repository based persistence for LoopBack 4",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "main": "index",
   "scripts": {

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.6",
   "description": "REST API controller implementing default CRUD semantics",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "main": "index",
   "publishConfig": {

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.10",
   "description": "LoopBack's API Explorer",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.13",
   "description": "A LoopBack component for security support.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.17",
   "description": "Service integration for LoopBack 4",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "main": "index",
   "scripts": {

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -3,7 +3,7 @@
   "version": "1.10.3",
   "description": "A collection of test utilities we use to write LoopBack tests.",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.1",
   "description": "LoopBack's TypeScript docs based on Microsoft api-extractor and api-documenter",
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "private": true,
   "scripts": {

--- a/sandbox/example/package.json
+++ b/sandbox/example/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"This is an example for sandbox\""
   },
   "engines": {
-    "node": ">=8.9"
+    "node": ">=10"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v8.x is now end of life. Please upgrade to version
10 and above. See https://nodejs.org/en/about/releases.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
