### PR TITLE
feat: .vscode add no spaces in braces + single quotes typescript rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,8 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "typescript.tsdk": "./packages/build/node_modules/typescript/lib",
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
+  "typescript.preferences.quoteStyle": "single",
   "eslint.run": "onSave",
   "eslint.nodePath": "./packages/build/node_modules",
   "eslint.validate": [

--- a/packages/cli/generators/project/templates/.vscode/settings.json
+++ b/packages/cli/generators/project/templates/.vscode/settings.json
@@ -4,6 +4,10 @@
   "editor.tabSize": 2,
   "editor.trimAutoWhitespace": true,
   "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true,
+    "source.fixAll.eslint": true
+  },
 
   "files.exclude": {
     "**/.DS_Store": true,
@@ -17,13 +21,12 @@
   "files.trimTrailingWhitespace": true,
 
   "typescript.tsdk": "./node_modules/typescript/lib",
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
+  "typescript.preferences.quoteStyle": "single",
   "eslint.run": "onSave",
   "eslint.nodePath": "./node_modules",
   "eslint.validate": [
     "javascript",
     "typescript"
-  ],
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
+  ]
 }


### PR DESCRIPTION
useful rule for when Prettier not enabled.

Implements #4584

Signed-off-by: Douglas McConnachie <dougal83+git@gmail.com>

## Checklist

- [x] `npm test` passes on your machine
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
