### PR TITLE
fix: filter null keys when including belongs-to relations in queries 

### DIFF
--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
@@ -160,6 +160,44 @@ export function belongsToInclusionResolverAcceptance(
       expect(toJSON(result)).to.deepEqual(toJSON(expected));
     });
 
+    it('queries entities with null foreign key', async () => {
+      const customer = await customerRepo.create({
+        name: 'Thor',
+      });
+
+      // order with customer relation
+      const order1 = await orderRepo.create({
+        customerId: customer.id,
+        description: 'Take Out',
+      });
+
+      // order without customer relation
+      const order2 = await orderRepo.create({
+        description: 'Dine in',
+      });
+
+      const expected = [
+        {
+          ...order1,
+          isShipped: features.emptyValue,
+          shipmentInfo: features.emptyValue,
+          customer: {
+            ...customer,
+            parentId: features.emptyValue,
+          },
+        },
+        {
+          ...order2,
+          customerId: features.emptyValue,
+          isShipped: features.emptyValue,
+          shipmentInfo: features.emptyValue,
+        },
+      ];
+
+      const result = await orderRepo.find({include: [{relation: 'customer'}]});
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
     it('throws error if the target repository does not have the registered resolver', async () => {
       const customer = await customerRepo.create({name: 'customer'});
       await orderRepo.create({

--- a/packages/repository/src/relations/belongs-to/belongs-to.inclusion-resolver.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.inclusion-resolver.ts
@@ -52,12 +52,13 @@ export function createBelongsToInclusionResolver<
     const sourceKey = relationMeta.keyFrom;
     const sourceIds = entities.map(e => (e as AnyObject)[sourceKey]);
     const targetKey = relationMeta.keyTo as StringKeyOf<Target>;
+    const dedupedSourceIds = deduplicate(sourceIds);
 
     const targetRepo = await getTargetRepo();
     const targetsFound = await findByForeignKeys(
       targetRepo,
       targetKey,
-      deduplicate(sourceIds),
+      dedupedSourceIds.filter(e => e),
       inclusion.scope as Filter<Target>,
       options,
     );


### PR DESCRIPTION
fixes https://github.com/strongloop/loopback-next/issues/4372

 fix querying related entities with null keys and add tests to repository-test

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
