### PR TITLE
Fix Windows-related issues in CLI tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "Run Mocha tests",
-      "program": "${workspaceRoot}/packages/build/node_modules/.bin/_mocha",
+      "program": "${workspaceRoot}/packages/build/node_modules/mocha/bin/_mocha",
       "cwd": "${workspaceRoot}",
       "args": [
         "--config",

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -81,7 +81,10 @@ describe('lb4 model integration', () => {
     assert.file(expectedModelFile);
   });
 
-  it('discovers a model from a datasource', async () => {
+  it('discovers a model from a datasource', async function() {
+    // This test takes a bit longer to finish on Windows.
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(3000);
     await testUtils
       .executeGenerator(generator)
       .inDir(SANDBOX_PATH, () =>

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -247,7 +247,7 @@ describe('lb4 model integration', () => {
       );
       assert.fileContent(
         expectedModelFile,
-        /export interface TestRelations {\n {2}\/\/ describe navigational properties here\n}/,
+        /export interface TestRelations {\r?\n {2}\/\/ describe navigational properties here\r?\n}/,
       );
     });
 

--- a/packages/cli/test/snapshot-matcher.js
+++ b/packages/cli/test/snapshot-matcher.js
@@ -107,7 +107,16 @@ function matchSnapshot(snapshotDir, currentTest, actualValue) {
     );
   }
 
-  assert.deepStrictEqual(actualValue, snapshotData[key]);
+  // When running on Windows, `actualValue` may be using `\r\n` as EOL.
+  // We are normalizing snapshot data to use `\n` as EOL, but depending on
+  // git settings, the content can be converted during git checkout to
+  // use `\r\n` instead.
+  // For maximum safety, we normalize line endings in both actual and expected
+  // values.
+  assert.deepStrictEqual(
+    normalizeNewlines(actualValue),
+    normalizeNewlines(snapshotData[key]),
+  );
 }
 
 function recordSnapshot(snapshots, currentTest, actualValue) {


### PR DESCRIPTION
While investigating failing `npm test` on Windows (see #4425), I have identified few more issues to fix:

- fix VSCode launch task for Mocha to work on Windows 
- increase timeout in a test running longer on Windows (this may fix the timing-related issues described in https://github.com/strongloop/loopback-next/issues/4425#issuecomment-584100049)
- fix source-code check to allow `\r\n` line ending on Windows
- normalize EOL values when comparing snapshots

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
