### PR TITLE
chore: update package-lock.json

### DIFF
--- a/acceptance/extension-logging-fluentd/package-lock.json
+++ b/acceptance/extension-logging-fluentd/package-lock.json
@@ -488,9 +488,9 @@
 					}
 				},
 				"tar-stream": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.1.tgz",
-					"integrity": "sha512-GZjLk64XcE/58qwIc1ZfXGqTSE4OutPMEkfBE/oh9eJ4x1eMRjYkgrLrav7PzddpvIpSJSGi8FgNNYXdB9Vumg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+					"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
 					"dev": true,
 					"requires": {
 						"bl": "^4.0.1",

--- a/acceptance/repository-cloudant/package-lock.json
+++ b/acceptance/repository-cloudant/package-lock.json
@@ -1395,9 +1395,9 @@
 			}
 		},
 		"tar-stream": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.1.tgz",
-			"integrity": "sha512-GZjLk64XcE/58qwIc1ZfXGqTSE4OutPMEkfBE/oh9eJ4x1eMRjYkgrLrav7PzddpvIpSJSGi8FgNNYXdB9Vumg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+			"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
 			"dev": true,
 			"requires": {
 				"bl": "^4.0.1",

--- a/acceptance/repository-mongodb/package-lock.json
+++ b/acceptance/repository-mongodb/package-lock.json
@@ -372,9 +372,9 @@
 			"dev": true
 		},
 		"mongodb": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.4.tgz",
-			"integrity": "sha512-xGH41Ig4dkSH5ROGezkgDbsgt/v5zbNUwE3TcFsSbDc6Qn3Qil17dhLsESSDDPTiyFDCPJRpfd4887dtsPgKtA==",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.5.tgz",
+			"integrity": "sha512-GCjDxR3UOltDq00Zcpzql6dQo1sVry60OXJY3TDmFc2SWFY6c8Gn1Ardidc5jDirvJrx2GC3knGOImKphbSL3A==",
 			"dev": true,
 			"requires": {
 				"bl": "^2.2.0",

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -22,9 +22,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -67,9 +67,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -813,9 +813,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"mkdirp": {
 			"version": "0.5.1",

--- a/examples/access-control-migration/package-lock.json
+++ b/examples/access-control-migration/package-lock.json
@@ -568,12 +568,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -787,9 +787,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -871,9 +871,9 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/context/package-lock.json
+++ b/examples/context/package-lock.json
@@ -417,12 +417,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -569,9 +569,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -631,9 +631,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/express-composition/package-lock.json
+++ b/examples/express-composition/package-lock.json
@@ -594,12 +594,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -812,9 +812,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -884,9 +884,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/file-upload-download/package-lock.json
+++ b/examples/file-upload-download/package-lock.json
@@ -120,12 +120,12 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.22.0.tgz",
-			"integrity": "sha512-BvxRLaTDVQ3N+Qq8BivLiE9akQLAOUfxNHIEhedOcg8B2+jY8Rc4/D+iVprvuMX1AdezFYautuGDwr9QxqSxBQ==",
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.23.0.tgz",
+			"integrity": "sha512-8iA4FvRsz8qTjR0L/nK9RcRUN3QtIHQiOm69FzV7WS3SE+7P7DyGGwh3k4UNR2JBbk+Ej2Io+jLAaqKibNhmtw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "2.22.0",
+				"@typescript-eslint/experimental-utils": "2.23.0",
 				"eslint-utils": "^1.4.3",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.0.0",
@@ -133,32 +133,32 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.22.0.tgz",
-			"integrity": "sha512-sJt1GYBe6yC0dWOQzXlp+tiuGglNhJC9eXZeC8GBVH98Zv9jtatccuhz0OF5kC/DwChqsNfghHx7OlIDQjNYAQ==",
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz",
+			"integrity": "sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.22.0",
+				"@typescript-eslint/typescript-estree": "2.23.0",
 				"eslint-scope": "^5.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.22.0.tgz",
-			"integrity": "sha512-FaZKC1X+nvD7qMPqKFUYHz3H0TAioSVFGvG29f796Nc5tBluoqfHgLbSFKsh7mKjRoeTm8J9WX2Wo9EyZWjG7w==",
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.23.0.tgz",
+			"integrity": "sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.22.0",
-				"@typescript-eslint/typescript-estree": "2.22.0",
+				"@typescript-eslint/experimental-utils": "2.23.0",
+				"@typescript-eslint/typescript-estree": "2.23.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "2.22.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.22.0.tgz",
-			"integrity": "sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==",
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz",
+			"integrity": "sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
@@ -566,12 +566,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -718,9 +718,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -779,9 +779,9 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/greeter-extension/package-lock.json
+++ b/examples/greeter-extension/package-lock.json
@@ -519,12 +519,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -671,9 +671,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -732,9 +732,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/greeting-app/package-lock.json
+++ b/examples/greeting-app/package-lock.json
@@ -519,12 +519,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -671,9 +671,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -732,9 +732,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -417,12 +417,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -569,9 +569,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -631,9 +631,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/lb3-application/package-lock.json
+++ b/examples/lb3-application/package-lock.json
@@ -875,12 +875,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -1210,9 +1210,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -1404,9 +1404,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/log-extension/package-lock.json
+++ b/examples/log-extension/package-lock.json
@@ -519,12 +519,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -671,9 +671,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -732,9 +732,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/metrics-prometheus/package-lock.json
+++ b/examples/metrics-prometheus/package-lock.json
@@ -417,12 +417,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -569,9 +569,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -631,9 +631,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/rest-crud/package-lock.json
+++ b/examples/rest-crud/package-lock.json
@@ -103,6 +103,14 @@
 				"lodash": "^4.17.15",
 				"semver": "^6.3.0",
 				"tsutils": "^3.17.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"accept-language": {
@@ -334,13 +342,6 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
 			}
 		},
 		"crypt": {
@@ -462,6 +463,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
 					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -1392,10 +1399,9 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"shebang-command": {
 			"version": "1.2.0",

--- a/examples/rpc-server/package-lock.json
+++ b/examples/rpc-server/package-lock.json
@@ -594,12 +594,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -812,9 +812,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -884,9 +884,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/soap-calculator/package-lock.json
+++ b/examples/soap-calculator/package-lock.json
@@ -710,12 +710,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -980,9 +980,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -1105,9 +1105,9 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/todo-list/package-lock.json
+++ b/examples/todo-list/package-lock.json
@@ -535,12 +535,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -746,9 +746,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -830,9 +830,9 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/examples/todo/package-lock.json
+++ b/examples/todo/package-lock.json
@@ -535,12 +535,12 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -746,9 +746,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.8.1"
@@ -830,9 +830,9 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.4",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
           "dev": true
         }
       }
@@ -1567,9 +1567,9 @@
       }
     },
     "@octokit/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-rvJP1Y9A/+Cky2C3var1vsw3Lf5Rjn/0sojNl2AjCX+WbpIHYccaJ46abrZoIxMYnOToul6S9tPytUVkFI7CXQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-KEnLwOfdXzxPNL34fj508bhi9Z9cStyN7qY1kOfVahmqtAfrWw6Oq3P4R+dtsg0lYtZdWBpUrS/Ixmd5YILSww==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -1623,9 +1623,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
+      "version": "13.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
       "dev": true
     },
     "@types/parse-json": {
@@ -2620,9 +2620,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -2741,9 +2741,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "readable-stream": {
@@ -2862,9 +2862,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -3368,9 +3368,9 @@
           "dev": true
         },
         "inquirer": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-          "integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+          "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -3561,12 +3561,12 @@
       "dev": true
     },
     "espree": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-      "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
+        "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
@@ -4237,9 +4237,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "parse-json": {
@@ -4439,9 +4439,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -4537,9 +4537,9 @@
       }
     },
     "globals": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-      "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
       "dev": true,
       "requires": {
         "type-fest": "^0.8.1"
@@ -5940,9 +5940,9 @@
       "dev": true
     },
     "node-fetch-npm": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.3.tgz",
+      "integrity": "sha512-DgwoKEsqLnFZtk3ap7GWBHcHwnUhsNmQqEDcdjfQ8GofLEFJ081NAd4Uin3R7RFZBWVJCwHISw1oaEqPgSLloA==",
       "dev": true,
       "requires": {
         "encoding": "^0.1.11",
@@ -7662,9 +7662,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -8374,18 +8374,18 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.0.tgz",
-      "integrity": "sha512-6qI/tTx7OVtA4qNqD0OyutbM6Z9EKu4rxWm/2Y3FDEBQ4/2X2XAnyuRXMzAE2+1BPyqzksJZtrIwblOHg0IEzA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.2.tgz",
+      "integrity": "sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.7"
       }
     },
     "yargs": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
-      "integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -8398,7 +8398,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^15.0.0"
+        "yargs-parser": "^15.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -8468,9 +8468,9 @@
           }
         },
         "yargs-parser": {
-          "version": "15.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/packages/authentication/package-lock.json
+++ b/packages/authentication/package-lock.json
@@ -14,9 +14,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -29,9 +29,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -55,9 +55,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},

--- a/packages/boot/package-lock.json
+++ b/packages/boot/package-lock.json
@@ -25,9 +25,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},

--- a/packages/booter-lb3app/package-lock.json
+++ b/packages/booter-lb3app/package-lock.json
@@ -40,9 +40,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -55,9 +55,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -87,9 +87,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -1998,9 +1998,9 @@
 			"integrity": "sha512-lXBnjPhfgoGFZNjeiEis0ueNIl1DXe2VY/3Lj86iX5dW2ZGy7S3FzRnC+QgbulFWu2gGGjmnDH2OSUuSwKBfgw=="
 		},
 		"regenerator-runtime": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-			"integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 		},
 		"request": {
 			"version": "2.88.2",
@@ -2726,9 +2726,9 @@
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yaml": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.0.tgz",
-			"integrity": "sha512-6qI/tTx7OVtA4qNqD0OyutbM6Z9EKu4rxWm/2Y3FDEBQ4/2X2XAnyuRXMzAE2+1BPyqzksJZtrIwblOHg0IEzA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.2.tgz",
+			"integrity": "sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==",
 			"requires": {
 				"@babel/runtime": "^7.8.7"
 			}

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -42,9 +42,9 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-			"integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
+			"integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
 			"requires": {
 				"@babel/types": "^7.8.7",
 				"jsesc": "^2.5.1",
@@ -99,9 +99,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-			"integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A=="
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+			"integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
 		},
 		"@babel/template": {
 			"version": "7.8.6",
@@ -789,11 +789,11 @@
 			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
 		},
 		"espree": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-			"integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
 			"requires": {
-				"acorn": "^7.1.0",
+				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
@@ -879,9 +879,9 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
-			"integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
@@ -1011,9 +1011,9 @@
 			}
 		},
 		"globals": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-			"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
 			"requires": {
 				"type-fest": "^0.8.1"
 			}
@@ -1112,9 +1112,9 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-			"integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+			"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
 			"requires": {
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^3.0.0",
@@ -1402,9 +1402,9 @@
 			},
 			"dependencies": {
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 				}
 			}
 		},

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -388,9 +388,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -5683,9 +5683,9 @@
 			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerator-runtime": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-			"integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -7472,9 +7472,9 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"yaml": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.0.tgz",
-			"integrity": "sha512-6qI/tTx7OVtA4qNqD0OyutbM6Z9EKu4rxWm/2Y3FDEBQ4/2X2XAnyuRXMzAE2+1BPyqzksJZtrIwblOHg0IEzA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.2.tgz",
+			"integrity": "sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==",
 			"requires": {
 				"@babel/runtime": "^7.8.7"
 			}
@@ -8050,19 +8050,19 @@
 			}
 		},
 		"yeoman-test": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-2.2.0.tgz",
-			"integrity": "sha512-JxZSiPnuxRR/7ESx0A/VK2HREbhnaCEtDK3vx4XwM8ltgdVe+jm4bCTXpBJVoWqcZ9JxGmUKxiS6TOQl5C+2fg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-2.3.0.tgz",
+			"integrity": "sha512-4noKP8/rN/CwKxC4Qf6y4IfI4IJKn3dcLPPrh693TKDmh3k0P4ZqXK1OInaCFxbtIFVrTJMbmlallRr9T5322w==",
 			"dev": true,
 			"requires": {
-				"inquirer": "^7.0.3",
+				"inquirer": "^7.1.0",
 				"lodash": "^4.17.15",
 				"mkdirp": "^0.5.1",
 				"pinkie-promise": "^2.0.1",
 				"rimraf": "^3.0.0",
 				"sinon": "^8.0.4",
-				"yeoman-environment": "^2.7.0",
-				"yeoman-generator": "^4.4.0"
+				"yeoman-environment": "^2.8.1",
+				"yeoman-generator": "^4.7.1"
 			},
 			"dependencies": {
 				"@sinonjs/formatio": {
@@ -8084,6 +8084,27 @@
 						"@sinonjs/commons": "^1.6.0",
 						"lodash.get": "^4.4.2",
 						"type-detect": "^4.0.8"
+					}
+				},
+				"inquirer": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+					"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^3.0.0",
+						"cli-cursor": "^3.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^3.0.0",
+						"lodash": "^4.17.15",
+						"mute-stream": "0.0.8",
+						"run-async": "^2.4.0",
+						"rxjs": "^6.5.3",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0",
+						"through": "^2.3.6"
 					}
 				},
 				"isarray": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -8050,19 +8050,19 @@
 			}
 		},
 		"yeoman-test": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-2.3.0.tgz",
-			"integrity": "sha512-4noKP8/rN/CwKxC4Qf6y4IfI4IJKn3dcLPPrh693TKDmh3k0P4ZqXK1OInaCFxbtIFVrTJMbmlallRr9T5322w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-2.2.0.tgz",
+			"integrity": "sha512-JxZSiPnuxRR/7ESx0A/VK2HREbhnaCEtDK3vx4XwM8ltgdVe+jm4bCTXpBJVoWqcZ9JxGmUKxiS6TOQl5C+2fg==",
 			"dev": true,
 			"requires": {
-				"inquirer": "^7.1.0",
+				"inquirer": "^7.0.3",
 				"lodash": "^4.17.15",
 				"mkdirp": "^0.5.1",
 				"pinkie-promise": "^2.0.1",
 				"rimraf": "^3.0.0",
 				"sinon": "^8.0.4",
-				"yeoman-environment": "^2.8.1",
-				"yeoman-generator": "^4.7.1"
+				"yeoman-environment": "^2.7.0",
+				"yeoman-generator": "^4.4.0"
 			},
 			"dependencies": {
 				"@sinonjs/formatio": {
@@ -8084,27 +8084,6 @@
 						"@sinonjs/commons": "^1.6.0",
 						"lodash.get": "^4.4.2",
 						"type-detect": "^4.0.8"
-					}
-				},
-				"inquirer": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-					"integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^3.0.0",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
-						"mute-stream": "0.0.8",
-						"run-async": "^2.4.0",
-						"rxjs": "^6.5.3",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0",
-						"through": "^2.3.6"
 					}
 				},
 				"isarray": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "strong-globalize-cli": "6.0.5",
     "yeoman-assert": "^3.1.1",
     "yeoman-environment": "^2.8.1",
-    "yeoman-test": "^2.2.0"
+    "yeoman-test": "~2.2.0"
   },
   "dependencies": {
     "@phenomnomnominal/tsquery": "^4.0.0",

--- a/packages/rest/package-lock.json
+++ b/packages/rest/package-lock.json
@@ -14,9 +14,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -29,9 +29,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -69,9 +69,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -121,9 +121,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -156,9 +156,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},

--- a/packages/testlab/package-lock.json
+++ b/packages/testlab/package-lock.json
@@ -129,9 +129,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -144,9 +144,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -175,9 +175,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -190,9 +190,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -230,9 +230,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -251,9 +251,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "13.9.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-					"integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+					"version": "13.9.1",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
 				}
 			}
 		},
@@ -1129,9 +1129,9 @@
 			"integrity": "sha512-lXBnjPhfgoGFZNjeiEis0ueNIl1DXe2VY/3Lj86iX5dW2ZGy7S3FzRnC+QgbulFWu2gGGjmnDH2OSUuSwKBfgw=="
 		},
 		"regenerator-runtime": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-			"integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -1505,9 +1505,9 @@
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yaml": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.0.tgz",
-			"integrity": "sha512-6qI/tTx7OVtA4qNqD0OyutbM6Z9EKu4rxWm/2Y3FDEBQ4/2X2XAnyuRXMzAE2+1BPyqzksJZtrIwblOHg0IEzA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.2.tgz",
+			"integrity": "sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==",
 			"requires": {
 				"@babel/runtime": "^7.8.7"
 			}


### PR DESCRIPTION
- Fixes https://github.com/strongloop/loopback-next/network/alert/package-lock.json/minimist/open

- Pin yeoman-test at ~2.2.0 to avoid windows hang with inquirer 7.1.x

See more information at:
- #4871
- SBoudrias/Inquirer.js#904

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
