### PR TITLE
chore(docs): fix feature parity link

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -15,7 +15,7 @@ multiple repos, as in v3. However, examples and externally-developed components
 will be in separate repositories.
 '%}
 
-{% include important.html content="Certain features from LoopBack 3 may still be a work in progress or are not planned to be migrated to LoopBack 4. See [Understanding the differences](understanding-the-differences.md)." %}
+{% include important.html content="Certain features from LoopBack 3 may still be a work in progress or are not planned to be migrated to LoopBack 4. See [Understanding the differences](Understanding-the-differences.md)." %}
 
 LoopBack is a highly extensible, open-source Node.js and TypeScript framework
 based on Express that enables you to quickly create APIs and microservices


### PR DESCRIPTION
See #4466

Fix a minor typo that prevents Jekyll from parsing and converting the
link into a navigatable URL.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
