### PR TITLE
Add more details about rejecting console logs in tests 

### DIFF
--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -132,6 +132,36 @@ npm run build
 
     `converage:ci` sets up integration with [Coveralls](https://coveralls.io/).
 
+## A note on console logs printed by tests
+
+We consider (console) logging from tests as a bad practice, because such logs
+usually clutter the test output and make it difficult to distinguish legitimate
+error messages from the noise.
+
+By default, `lb-mocha` detects when the tests and/or the application tested have
+printed console logs and fails the test run with the following message:
+
+```
+=== ATTENTION - INVALID USAGE OF CONSOLE LOGS DETECTED ===
+```
+
+If you need more information about behavior in the test, then the first choice
+should be to use a better or more descriptive error assertion. If that's not
+possible, then use debug statements to print additional information when
+explicitly requested.
+
+A typical situation is that a test is sending an HTTP request and the server
+responds with an error code as expected. However, because the server is
+configured to log failed requests, it will print a log also for requests where
+the failure was expected and intentional. The solution is to configure your REST
+server to suppress error messages for that specific error code only. Our
+`@loopback/testlab` module is providing a helper
+[`createUnexpectedHttpErrorLogger`](https://github.com/strongloop/loopback-next/tree/master/packages/testlab#createUnexpectedHttpErrorLogger)
+that makes this task super easy.
+
+Alternatively, it's also possible to disable detection of console logs by
+calling `lb-mocha` with `--allow-console-logs` argument.
+
 ## Contributions
 
 - [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md)

--- a/packages/build/src/fail-on-console-logs.js
+++ b/packages/build/src/fail-on-console-logs.js
@@ -54,7 +54,11 @@ process.on('exit', code => {
   if (!problems.length) return;
   const log = originalConsole.log;
 
-  log('\n=== ATTENTION - INVALID USAGE OF CONSOLE LOGS DETECTED ===\n');
+  log(
+    '\n=== ATTENTION - INVALID USAGE OF CONSOLE LOGS DETECTED ===',
+    '\nLearn more at',
+    'https://github.com/strongloop/loopback-next/blob/master/packages/build/README.md#a-note-on-console-logs-printed-by-tests\n',
+  );
 
   for (const p of problems) {
     // print the first line of the console log

--- a/packages/testlab/README.md
+++ b/packages/testlab/README.md
@@ -350,7 +350,10 @@ import {RestApplication} from '@loopback/rest';
 describe('MyApp', () => {
   it('does not log a known 401 error to console', async () => {
     const app = new RestApplication();
+
     const errorLogger = createUnexpectedHttpErrorLogger(401);
+    // binds the custom error logger
+    app.bind(SequenceActions.LOG_ERROR).to(errorLogger);
 
     const spec = {
       responses: {
@@ -363,9 +366,8 @@ describe('MyApp', () => {
 
     app.route('get', '/', spec, throwUnauthorizedError);
 
-    // binds the custom error logger
-    app.bind(SequenceActions.LOG_ERROR).to(errorLogger);
     await app.start();
+    // make `GET /` request, assert that 401 is returned
   });
 });
 ```


### PR DESCRIPTION
As a follow-up to the conversation we had on Slack, I am proposing to add some documentation for `ATTENTION - INVALID USAGE OF CONSOLE LOGS DETECTED` and make this docs easier to discover by modifying `lb-mocha` to print a URL for that content.

See also https://github.com/strongloop/loopback-next/pull/1058 which introduced log detection to `lb-mocha`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
