### PR TITLE
fix(example-todo): throw if geocode address is not found

### DIFF
--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -225,8 +225,15 @@ export class TodoController {
     todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
     if (todo.remindAtAddress) {
-      // TODO handle "address not found"
       const geo = await this.geoService.geocode(todo.remindAtAddress);
+
+      if (!geo[0]) {
+        // address not found
+        throw new HttpErrors.BadRequest(
+          `Address not found: ${todo.remindAtAddress}`,
+        );
+      }
+
       // Encode the coordinates as "lat,lng" (Google Maps API format). See also
       // https://stackoverflow.com/q/7309121/69868
       // https://gis.stackexchange.com/q/7379

--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -106,6 +106,24 @@ describe('TodoApplication', () => {
     expect(result).to.containEql(todo);
   });
 
+  it('returns 400 if it cannot find an address', async function() {
+    // eslint-disable-next-line no-invalid-this
+    if (!available) return this.skip();
+    // Increase the timeout to accommodate slow network connections
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(30000);
+
+    const todo = givenTodo({remindAtAddress: 'this address does not exist'});
+    const response = await client
+      .post('/todos')
+      .send(todo)
+      .expect(400);
+
+    expect(response.body.error.message).to.eql(
+      'Address not found: this address does not exist',
+    );
+  });
+
   context('when dealing with a single persisted todo', () => {
     let persistedTodo: Todo;
 

--- a/examples/todo/src/controllers/todo.controller.ts
+++ b/examples/todo/src/controllers/todo.controller.ts
@@ -10,6 +10,7 @@ import {
   get,
   getFilterSchemaFor,
   getModelSchemaRef,
+  HttpErrors,
   param,
   patch,
   post,
@@ -45,8 +46,14 @@ export class TodoController {
     todo: Omit<Todo, 'id'>,
   ): Promise<Todo> {
     if (todo.remindAtAddress) {
-      // TODO(bajtos) handle "address not found"
       const geo = await this.geoService.geocode(todo.remindAtAddress);
+
+      if (!geo[0]) {
+        // address not found
+        throw new HttpErrors.BadRequest(
+          `Address not found: ${todo.remindAtAddress}`,
+        );
+      }
       // Encode the coordinates as "lat,lng" (Google Maps API format). See also
       // https://stackoverflow.com/q/7309121/69868
       // https://gis.stackexchange.com/q/7379


### PR DESCRIPTION
Throw an error if the geocoder service cannot find the address.

Related PR https://github.com/strongloop/loopback-next/pull/3512
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
