### PR TITLE
chore: use configure/@config for RestExplorer component

### DIFF
--- a/docs/site/tutorials/authentication/Authentication-Tutorial.md
+++ b/docs/site/tutorials/authentication/Authentication-Tutorial.md
@@ -1272,7 +1272,7 @@ export class ShoppingApplication extends BootMixin(
     this.static('/', path.join(__dirname, '../public'));
 
     // Customize @loopback/rest-explorer configuration here
-    this.bind(RestExplorerBindings.CONFIG).to({
+    this.configure(RestExplorerBindings.COMPONENT).to({
       path: '/explorer',
     });
     this.component(RestExplorerComponent);

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -33,7 +33,7 @@ export class <%= project.applicationName %> extends BootMixin(RestApplication) {
     this.static('/', path.join(__dirname, '../public'));
 
     // Customize @loopback/rest-explorer configuration here
-    this.bind(RestExplorerBindings.CONFIG).to({
+    this.configure(RestExplorerBindings.COMPONENT).to({
       path: '/explorer',
     });
     this.component(RestExplorerComponent);

--- a/packages/rest-explorer/README.md
+++ b/packages/rest-explorer/README.md
@@ -97,7 +97,7 @@ constructor of your custom Application class. Typically the component will be
 located in `./src/application.ts` and consist of two items, for example:
 
 ```ts
-this.bind(RestExplorerBindings.CONFIG).to({
+this.configure(RestExplorerBindings.COMPONENT).to({
   path: '/openapi/ui',
 });
 this.component(RestExplorerComponent);

--- a/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
+++ b/packages/rest-explorer/src/__tests__/acceptance/rest-explorer.express.acceptance.ts
@@ -92,7 +92,7 @@ describe('REST Explorer mounted as an express router', () => {
     options.rest = givenHttpServerConfig(options.rest);
     const app = new RestApplication(options);
     if (explorerConfig) {
-      app.bind(RestExplorerBindings.CONFIG).to(explorerConfig);
+      app.configure(RestExplorerBindings.COMPONENT).to(explorerConfig);
     }
     app.component(RestExplorerComponent);
     server = await app.getServer(RestServer);

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -3,7 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import {config, inject} from '@loopback/context';
 import {
   OpenApiSpecForm,
   RequestContext,
@@ -35,7 +36,7 @@ export class ExplorerController {
   constructor(
     @inject(RestBindings.CONFIG, {optional: true})
     restConfig: RestServerConfig = {},
-    @inject(RestExplorerBindings.CONFIG, {optional: true})
+    @config({fromBinding: RestExplorerBindings.COMPONENT})
     explorerConfig: RestExplorerConfig = {},
     @inject(RestBindings.BASE_PATH) private serverBasePath: string,
     @inject(RestBindings.SERVER) private restServer: RestServer,

--- a/packages/rest-explorer/src/rest-explorer.keys.ts
+++ b/packages/rest-explorer/src/rest-explorer.keys.ts
@@ -11,9 +11,18 @@ import {RestExplorerConfig} from './rest-explorer.types';
  * Binding keys used by this component.
  */
 export namespace RestExplorerBindings {
+  /**
+   * Binding key for RestExplorerComponent
+   */
   export const COMPONENT = BindingKey.create<RestExplorerComponent>(
     'components.RestExplorerComponent',
   );
+  /**
+   * Binding key for configuration of RestExplorerComponent.
+   *
+   * We recommend `ctx.configure(RestExplorerBindings.COMPONENT)` to be used
+   * instead of `ctx.bind(RestExplorerBindings.CONFIG)`.
+   */
   export const CONFIG = BindingKey.buildKeyForConfig<RestExplorerConfig>(
     COMPONENT,
   );


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
