### PR TITLE
fix: extend test timeout for windows

### DIFF
--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -263,7 +263,11 @@ describe('app-generator with tilde project path', () => {
   const cwd = process.cwd();
 
   // If the test runs outside $home directory
-  if (process.env.CI && !process.env.DEBUG && tildify(sandbox) === sandbox) {
+  const runsOutsideRoot =
+    process.env.CI && !process.env.DEBUG && tildify(sandbox) === sandbox
+      ? true
+      : false;
+  if (runsOutsideRoot) {
     sandbox = path.join(os.homedir(), '.lb4sandbox/tilde-path-app');
     pathWithTilde = '~/.lb4sandbox/tilde-path-app';
   }
@@ -295,7 +299,12 @@ describe('app-generator with tilde project path', () => {
     // eslint-disable-next-line no-invalid-this
     this.timeout(30 * 1000);
 
-    process.chdir(sandbox);
+    // Handle special case - Skipping... not inside the project root directory.
+    if (runsOutsideRoot) {
+      process.chdir(sandbox);
+    } else {
+      process.chdir(rootDir);
+    }
     build.clean(['node', 'run-clean', sandbox]);
     process.chdir(cwd);
   });

--- a/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
+++ b/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
@@ -196,7 +196,10 @@ describe('HttpCachingProxy', () => {
     expect(result2).to.equal('2');
   });
 
-  it('handles the case where backend service is not running', async () => {
+  it('handles the case where backend service is not running', async function() {
+    // This test takes a bit longer to finish on windows.
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(3000);
     await givenRunningProxy({logError: false});
 
     await expect(

--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -44,7 +44,10 @@ describe('HttpServer (integration)', () => {
       .expect(200);
   });
 
-  it('stops server', async () => {
+  it('stops server', async function() {
+    // This test takes a bit longer to finish on windows.
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(3000);
     const serverOptions = givenHttpServerConfig();
     server = new HttpServer(dummyRequestHandler, serverOptions);
     await server.start();
@@ -52,7 +55,10 @@ describe('HttpServer (integration)', () => {
     await expect(httpGetAsync(server.url)).to.be.rejectedWith(/ECONNREFUSED/);
   });
 
-  it('stops server with grace period and inflight request', async () => {
+  it('stops server with grace period and inflight request', async function() {
+    // This test takes a bit longer to finish on windows.
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(3000);
     const serverOptions = givenHttpServerConfig() as HttpServerOptions;
     serverOptions.gracePeriodForClose = 1000;
     const {emitter, deferredRequestHandler} = createDeferredRequestHandler();
@@ -77,7 +83,10 @@ describe('HttpServer (integration)', () => {
     await expect(httpGetAsync(server.url)).to.be.rejectedWith(/ECONNREFUSED/);
   });
 
-  it('stops server with shorter grace period and inflight request', async () => {
+  it('stops server with shorter grace period and inflight request', async function() {
+    // This test takes a bit longer to finish on windows.
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(3000);
     const serverOptions = givenHttpServerConfig() as HttpServerOptions;
     serverOptions.gracePeriodForClose = 10;
     const {deferredRequestHandler} = createDeferredRequestHandler();


### PR DESCRIPTION
Give windows extra time to complete tests
Fixes #4425

fix: cleanup tilde-path-app post test …
ensure test app is remove afterward
Fixes #4652

## Checklist

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)