### PR TITLE
feat(context): emit bind/unbind events on ContextView

### DIFF
--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -554,6 +554,8 @@ injection.
 
 A `ContextView` object can emit one of the following events:
 
+- 'bind': when a binding is added to the view
+- 'unbind': when a binding is removed from the view
 - 'refresh': when the view is refreshed as bindings are added/removed
 - 'resolve': when the cached values are resolved and updated
 - 'close': when the view is closed (stopped observing context events)

--- a/packages/context/src/context-view.ts
+++ b/packages/context/src/context-view.ts
@@ -10,6 +10,7 @@ import {Binding} from './binding';
 import {BindingFilter} from './binding-filter';
 import {BindingComparator} from './binding-sorter';
 import {Context} from './context';
+import {ContextEvent} from './context-event';
 import {ContextEventType, ContextObserver} from './context-observer';
 import {Subscription} from './context-subscription';
 import {Getter} from './inject';
@@ -97,7 +98,17 @@ export class ContextView<T = unknown> extends EventEmitter
   /**
    * Listen on `bind` or `unbind` and invalidate the cache
    */
-  observe(event: ContextEventType, binding: Readonly<Binding<unknown>>) {
+  observe(
+    event: ContextEventType,
+    binding: Readonly<Binding<unknown>>,
+    context: Context,
+  ) {
+    const ctxEvent: ContextEvent = {
+      context,
+      binding,
+      type: event,
+    };
+    this.emit(event, ctxEvent);
     this.refresh();
   }
 


### PR DESCRIPTION
This allows applications to listen on an injected context view to react
on bind/unbind events in addition to refresh for more fine-grained update.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
