### PR TITLE
fix: remove booter-rest package from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -252,7 +252,6 @@
 # - Standby owner(s): n/a
 /packages/model-api-builder @nabdelgadir
 /packages/rest-crud @nabdelgadir
-/packages/booter-rest @nabdelgadir
 
 #
 # Cloud Native tooling


### PR DESCRIPTION
Removing `/packages/booter-rest` since it doesn't exist

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
