### PR TITLE
feat(eslint-config): disallow non-null assertions after optional chain

### DIFF
--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -91,6 +91,7 @@ module.exports = {
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/no-triple-slash-reference': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
+    '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
 
     /**
      * The following rules are enforced to support legacy tslint configuration


### PR DESCRIPTION
fixes #4675

BREAKING CHANGE: eslint rule `@typescript-eslint/no-non-null-asserted-optional-chain` is set to `error` which may break existing lint tests.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
