### PR TITLE
paramTypes does not always exist

### DIFF
--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -320,7 +320,7 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
       constructor.prototype,
       op,
     );
-    const paramTypes = opMetadata.parameterTypes;
+    const paramTypes = opMetadata.parameterTypes || [];
 
     const isComplexType = (ctor: Function) =>
       !includes([String, Number, Boolean, Array, Object], ctor);


### PR DESCRIPTION
Adding this condition, made the following code example work.

```
import {ApplicationConfig} from '@loopback/core';
import {RestApplication, RestServer, get, param} from '@loopback/rest';


export class HelloController {
  @get('/hello/{name}')
  hello(@param.path.string('name') name: string): string {
    return `hello ${name}`;
  }
}

export class HelloWorldApplication extends RestApplication {
  constructor(options: ApplicationConfig = {}) {
    super(options);

    this.controller(HelloController);
  }

  async start() {
    await super.start();
    const rest = await this.getServer(RestServer);
    console.log(
      `REST server running on localhost:${await rest.get('rest.port')}`,
    );
  }
}
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
