### PR TITLE
feat(repository): make `targetsMany` property required

### DIFF
--- a/packages/repository/src/__tests__/integration/repositories/relation.factory.integration.ts
+++ b/packages/repository/src/__tests__/integration/repositories/relation.factory.integration.ts
@@ -217,6 +217,7 @@ class Order extends Entity {
     .addRelation({
       name: 'customer',
       type: RelationType.belongsTo,
+      targetsMany: false,
       source: Order,
       target: () => Customer,
       keyFrom: 'customerId',

--- a/packages/repository/src/__tests__/unit/errors/invalid-relation-error.test.ts
+++ b/packages/repository/src/__tests__/unit/errors/invalid-relation-error.test.ts
@@ -48,6 +48,7 @@ function givenAnErrorInstance() {
   return new InvalidRelationError('a reason', {
     name: 'products',
     type: RelationType.hasMany,
+    targetsMany: true,
     source: Category,
     target: () => Product,
   });

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -24,14 +24,12 @@ export interface RelationDefinitionBase {
    */
   type: RelationType;
 
-  // TODO(semver-major): We should make targetsMany as mandatory
-  // in next major release
   /**
    * True for relations targeting multiple instances (e.g. HasMany),
    * false for relations with a single target (e.g. BelongsTo, HasOne).
    * This property is needed by OpenAPI/JSON Schema generator.
    */
-  targetsMany?: boolean;
+  targetsMany: boolean;
 
   /**
    * The relation name, typically matching the name of the accessor property


### PR DESCRIPTION
Modify `RelationDefinitionBase` to require all relation definitions to provide value of `targetsMany` field.

**BREAKING CHANGE**

If you are building a custom relation type with its own definition interface, make sure the interface includes `targetsMany` property. Typically, the type of this property is hard-coded as `true` or `false`, depending on the relation type.

```ts
interface HasManyDefinition extends RelationDefinitionBase {
  type: RelationType.hasMany;
  targetsMany: true;
  // etc.
}

export interface BelongsToDefinition extends RelationDefinitionBase {
  type: RelationType.belongsTo;
  targetsMany: false;
  // etc.
}
```

When creating an instance of a relation definition, make sure to include a value for `targetsMany` property.

```ts
new ModelDefinition('Order')
  .addRelation({
    name: 'customer',
    type: RelationType.belongsTo,
    targetsMany: false,
    source: Order,
    target: () => Customer,
    keyFrom: 'customerId',
    keyTo: 'id',
  });
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
