### PR TITLE
docs: correct controller base path

### DIFF
--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -49,12 +49,12 @@ And voilà! We now have a set of basic APIs for todo-lists, just like that!
 In order to get our related `Todo`s for each `TodoList`, let's update the
 `schema`.
 
-In `src/models/todo-list.controller.ts`, first import `getModelSchemaRef` from
-`@loopback/rest`.
+In `src/controllers/todo-list.controller.ts`, first import `getModelSchemaRef`
+from `@loopback/rest`.
 
 Then update the following `schema`s in `responses`'s `content`:
 
-{% include code-caption.html content="src/models/todo-list.controller.ts" %}
+{% include code-caption.html content="src/controllers/todo-list.controller.ts" %}
 
 ```ts
 @get('/todo-lists', {
@@ -91,7 +91,7 @@ async findById(/*...*/) {/*...*/}
 
 Let's also update it in the `TodoController`:
 
-{% include code-caption.html content="src/models/todo.controller.ts" %}
+{% include code-caption.html content="src/controllers/todo.controller.ts" %}
 
 ```ts
 @get('/todos', {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

File paths contain the 'models' directory. Replaced by 'controllers'.

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
