### PR TITLE
docs: fix typo in Component doc

### DIFF
--- a/docs/site/Components.md
+++ b/docs/site/Components.md
@@ -26,9 +26,9 @@ properties:
 - `classes` - A map of TypeScipt classes to be bound to the application context.
 - `servers` - A map of name/class pairs for [servers](Server.md).
 - `lifeCycleObservers` - An array of [life cycle observers](Life-cycle.md).
-- `bindings` - An array of [bindings](Bindings.md) to be aded to the application
-  context. A good example of using bindings to extend the functionality of a
-  LoopBack 4 app is
+- `bindings` - An array of [bindings](Bindings.md) to be added to the
+  application context. A good example of using bindings to extend the
+  functionality of a LoopBack 4 app is
   [contributing an additional body parser](Extending-request-body-parsing.html#contribute-a-body-parser-from-a-component).
 
 These properties contribute to the application to add additional features and


### PR DESCRIPTION
Change 'aded' to 'added'

Signed-off-by: Dominique Emond <dremond@ca.ibm.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
