### PR TITLE
feat(docs): generate Jekyll friendly pages for CHANGELOG files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ benchmark/dist
 packages/tsdocs/fixtures/monorepo/docs
 packages/tsdocs/fixtures/monorepo/packages/pkg1/docs
 /docs/site/readmes
+/docs/site/changelogs
+/docs/site/CHANGELOG.md
 /docs/apidocs/reports-temp
 /docs/apidocs/models
 *.tsbuildinfo

--- a/docs/bin/build-preview-site.sh
+++ b/docs/bin/build-preview-site.sh
@@ -35,6 +35,9 @@ node bin/build-jekyll-preview-config $SOURCE_DIR/_config.yml $JEKYLL_DIR/_config
 echo "Copying LB4 readmes"
 node bin/copy-readmes
 
+echo "Copying LB4 changelogs"
+node bin/copy-changelogs
+
 echo "Copyping Gemfile, index.html and data files"
 rm -rf $JEKYLL_DIR/{_data,_includes,_layouts}
 cp -r $SOURCE_DIR/Gemfile* $JEKYLL_DIR/

--- a/docs/bin/copy-changelogs.js
+++ b/docs/bin/copy-changelogs.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Copyright IBM Corp. 2017,2020. All Rights Reserved.
+// Node module: loopback-next
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+/*
+ * This is an internal script to gather CHANGELOGs of all packages
+ * in our monorepo and copy them to `site/changelogs` for consumption
+ * from the docs. It also generates Jekyll friendly pages for CHANGELOG files.
+ */
+
+const Project = require('@lerna/project');
+const fs = require('fs-extra');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const DEST_ROOT = path.resolve(__dirname, '../site/changelogs');
+const SITE_ROOT = path.resolve(__dirname, '../site');
+
+if (require.main === module) {
+  copyChangelogs().catch(err => {
+    console.error('Unhandled error.', err);
+    process.exit(1);
+  });
+}
+
+async function copyChangelogs() {
+  // Remove the original folder so we remove files from deleted packages
+  await fs.remove(DEST_ROOT);
+
+  const project = new Project(REPO_ROOT);
+  const allPackages = await project.getPackages();
+
+  const packages = allPackages
+    .filter(shouldCopyChangelog)
+    .map(pkg => {
+      let shortName = pkg.name;
+      if (pkg.name.startsWith('@loopback/')) {
+        shortName = pkg.name.substring('@loopback/'.length);
+      }
+
+      const location = path.relative(REPO_ROOT, pkg.location);
+      const meta = {
+        name: pkg.name,
+        shortName,
+        private: pkg.private,
+        location,
+        dir: path.dirname(location),
+      };
+      return meta;
+    })
+    .sort((a, b) => b.location.localeCompare(a.location));
+
+  const packagesByDir = {};
+  packages.forEach(pkg => {
+    let list = packagesByDir[pkg.dir];
+    if (list == null) {
+      list = [];
+      packagesByDir[pkg.dir] = list;
+    }
+    list.push(pkg);
+  });
+
+  // Index page for all CHANGELOG files
+  const changelogIndexPage = [
+    `---
+lang: en
+title: 'CHANGELOG Docs'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/changelog.index.html
+---
+
+## CHANGELOG`,
+  ];
+
+  for (const dir in packagesByDir) {
+    const arr = packagesByDir[dir]
+      .filter(shouldPublishChangelog)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    if (arr.length) {
+      // Add an entry to the index for each dir
+      changelogIndexPage.push(`\n### ${dir}\n`);
+    }
+    for (const {location, name, shortName} of arr) {
+      const src = path.join(REPO_ROOT, location, 'CHANGELOG.md');
+      const exists = await fs.exists(src);
+      if (!exists) continue;
+
+      const content = await fs.readFile(src, 'utf-8');
+      const md = `---
+lang: en
+title: 'CHANGELOG - ${name}'
+keywords: LoopBack 4.0, LoopBack 4, CHANGELOG
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/changelog.${shortName}.html
+---
+
+${content}
+`;
+      const dest = path.join(DEST_ROOT, location, 'CHANGELOG.md');
+      await fs.outputFile(dest, md, 'utf-8');
+
+      // Add an entry to the index
+      changelogIndexPage.push(
+        `- [${name}](changelogs/${location}/CHANGELOG.md)`,
+      );
+    }
+  }
+
+  // Write `site/CHANGELOG.md`
+  await fs.outputFile(
+    path.join(SITE_ROOT, 'CHANGELOG.md'),
+    changelogIndexPage.join('\n'),
+    'utf-8',
+  );
+}
+
+/**
+ * Control if CHANGELOG for the given package should be copied
+ * @param {object} pkg
+ */
+function shouldCopyChangelog(pkg) {
+  return (
+    !pkg.private &&
+    !pkg.name.startsWith('@loopback/sandbox-') &&
+    pkg.name !== '@loopback/docs' &&
+    pkg.name !== '@loopback/benchmark'
+  );
+}
+
+/**
+ * Test if CHANGELOG should be published for the given package
+ * @param {object} pkg
+ */
+function shouldPublishChangelog(pkg) {
+  return !pkg.private;
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,8 @@
     "docs"
   ],
   "scripts": {
-    "prepack": "node ./bin/copy-readmes && cd .. && npm run tsdocs",
-    "clean": "lb-clean loopback-docs*.tgz package apidocs site/readmes site/apidocs"
+    "prepack": "node ./bin/copy-readmes.js && node ./bin/copy-changelogs.js && cd .. && npm run tsdocs",
+    "clean": "lb-clean loopback-docs*.tgz package apidocs site/readmes site/changelogs site/apidocs"
   },
   "devDependencies": {
     "@loopback/build": "^4.0.0"

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -832,6 +832,10 @@ children:
       url: submitting_a_pr.html
       output: 'web, pdf'
 
+- title: 'Change logs'
+  url: changelog.index.html
+  output: 'web, pdf'
+
 - title: 'Reference'
   url: Reference.html
   output: 'web, pdf'


### PR DESCRIPTION
This PR adds an internal script to generate Jekyll friendly pages for CHANGELOG files. The sidebar has a new section `CHANGELOG` as the index page for all changelogs.

The script is run at `prepack` phase. It adds:

- docs/site/CHANGELOG.md (as index page with links to all modules)
- docs/site/changelogs/*

<img width="1238" alt="Screen Shot 2020-03-12 at 10 14 40 AM" src="https://user-images.githubusercontent.com/540892/76547552-9a75f280-644a-11ea-98c8-0733b7f98fd6.png">


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
