### PR TITLE
feat(repository): add JSON Schema defs for model property

### DIFF
--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -18,6 +18,21 @@ import {Type} from './types';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export interface JsonSchemaWithExtensions extends JsonSchema {
+  /**
+   * A custom AJV error message if the JSON schema validation fails. See
+   * {@link https://loopback.io/doc/en/lb4/Parsing-requests.html#custom-error-messages | Custom error messages}.
+   *
+   * @example
+   * ```ts
+   * errorMessage: 'Generic error message for JSON schema validation'
+   * ```
+   */
+  errorMessage: string | AnyObject;
+
+  /**
+   * Allow custom keywords, see
+   * {@link https://github.com/epoberezkin/ajv-keywords}.
+   */
   [attributes: string]: any;
 }
 


### PR DESCRIPTION
see: #4645

Add JSON Schema definitions to the property definition to enable autocomplete.

**BREAKING CHANGE:** `ModelDefinitionSyntax` no longer accepts objects with
string key  and arbritary value pairs.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
