### PR TITLE
chore: enable conventional-graduate flag for lerna version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -17,6 +17,7 @@
     "version": {
       "forcePublish": "@loopback/cli,@loopback/docs",
       "conventionalCommits": true,
+      "conventionalGraduate": true,
       "message": "chore: publish release"
     },
     "publish": {


### PR DESCRIPTION
This flag allows us to use prerelease version such as 1.0.0-1 when a new
package is added. The release process will then graduate it into 1.0.0.

See https://github.com/lerna/lerna/blob/master/commands/version/README.md#--conventional-graduate

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
