### PR TITLE
feat(testlab): remove legacy API `itSkippedOnTravis`

### DIFF
--- a/packages/testlab/src/skip.ts
+++ b/packages/testlab/src/skip.ts
@@ -74,39 +74,3 @@ export function skipOnTravis<ARGS extends unknown[], RETVAL>(
     return verb(name, ...args);
   }
 }
-
-/*** LEGACY API FOR BACKWARDS COMPATIBILITY ***/
-
-// TODO(semver-major) remove this code
-
-// Simplified test function type from Mocha
-export interface TestFn {
-  (this: TestContext): PromiseLike<unknown>;
-  (this: TestContext, done: Function): void;
-}
-
-// Type of "this" object provided by Mocha to test functions
-export interface TestContext {
-  skip(): this;
-  timeout(ms: number | string): this;
-  retries(n: number): this;
-  slow(ms: number): this;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [index: string]: any;
-}
-
-/**
- * Helper function for skipping tests on Travis env - legacy variant
- * supporting `it` only.
- *
- * @param expectation - The test name (the first argument of `it` function).
- * @param callback - The test function (the second argument of `it` function).
- *
- * @deprecated Use `skipOnTravis(it, name, fn)` instead.
- */
-export function itSkippedOnTravis(
-  expectation: string,
-  callback?: TestFn,
-): void {
-  skipOnTravis(it, expectation, callback);
-}


### PR DESCRIPTION
**BREAKING CHANGE**

The helper `itSkippedOnTravis` is no longer available, please change your tests to use `skipOnTravis` instead.

```diff
- itSkippedOnTravis('supports IPv6', () => {
+ skipOnTravis(it, 'supports IPv6', () => {
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
