### PR TITLE
chore: fix setup of docs preview site

### DIFF
--- a/docs/bin/build-preview-site.sh
+++ b/docs/bin/build-preview-site.sh
@@ -51,11 +51,17 @@ cp -r $SOURCE_DIR/doc/index.md $JEKYLL_DIR/doc
 
 echo "Setting up LB4 doc pages",
 rm -rf $JEKYLL_DIR/pages
-ln -s $PWD/site $JEKYLL_DIR/pages
+# Create hardlinks because Jekyll does not support symbolic links any more.
+# Use `pax` because `ln` does not support directory recursion.
+mkdir $JEKYLL_DIR/pages
+(TARGET="$PWD/$JEKYLL_DIR/pages" && cd "$PWD/site" && pax -rwlpe . $TARGET)
 
 echo "Setting up sidebar(s)"
 rm -rf $JEKYLL_DIR/_data/sidebars
-ln -s $PWD/site/sidebars $JEKYLL_DIR/_data/sidebars
+# Create hardlinks because Jekyll does not support symbolic links any more.
+# Use `pax` because `ln` does not support directory recursion.
+mkdir $JEKYLL_DIR/_data/sidebars
+(TARGET="$PWD/$JEKYLL_DIR/_data/sidebars" && cd "$PWD/site/sidebars" && pax -rwlpe . $TARGET)
 
 echo "Installing Ruby dependencies"
 (cd $JEKYLL_DIR && bundle install)


### PR DESCRIPTION
Rework the script setting up docs preview to create hard-links instead of symbolic links, because Jekyll no longer supports symbolic links pointing outside of the site directory.

The new solution is based on `pax` tool, which is a part of POSIX, included in MacOS but often not included in GNU/Linux distributions by default. Developers working on loopback-next in Linux may need to install the tool via the package manager provided by their distro. Learn more here: https://en.wikipedia.org/wiki/Pax_(Unix)

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
