### PR TITLE
feat: Introduce @requestBody.file and @oas.response.file decorators

### DIFF
--- a/docs/site/File-upload-download.md
+++ b/docs/site/File-upload-download.md
@@ -1,0 +1,301 @@
+---
+lang: en
+title: 'Upload and download files'
+keywords: LoopBack 4.0, LoopBack-Next
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/File-upload-download.html
+---
+
+## File upload and download
+
+It's a common requirement for API applications to support file upload and
+download. This page describes how to expose REST APIs for uploading and
+downloading files using LoopBack 4. It also illustrates how to build a simple
+Web UI to interact with such APIs.
+
+A fully-functional example is available at
+[@loopback/example-file-upload-download](https://github.com/strongloop/loopback-next/tree/master/examples/file-upload-download).
+We use code snippets from the example to walk through the key artifacts.
+
+### File upload
+
+A few steps are involved to create an endpoint for file upload.
+
+1. Create a controller class such as
+   [`FileUploadController`](https://github.com/strongloop/loopback-next/blob/master/examples/file-upload-download/src/controllers/file-upload.controller.ts)
+
+```ts
+import {inject} from '@loopback/context';
+import {
+  post,
+  Request,
+  requestBody,
+  Response,
+  RestBindings,
+} from '@loopback/rest';
+import {FILE_UPLOAD_SERVICE} from '../keys';
+import {FileUploadHandler} from '../types';
+/**
+ * A controller to handle file uploads using multipart/form-data media type
+ */
+export class FileUploadController {
+  /**
+   * Constructor
+   * @param handler - Inject an express request handler to deal with the request
+   */
+  constructor(
+    @inject(FILE_UPLOAD_SERVICE) private handler: FileUploadHandler,
+  ) {}
+}
+```
+
+In the example, we inject an instance of `FileUploadService` backed by
+[multer](https://github.com/expressjs/multer) to process the incoming http
+request. The
+[`FileUploadService`](https://github.com/strongloop/loopback-next/blob/master/examples/file-upload-download/src/services/file-upload.service.ts)
+is configurable to support various storage engines.
+
+2. Add a method for file upload
+
+```ts
+/**
+ * A controller to handle file uploads using multipart/form-data media type
+ */
+export class FileUploadController {
+  @post('/files', {
+    responses: {
+      200: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+            },
+          },
+        },
+        description: 'Files and fields',
+      },
+    },
+  })
+  async fileUpload(
+    @requestBody.file()
+    request: Request,
+    @inject(RestBindings.Http.RESPONSE) response: Response,
+  ): Promise<object> {
+    return new Promise<object>((resolve, reject) => {
+      this.handler(request, response, err => {
+        if (err) reject(err);
+        else {
+          resolve(FileUploadController.getFilesAndFields(request));
+        }
+      });
+    });
+  }
+}
+```
+
+The `@post` decoration exposes the method over `POST /files` endpoint to accept
+file upload. We also apply `@requestBody.file()` to mark the request body to be
+files being uploaded using `multipart/form-data` content type. The injected
+`request` and `response` objects are passed into the `multer` handler to process
+the stream, saving to `.sandbox` directory in our example.
+
+See more details about `@requestBody.file` in
+[OpenAPI decorators](decorators/Decorators_openapi.md#requestbodyfile).
+
+### File download
+
+To download files from the backend, please follow the following steps.
+
+1. Create a controller class such as
+   [`FileDownloadController`](https://github.com/strongloop/loopback-next/blob/master/examples/file-upload-download/src/controllers/file-download.controller.ts)
+
+```ts
+import {inject} from '@loopback/context';
+import {
+  get,
+  HttpErrors,
+  oas,
+  param,
+  Response,
+  RestBindings,
+} from '@loopback/rest';
+import fs from 'fs';
+import path from 'path';
+import {promisify} from 'util';
+
+const readdir = promisify(fs.readdir);
+
+const SANDBOX = path.resolve(__dirname, '../../.sandbox');
+
+/**
+ * A controller to handle file downloads using multipart/form-data media type
+ */
+export class FileDownloadController {}
+```
+
+2. (optional) Add a method to list available files
+
+```ts
+export class FileDownloadController {
+  @get('/files', {
+    responses: {
+      200: {
+        content: {
+          // string[]
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        description: 'A list of files',
+      },
+    },
+  })
+  async listFiles() {
+    const files = await readdir(SANDBOX);
+    return files;
+  }
+```
+
+The `@get` decorator exposes `GET /files` to list available file. Our example
+implementation simply returns an array of file names under the `.sandbox`
+directory.
+
+3. Add a method to download a file by name
+
+```ts
+export class FileDownloadController {
+  @get('/files/{filename}')
+  @oas.response.file()
+  downloadFile(
+    @param.path.string('filename') fileName: string,
+    @inject(RestBindings.Http.RESPONSE) response: Response,
+  ) {
+    const file = validateFileName(fileName);
+    response.download(file, fileName);
+    return response;
+  }
+}
+
+/**
+ * Validate file names to prevent them goes beyond the designated directory
+ * @param fileName - File name
+ */
+function validateFileName(fileName: string) {
+  const resolved = path.resolve(SANDBOX, fileName);
+  if (resolved.startsWith(SANDBOX)) return resolved;
+  // The resolved file is outside sandbox
+  throw new HttpErrors.BadRequest(`Invalid file name: ${fileName}`);
+}
+```
+
+The `@get` decorator exposes `GET /files/{filename}` for file download. We use
+`response.download` from `Express` to send the file.
+
+The decoration of `@oas.response.file()` sets the OpenAPI response object for
+file download. See more details about `@oas.response.file` in
+[OpenAPI decorators](decorators/Decorators_openapi.md#using-oasresponsefile).
+
+{% include note.html content="
+The `downloadFile` returns `response` as-is to instruct LoopBack to skip the
+response serialization step as `response.download` manipulates the `response`
+stream directly.
+" %}
+
+{% include warning.html content="
+The `fileName` argument is from user input. We have to validate the value to
+prevent the request to access files outside the `.sandbox` directory. The
+`validateFileName` method resolves the file by name and rejects the request if
+the file is outside the sandbox.
+" %}
+
+### Build a simple UI
+
+The example application comes with a
+[simple HTML page](https://github.com/strongloop/loopback-next/blob/master/examples/file-upload-download/public/index.html).
+
+The page contains the following JavaScript functions:
+
+```js
+/**
+ * Submit the upload form
+ */
+function setupUploadForm() {
+  const formElem = document.getElementById('uploadForm');
+  formElem.onsubmit = async e => {
+    e.preventDefault();
+    const res = await fetch('/files', {
+      method: 'POST',
+      body: new FormData(formElem),
+    });
+    const body = await res.json();
+    console.log('Response from upload', body);
+    await fetchFiles();
+  };
+}
+/**
+ * List uploaded files
+ */
+async function fetchFiles() {
+  const res = await fetch('/files');
+  const files = await res.json();
+  console.log('Response from list', files);
+  const list = files.map(f => `<li><a href="/files/${f}">${f}</a></li>\n`);
+  document.getElementById('fileList').innerHTML = list.join('');
+}
+async function init() {
+  setupUploadForm();
+  await fetchFiles();
+}
+```
+
+The page has two key divisions:
+
+- A form for file selection and upload
+- A list of files with URL links to be downloaded
+
+```html
+<body onload="init();">
+  <div class="info">
+    <h1>File upload and download</h1>
+
+    <div id="upload">
+      <h3>Upload files</h3>
+      <form id="uploadForm">
+        <label for="files">Select files:</label>
+        <input type="file" id="files" name="files" multiple /><br /><br />
+        <label for="note">Note:</label>
+        <input
+          type="text"
+          name="note"
+          id="note"
+          placeholder="Note about the files"
+        />
+        <br /><br />
+        <input type="submit" />
+      </form>
+    </div>
+
+    <div id="download">
+      <h3>Download files</h3>
+      <ul id="fileList"></ul>
+      <button onclick="fetchFiles()">Refresh</button>
+    </div>
+
+    <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h3>
+    <h3>API Explorer: <a href="/explorer">/explorer</a></h3>
+  </div>
+
+  <footer class="power">
+    <a href="https://loopback.io" target="_blank">
+      <img
+        src="https://loopback.io/images/branding/powered-by-loopback/blue/powered-by-loopback-sm.png"
+      />
+    </a>
+  </footer>
+</body>
+```

--- a/docs/site/Usage-scenarios.md
+++ b/docs/site/Usage-scenarios.md
@@ -14,4 +14,5 @@ databases, integrating to other infrastructures and calling other services.
 - [call other services](Calling-other-APIs-and-Web-Services.md)
 - [integrate with infrastructures](Integrate-with-infrastructures.md)
 - [serve static files](Serving-static-files.md)
+- [upload and download files](File-upload-download.md)
 - [deploy to cloud](Deployment.md)

--- a/docs/site/decorators/Decorators_openapi.md
+++ b/docs/site/decorators/Decorators_openapi.md
@@ -357,6 +357,25 @@ class MyController {
 }
 ```
 
+#### @requestBody.file
+
+`@requestBody.file` marks a request body for `multipart/form-data` based file
+upload. For example,
+
+```ts
+import {post, requestBody} from '@loopback/openapi-v3';
+import {Request} from '@loopback/rest';
+class MyController {
+  @post('/pictures')
+  upload(
+    @requestBody.file()
+    request: Request,
+  ) {
+    // ...
+  }
+}
+```
+
 _We plan to support more `@requestBody` shortcuts in the future. You can track
 the feature in
 [story 1064](https://github.com/strongloop/loopback-next/issues/1064)._
@@ -753,6 +772,27 @@ class MyController {
   @oas.response(200, {$ref: '#/path/to/schema'})
   returnFromResponseObject() {
     return {message: 'Hello, world!'};
+  }
+}
+```
+
+#### Using @oas.response.file
+
+`@oas.response.file` is a shortcut decorator to describe response object for
+file download. For example:
+
+```ts
+import {oas, get, param} from '@loopback/openapi-v3';
+import {RestBindings, Response} from '@loopback/rest';
+
+class MyController {
+  @get('/files/{filename}')
+  @oas.response.file('image/jpeg', 'image/png')
+  download(
+    @param.path.string('filename') fileName: string,
+    @inject(RestBindings.Http.RESPONSE) response: Response,
+  ) {
+    // use response.download(...);
   }
 }
 ```

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -191,8 +191,12 @@ children:
         url: Appsody-LoopBack.html
         output: 'web, pdf'
 
-  - title: 'Serving static files'
+  - title: 'Serving Static Files'
     url: Serving-static-files.html
+    output: 'web, pdf'
+
+  - title: 'Uploading and Downloading Files'
+    url: File-upload-download.html
     output: 'web, pdf'
 
 - title: 'Behind the Scene'

--- a/examples/file-upload-download/src/controllers/file-download.controller.ts
+++ b/examples/file-upload-download/src/controllers/file-download.controller.ts
@@ -4,7 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {inject} from '@loopback/context';
-import {get, HttpErrors, param, Response, RestBindings} from '@loopback/rest';
+import {
+  get,
+  HttpErrors,
+  oas,
+  param,
+  Response,
+  RestBindings,
+} from '@loopback/rest';
 import fs from 'fs';
 import path from 'path';
 import {promisify} from 'util';
@@ -40,23 +47,9 @@ export class FileDownloadController {
     return files;
   }
 
-  @get('/files/{filename}', {
-    responses: {
-      200: {
-        content: {
-          // file
-          'application/octet-stream': {
-            schema: {
-              type: 'string',
-              format: 'binary', // This is required by OpenAPI spec 3.x
-            },
-          },
-        },
-        description: 'The file content',
-      },
-    },
-  })
-  async downloadFile(
+  @get('/files/{filename}')
+  @oas.response.file()
+  downloadFile(
     @param.path.string('filename') fileName: string,
     @inject(RestBindings.Http.RESPONSE) response: Response,
   ) {

--- a/examples/file-upload-download/src/controllers/file-upload.controller.ts
+++ b/examples/file-upload-download/src/controllers/file-upload.controller.ts
@@ -40,38 +40,7 @@ export class FileUploadController {
     },
   })
   async fileUpload(
-    @requestBody({
-      description: 'multipart/form-data for files/fields',
-      required: true,
-      content: {
-        // Media type for file upload
-        'multipart/form-data': {
-          // Skip body parsing
-          'x-parser': 'stream',
-          schema: {
-            type: 'object',
-            properties: {
-              file: {
-                type: 'string',
-                // This is required by OpenAPI spec 3.x for file upload
-                format: 'binary',
-              },
-              // Multiple file upload is not working with swagger-ui
-              // https://github.com/swagger-api/swagger-ui/issues/4600
-              /*
-              filename: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  format: 'binary',
-                },
-              },
-              */
-            },
-          },
-        },
-      },
-    })
+    @requestBody.file()
     request: Request,
     @inject(RestBindings.Http.RESPONSE) response: Response,
   ): Promise<object> {

--- a/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-shortcut.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/request-body/request-body-shortcut.decorator.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {getControllerSpec, requestBody, post} from '../../../../';
+import {getControllerSpec, post, requestBody} from '../../../../';
 
 describe('requestBody decorator - shortcuts', () => {
   context('array', () => {
@@ -13,10 +13,7 @@ describe('requestBody decorator - shortcuts', () => {
       class MyController {
         @post('/greeting')
         greet(
-          @requestBody.array(
-            {type: 'string'},
-            {description: description, required: false},
-          )
+          @requestBody.array({type: 'string'}, {description, required: false})
           name: string[],
         ) {}
       }
@@ -33,8 +30,39 @@ describe('requestBody decorator - shortcuts', () => {
 
       const requestBodySpec = actualSpec.paths['/greeting']['post'].requestBody;
       expect(requestBodySpec).to.have.properties({
-        description: description,
+        description,
         required: false,
+        content: expectedContent,
+      });
+    });
+  });
+
+  context('file', () => {
+    it('generates the correct schema spec for a file argument', () => {
+      const description = 'a picture';
+      class MyController {
+        @post('/pictures')
+        upload(
+          @requestBody.file({description, required: true})
+          request: unknown, // It should be `Request` from `@loopback/rest`
+        ) {}
+      }
+
+      const actualSpec = getControllerSpec(MyController);
+      const expectedContent = {
+        'multipart/form-data': {
+          'x-parser': 'stream',
+          schema: {
+            type: 'object',
+            properties: {file: {type: 'string', format: 'binary'}},
+          },
+        },
+      };
+
+      const requestBodySpec = actualSpec.paths['/pictures']['post'].requestBody;
+      expect(requestBodySpec).to.have.properties({
+        description,
+        required: true,
         content: expectedContent,
       });
     });

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -144,10 +144,10 @@ export namespace requestBody {
    * @param properties - The requestBody properties other than `content`
    * @param itemSpec - the full item object
    */
-  export const array = function(
+  export const array = (
     itemSpec: SchemaObject | ReferenceObject,
     properties?: {description?: string; required?: boolean},
-  ) {
+  ) => {
     return requestBody({
       ...properties,
       content: {
@@ -155,6 +155,69 @@ export namespace requestBody {
           schema: {type: 'array', items: itemSpec},
         },
       },
+    });
+  };
+
+  /**
+   * Define a requestBody of `file` type. This is used to support
+   * multipart/form-data based file upload. Use `@requestBody` for other content
+   * types.
+   *
+   * {@link https://swagger.io/docs/specification/describing-request-body/file-upload | OpenAPI file upload}
+   *
+   * @example
+   * import {Request} from '@loopback/rest';
+   *
+   * ```ts
+   * class MyController {
+   *   @post('/pictures')
+   *   upload(
+   *     @requestBody.file()
+   *     request: Request,
+   *   ) {
+   *     // ...
+   *   }
+   * }
+   * ```
+   *
+   * @param properties - Optional description and required flag
+   */
+  export const file = (properties?: {
+    description?: string;
+    required?: boolean;
+  }) => {
+    return requestBody({
+      description: 'Request body for multipart/form-data based file upload',
+      required: true,
+      content: {
+        // Media type for file upload
+        'multipart/form-data': {
+          // Skip body parsing
+          'x-parser': 'stream',
+          schema: {
+            type: 'object',
+            properties: {
+              file: {
+                type: 'string',
+                // This is required by OpenAPI spec 3.x for file upload
+                format: 'binary',
+              },
+              // Multiple file upload is not working with swagger-ui
+              // https://github.com/swagger-api/swagger-ui/issues/4600
+              /*
+              files: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  format: 'binary',
+                },
+              },
+              */
+            },
+          },
+        },
+      },
+      ...properties,
     });
   };
 }

--- a/packages/openapi-v3/src/decorators/response.decorator.ts
+++ b/packages/openapi-v3/src/decorators/response.decorator.ts
@@ -41,7 +41,7 @@ function buildDecoratorReducer(
             | SchemaObject
             | ReferenceObject,
           contentType: ct,
-          description,
+          description: m.description ?? description,
         });
       });
     } else {
@@ -80,4 +80,48 @@ export function response(
     ),
     {decoratorName: '@response', allowInheritance: false},
   );
+}
+
+export namespace response {
+  /**
+   * Decorate the response as a file
+   *
+   * @example
+   * ```ts
+   * import {oas, get, param} from '@loopback/openapi-v3';
+   * import {RestBindings, Response} from '@loopback/rest';
+   *
+   * class MyController {
+   *   @get('/files/{filename}')
+   *   @oas.response.file('image/jpeg', 'image/png')
+   *   download(
+   *     @param.path.string('filename') fileName: string,
+   *     @inject(RestBindings.Http.RESPONSE) response: Response,
+   *   ) {
+   *     // use response.download(...);
+   *   }
+   * }
+   * ```
+   * @param mediaTypes - A list of media types for the file response. It's
+   * default to `['application/octet-stream']`.
+   */
+  export const file = (...mediaTypes: string[]) => {
+    if (mediaTypes.length === 0) {
+      mediaTypes = ['application/octet-stream'];
+    }
+    const responseWithContent: ResponseWithContent = {
+      content: {},
+      description: 'The file content',
+    };
+    for (const t of mediaTypes) {
+      responseWithContent.content[t] = {
+        schema: {
+          type: 'string',
+          format: 'binary', // This is required by OpenAPI spec 3.x
+        },
+      };
+    }
+
+    return response(200, responseWithContent);
+  };
 }


### PR DESCRIPTION
This PR introduces two sugar openapi decorators to further simplify configuration of file upload/download.

- `@requestBody.file` - configure the request body for file upload
- `@oas.response.file` - configure the response for file download

The file upload/download example is now simplified with these decorators.

A new page is added under `Usage Scenarios` to cover file upload/download.

Fixes https://github.com/strongloop/loopback-next/issues/1873

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
