### PR TITLE
fix(docs): update connector reference to lb4 link

### DIFF
--- a/docs/site/Calling-other-APIs-and-Web-Services.md
+++ b/docs/site/Calling-other-APIs-and-Web-Services.md
@@ -104,11 +104,11 @@ The next step is to edit the DataSource JSON file for `options` and
 The REST connector uses the
 [request module](https://www.npmjs.com/package/request) as the HTTP client. You
 can configure the same options as for the `request()` function. See details in
-[this documentation page](https://loopback.io/doc/en/lb3/REST-connector.html#configure-options-for-request).
+[this documentation page](https://loopback.io/doc/en/lb4/REST-connector.html#configure-options-for-request).
 
 The `template` object specifies the REST API invocation as a JSON template. You
 can find more details in the
-[Defining a custom method using a template page](https://loopback.io/doc/en/lb3/REST-connector.html#defining-a-custom-method-using-a-template).
+[Defining a custom method using a template page](https://loopback.io/doc/en/lb4/REST-connector.html#defining-a-custom-method-using-a-template).
 
 ```json
 {
@@ -223,9 +223,9 @@ Service interface.
 ## More examples
 
 - SOAP web service tutorial:
-  https://loopback.io/doc/en/lb4/soap-calculator-tutorial.html
+  [https://loopback.io/doc/en/lb4/soap-calculator-tutorial.html](https://loopback.io/doc/en/lb4/soap-calculator-tutorial.html)
 - REST service tutorial:
-  https://loopback.io/doc/en/lb4/todo-tutorial-geocoding-service.html
+  [https://loopback.io/doc/en/lb4/todo-tutorial-geocoding-service.html](https://loopback.io/doc/en/lb4/todo-tutorial-geocoding-service.html)
 
 ## Testing your application
 

--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -58,7 +58,7 @@ Datasource Geocoder was created in src/datasources/
 
 Edit the newly created datasource configuration to configure Geocoder API
 endpoints. Configuration options provided by REST Connector are described in our
-docs here: [REST connector](/doc/en/lb3/REST-connector.html).
+docs here: [REST connector](/doc/en/lb4/REST-connector.html).
 
 {% include code-caption.html content="/src/datasources/geocoder.datasource.config.json" %}
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Now that we have the connector reference under /doc/lb4, it's time to update the URL reference in the following 2 pages:
- Calling other APIs and web services
- todo tutorial


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
