### PR TITLE
feat(core): add more flavors of @extensions decorator

### DIFF
--- a/docs/site/Extension-point-and-extensions.md
+++ b/docs/site/Extension-point-and-extensions.md
@@ -50,6 +50,11 @@ decorators and functions are provided to ensure consistency and convention.
   custom name
 - `@extensions`: injects a getter function to access extensions to the target
   extension point
+- `@extensions.view`: injects a context view to access extensions to the target
+  extension point. The view can be listened for context events.
+- `@extensions.list`: injects an array of extensions to the target extension
+  point. The list is fixed when the injection is done and it does not add or
+  remove extensions afterward.
 - `extensionFilter`: creates a binding filter function to find extensions for
   the named extension point
 - `extensionFor`: creates a binding template function to set the binding to be
@@ -58,7 +63,51 @@ decorators and functions are provided to ensure consistency and convention.
 - `addExtension`: registers an extension class to the context for the named
   extension point
 
-The usage of these helper decorators and functions are illustrated in the
+## Examples
+
+1. Inject a getter function for extensions
+
+   ```ts
+   import {Getter} from '@loopback/context';
+   import {extensionPoint, extensions} from '@loopback/core';
+
+   @extensionPoint('greeters')
+   class GreetingService {
+     @extensions()
+     public getGreeters: Getter<Greeter[]>;
+   }
+   ```
+
+2. Inject a context view for extensions
+
+   ```ts
+   import {ContextView} from '@loopback/context';
+   import {extensionPoint, extensions} from '@loopback/core';
+
+   @extensionPoint('greeters')
+   class GreetingService {
+     constructor(
+       @extensions.view()
+       public readonly greetersView: ContextView<Greeter>,
+     ) {
+       // ...
+     }
+   }
+   ```
+
+3. Inject an array of resolved extensions
+
+   ```ts
+   import {extensionPoint, extensions} from '@loopback/core';
+
+   @extensionPoint('greeters')
+   class GreetingService {
+     @extensions.list()
+     public greeters: Greeter[];
+   }
+   ```
+
+More usage of these helper decorators and functions are illustrated in the
 `greeter-extension` tutorial.
 
 ## Tutorial


### PR DESCRIPTION
This allows a getter, a view, or a list of extensions to be injected.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
