### PR TITLE
feat(repository): remove generic parameters from `Inclusion` type

### DIFF
--- a/packages/repository/src/query.ts
+++ b/packages/repository/src/query.ts
@@ -169,9 +169,7 @@ export type Fields<MT = AnyObject> = {[P in keyof MT]?: boolean};
  * Example:
  * `{relation: 'aRelationName', scope: {<AFilterObject>}}`
  */
-export interface Inclusion<MT extends object = AnyObject> {
-  // ^^^ TODO(semver-major): remove the generic argument <MT>
-
+export interface Inclusion {
   relation: string;
 
   // Technically, we should restrict the filter to target model.
@@ -220,7 +218,7 @@ export interface Filter<MT extends object = AnyObject> {
   /**
    * To include related objects
    */
-  include?: Inclusion<MT>[];
+  include?: Inclusion[];
 }
 
 /**
@@ -561,7 +559,7 @@ export class FilterBuilder<MT extends object = AnyObject> {
    * @param i - A relation name, an array of relation names, or an `Inclusion`
    * object for the relation/scope definitions
    */
-  include(...i: (string | string[] | Inclusion<MT>)[]): this {
+  include(...i: (string | string[] | Inclusion)[]): this {
     if (this.filter.include == null) {
       this.filter.include = [];
     }

--- a/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
@@ -42,7 +42,7 @@ export function createHasManyInclusionResolver<
 
   return async function fetchHasManyModels(
     entities: Entity[],
-    inclusion: Inclusion<AnyObject>,
+    inclusion: Inclusion,
     options?: Options,
   ): Promise<((Target & TargetRelations)[] | undefined)[]> {
     if (!entities.length) return [];

--- a/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
@@ -39,7 +39,7 @@ export function createHasOneInclusionResolver<
 
   return async function fetchHasOneModel(
     entities: Entity[],
-    inclusion: Inclusion<AnyObject>,
+    inclusion: Inclusion,
     options?: Options,
   ): Promise<((Target & TargetRelations) | undefined)[]> {
     if (!entities.length) return [];

--- a/packages/repository/src/relations/relation.helpers.ts
+++ b/packages/repository/src/relations/relation.helpers.ts
@@ -11,10 +11,10 @@ import {
   Entity,
   EntityCrudRepository,
   Filter,
+  FilterBuilder,
   Inclusion,
   Options,
   Where,
-  FilterBuilder,
 } from '..';
 const debug = debugFactory('loopback:repository:relation-helpers');
 
@@ -84,7 +84,7 @@ export async function includeRelatedModels<
 >(
   targetRepository: EntityCrudRepository<T, unknown, Relations>,
   entities: T[],
-  include?: Inclusion<T>[],
+  include?: Inclusion[],
   options?: Options,
 ): Promise<(T & Relations)[]> {
   const result = entities as (T & Relations)[];

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {AnyObject, Options} from '../common-types';
+import {Options} from '../common-types';
 import {Entity} from '../model';
 import {Inclusion} from '../query';
 import {TypeResolver} from '../type-resolver';
@@ -180,7 +180,7 @@ export type InclusionResolver<S extends Entity, T extends Entity> = (
   /**
    * Inclusion requested by the user (e.g. scope constraints to apply).
    */
-  inclusion: Inclusion<AnyObject>,
+  inclusion: Inclusion,
   /**
    * Generic options object, e.g. carrying the Transaction object.
    */

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -530,7 +530,7 @@ export class DefaultCrudRepository<
    */
   protected async includeRelatedModels(
     entities: T[],
-    include?: Inclusion<T>[],
+    include?: Inclusion[],
     options?: Options,
   ): Promise<(T & Relations)[]> {
     return includeRelatedModels<T, Relations>(this, entities, include, options);


### PR DESCRIPTION
Ideally, `Inclusion` interface should use type information from the source model to restrict the allowed values in the filter for a target model. That is unfortunately rather difficult to achieve,
because an `Entity` does not provide type information about related models. We could use `{ModelName}WithRelations` interface for first-level inclusion, but that won't handle second-level (and deeper) inclusions. To keep things simple, `Inclusion` allows any filters and thus does not require any generic parameter.

**BREAKING CHANGE**

The type `Inclusion` is no longer generic. Please update your code and remove any generic arguments provided for the type.

```diff
- Inclusion<MyModel>
+ Inclusion
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
