### PR TITLE
fix(docs): corrected AuthorizationOptions example line endings

### DIFF
--- a/packages/authorization/README.md
+++ b/packages/authorization/README.md
@@ -98,17 +98,17 @@ application. The authorization component can be configured with options:
 
 ```ts
 const options: AuthorizationOptions = {
-  precedence: AuthorizationDecisions.DENY;
-  defaultDecision: AuthorizationDecisions.DENY;
-}
+  precedence: AuthorizationDecisions.DENY,
+  defaultDecision: AuthorizationDecisions.DENY,
+};
 
 const binding = app.component(AuthorizationComponent);
 app.configure(binding.key).to(options);
 
-app.bind('authorizationProviders.my-authorizer-provider')
-      .toProvider(MyAuthorizationProvider)
-      .tag(AuthorizationTags.AUTHORIZER);
-
+app
+  .bind('authorizationProviders.my-authorizer-provider')
+  .toProvider(MyAuthorizationProvider)
+  .tag(AuthorizationTags.AUTHORIZER);
 ```
 
 After setting up the authorization system, you can create a user with role


### PR DESCRIPTION
…ns and put comma

- [x] `npm test` passes on your machine
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] New tests added or existing tests modified to cover all changes
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

It is a minor fix on documentation.
