### PR TITLE
feat(authentication): extend TokenService for revokeable tokens

### DIFF
--- a/packages/authentication/src/services/token.service.ts
+++ b/packages/authentication/src/services/token.service.ts
@@ -11,10 +11,28 @@ import {UserProfile} from '@loopback/security';
 export interface TokenService {
   /**
    * Verifies the validity of a token string and returns a user profile
+   *
+   * @param token The token/secret which should be validated/verified.
+   *
+   * @returns The UserProfile which belongs to the given token.
    */
   verifyToken(token: string): Promise<UserProfile>;
+
   /**
    * Generates a token string based on a user profile
+   *
+   * @param userProfile A UserProfile for which a token should be generated.
+   *
+   * @returns a generated token/secret for a given UserProfile.
    */
   generateToken(userProfile: UserProfile): Promise<string>;
+
+  /**
+   * Revokes a given token (if supported by token system)
+   *
+   * @param token The token/secret which should be revoked/invalidated.
+   *
+   * @returns true, if the given token was invalidated.
+   */
+  revokeToken?(token: string): Promise<boolean>;
 }


### PR DESCRIPTION
When implementing token systems other then `jwt` there is a need to **revoke a token**. I also discovered that there is a need to access the `UserProfile` of the current user to validate tokens in some token systems.

Example usecases:
 - `RefreshToken`, e.g https://github.com/strongloop/loopback4-example-shopping/pull/537
 - Reimplementing `lb3` `AccessToken` in `lb4`

Related to #4573.

With this PR I'm suggesting to change the `TokenService` interface.
~~This is a BREAKING CHANGE.~~

WDYT?

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
