### PR TITLE
chore(build): add docs for code coverage

### DIFF
--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -980,3 +980,34 @@ that rejects anonymous requests for certain endpoints, then you can write a test
 making an anonymous request to those endpoints to verify that it's correctly
 rejected. These tests are essentially the same as the tests verifying
 implementation of individual endpoints as described in the previous section.
+
+# Code coverage
+
+`@loopback/build` contains a command line tool (`lb-nyc`) that acts as a wrapper
+for [`nyc`](https://github.com/istanbuljs/nyc).
+
+To set up code coverage:
+
+- Create `.nycrc` in your project's root directory
+
+  ```json
+  {
+    "include": ["dist"],
+    "exclude": ["dist/__tests__/"],
+    "extension": [".js", ".ts"],
+    "reporter": ["text", "html"],
+    "exclude-after-remap": false
+  }
+  ```
+
+- Update your `package.json` scripts:
+
+  ```json
+  "precoverage": "npm test",
+  "coverage": "open coverage/index.html",
+  "coverage:ci": "lb-nyc report --reporter=text-lcov | coveralls",
+  "test": "lb-nyc npm run mocha --scripts-prepend-node-path",
+  "test:ci": "lb-nyc npm run mocha --scripts-prepend-node-path"
+  ```
+
+  `converage:ci` sets up integration with [Coveralls](https://coveralls.io/).

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -101,6 +101,38 @@ Now you run the scripts, such as:
 npm run build
 ```
 
+5.  Run code coverage reports
+
+- `lb-nyc`
+
+  `lb-nyc` is a simple wrapper for [`nyc`](https://github.com/istanbuljs/nyc).
+
+  To customize the configuration:
+
+  - Create `.nycrc` in your project's root directory
+
+    ```json
+    {
+      "include": ["dist"],
+      "exclude": ["dist/__tests__/"],
+      "extension": [".js", ".ts"],
+      "reporter": ["text", "html"],
+      "exclude-after-remap": false
+    }
+    ```
+
+  - Update your `package.json` scripts:
+
+    ```json
+    "precoverage": "npm test",
+    "coverage": "open coverage/index.html",
+    "coverage:ci": "lb-nyc report --reporter=text-lcov | coveralls",
+    "test": "lb-nyc npm run mocha --scripts-prepend-node-path",
+    "test:ci": "lb-nyc npm run mocha --scripts-prepend-node-path"
+    ```
+
+    `converage:ci` sets up integration with [Coveralls](https://coveralls.io/).
+
 ## Contributions
 
 - [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md)


### PR DESCRIPTION
add docs for setting up code coverage using 'lb-nyc'

closes #3227
closes #3301

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
