### PR TITLE
chore: fix verify-docs build failure with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
     - node_js: "12"
       os: linux
       env: TASK=verify-docs
+      # The default npm for node v12.16.1 (npm v6.13.4) fails with cb() never called
+      before_install: npm i -g npm
       script: ./bin/verify-doc-changes.sh
     - node_js: "12"
       os: linux


### PR DESCRIPTION
The default npm for node v12.16.1 (npm v6.13.4) fails with `cb() never called`
Upgrading to `npm@6.14.2` fixed `lerna bootstrap`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
