### PR TITLE
refactor(rest): extract AJV to a separate service provider

### DIFF
--- a/packages/rest/src/__tests__/unit/ajv.service.unit.ts
+++ b/packages/rest/src/__tests__/unit/ajv.service.unit.ts
@@ -1,0 +1,53 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {BindingKey, Context} from '@loopback/core';
+import {expect} from '@loopback/testlab';
+import {Ajv} from 'ajv';
+import {RestBindings} from '../..';
+import {AjvProvider} from '../../validation/ajv.service';
+
+describe('Ajv service', () => {
+  const AJV_SERVICE = BindingKey.create<Ajv>('services.Ajv');
+  let ctx: Context;
+
+  beforeEach(givenContext);
+
+  it('allows binary format by default', async () => {
+    const ajv = await ctx.get(AJV_SERVICE);
+    const validator = ajv.compile({type: 'string', format: 'binary'});
+    const result = await validator('ABC123');
+    expect(result).to.be.true();
+  });
+
+  it('honors request body parser options', async () => {
+    ctx
+      .bind(RestBindings.REQUEST_BODY_PARSER_OPTIONS)
+      .to({validation: {unknownFormats: ['gmail']}});
+    const ajv = await ctx.get(AJV_SERVICE);
+    const validator = ajv.compile({type: 'string', format: 'gmail'});
+    const result = await validator('example@gmail.com');
+    expect(result).to.be.true();
+  });
+
+  it('accepts request body parser options via constructor', async () => {
+    const ajv = new AjvProvider({unknownFormats: ['gmail']}).value();
+    const validator = ajv.compile({type: 'string', format: 'gmail'});
+    const result = await validator('example@gmail.com');
+    expect(result).to.be.true();
+  });
+
+  it('reports unknown format', async () => {
+    const ajv = await ctx.get(AJV_SERVICE);
+    expect(() => ajv.compile({type: 'string', format: 'gmail'})).to.throw(
+      /unknown format "gmail" is used in schema/,
+    );
+  });
+
+  function givenContext() {
+    ctx = new Context();
+    ctx.bind(AJV_SERVICE).toProvider(AjvProvider);
+  }
+});

--- a/packages/rest/src/validation/ajv.service.ts
+++ b/packages/rest/src/validation/ajv.service.ts
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {inject, Provider} from '@loopback/core';
+import AJVCtor, {Ajv} from 'ajv';
+import debugModule from 'debug';
+import {RestBindings} from '../keys';
+import {RequestBodyValidationOptions} from '../types';
+const debug = debugModule('loopback:rest:ajv');
+
+const ajvKeywords = require('ajv-keywords');
+const ajvErrors = require('ajv-errors');
+
+/**
+ * A provider class that instantiate an AJV instance
+ */
+export class AjvProvider implements Provider<Ajv> {
+  constructor(
+    @inject(
+      RestBindings.REQUEST_BODY_PARSER_OPTIONS.deepProperty('validation'),
+      {optional: true},
+    )
+    private options: RequestBodyValidationOptions = {},
+  ) {}
+
+  value() {
+    let options = this.options;
+    // See https://github.com/epoberezkin/ajv#options
+    options = {
+      allErrors: true,
+      jsonPointers: true,
+      // nullable: support keyword "nullable" from Open API 3 specification.
+      nullable: true,
+      // Allow OpenAPI spec binary format
+      unknownFormats: ['binary'],
+      ...options,
+    };
+
+    debug('AJV options', options);
+    const ajv = new AJVCtor(options);
+
+    if (options.ajvKeywords === true) {
+      ajvKeywords(ajv);
+    } else if (Array.isArray(options.ajvKeywords)) {
+      ajvKeywords(ajv, options.ajvKeywords);
+    }
+
+    if (options.ajvErrors === true) {
+      ajvErrors(ajv);
+    } else if (options.ajvErrors?.constructor === Object) {
+      ajvErrors(ajv, options.ajvErrors);
+    }
+    return ajv;
+  }
+}


### PR DESCRIPTION
Inspired by #4801 

- Extract AJV to a separate service provider (use as a factory function for now without DI)
- Allow to ignore `binary` format by default

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
