### PR TITLE
feat(repository-json-schema): remove deprecated `MODEL_TYPE_KEYS`

### DIFF
--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -17,7 +17,6 @@ import {
   JsonSchema,
   JSON_SCHEMA_KEY,
   modelToJsonSchema,
-  MODEL_TYPE_KEYS,
 } from '../..';
 import {expectValidJsonSchema} from '../helpers/expect-valid-json-schema';
 
@@ -746,7 +745,7 @@ describe('build-schema', () => {
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
-        {[MODEL_TYPE_KEYS.ModelOnly]: cachedSchema},
+        {modelOnly: cachedSchema},
         TestModel,
       );
       const jsonSchema = getJsonSchema(TestModel);
@@ -957,7 +956,7 @@ describe('build-schema', () => {
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
-        {[MODEL_TYPE_KEYS.ModelWithRelations]: cachedSchema},
+        {modelWithRelations: cachedSchema},
         Category,
       );
       const jsonSchema = getJsonSchema(Category, {includeRelations: true});
@@ -1008,7 +1007,7 @@ describe('build-schema', () => {
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
-        {[MODEL_TYPE_KEYS.ModelWithRelations]: cachedSchema},
+        {modelWithRelations: cachedSchema},
         Category,
       );
       const jsonSchema = getJsonSchema(Category);

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -15,7 +15,7 @@ import {
 import debugFactory from 'debug';
 import {JSONSchema6 as JSONSchema} from 'json-schema';
 import {inspect} from 'util';
-import {JSON_SCHEMA_KEY, MODEL_TYPE_KEYS} from './keys';
+import {JSON_SCHEMA_KEY} from './keys';
 const debug = debugFactory('loopback:repository-json-schema:build-schema');
 
 export interface JsonSchemaOptions<T extends object> {
@@ -66,7 +66,7 @@ export function buildModelCacheKey<T extends object>(
 ): string {
   // Backwards compatibility: preserve cache key "modelOnly"
   if (Object.keys(options).length === 0) {
-    return MODEL_TYPE_KEYS.ModelOnly;
+    return 'modelOnly';
   }
 
   // New key schema: use the same suffix as we use for schema title

--- a/packages/repository-json-schema/src/keys.ts
+++ b/packages/repository-json-schema/src/keys.ts
@@ -7,16 +7,6 @@ import {MetadataAccessor} from '@loopback/metadata';
 import {JSONSchema6 as JSONSchema} from 'json-schema';
 
 /**
- * TODO(semver-major) remove these constants in the next major version
- * @deprecated Use the helper `buildModelCacheKey` to obtain the cache key
- * for a given set of schema options.
- */
-export const enum MODEL_TYPE_KEYS {
-  ModelOnly = 'modelOnly',
-  ModelWithRelations = 'modelWithRelations',
-}
-
-/**
  * Metadata key used to set or retrieve repository JSON Schema
  */
 export const JSON_SCHEMA_KEY = MetadataAccessor.create<


### PR DESCRIPTION
**BREAKING CHANGE**

The following constants are no longer available:
- `MODEL_TYPE_KEYS.ModelOnly`
- `MODEL_TYPE_KEYS.ModelWithRelations`

Please use the helper `buildModelCacheKey` to obtain the cache key for a given set of schema options.

```diff
- MODEL_TYPE_KEYS.ModelOnly
+ buildModelCacheKey()

- MODEL_TYPE_KEYS.ModelWithRelations
+ buildModelCacheKey({includeRelations: true})
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
