### PR TITLE
feat(core): allow an extension to be used by multiple extension points

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -337,6 +337,38 @@ binding.tag('controller', {name: 'MyController'});
 
 The binding tags can be accessed via `binding.tagMap` or `binding.tagNames`.
 
+Binding tags play an import role in discovering artifacts with matching tags.
+The `filterByTag` helper function and `context.findByTag` method can be used to
+match/find bindings by tag. The search criteria can be one of the followings:
+
+1. A tag name, such as `controller`
+2. A tag name wildcard or regular expression, such as `controller.*` or
+   `/controller/`
+3. An object contains tag name/value pairs, such as
+   `{name: 'my-controller', type: 'controller'}`. In addition to exact match,
+   the value for a tag name can be a function that determines if a given tag
+   value matches. For example,
+
+   ```ts
+   import {
+     ANY_TAG_VALUE, // Match any value if it exists
+     filterByTag,
+     includesTagValue, // Match tag value as an array that includes the item
+     TagValueMatcher,
+   } from '@loopback/context';
+   // Match a binding with a named service
+   ctx.find(filterByTag({name: ANY_TAG_VALUE, service: 'service'}));
+
+   // Match a binding as an extension for `my-extension-point`
+   ctx.find(
+     filterByTag({extensionFor: includesTagValue('my-extension-point')}),
+   );
+
+   // Match a binding with weight > 100
+   const weightMatcher: TagValueMatcher = tagValue => tagValue > 100;
+   ctx.find(filterByTag({weight: weightMatcher}));
+   ```
+
 ### Chain multiple steps
 
 The `Binding` fluent APIs allow us to chain multiple steps as follows:

--- a/docs/site/Extension-point-and-extensions.md
+++ b/docs/site/Extension-point-and-extensions.md
@@ -53,7 +53,8 @@ decorators and functions are provided to ensure consistency and convention.
 - `extensionFilter`: creates a binding filter function to find extensions for
   the named extension point
 - `extensionFor`: creates a binding template function to set the binding to be
-  an extension for the named extension point
+  an extension for the named extension point(s). It can accept one or more
+  extension point names to contribute to given extension points
 - `addExtension`: registers an extension class to the context for the named
   extension point
 

--- a/packages/context/src/__tests__/unit/binding-filter.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-filter.unit.ts
@@ -11,6 +11,7 @@ import {
   BindingKey,
   filterByKey,
   filterByTag,
+  includesTagValue,
   isBindingAddress,
   isBindingTagFilter,
 } from '../..';
@@ -63,6 +64,30 @@ describe('BindingFilter', () => {
       expect(filter(binding)).to.be.true();
     });
 
+    it('accepts bindings MATCHING the provided tag map with array values', () => {
+      const filter = filterByTag({
+        extensionFor: includesTagValue('greeting-service'),
+        name: 'my-name',
+      });
+      binding.tag({
+        extensionFor: ['greeting-service', 'anther-extension-point'],
+      });
+      binding.tag({name: 'my-name'});
+      expect(filter(binding)).to.be.true();
+    });
+
+    it('rejects bindings NOT MATCHING the provided tag map with array values', () => {
+      const filter = filterByTag({
+        extensionFor: includesTagValue('extension-point-3'),
+        name: 'my-name',
+      });
+      binding.tag({
+        extensionFor: ['extension-point-1', 'extension-point-2'],
+      });
+      binding.tag({name: 'my-name'});
+      expect(filter(binding)).to.be.false();
+    });
+
     it('matches ANY_TAG_VALUE if the tag name exists', () => {
       const filter = filterByTag({
         controller: ANY_TAG_VALUE,
@@ -78,6 +103,39 @@ describe('BindingFilter', () => {
         name: 'my-name',
       });
       binding.tag({name: 'my-name'});
+      expect(filter(binding)).to.be.false();
+    });
+
+    it('allows include tag value matcher - true for exact match', () => {
+      const filter = filterByTag({
+        controller: includesTagValue('MyController'),
+        name: 'my-name',
+      });
+      binding.tag({name: 'my-name', controller: 'MyController'});
+      expect(filter(binding)).to.be.true();
+    });
+
+    it('allows include tag value matcher - true for included match', () => {
+      const filter = filterByTag({
+        controller: includesTagValue('MyController'),
+        name: 'my-name',
+      });
+      binding.tag({
+        name: 'my-name',
+        controller: ['MyController', 'YourController'],
+      });
+      expect(filter(binding)).to.be.true();
+    });
+
+    it('allows include tag value matcher - false for no match', () => {
+      const filter = filterByTag({
+        controller: includesTagValue('XYZController'),
+        name: 'my-name',
+      });
+      binding.tag({
+        name: 'my-name',
+        controller: ['MyController', 'YourController'],
+      });
       expect(filter(binding)).to.be.false();
     });
 


### PR DESCRIPTION
The PR is to address the need by https://github.com/strongloop/loopback-next/pull/4693#discussion_r389321928.

1. Introduce `TagValueMatcher` function type for more flexible tag value matching used by `filterByTag`
2. Use an array inclusion based TagValueMatcher to discover extensions tagged for multiple extension points.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
