### PR TITLE
feat: enable `importHelpers` option for TypeScript compilation

### DIFF
--- a/acceptance/extension-logging-fluentd/package-lock.json
+++ b/acceptance/extension-logging-fluentd/package-lock.json
@@ -545,6 +545,12 @@
 			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
 			"dev": true
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+			"dev": true
+		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",

--- a/acceptance/extension-logging-fluentd/package.json
+++ b/acceptance/extension-logging-fluentd/package.json
@@ -24,7 +24,8 @@
     "@loopback/extension-logging": "^0.1.0",
     "@loopback/testlab": "^1.9.2",
     "@types/node": "^10.17.16",
-    "testcontainers": "^2.4.0"
+    "testcontainers": "^2.4.0",
+    "tslib": "^1.11.0"
   },
   "files": [
     "README.md",

--- a/acceptance/repository-cloudant/package-lock.json
+++ b/acceptance/repository-cloudant/package-lock.json
@@ -1369,6 +1369,12 @@
 				"punycode": "^2.1.1"
 			}
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+			"dev": true
+		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",

--- a/acceptance/repository-cloudant/package.json
+++ b/acceptance/repository-cloudant/package.json
@@ -30,6 +30,7 @@
     "lodash": "^4.17.11",
     "loopback-connector-cloudant": "2.4.0",
     "ms": "2.1.2",
+    "tslib": "^1.11.0",
     "typescript": "~3.8.2"
   },
   "files": [

--- a/acceptance/repository-mongodb/package-lock.json
+++ b/acceptance/repository-mongodb/package-lock.json
@@ -675,6 +675,12 @@
 				}
 			}
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+			"dev": true
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/acceptance/repository-mongodb/package.json
+++ b/acceptance/repository-mongodb/package.json
@@ -23,7 +23,8 @@
     "@loopback/repository": "^1.19.1",
     "@loopback/repository-tests": "^0.10.1",
     "@types/node": "^10.17.16",
-    "loopback-connector-mongodb": "^5.2.2"
+    "loopback-connector-mongodb": "^5.2.2",
+    "tslib": "^1.11.0"
   },
   "files": [
     "README.md",

--- a/acceptance/repository-mysql/package-lock.json
+++ b/acceptance/repository-mysql/package-lock.json
@@ -665,6 +665,12 @@
 				}
 			}
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+			"dev": true
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/acceptance/repository-mysql/package.json
+++ b/acceptance/repository-mysql/package.json
@@ -23,7 +23,8 @@
     "@loopback/repository": "^1.19.1",
     "@loopback/repository-tests": "^0.10.1",
     "@types/node": "^10.17.16",
-    "loopback-connector-mysql": "^5.4.2"
+    "loopback-connector-mysql": "^5.4.2",
+    "tslib": "^1.11.0"
   },
   "files": [
     "README.md",

--- a/acceptance/repository-postgresql/package-lock.json
+++ b/acceptance/repository-postgresql/package-lock.json
@@ -503,9 +503,9 @@
 			"dev": true
 		},
 		"pg": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/pg/-/pg-7.18.1.tgz",
-			"integrity": "sha512-1KtKBKg/zWrjEEv//klBbVOPGucuc7HHeJf6OEMueVcUeyF3yueHf+DvhVwBjIAe9/97RAydO/lWjkcMwssuEw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
+			"integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
 			"dev": true,
 			"requires": {
 				"buffer-writer": "2.0.0",
@@ -792,6 +792,12 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
 			"dev": true
 		},
 		"util-deprecate": {

--- a/acceptance/repository-postgresql/package.json
+++ b/acceptance/repository-postgresql/package.json
@@ -23,7 +23,8 @@
     "@loopback/repository": "^1.19.1",
     "@loopback/repository-tests": "^0.10.1",
     "@types/node": "^10.17.16",
-    "loopback-connector-postgresql": "^3.8.3"
+    "loopback-connector-postgresql": "^3.8.3",
+    "tslib": "^1.11.0"
   },
   "files": [
     "README.md",

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -1188,6 +1188,11 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -42,7 +42,8 @@
     "axios": "^0.19.2",
     "byline": "^5.0.0",
     "debug": "^4.1.1",
-    "path-to-regexp": "^6.1.0"
+    "path-to-regexp": "^6.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -27,6 +27,11 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,6 +32,7 @@
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
   "dependencies": {
-    "fs-extra": "^8.1.0"
+    "fs-extra": "^8.1.0",
+    "tslib": "^1.11.0"
   }
 }

--- a/examples/context/package-lock.json
+++ b/examples/context/package-lock.json
@@ -1071,10 +1071,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -37,7 +37,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@loopback/context": "^2.1.1"
+    "@loopback/context": "^2.1.1",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/express-composition/package-lock.json
+++ b/examples/express-composition/package-lock.json
@@ -1492,10 +1492,9 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -52,7 +52,8 @@
     "@loopback/rest-explorer": "^1.4.10",
     "@loopback/service-proxy": "^1.3.17",
     "express": "^4.17.1",
-    "p-event": "^4.1.0"
+    "p-event": "^4.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/greeter-extension/package-lock.json
+++ b/examples/greeter-extension/package-lock.json
@@ -1252,10 +1252,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -62,6 +62,7 @@
     "@loopback/core": "^1.12.4",
     "@loopback/openapi-v3": "^2.0.0",
     "chalk": "^3.0.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   }
 }

--- a/examples/greeting-app/package-lock.json
+++ b/examples/greeting-app/package-lock.json
@@ -1252,10 +1252,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -65,6 +65,7 @@
     "@loopback/openapi-v3": "^2.0.0",
     "@loopback/rest": "^2.0.0",
     "chalk": "^3.0.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   }
 }

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -1071,10 +1071,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -38,7 +38,8 @@
   "license": "MIT",
   "dependencies": {
     "@loopback/core": "^1.12.4",
-    "@loopback/rest": "^2.0.0"
+    "@loopback/rest": "^2.0.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/lb3-application/package-lock.json
+++ b/examples/lb3-application/package-lock.json
@@ -2846,10 +2846,9 @@
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -50,7 +50,8 @@
     "helmet": "^3.21.2",
     "loopback": "^3.26.0",
     "loopback-boot": "^3.3.1",
-    "p-event": "^4.1.0"
+    "p-event": "^4.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/log-extension/package-lock.json
+++ b/examples/log-extension/package-lock.json
@@ -1252,10 +1252,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -60,6 +60,7 @@
     "@loopback/openapi-v3": "^2.0.0",
     "@loopback/rest": "^2.0.0",
     "chalk": "^3.0.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   }
 }

--- a/examples/metrics-prometheus/package-lock.json
+++ b/examples/metrics-prometheus/package-lock.json
@@ -1071,10 +1071,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -41,7 +41,8 @@
     "@loopback/boot": "^1.7.4",
     "@loopback/core": "^1.12.4",
     "@loopback/extension-metrics": "^0.1.6",
-    "@loopback/rest": "^2.0.0"
+    "@loopback/rest": "^2.0.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/rpc-server/package-lock.json
+++ b/examples/rpc-server/package-lock.json
@@ -1492,10 +1492,9 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -41,7 +41,8 @@
     "@loopback/context": "^2.1.1",
     "@loopback/core": "^1.12.4",
     "express": "^4.17.1",
-    "p-event": "^4.1.0"
+    "p-event": "^4.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/soap-calculator/package-lock.json
+++ b/examples/soap-calculator/package-lock.json
@@ -2139,10 +2139,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -48,7 +48,8 @@
     "@loopback/rest": "^2.0.0",
     "@loopback/rest-explorer": "^1.4.10",
     "@loopback/service-proxy": "^1.3.17",
-    "loopback-connector-soap": "^5.1.0"
+    "loopback-connector-soap": "^5.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/todo-list/package-lock.json
+++ b/examples/todo-list/package-lock.json
@@ -1538,10 +1538,9 @@
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -44,7 +44,8 @@
     "@loopback/rest": "^2.0.0",
     "@loopback/rest-explorer": "^1.4.10",
     "@loopback/service-proxy": "^1.3.17",
-    "loopback-connector-rest": "^3.6.0"
+    "loopback-connector-rest": "^3.6.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/examples/todo/package-lock.json
+++ b/examples/todo/package-lock.json
@@ -1538,10 +1538,9 @@
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -44,7 +44,8 @@
     "@loopback/rest": "^2.0.0",
     "@loopback/rest-explorer": "^1.4.10",
     "@loopback/service-proxy": "^1.3.17",
-    "loopback-connector-rest": "^3.6.0"
+    "loopback-connector-rest": "^3.6.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/extensions/authentication-passport/package-lock.json
+++ b/extensions/authentication-passport/package-lock.json
@@ -119,6 +119,11 @@
 			"resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
 			"integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"util-promisifyall": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/util-promisifyall/-/util-promisifyall-1.0.6.tgz",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -48,6 +48,7 @@
     "@loopback/rest": "^2.0.0",
     "@loopback/security": "^0.1.13",
     "passport": "^0.4.1",
+    "tslib": "^1.11.0",
     "util-promisifyall": "^1.0.6"
   },
   "devDependencies": {

--- a/extensions/health/package-lock.json
+++ b/extensions/health/package-lock.json
@@ -35,6 +35,11 @@
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -20,7 +20,8 @@
     "@cloudnative/health": "^2.1.2",
     "@loopback/core": "^1.12.4",
     "@loopback/rest": "^2.0.0",
-    "p-event": "^4.1.0"
+    "p-event": "^4.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/extensions/logging/package-lock.json
+++ b/extensions/logging/package-lock.json
@@ -406,6 +406,11 @@
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
 			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -21,6 +21,7 @@
     "@loopback/rest": "^2.0.0",
     "fluent-logger": "^3.4.1",
     "morgan": "^1.9.1",
+    "tslib": "^1.11.0",
     "winston": "^3.2.1",
     "winston-transport": "^4.3.0"
   },

--- a/extensions/metrics/package-lock.json
+++ b/extensions/metrics/package-lock.json
@@ -505,6 +505,11 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -19,7 +19,8 @@
     "@loopback/context": "^2.1.1",
     "@loopback/core": "^1.12.4",
     "@loopback/rest": "^2.0.0",
-    "prom-client": "^12.0.0"
+    "prom-client": "^12.0.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7787,9 +7787,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+      "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
       "dev": true
     },
     "tsutils": {

--- a/packages/authentication/package-lock.json
+++ b/packages/authentication/package-lock.json
@@ -209,6 +209,11 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -27,7 +27,8 @@
     "@loopback/security": "^0.1.13",
     "@types/express": "^4.17.2",
     "@types/lodash": "^4.14.149",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/authorization/package-lock.json
+++ b/packages/authorization/package-lock.json
@@ -73,6 +73,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -25,7 +25,8 @@
     "@loopback/context": "^2.1.1",
     "@loopback/core": "^1.12.4",
     "@loopback/security": "^0.1.13",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/boot/package-lock.json
+++ b/packages/boot/package-lock.json
@@ -127,6 +127,11 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -30,7 +30,8 @@
     "@types/debug": "^4.1.5",
     "@types/glob": "^7.1.1",
     "debug": "^4.1.1",
-    "glob": "^7.1.6"
+    "glob": "^7.1.6",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/booter-lb3app/package-lock.json
+++ b/packages/booter-lb3app/package-lock.json
@@ -2538,6 +2538,11 @@
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -21,7 +21,8 @@
     "loopback": "^3.26.0",
     "loopback-swagger": "^5.8.0",
     "p-event": "^4.1.0",
-    "swagger2openapi": "^5.3.3"
+    "swagger2openapi": "^5.3.3",
+    "tslib": "^1.11.0"
   },
   "peerDependencies": {
     "@loopback/boot": "^1.2.2",

--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -18,6 +18,7 @@
     "moduleResolution": "node",
     "target": "es2017",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "importHelpers": true
   }
 }

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -2230,9 +2230,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -84,13 +84,14 @@
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
 <% if (project.services) { -%>
     "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",
-    "@loopback/service-proxy": "<%= project.dependencies['@loopback/service-proxy'] -%>"
+    "@loopback/service-proxy": "<%= project.dependencies['@loopback/service-proxy'] -%>",
 <% } else { -%>
-    "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>"
+    "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",
 <% } -%>
 <% } else { /* NOT AN APPLICATION */-%>
-    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>"
+    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
 <% } -%>
+  "tslib": "<%= project.dependencies['tslib'] -%>"
   },
   "devDependencies": {
     "@loopback/build": "<%= project.dependencies['@loopback/build'] -%>",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -79,10 +79,11 @@
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
-    "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>"
+    "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",
 <% } else { -%>
-    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>"
+    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
 <% } -%>
+  "tslib": "<%= project.dependencies['tslib'] -%>"
   },
   "devDependencies": {
     "rimraf": "<%= project.dependencies['rimraf'] -%>",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2067,15 +2067,16 @@
 			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
 		},
 		"fast-glob": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
-			"integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.1.tgz",
+			"integrity": "sha512-XObtOQLTl4EptWcBbO9O6wd17VlVf9YXYY/zuzuu7nZfTsv4BL3KupMAMUVzH88CUwWkI3uNHBfxtfU8PveVTQ==",
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.0",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.2"
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
 			}
 		},
 		"fast-json-patch": {
@@ -6706,9 +6707,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -96,6 +96,7 @@
       "rimraf": "^3.0.1",
       "source-map-support": "^0.5.16",
       "typescript": "~3.8.2",
+      "tslib": "^1.10.0",
       "@loopback/authentication": "^3.3.3",
       "@loopback/boot": "^1.7.4",
       "@loopback/build": "^3.1.1",

--- a/packages/context/package-lock.json
+++ b/packages/context/package-lock.json
@@ -68,6 +68,11 @@
 				"p-finally": "^1.0.0"
 			}
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -21,6 +21,7 @@
     "@loopback/metadata": "^1.4.1",
     "debug": "^4.1.1",
     "p-event": "^4.1.0",
+    "tslib": "^1.11.0",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -49,6 +49,11 @@
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@loopback/context": "^2.1.1",
     "debug": "^4.1.1",
-    "p-event": "^4.1.0"
+    "p-event": "^4.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/http-caching-proxy/package-lock.json
+++ b/packages/http-caching-proxy/package-lock.json
@@ -525,6 +525,11 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"tunnel": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -20,7 +20,8 @@
     "cacache": "^15.0.0",
     "debug": "^4.1.1",
     "p-event": "^4.1.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/http-server/package-lock.json
+++ b/packages/http-server/package-lock.json
@@ -44,6 +44,11 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "p-event": "^4.1.0",
-    "stoppable": "^1.1.0"
+    "stoppable": "^1.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/metadata/package-lock.json
+++ b/packages/metadata/package-lock.json
@@ -44,6 +44,11 @@
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
 			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/model-api-builder/package-lock.json
+++ b/packages/model-api-builder/package-lock.json
@@ -9,6 +9,11 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.16.tgz",
 			"integrity": "sha512-A4283YSA1OmnIivcpy/4nN86YlnKRiQp8PYwI2KdPCONEBN093QTb0gCtERtkLyVNGKKIGazTZ2nAmVzQU51zA==",
 			"dev": true
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -41,5 +41,8 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "packages/model-api-builder"
+  },
+  "dependencies": {
+    "tslib": "^1.11.0"
   }
 }

--- a/packages/openapi-spec-builder/package-lock.json
+++ b/packages/openapi-spec-builder/package-lock.json
@@ -14,6 +14,11 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-1.3.0.tgz",
 			"integrity": "sha512-Xk3hsB0PzB4dzr/r/FdmK+VfQbZH7lQQ2iipMS1/1eoz1wUvh5R7rmOakYvw0bQJJE6PYrOLx8UHsYmzgTr+YQ=="
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -23,7 +23,8 @@
     "Testing"
   ],
   "dependencies": {
-    "openapi3-ts": "^1.3.0"
+    "openapi3-ts": "^1.3.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/openapi-v3/package-lock.json
+++ b/packages/openapi-v3/package-lock.json
@@ -217,6 +217,11 @@
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
 			}
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -12,7 +12,8 @@
     "http-status": "^1.4.2",
     "json-merge-patch": "^0.2.3",
     "lodash": "^4.17.15",
-    "openapi3-ts": "^1.3.0"
+    "openapi3-ts": "^1.3.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/repository-json-schema/package-lock.json
+++ b/packages/repository-json-schema/package-lock.json
@@ -70,6 +70,11 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -27,7 +27,8 @@
     "@loopback/metadata": "^1.4.1",
     "@loopback/repository": "^1.19.1",
     "@types/json-schema": "^7.0.4",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/repository-tests/package-lock.json
+++ b/packages/repository-tests/package-lock.json
@@ -39,6 +39,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -31,7 +31,8 @@
     "@loopback/context": "^2.1.1",
     "@loopback/testlab": "^1.10.3",
     "@types/debug": "^4.1.5",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   },
   "peerDependencies": {
     "@loopback/repository": "^1.6.1"

--- a/packages/repository/package-lock.json
+++ b/packages/repository/package-lock.json
@@ -698,9 +698,9 @@
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"upper-case": {
 			"version": "2.0.1",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -32,7 +32,8 @@
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
-    "loopback-datasource-juggler": "^4.18.1"
+    "loopback-datasource-juggler": "^4.18.1",
+    "tslib": "^1.11.0"
   },
   "files": [
     "README.md",

--- a/packages/rest-crud/package-lock.json
+++ b/packages/rest-crud/package-lock.json
@@ -28,6 +28,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "@loopback/model-api-builder": "^1.1.3",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^1.7.1",
@@ -29,8 +30,8 @@
     "@loopback/repository": "^1.19.1",
     "@loopback/rest": "^2.0.0",
     "@loopback/testlab": "^1.10.3",
-    "@types/node": "^10.17.16",
-    "@types/debug": "^4.1.5"
+    "@types/debug": "^4.1.5",
+    "@types/node": "^10.17.16"
   },
   "peerDependencies": {
     "@loopback/core": "^1.12.4",

--- a/packages/rest-explorer/package-lock.json
+++ b/packages/rest-explorer/package-lock.json
@@ -476,6 +476,11 @@
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -20,7 +20,8 @@
     "@loopback/core": "^1.12.4",
     "@loopback/rest": "^2.0.0",
     "ejs": "^3.0.1",
-    "swagger-ui-dist": "^3.25.0"
+    "swagger-ui-dist": "^3.25.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/rest/package-lock.json
+++ b/packages/rest/package-lock.json
@@ -1351,6 +1351,11 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -46,6 +46,7 @@
     "path-to-regexp": "^6.1.0",
     "qs": "^6.9.1",
     "strong-error-handler": "^3.4.0",
+    "tslib": "^1.11.0",
     "type-is": "^1.6.18",
     "validator": "^12.2.0"
   },

--- a/packages/security/package-lock.json
+++ b/packages/security/package-lock.json
@@ -28,6 +28,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		}
 	}
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@loopback/context": "^2.1.1",
     "@loopback/core": "^1.12.4",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/service-proxy/package-lock.json
+++ b/packages/service-proxy/package-lock.json
@@ -640,9 +640,9 @@
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"upper-case": {
 			"version": "2.0.1",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@loopback/context": "^2.1.1",
     "@loopback/core": "^1.12.4",
-    "loopback-datasource-juggler": "^4.18.1"
+    "loopback-datasource-juggler": "^4.18.1",
+    "tslib": "^1.11.0"
   },
   "files": [
     "README.md",

--- a/packages/testlab/package-lock.json
+++ b/packages/testlab/package-lock.json
@@ -1397,6 +1397,11 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -27,7 +27,8 @@
     "oas-validator": "^3.3.3",
     "should": "^13.2.3",
     "sinon": "^9.0.0",
-    "supertest": "^4.0.2"
+    "supertest": "^4.0.2",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",

--- a/packages/tsdocs/package-lock.json
+++ b/packages/tsdocs/package-lock.json
@@ -261,6 +261,11 @@
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
 		},
+		"tslib": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+		},
 		"typescript": {
 			"version": "3.7.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -24,7 +24,8 @@
     "@microsoft/api-documenter": "^7.7.12",
     "@microsoft/api-extractor": "^7.7.8",
     "debug": "^4.1.1",
-    "fs-extra": "^8.1.0"
+    "fs-extra": "^8.1.0",
+    "tslib": "^1.11.0"
   },
   "devDependencies": {
     "@loopback/build": "^3.1.1",


### PR DESCRIPTION
Closes #4676 

*1st commit* adds `tslib@1.10.0` as a `dependency` to packages dependent on `@loopback/build`.

Packages untouched by 1st commit: `build`, `cli`, `eslint-config`, `sandbox-example`

*2nd commit* **BREAKING CHANGE:** enables `importHelpers` in the shared `tsconfig.common.json` in `@loopback/build`.

*3rd commit* adds `tslib@1.10.0` as a CLI template dependency

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
