### PR TITLE
refactor: move const into bindings

### DIFF
--- a/docs/site/Extending-OpenAPI-specification.md
+++ b/docs/site/Extending-OpenAPI-specification.md
@@ -105,25 +105,25 @@ enhancer by name, or apply all enhancers automatically.
 ### Registering an Enhancer Service
 
 You can bind the OAS enhancer extension point to your app via key
-`OAS_ENHANCER_SERVICE`:
+`OASEnhancerBindings.OAS_ENHANCER_SERVICE`:
 
 ```ts
 import {RestApplication} from '@loopback/rest';
-import {OASEnhancerService, OAS_ENHANCER_SERVICE} from '@loopback/openapi-v3';
+import {OASEnhancerService, OASEnhancerBindings} from '@loopback/openapi-v3';
 
 class MyApplication extends RestApplication {
   constructor() {
     super();
     this.add(
       createBindingFromClass(OASEnhancerService, {
-        key: OAS_ENHANCER_SERVICE,
+        key: OASEnhancerBindings.OAS_ENHANCER_SERVICE,
       }),
     );
   }
 
   // define a function to return a spec service by the same key
   getSpecService() {
-    return this.get(OAS_ENHANCER_SERVICE);
+    return this.get(OASEnhancerBindings.OAS_ENHANCER_SERVICE);
   }
 }
 ```

--- a/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
+++ b/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
@@ -7,7 +7,7 @@ import {bind, Context, createBindingFromClass} from '@loopback/context';
 import {
   asSpecEnhancer,
   OASEnhancer,
-  OAS_ENHANCER_EXTENSION_POINT_NAME,
+  OASEnhancerBindings,
   OpenApiSpec,
 } from '@loopback/openapi-v3';
 import {Request} from '@loopback/rest';
@@ -33,7 +33,7 @@ describe('registerAuthenticationStrategy', () => {
     expect(binding.tagMap).to.containEql({
       extensionFor: [
         AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME,
-        OAS_ENHANCER_EXTENSION_POINT_NAME,
+        OASEnhancerBindings.OAS_ENHANCER_EXTENSION_POINT_NAME,
       ],
     });
     expect(binding.key).to.eql(
@@ -46,11 +46,11 @@ describe('registerAuthenticationStrategy', () => {
     expect(binding.tagMap).to.containEql({
       extensionFor: [
         AuthenticationBindings.AUTHENTICATION_STRATEGY_EXTENSION_POINT_NAME,
-        OAS_ENHANCER_EXTENSION_POINT_NAME,
+        OASEnhancerBindings.OAS_ENHANCER_EXTENSION_POINT_NAME,
       ],
     });
     expect(binding.key).to.eql(
-      `${OAS_ENHANCER_EXTENSION_POINT_NAME}.MyAuthenticationStrategy`,
+      `${OASEnhancerBindings.OAS_ENHANCER_EXTENSION_POINT_NAME}.MyAuthenticationStrategy`,
     );
   });
 

--- a/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/application.ts
+++ b/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/application.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Application, createBindingFromClass} from '@loopback/core';
-import {OASEnhancerService, OAS_ENHANCER_SERVICE} from '../../../..';
+import {OASEnhancerBindings, OASEnhancerService} from '../../../..';
 import {InfoSpecEnhancer} from './info.spec.extension';
 import {SecuritySpecEnhancer} from './security.spec.extension';
 
@@ -13,7 +13,7 @@ export class SpecServiceApplication extends Application {
     super();
     this.add(
       createBindingFromClass(OASEnhancerService, {
-        key: OAS_ENHANCER_SERVICE,
+        key: OASEnhancerBindings.OAS_ENHANCER_SERVICE,
       }),
     );
     this.add(createBindingFromClass(SecuritySpecEnhancer));
@@ -23,6 +23,6 @@ export class SpecServiceApplication extends Application {
   async main() {}
 
   getSpecService() {
-    return this.get(OAS_ENHANCER_SERVICE);
+    return this.get(OASEnhancerBindings.OAS_ENHANCER_SERVICE);
   }
 }

--- a/packages/openapi-v3/src/enhancers/keys.ts
+++ b/packages/openapi-v3/src/enhancers/keys.ts
@@ -1,14 +1,16 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/openapi-v3
-// This file is licensed under the MIT License.
-// License text available at https://opensource.org/licenses/MIT
-
 import {BindingKey} from '@loopback/core';
 import {OASEnhancerService} from './spec-enhancer.service';
 
-/**
- * Strongly-typed binding key for SpecService
- */
-export const OAS_ENHANCER_SERVICE = BindingKey.create<OASEnhancerService>(
-  'services.SpecService',
-);
+export namespace OASEnhancerBindings {
+  /**
+   * Strongly-typed binding key for SpecService
+   */
+  export const OAS_ENHANCER_SERVICE = BindingKey.create<OASEnhancerService>(
+    'services.SpecService',
+  );
+
+  /**
+   * Name/id of the OAS enhancer extension point
+   */
+  export const OAS_ENHANCER_EXTENSION_POINT_NAME = 'oas-enhancer';
+}

--- a/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
+++ b/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
@@ -8,7 +8,8 @@ import debugModule from 'debug';
 import * as _ from 'lodash';
 import {inspect} from 'util';
 import {OpenApiSpec, SecuritySchemeObject} from '../types';
-import {OASEnhancer, OAS_ENHANCER_EXTENSION_POINT_NAME} from './types';
+import {OASEnhancerBindings} from './keys';
+import {OASEnhancer} from './types';
 const jsonmergepatch = require('json-merge-patch');
 
 const debug = debugModule('loopback:openapi:spec-enhancer');
@@ -28,7 +29,7 @@ export interface OASEnhancerServiceOptions {
  * A typical use of it would be generating the OpenAPI spec for the endpoints on a server
  * in the `@loopback/rest` module.
  */
-@extensionPoint(OAS_ENHANCER_EXTENSION_POINT_NAME)
+@extensionPoint(OASEnhancerBindings.OAS_ENHANCER_EXTENSION_POINT_NAME)
 export class OASEnhancerService {
   constructor(
     /**

--- a/packages/openapi-v3/src/enhancers/types.ts
+++ b/packages/openapi-v3/src/enhancers/types.ts
@@ -5,6 +5,7 @@
 
 import {BindingTemplate, extensionFor} from '@loopback/core';
 import {OpenApiSpec} from '../types';
+import {OASEnhancerBindings} from './keys';
 
 /**
  * Typically an extension point defines an interface as the contract for
@@ -16,15 +17,10 @@ export interface OASEnhancer {
 }
 
 /**
- * Name/id of the OAS enhancer extension point
- */
-export const OAS_ENHANCER_EXTENSION_POINT_NAME = 'oas-enhancer';
-
-/**
  * A binding template for spec contributor extensions
  */
 export const asSpecEnhancer: BindingTemplate = binding => {
-  extensionFor(OAS_ENHANCER_EXTENSION_POINT_NAME)(binding);
+  extensionFor(OASEnhancerBindings.OAS_ENHANCER_EXTENSION_POINT_NAME)(binding);
   // is it ok to have a different namespace than the extension point name?
   binding.tag({namespace: 'oas-enhancer'});
 };

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -20,8 +20,8 @@ import {Application, CoreBindings, Server} from '@loopback/core';
 import {HttpServer, HttpServerOptions} from '@loopback/http-server';
 import {
   getControllerSpec,
+  OASEnhancerBindings,
   OASEnhancerService,
-  OAS_ENHANCER_SERVICE,
   OpenAPIObject,
   OpenApiSpec,
   OperationObject,
@@ -242,10 +242,10 @@ export class RestServer extends Context implements Server, HttpServerLike {
     if (this._OASEnhancer != null) return;
     this.add(
       createBindingFromClass(OASEnhancerService, {
-        key: OAS_ENHANCER_SERVICE,
+        key: OASEnhancerBindings.OAS_ENHANCER_SERVICE,
       }),
     );
-    this._OASEnhancer = this.getSync(OAS_ENHANCER_SERVICE);
+    this._OASEnhancer = this.getSync(OASEnhancerBindings.OAS_ENHANCER_SERVICE);
   }
 
   protected _setupRequestHandlerIfNeeded() {


### PR DESCRIPTION
Refactor const into bindings 
will wait for https://github.com/strongloop/loopback-next/pull/4693 and rebase

Export `OAS_ENHANCER_SERVICE` and  `OAS_ENHANCER_EXTENSION_POINT_NAME` from namespace `OASEnhancerBindings`

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
