### PR TITLE
chore: add Migration Docs issue template + docs alerts

### DIFF
--- a/.github/ISSUE_TEMPLATE/Migration_docs.md
+++ b/.github/ISSUE_TEMPLATE/Migration_docs.md
@@ -1,0 +1,43 @@
+---
+name: Migration help
+about: Get help with migrating from LoopBack 3 to LoopBack 4
+labels: question,Doc,Migration
+
+---
+
+<!-- 🚨 STOP 🚨 STOP 🚨 STOP 🚨
+
+HELP US HELP YOU, PLEASE
+- Do a quick search to avoid duplicate issues
+- Provide as much information as possible (reproduction sandbox, use case for features, etc.)
+- Consider using a more suitable venue for questions such as Stack Overflow, Gitter, etc.
+
+Please fill in the *entire* template below.
+
+-->
+
+## LoopBack 3 use case
+
+<!--
+Describe the specific part of your LoopBack 3 application that you don't know
+how to migrate to LoopBack 4.
+-->
+
+## Link to reproduction sandbox
+
+<!--
+Create a *minimal* LB3 application showing your use case,
+see https://loopback.io/doc/en/contrib/Reporting-issues.html#loopback-3x-bugs
+-->
+
+## Additional information
+
+<!--
+Anything else to make it easier to understand your use case.
+
+Please include links to related issues and/or answers you found while looking
+for a solution.
+-->
+
+_See [Reporting Issues](http://loopback.io/doc/en/contrib/Reporting-issues.html) for more tips on writing good issues_
+

--- a/docs/site/migration/auth/built-in.md
+++ b/docs/site/migration/auth/built-in.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-built-in.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 {% include note.html content="
 This is a placeholder page, the task of adding content is tracked by the
 following GitHub issue:

--- a/docs/site/migration/auth/example.md
+++ b/docs/site/migration/auth/example.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-access-control-example.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 This example is migrated from
 [loopback-example-access-control](https://github.com/strongloop/loopback-example-access-control),
 and uses the authentication and authorization system in LoopBack 4 to implement

--- a/docs/site/migration/auth/oauth2.md
+++ b/docs/site/migration/auth/oauth2.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-oauth2.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 {% include note.html content="
 This is a placeholder page, the task of adding content is tracked by the
 following GitHub issue:

--- a/docs/site/migration/auth/overview.md
+++ b/docs/site/migration/auth/overview.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-overview.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 LoopBack version 3 provides several options for adding authentication and
 authorization to secure the applications:
 

--- a/docs/site/migration/auth/passport.md
+++ b/docs/site/migration/auth/passport.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-passport.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 {% include note.html content="
 This is a placeholder page, the task of adding content is tracked by the
 following GitHub issue:

--- a/docs/site/migration/boot-scripts.md
+++ b/docs/site/migration/boot-scripts.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-boot-scripts.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 In LoopBack 3, predefined boot scripts are organized in the `/server/boot`
 directory, and are executed right before the server starts to perform some
 custom application initialization. The same functionality can also be achieved

--- a/docs/site/migration/cli.md
+++ b/docs/site/migration/cli.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-cli.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 {% include note.html content="
 This is a placeholder page, the task of adding content is tracked by the
 following GitHub issue:

--- a/docs/site/migration/clients.md
+++ b/docs/site/migration/clients.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-clients.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 {% include note.html content="
 This is a placeholder page, the task of adding content is tracked by the
 following GitHub issue:

--- a/docs/site/migration/datasources.md
+++ b/docs/site/migration/datasources.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-datasources.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 ## Overview
 
 LoopBack 3 datasources are compatible with LoopBack 4 datasources, so migrating

--- a/docs/site/migration/express-middleware.md
+++ b/docs/site/migration/express-middleware.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-express-middleware.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 Migrating Express middleware from LoopBack 3 (LB3) application to LoopBack 4
 (LB4) application requires the use of a base Express application that will mount
 the LB4 application, which in turn mounts the LB3 application.

--- a/docs/site/migration/extensions.md
+++ b/docs/site/migration/extensions.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-extensions.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 {% include note.html content="
 This is a placeholder page, the task of adding content is tracked by the
 following GitHub issue:

--- a/docs/site/migration/models/core.md
+++ b/docs/site/migration/models/core.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-core.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 In LoopBack 3, a single model class has three responsibilities: it describes
 shape of data (schema), provides persistence-related behavior and implements
 public (REST) API.

--- a/docs/site/migration/models/methods.md
+++ b/docs/site/migration/models/methods.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-methods.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 ## Introduction
 
 This document will guide you in migrating custom model methods in LoopBack 3 to

--- a/docs/site/migration/models/mixins.md
+++ b/docs/site/migration/models/mixins.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-mixins.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 ## Introduction
 
 This document will guide you in migrating custom model mixins, and custom

--- a/docs/site/migration/models/operation-hooks.md
+++ b/docs/site/migration/models/operation-hooks.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-operation-hooks.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 Operation hooks are not supported in LoopBack 4 yet. See the
 [Operation hooks for models/repositories spike](https://github.com/strongloop/loopback-next/issues/1919)
 to follow the progress made on this subject.

--- a/docs/site/migration/models/overview.md
+++ b/docs/site/migration/models/overview.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-overview.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 In LoopBack 3, models are the cornerstone. They describe shape of data (schema),
 provide persistence-related behavior and implement public (REST) API. Besides
 this core functionality, there are many ways how to extend the built-in

--- a/docs/site/migration/models/relations.md
+++ b/docs/site/migration/models/relations.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-relations.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 When you define a relation in a LoopBack 3 model JSON file, the framework will
 create the following artifacts for you automatically:
 

--- a/docs/site/migration/models/remoting-hooks.md
+++ b/docs/site/migration/models/remoting-hooks.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-remoting-hooks.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 ## Introduction
 
 In LoopBack 3, a [Remote hook](../../../lb3/Remote-hooks.md) enables you to

--- a/docs/site/migration/mounting-lb3app.md
+++ b/docs/site/migration/mounting-lb3app.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-mounting-lb3app.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 Migrating from LoopBack version 3 to version 4 is a big task because so many
 things have changed between the versions. To make this process easier, we
 implemented a feature allowing users to run their existing LoopBack 3

--- a/docs/site/migration/not-planned.md
+++ b/docs/site/migration/not-planned.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-not-planned.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 {% include note.html content="
 This is a placeholder page, the task of adding content is tracked by the
 following GitHub issue:

--- a/docs/site/migration/overview.md
+++ b/docs/site/migration/overview.md
@@ -6,6 +6,10 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-overview.html
 ---
 
+{% include tip.html content="
+Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
+" %}
+
 As mentioned elsewhere in the documentation, we wrote LoopBack 4 from the ground
 up and therefore the migration requires more effort than in previous major
 versions. The migration guide presented in the nested pages describe steps to


### PR DESCRIPTION
1. Add a new issue template for reporting missing documentation related to migration from LoopBack 3 to LoopBack 4.

2. Update all doc pages in our migration guide, add a "tip" alert asking users to open a new issue if they are missing instructions for their particular use case.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
