### PR TITLE
feat(context): allow tags to be matched by a given name with any value

### DIFF
--- a/packages/context/src/__tests__/unit/binding-filter.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-filter.unit.ts
@@ -5,6 +5,7 @@
 
 import {expect} from '@loopback/testlab';
 import {
+  ANY_TAG_VALUE,
   Binding,
   BindingFilter,
   BindingKey,
@@ -60,6 +61,24 @@ describe('BindingFilter', () => {
       binding.tag({controller: 'my-controller'});
       binding.tag({name: 'my-name'});
       expect(filter(binding)).to.be.true();
+    });
+
+    it('matches ANY_TAG_VALUE if the tag name exists', () => {
+      const filter = filterByTag({
+        controller: ANY_TAG_VALUE,
+        name: 'my-name',
+      });
+      binding.tag({name: 'my-name', controller: 'MyController'});
+      expect(filter(binding)).to.be.true();
+    });
+
+    it('does not match ANY_TAG_VALUE if the tag name does not exists', () => {
+      const filter = filterByTag({
+        controller: ANY_TAG_VALUE,
+        name: 'my-name',
+      });
+      binding.tag({name: 'my-name'});
+      expect(filter(binding)).to.be.false();
     });
 
     it('rejects bindings NOT MATCHING the provided tag map', () => {

--- a/packages/context/src/binding-filter.ts
+++ b/packages/context/src/binding-filter.ts
@@ -112,6 +112,22 @@ export function isBindingTagFilter(
 }
 
 /**
+ * A symbol that can be used to match binding tags by name regardless of the
+ * value.
+ *
+ * @example
+ *
+ * The following code matches bindings with tag `{controller: 'A'}` or
+ * `{controller: 'controller'}`. But if the tag name 'controller' does not
+ * exist for a binding, the binding will NOT be included.
+ *
+ * ```ts
+ * ctx.findByTag({controller: ANY_TAG_VALUE})
+ * ```
+ */
+export const ANY_TAG_VALUE = Symbol.for('loopback.AnyTagValue');
+
+/**
  * Create a binding filter for the tag pattern
  * @param tagPattern - Binding tag name, regexp, or object
  */
@@ -141,6 +157,7 @@ export function filterByTag(tagPattern: BindingTag | RegExp): BindingTagFilter {
     const tagMap = tagPattern as MapObject<unknown>;
     filter = b => {
       for (const t in tagPattern) {
+        if (tagMap[t] === ANY_TAG_VALUE) return t in b.tagMap;
         // One tag name/value does not match
         if (b.tagMap[t] !== tagMap[t]) return false;
       }


### PR DESCRIPTION
This allows us to find all bindings that match multiple tag name/value
pairs but we don't care about the value for certain tags. For example,
we can now find controller bindings by name as follows:

```ts
const bindings = ctx.findByTag({
  controller: ANY_TAG_VALUE,
  name: 'my-name',
});
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
