### PR TITLE
feat: support any type

### DIFF
--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -65,6 +65,14 @@ describe('TodoApplication', () => {
     expect(result).to.containDeep(todo);
   });
 
+  it('creates a todo with arbitrary property', async function () {
+    const todo = givenTodo({tag: {random: 'random'}});
+    const response = await client.post('/todos').send(todo).expect(200);
+    expect(response.body).to.containDeep(todo);
+    const result = await todoRepo.findById(response.body.id);
+    expect(result).to.containDeep(todo);
+  });
+
   it('rejects requests to create a todo with no title', async () => {
     const todo = givenTodo();
     delete todo.title;

--- a/examples/todo/src/models/todo.model.ts
+++ b/examples/todo/src/models/todo.model.ts
@@ -41,6 +41,12 @@ export class Todo extends Entity {
   })
   remindAtGeo?: string; // latitude,longitude
 
+  @property({
+    type: 'any',
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tag?: any;
+
   constructor(data?: Partial<Todo>) {
     super(data);
   }

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -179,6 +179,24 @@ describe('build-schema', () => {
         expectValidJsonSchema(jsonSchema);
       });
 
+      it('properly converts any properties', () => {
+        @model()
+        class TestModel {
+          @property({
+            type: 'any',
+          })
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          anyProp: any;
+        }
+
+        const jsonSchema = modelToJsonSchema(TestModel);
+        expect(jsonSchema.properties).to.deepEqual({
+          anyProp: {},
+        });
+
+        expectValidJsonSchema(jsonSchema);
+      });
+
       it('properly converts primitive array properties', () => {
         @model()
         class TestModel {

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -51,6 +51,10 @@ describe('build-schema', () => {
       it('returns Object for "object"', () => {
         expect(stringTypeToWrapper('object')).to.eql(Object);
       });
+
+      it('returns AnyType for "any"', () => {
+        expect(stringTypeToWrapper('any')).to.eql(Object);
+      });
     });
 
     it('errors out if other types are given', () => {
@@ -174,6 +178,10 @@ describe('build-schema', () => {
         type: 'array',
         items: {$ref: '#/definitions/CustomType'},
       });
+    });
+
+    it('converts type any', () => {
+      expect(metaToJsonProperty({type: 'any'})).to.eql({});
     });
 
     it('keeps description on property', () => {

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -181,7 +181,8 @@ export function stringTypeToWrapper(type: string | Function): Function {
       wrapper = Array;
       break;
     }
-    case 'object': {
+    case 'object':
+    case 'any': {
       wrapper = Object;
       break;
     }
@@ -235,6 +236,8 @@ export function metaToJsonProperty(meta: PropertyDefinition): JSONSchema {
       type: 'string',
       format: 'date-time',
     });
+  } else if (propertyType === 'any') {
+    // no-op, the json schema for any type is {}
   } else if (isBuiltinType(resolvedType)) {
     Object.assign(propDef, {
       type: resolvedType.name.toLowerCase(),

--- a/packages/rest/src/__tests__/unit/ajv.service.unit.ts
+++ b/packages/rest/src/__tests__/unit/ajv.service.unit.ts
@@ -39,6 +39,93 @@ describe('Ajv service', () => {
     expect(result).to.be.true();
   });
 
+  // possible values for type any
+  const TEST_VALUES = {
+    string: 'abc',
+    number: 123,
+    object: {random: 'random'},
+    array: [1, 2, 3],
+    null: null,
+  };
+
+  context('accepts any type with schema {}', () => {
+    for (const v in TEST_VALUES) {
+      testAnyTypeWith(v);
+    }
+
+    function testAnyTypeWith(value: string) {
+      it(`with value ${value}`, async () => {
+        const ajv = new AjvProvider().value();
+        const validator = ajv.compile({});
+        const result = await validator(value);
+        expect(result).to.be.true();
+      });
+    }
+  });
+
+  context('accepts any type with schema {} - property', () => {
+    for (const v in TEST_VALUES) {
+      testAnyTypeWith(v);
+    }
+
+    function testAnyTypeWith(value: string) {
+      it(`with value ${value}`, async () => {
+        const ajv = new AjvProvider().value();
+        const validator = ajv.compile({
+          type: 'object',
+          properties: {
+            name: {type: 'string'},
+            arbitraryProp: {},
+          },
+        });
+        const result = await validator({
+          name: 'Zoe',
+          arbitraryProp: value,
+        });
+        expect(result).to.be.true();
+      });
+    }
+  });
+
+  context('accepts any type with schema true', () => {
+    for (const v in TEST_VALUES) {
+      testAnyTypeWith(v);
+    }
+
+    function testAnyTypeWith(value: string) {
+      it(`with value ${value}`, async () => {
+        const ajv = new AjvProvider().value();
+        const validator = ajv.compile(true);
+        const result = await validator(value);
+        expect(result).to.be.true();
+      });
+    }
+  });
+
+  context('accepts any type with schema true - property', () => {
+    for (const v in TEST_VALUES) {
+      testAnyTypeWith(v);
+    }
+
+    function testAnyTypeWith(value: string) {
+      it(`with value ${value}`, async () => {
+        const ajv = new AjvProvider().value();
+        const validator = ajv.compile({
+          type: 'object',
+          properties: {
+            name: {type: 'string'},
+            arbitraryProp: true,
+          },
+        });
+        const result = await validator({
+          name: 'Zoe',
+          arbitraryProp: value,
+        });
+        expect(result).to.be.true();
+      });
+    }
+  });
+
   it('reports unknown format', async () => {
     const ajv = await ctx.get(AJV_SERVICE);
     expect(() => ajv.compile({type: 'string', format: 'gmail'})).to.throw(


### PR DESCRIPTION
Implements https://github.com/strongloop/loopback-next/issues/4255, which supports the `any` as the type for arbitrary model property.

*This is the first PR created to support `any` type. We need another PR to append the `any` type's openapi schema in `components.schemas`*

### Description 

Define the property in model as:
  
```ts
import {AnyType} from '@loopback/repository';
@property({
    // `@loopback/repository-json-schema` recognizes it
    type: 'any'
  })
  // specify `AnyType` for it
  arbitraryProp: AnyType
```

Generated json schema would be

```ts
arbitraryProp: {
    $ref: '#/definitions/AnyType'
}
```

Generated openapi spec would be

```ts
"components": {
    "schemas": {
      "Todo": {
        "title": "Todo",
        "properties": {
          "id": {
            "type": "number"
          },
          // ...other properties
          // The schema will be generated as a reference
          // TODO: to completely support this feature, we can provide swagger AnyType schema
          // out-of-the-box
          // see link https://swagger.io/docs/specification/data-models/data-types/#any
          "arbitraryProp": {
            "$ref": "#/components/schemas/AnyType"
          }
        },
        "required": [
          "title"
        ],
        "additionalProperties": false
      },
  },
}
```

-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
