### PR TITLE
feat(cli): add `lb4 rest-crud` command to generate model endpoints from model/datasource

### DIFF
--- a/docs/site/Rest-Crud-generator.md
+++ b/docs/site/Rest-Crud-generator.md
@@ -1,0 +1,83 @@
+---
+lang: en
+title: 'REST CRUD model endpoints generator'
+keywords: LoopBack 4.0, LoopBack 4
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Rest-Crud-generator.html
+---
+
+{% include content/generator-create-app.html lang=page.lang %}
+
+### Synopsis
+
+Adds a new
+[Rest config for model endpoint (or multiple backed by the same datasource)](Creating-CRUD-REST-apis.md)
+to a LoopBack application with one single command.
+
+```sh
+lb4 rest-crud [options]
+```
+
+### Options
+
+`--datasource` : _(Optional)_ name of a valid datasource already created in
+src/datasources
+
+`--model` : _(Optional)_ name of a valid model already created in src/models
+
+`--basePath` : _(Optional)_ base path of the model endpoint
+
+### Configuration file
+
+This generator supports a config file with the following format, see the
+Standard options below to see different ways you can supply this configuration
+file.
+
+```ts
+{
+  "datasource": "validDataSourceName",
+  "model": "validModelName",
+  "basePath": "/<base-path>"
+}
+```
+
+### Notes
+
+Service oriented datasources such as REST or SOAP are not considered valid in
+this context and will not be presented to you in the selection list.
+
+There should be at least one valid _(Persisted)_ data source and one model
+already created in their respective directories.
+
+{% include_relative includes/CLI-std-options.md %}
+
+### Interactive Prompts
+
+The tool will prompt you for:
+
+- **Please select the datasource.** _(name)_ If the name of the datasource had
+  been supplied from the command line, the prompt is skipped, otherwise it will
+  present you the list of available datasources to select one. It will use this
+  datasource to check what kind of model endpoint it will generate.
+
+- **Select the model(s) you want to generate a model endpoint.** _(model)_ If
+  the name of the model had been supplied from the command line with `--model`
+  option and it is a valid model, then the prompt is skipped, otherwise it will
+  present the error `Error: No models found` in the console.
+
+  If no `--model` is supplied, then the it will present you with a valid list of
+  models from `src/models` directory and you will be able to select one or
+  multiple models. The tool will generate a rest config of model endpoint for
+  each of the selected models.
+
+- **Please specify the base path.**. _(basePath)_ If the base path had been
+  supplied from the command line with `--basePath` option or more than one
+  models are selected, the prompt is skipped.
+
+### Output
+
+Once all the prompts have been answered, the CLI will do the following for each
+of the selected models.
+
+- Create a rest config file for selected models as follows:
+  `/src/model-endpoints/${modelName}.rest-config.ts`

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -503,6 +503,10 @@ children:
     url: Repository-generator.html
     output: 'web, pdf'
 
+  - title: 'REST CRUD model endpoints generator'
+    url: Rest-Crud-generator.html
+    output: 'web, pdf'
+
   - title: 'Service generator'
     url: Service-generator.html
     output: 'web, pdf'

--- a/docs/site/tables/lb4-artifact-commands.html
+++ b/docs/site/tables/lb4-artifact-commands.html
@@ -81,5 +81,11 @@
       <td>Check and/or update project dependencies of LoopBack modules</td>
       <td><a href="Update-generator.html">Project dependency update</a></td>
     </tr>
+
+    <tr>
+      <td><code>lb4 rest-crud</code></td>
+      <td>Generate rest configs for model endpoints</td>
+      <td><a href="Rest-Crud-generator.html">Model endpoint generator</a></td>
+    </tr>
   </tbody>
 </table>

--- a/packages/cli/generators/rest-crud/crud-rest-component.js
+++ b/packages/cli/generators/rest-crud/crud-rest-component.js
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const ast = require('ts-morph');
+const path = require('path');
+
+/**
+ * Update `src/application.ts`
+ * @param projectRoot - Project root directory
+ */
+async function updateApplicationTs(projectRoot) {
+  const CRUD_REST_COMPONENT = 'CrudRestComponent';
+  const applicationTsFile = path.join(projectRoot, 'src/application.ts');
+
+  // Create an AST project
+  const project = new ast.Project({
+    manipulationSettings: {
+      indentationText: ast.IndentationText.TwoSpaces,
+      insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: false,
+      newLineKind: ast.NewLineKind.LineFeed,
+      quoteKind: ast.QuoteKind.Single,
+    },
+  });
+
+  // import {CrudRestComponent} from '@loopback/rest-crud';
+  const importDeclaration = {
+    kind: ast.StructureKind.ImportDeclaration,
+    moduleSpecifier: '@loopback/rest-crud',
+    namedImports: [CRUD_REST_COMPONENT],
+  };
+
+  const pFile = project.addSourceFileAtPath(applicationTsFile);
+
+  // Check if `import {CrudRestComponent} from '@loopback/rest-crud'` exists
+  const restCrudImport = pFile.getImportDeclaration('@loopback/rest-crud');
+
+  if (restCrudImport == null) {
+    // Not found
+    pFile.addImportDeclaration(importDeclaration);
+  } else {
+    // Further check named import for CrudRestComponent
+    const names = restCrudImport.getNamedImports().map(i => i.getName());
+    if (!names.includes(CRUD_REST_COMPONENT)) {
+      restCrudImport.addNamedImport(CRUD_REST_COMPONENT);
+    }
+  }
+
+  // Find the constructor
+  const ctor = pFile.getClasses()[0].getConstructors()[0];
+  const body = ctor.getBodyText();
+
+  // Check if `this.component(CrudRestComponent)` exists
+  if (!body.includes(`this.component(${CRUD_REST_COMPONENT}`)) {
+    ctor.addStatements(`this.component(${CRUD_REST_COMPONENT});`);
+  }
+
+  await pFile.save();
+}
+
+exports.updateApplicationTs = updateApplicationTs;

--- a/packages/cli/generators/rest-crud/index.js
+++ b/packages/cli/generators/rest-crud/index.js
@@ -1,0 +1,395 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const _ = require('lodash');
+const ArtifactGenerator = require('../../lib/artifact-generator');
+const fs = require('fs');
+const debug = require('../../lib/debug')('rest-crud-generator');
+const inspect = require('util').inspect;
+const path = require('path');
+const chalk = require('chalk');
+const utils = require('../../lib/utils');
+const g = require('../../lib/globalize');
+const cliPkg = require('../../lib/version-helper').cliPkg;
+
+const {updateApplicationTs} = require('./crud-rest-component');
+
+const VALID_CONNECTORS_FOR_REPOSITORY = ['PersistedModel'];
+
+const REST_CONFIG_TEMPLATE = 'model.rest-config-template.ts.ejs';
+
+const PROMPT_MESSAGE_MODEL = g.f(
+  'Select the model(s) you want to generate a CRUD REST endpoint',
+);
+const PROMPT_MESSAGE_DATA_SOURCE = g.f('Please select the datasource');
+const PROMPT_MESSAGE_BASE_PATH = g.f('Please specify the base path');
+
+const ERROR_NO_DATA_SOURCES_FOUND = g.f('No datasources found at');
+const ERROR_NO_MODELS_FOUND = g.f('No models found at');
+const ERROR_NO_MODEL_SELECTED = g.f('You did not select a valid model');
+
+module.exports = class RestCrudGenerator extends ArtifactGenerator {
+  // Note: arguments and options should be defined in the constructor.
+  constructor(args, opts) {
+    super(args, opts);
+  }
+
+  /**
+   * helper method to inspect and validate a datasource type
+   */
+  async _inferDataSourceNames() {
+    if (!this.artifactInfo.dataSourceClass) {
+      return;
+    }
+
+    this.artifactInfo.dataSourceName = utils.getDataSourceName(
+      this.artifactInfo.datasourcesDir,
+      this.artifactInfo.dataSourceClass,
+    );
+
+    this.artifactInfo.dataSourceClassName =
+      utils.toClassName(this.artifactInfo.dataSourceName) + 'DataSource';
+  }
+
+  _setupGenerator() {
+    this.artifactInfo = {
+      type: 'rest-config',
+      rootDir: utils.sourceRootDir,
+    };
+
+    this.artifactInfo.outDir = path.resolve(
+      this.artifactInfo.rootDir,
+      utils.modelEndpointsDir,
+    );
+    this.artifactInfo.datasourcesDir = path.resolve(
+      this.artifactInfo.rootDir,
+      utils.datasourcesDir,
+    );
+    this.artifactInfo.modelDir = path.resolve(
+      this.artifactInfo.rootDir,
+      utils.modelsDir,
+    );
+
+    this.artifactInfo.defaultTemplate = REST_CONFIG_TEMPLATE;
+
+    this.option('model', {
+      type: String,
+      required: false,
+      description: g.f('A valid model name'),
+    });
+
+    this.option('datasource', {
+      type: String,
+      required: false,
+      description: g.f('A valid datasource name'),
+    });
+
+    this.option('basePath', {
+      type: String,
+      required: false,
+      description: g.f('A valid base path'),
+    });
+
+    return super._setupGenerator();
+  }
+
+  setOptions() {
+    return super.setOptions();
+  }
+
+  checkLoopBackProject() {
+    if (this.shouldExit()) return;
+    return super.checkLoopBackProject();
+  }
+
+  async checkPaths() {
+    if (this.shouldExit()) return;
+    // check for datasources
+    if (!fs.existsSync(this.artifactInfo.datasourcesDir)) {
+      return this.exit(
+        new Error(
+          `${ERROR_NO_DATA_SOURCES_FOUND} ${this.artifactInfo.datasourcesDir}.
+        ${chalk.yellow(
+          'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
+        )}`,
+        ),
+      );
+    }
+
+    // check for models
+    if (!fs.existsSync(this.artifactInfo.modelDir)) {
+      return this.exit(
+        new Error(
+          `${ERROR_NO_MODELS_FOUND} ${this.artifactInfo.modelDir}.
+        ${chalk.yellow(
+          'Please visit https://loopback.io/doc/en/lb4/Model-generator.html for information on how models are discovered',
+        )}`,
+        ),
+      );
+    }
+  }
+
+  async promptDataSourceName() {
+    if (this.shouldExit()) return false;
+
+    debug('Prompting for a datasource ');
+    let datasourcesList;
+
+    // grab the datasourcename from the command line
+    const cmdDatasourceName = this.options.datasource
+      ? utils.toClassName(this.options.datasource) + 'Datasource'
+      : '';
+
+    debug(`command line datasource is  ${cmdDatasourceName}`);
+
+    try {
+      datasourcesList = await utils.getArtifactList(
+        this.artifactInfo.datasourcesDir,
+        'datasource',
+        true,
+      );
+      debug(
+        `datasourcesList from ${utils.sourceRootDir}/${utils.datasourcesDir} : ${datasourcesList}`,
+      );
+    } catch (err) {
+      return this.exit(err);
+    }
+
+    const availableDatasources = datasourcesList.filter(item => {
+      debug(`data source inspecting item: ${item}`);
+      const result = utils.isConnectorOfType(
+        VALID_CONNECTORS_FOR_REPOSITORY,
+        this.artifactInfo.datasourcesDir,
+        item,
+      );
+      return result !== false;
+    });
+
+    debug(`artifactInfo.dataSourceClass ${this.artifactInfo.dataSourceClass}`);
+
+    if (availableDatasources.length === 0) {
+      return this.exit(
+        new Error(
+          `${ERROR_NO_DATA_SOURCES_FOUND} ${this.artifactInfo.datasourcesDir}.
+        ${chalk.yellow(
+          'Please visit https://loopback.io/doc/en/lb4/DataSource-generator.html for information on how datasources are discovered',
+        )}`,
+        ),
+      );
+    }
+
+    if (availableDatasources.includes(cmdDatasourceName)) {
+      Object.assign(this.artifactInfo, {
+        dataSourceClass: cmdDatasourceName,
+      });
+    }
+
+    return this.prompt([
+      {
+        type: 'list',
+        name: 'dataSourceClass',
+        message: PROMPT_MESSAGE_DATA_SOURCE,
+        choices: availableDatasources,
+        when: !this.artifactInfo.dataSourceClass,
+        default: availableDatasources[0],
+        validate: utils.validateClassName,
+      },
+    ])
+      .then(props => {
+        Object.assign(this.artifactInfo, props);
+        debug(`props after datasource prompt: ${inspect(props)}`);
+        return props;
+      })
+      .catch(err => {
+        debug(`Error during datasource prompt: ${err}`);
+        return this.exit(err);
+      });
+  }
+
+  async promptModels() {
+    if (this.shouldExit()) return false;
+
+    await this._inferDataSourceNames();
+
+    let modelList;
+    try {
+      debug(`model list dir ${this.artifactInfo.modelDir}`);
+      modelList = await utils.getArtifactList(
+        this.artifactInfo.modelDir,
+        'model',
+      );
+    } catch (err) {
+      return this.exit(err);
+    }
+
+    if (this.options.model) {
+      debug(`Model name received from command line: ${this.options.model}`);
+
+      this.options.model = utils.toClassName(this.options.model);
+      // assign the model name from the command line only if it is valid
+      if (
+        modelList &&
+        modelList.length > 0 &&
+        modelList.includes(this.options.model)
+      ) {
+        Object.assign(this.artifactInfo, {modelNameList: [this.options.model]});
+      } else {
+        modelList = [];
+      }
+    }
+
+    if (modelList.length === 0) {
+      return this.exit(
+        new Error(
+          `${ERROR_NO_MODELS_FOUND} ${this.artifactInfo.modelDir}.
+        ${chalk.yellow(
+          'Please visit https://loopback.io/doc/en/lb4/Model-generator.html for information on how models are discovered',
+        )}`,
+        ),
+      );
+    }
+
+    return this.prompt([
+      {
+        type: 'checkbox',
+        name: 'modelNameList',
+        message: PROMPT_MESSAGE_MODEL,
+        choices: modelList.map(m => ({name: m, value: m, checked: true})),
+        when: this.artifactInfo.modelNameList === undefined,
+        // Require at least one model to be selected
+        // This prevents users from accidentally pressing ENTER instead of SPACE
+        // to select a model from the list
+        validate: result => !!result.length,
+      },
+    ])
+      .then(props => {
+        Object.assign(this.artifactInfo, props);
+        debug(`props after model list prompt: ${inspect(props)}`);
+        return props;
+      })
+      .catch(err => {
+        debug(`Error during model list prompt: ${err}`);
+        return this.exit(err);
+      });
+  }
+
+  /**
+   * Prompt for basePath if only one model is selected
+   */
+  async promptBasePath() {
+    if (this.options.basePath) {
+      this.artifactInfo.basePath = this.options.basePath;
+      return;
+    }
+
+    if (
+      this.artifactInfo.modelNameList &&
+      this.artifactInfo.modelNameList.length === 1
+    ) {
+      const model = this.artifactInfo.modelNameList[0];
+      const props = await this.prompt([
+        {
+          type: 'input',
+          name: 'basePath',
+          message: PROMPT_MESSAGE_BASE_PATH,
+          default: utils.prependBackslash(
+            utils.pluralize(utils.urlSlug(model)),
+          ),
+          validate: utils.validateUrlSlug,
+          filter: utils.prependBackslash,
+        },
+      ]);
+      if (props) {
+        this.artifactInfo.basePath = props.basePath;
+      }
+    }
+  }
+
+  async scaffold() {
+    if (this.shouldExit()) return false;
+
+    if (_.isEmpty(this.artifactInfo.modelNameList)) {
+      return this.exit(new Error(`${ERROR_NO_MODEL_SELECTED}`));
+    }
+
+    this.artifactInfo.disableIndexUpdate = true;
+    for (const model of this.artifactInfo.modelNameList) {
+      this.artifactInfo.modelName = model;
+      this.artifactInfo.outFile = utils.getRestConfigFileName(model);
+      if (
+        !this.artifactInfo.basePath ||
+        this.artifactInfo.modelNameList.length > 1
+      ) {
+        const defaultBasePath =
+          this.options.basePath ||
+          utils.prependBackslash(utils.pluralize(utils.urlSlug(model)));
+        this.artifactInfo.basePath = defaultBasePath;
+      }
+
+      const source = this.templatePath(
+        path.join(
+          utils.sourceRootDir,
+          utils.modelEndpointsDir,
+          this.artifactInfo.defaultTemplate,
+        ),
+      );
+
+      const dest = this.destinationPath(
+        path.join(this.artifactInfo.outDir, this.artifactInfo.outFile),
+      );
+
+      if (debug.enabled) {
+        debug(`artifactInfo: ${inspect(this.artifactInfo)}`);
+        debug(`Copying artifact to: ${dest}`);
+      }
+
+      this.copyTemplatedFiles(source, dest, this.artifactInfo);
+    }
+
+    this.log(
+      'Updating src/application.ts to register CrudRestComponent from @loopback/rest-crud',
+    );
+    await updateApplicationTs(this.destinationPath());
+    return;
+  }
+
+  install() {
+    if (this.shouldExit()) return false;
+    debug('install npm dependencies');
+    const pkgJson = this.packageJson || {};
+    const deps = pkgJson.dependencies || {};
+    const pkgs = [];
+
+    const version = cliPkg.config.templateDependencies['@loopback/rest-crud'];
+
+    if (!deps['@loopback/rest-crud']) {
+      pkgs.push(`@loopback/rest-crud@${version}`);
+    }
+
+    if (pkgs.length) this.npmInstall(pkgs, {save: true});
+  }
+
+  async end() {
+    this.artifactInfo.type =
+      this.artifactInfo.modelNameList &&
+      this.artifactInfo.modelNameList.length > 1
+        ? 'RestConfigs'
+        : 'RestConfig';
+
+    this.artifactInfo.modelNameList = _.map(
+      this.artifactInfo.modelNameList,
+      name => {
+        return name + '.rest-config';
+      },
+    );
+
+    this.artifactInfo.name = this.artifactInfo.modelNameList
+      ? this.artifactInfo.modelNameList.join(this.classNameSeparator)
+      : this.artifactInfo.modelName;
+
+    await super.end();
+  }
+};

--- a/packages/cli/generators/rest-crud/templates/src/model-endpoints/model.rest-config-template.ts.ejs
+++ b/packages/cli/generators/rest-crud/templates/src/model-endpoints/model.rest-config-template.ts.ejs
@@ -1,0 +1,10 @@
+import {ModelCrudRestApiConfig} from '@loopback/rest-crud';
+import {<%= modelName %>} from '../models';
+
+const config: ModelCrudRestApiConfig = {
+  model: <%= modelName %>,
+  pattern: 'CrudRest',
+  dataSource: '<%= dataSourceName %>',
+  basePath: '<%= basePath %>',
+};
+module.exports = config;

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -101,6 +101,14 @@ function setupGenerators() {
     PREFIX + 'relation',
   );
   env.register(path.join(__dirname, '../generators/update'), PREFIX + 'update');
+  env.register(
+    path.join(__dirname, '../generators/relation'),
+    PREFIX + 'relation',
+  );
+  env.register(
+    path.join(__dirname, '../generators/rest-crud'),
+    PREFIX + 'rest-crud',
+  );
   return env;
 }
 

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -496,6 +496,14 @@ exports.getRepositoryFileName = function(repositoryName) {
 };
 
 /**
+ * Returns the rest-config in the directory file format for the model endpoint
+ * @param {string} modelName
+ */
+exports.getRestConfigFileName = function(modelName) {
+  return `${toFileName(modelName)}.rest-config.ts`;
+};
+
+/**
  * Returns the serviceName in the directory file format for the service
  * @param {string} serviceName
  */
@@ -659,4 +667,5 @@ exports.servicesDir = 'services';
 exports.modelsDir = 'models';
 exports.observersDir = 'observers';
 exports.interceptorsDir = 'interceptors';
+exports.modelEndpointsDir = 'model-endpoints';
 exports.sourceRootDir = 'src';

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -24,6 +24,7 @@ Available commands:
   lb4 discover
   lb4 relation
   lb4 update
+  lb4 rest-crud
 `;
 
 
@@ -44,4 +45,5 @@ Available commands:
   lb4 discover
   lb4 relation
   lb4 update
+  lb4 rest-crud
 `;

--- a/packages/cli/test/fixtures/rest-crud/application.ts
+++ b/packages/cli/test/fixtures/rest-crud/application.ts
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/example-rest-crud
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {RestExplorerComponent} from '@loopback/rest-explorer';
+import path from 'path';
+import {MySequence} from './sequence';
+
+export class TodoApplication extends BootMixin(
+  RepositoryMixin(RestApplication),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Set up the custom sequence
+    this.sequence(MySequence);
+
+    // Set up default home page
+    this.static('/', path.join(__dirname, '../public'));
+
+    this.component(RestExplorerComponent);
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}

--- a/packages/cli/test/fixtures/rest-crud/index.js
+++ b/packages/cli/test/fixtures/rest-crud/index.js
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const DATASOURCE_APP_PATH = 'src/datasources';
+const MODEL_APP_PATH = 'src/models';
+const CONFIG_PATH = '.';
+const DUMMY_CONTENT = '--DUMMY VALUE--';
+const fs = require('fs');
+
+exports.SANDBOX_FILES = [
+  {
+    path: CONFIG_PATH,
+    file: 'myconfig.json',
+    content: JSON.stringify({
+      datasource: 'dbmem',
+      model: 'DecoratorDefined',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbkv.datasource.config.json',
+    content: JSON.stringify({
+      name: 'dbkv',
+      connector: 'kv-redis',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbkv.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.config.json',
+    content: JSON.stringify({
+      name: 'dbmem',
+      connector: 'memory',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'my-ds.datasource.config.json',
+    content: JSON.stringify({
+      name: 'MyDS',
+      connector: 'memory',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'dbmem.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.config.json',
+    content: JSON.stringify({
+      name: 'restdb',
+      connector: 'rest',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'sqlite3.datasource.config.json',
+    content: JSON.stringify({
+      name: 'sqlite3',
+      connector: 'loopback-connector-sqlite3',
+    }),
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'sqlite3.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: DATASOURCE_APP_PATH,
+    file: 'restdb.datasource.ts',
+    content: DUMMY_CONTENT,
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'decorator-defined.model.ts',
+    content: fs.readFileSync(
+      require.resolve('./models/decorator-defined.model.txt'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'default-model.model.ts',
+    content: fs.readFileSync(
+      require.resolve('./models/default-model.model.txt'),
+      {
+        encoding: 'utf-8',
+      },
+    ),
+  },
+  {
+    path: MODEL_APP_PATH,
+    file: 'multi-word.model.ts',
+    content: fs.readFileSync(require.resolve('./models/multi-word.model.txt'), {
+      encoding: 'utf-8',
+    }),
+  },
+  {
+    path: 'src',
+    file: 'application.ts',
+    content: fs.readFileSync(require.resolve('./application.ts'), {
+      encoding: 'utf-8',
+    }),
+  },
+];

--- a/packages/cli/test/fixtures/rest-crud/models/decorator-defined.model.txt
+++ b/packages/cli/test/fixtures/rest-crud/models/decorator-defined.model.txt
@@ -1,0 +1,17 @@
+import {Entity, model} from '@loopback/repository';
+
+@model({
+  name: 'Product',
+  properties: {
+    thePK: {type: 'number', id: true},
+    name: {type: 'string', required: true},
+  },
+})
+export class DecoratorDefined extends Entity {
+  thePK: number;
+  name: string;
+
+  constructor(data?: Partial<DecoratorDefined>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/rest-crud/models/default-model.model.txt
+++ b/packages/cli/test/fixtures/rest-crud/models/default-model.model.txt
@@ -1,0 +1,26 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class DefaultModel extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    default: 0,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+  })
+  desc?: string;
+
+  @property({
+    type: 'number',
+    default: 0,
+  })
+  balance?: number;
+
+  constructor(data?: Partial<DefaultModel>) {
+    super(data);
+  }
+}

--- a/packages/cli/test/fixtures/rest-crud/models/multi-word.model.txt
+++ b/packages/cli/test/fixtures/rest-crud/models/multi-word.model.txt
@@ -1,0 +1,20 @@
+import {Entity, model, property} from '@loopback/repository';
+
+    @model()
+    export class MultiWord extends Entity {
+      @property({
+        type: 'string',
+        id: true,
+        default: 0,
+      })
+      pk?: string;
+
+      @property({
+        type: 'string',
+      })
+      desc?: string;
+
+      constructor(data?: Partial<MultiWord>) {
+        super(data);
+      }
+    }

--- a/packages/cli/test/integration/generators/rest-crud.integration.js
+++ b/packages/cli/test/integration/generators/rest-crud.integration.js
@@ -1,0 +1,254 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const assert = require('yeoman-assert');
+const testlab = require('@loopback/testlab');
+
+const expect = testlab.expect;
+const TestSandbox = testlab.TestSandbox;
+
+const generator = path.join(__dirname, '../../../generators/rest-crud');
+const SANDBOX_FILES = require('../../fixtures/rest-crud').SANDBOX_FILES;
+const testUtils = require('../../test-utils');
+
+// Test Sandbox
+const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
+const sandbox = new TestSandbox(SANDBOX_PATH);
+
+describe('lb4 rest-crud', function() {
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(30000);
+
+  beforeEach('reset sandbox', async () => {
+    await sandbox.reset();
+  });
+
+  // special cases regardless of the rest-crud type
+  describe('generate rest configs', () => {
+    it('generates multiple model endpoint rest-configs from multiple models', async () => {
+      const multiItemPrompt = {
+        datasource: 'dbmem',
+        modelNameList: ['MultiWord', 'DefaultModel'],
+      };
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(multiItemPrompt);
+
+      const expectedMultiWordFile = path.join(
+        SANDBOX_PATH,
+        MODEL_ENDPOINT_PATH,
+        'multi-word.rest-config.ts',
+      );
+      const expectedDefaultModelFile = path.join(
+        SANDBOX_PATH,
+        MODEL_ENDPOINT_PATH,
+        'default-model.rest-config.ts',
+      );
+
+      assert.file(expectedMultiWordFile);
+      assert.file(expectedDefaultModelFile);
+
+      assert.fileContent(
+        expectedMultiWordFile,
+        /import \{MultiWord\} from '\.\.\/models'/,
+      );
+      assert.fileContent(expectedMultiWordFile, /dataSource: 'dbmem'/);
+      assert.fileContent(expectedMultiWordFile, /basePath: '\/multi-words'/);
+
+      assert.fileContent(expectedDefaultModelFile, /dataSource: 'dbmem'/);
+      assert.fileContent(
+        expectedDefaultModelFile,
+        /basePath: '\/default-models'/,
+      );
+
+      assert.noFile(INDEX_FILE);
+
+      assertApplicationTsFileUpdated();
+    });
+
+    it('generates a multi-word rest-crud model endpoint', async () => {
+      const multiItemPrompt = {
+        dataSourceName: 'dbmem',
+        modelNameList: ['MultiWord'],
+      };
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(multiItemPrompt);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        MODEL_ENDPOINT_PATH,
+        'multi-word.rest-config.ts',
+      );
+
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /import \{MultiWord\} from '\.\.\/models'/,
+      );
+      assert.fileContent(expectedFile, /dataSource: 'dbmem'/);
+      assert.fileContent(expectedFile, /basePath: '\/multi-words'/);
+      assertApplicationTsFileUpdated();
+    });
+
+    it('generates a single rest-crud model endpoint with base path', async () => {
+      const singleModelPrompt = {
+        basePath: '/multiWords',
+        dataSourceName: 'dbmem',
+        modelNameList: ['MultiWord'],
+      };
+
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withPrompts(singleModelPrompt);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        MODEL_ENDPOINT_PATH,
+        'multi-word.rest-config.ts',
+      );
+
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /import \{MultiWord\} from '\.\.\/models'/,
+      );
+      assert.fileContent(expectedFile, /dataSource: 'dbmem'/);
+      assert.fileContent(expectedFile, /basePath: '\/multiWords'/);
+      assertApplicationTsFileUpdated();
+    });
+
+    it('generates a single rest-crud model endpoint with options', async () => {
+      const options = {
+        basePath: '/multiWords',
+        datasource: 'dbmem',
+        model: 'MultiWord',
+      };
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withOptions(options);
+
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        MODEL_ENDPOINT_PATH,
+        'multi-word.rest-config.ts',
+      );
+
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /import \{MultiWord\} from '\.\.\/models'/,
+      );
+      assert.fileContent(expectedFile, /dataSource: 'dbmem'/);
+      assert.fileContent(expectedFile, /basePath: '\/multiWords'/);
+      assertApplicationTsFileUpdated();
+    });
+
+    it('generates a rest-crud model endpoint from a config file', async () => {
+      await testUtils
+        .executeGenerator(generator)
+        .inDir(SANDBOX_PATH, () =>
+          testUtils.givenLBProject(SANDBOX_PATH, {
+            additionalFiles: SANDBOX_FILES,
+          }),
+        )
+        .withArguments('--config myconfig.json');
+      const expectedFile = path.join(
+        SANDBOX_PATH,
+        MODEL_ENDPOINT_PATH,
+        'decorator-defined.rest-config.ts',
+      );
+      assert.file(expectedFile);
+      assert.fileContent(
+        expectedFile,
+        /import \{DecoratorDefined\} from '\.\.\/models'/,
+      );
+      assert.fileContent(expectedFile, /dataSource: 'dbmem'/);
+      assert.fileContent(expectedFile, /basePath: '\/decorator-defineds'/);
+      assertApplicationTsFileUpdated();
+    });
+  });
+
+  describe('all invalid parameters and usage', () => {
+    it('does not run with an invalid model name', async () => {
+      const basicPrompt = {
+        dataSourceName: 'db',
+      };
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(SANDBOX_PATH, () =>
+            testUtils.givenLBProject(SANDBOX_PATH, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withPrompts(basicPrompt)
+          .withArguments(' --model InvalidModel'),
+      ).to.be.rejectedWith(/No models found/);
+    });
+
+    it("does not run when user doesn't select a model", async () => {
+      const basicPrompt = {
+        dataSourceName: 'db',
+      };
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(SANDBOX_PATH, () =>
+            testUtils.givenLBProject(SANDBOX_PATH, {
+              additionalFiles: SANDBOX_FILES,
+            }),
+          )
+          .withPrompts(basicPrompt),
+      ).to.be.rejectedWith(/You did not select a valid model/);
+    });
+
+    it('does not run with empty datasource list', async () => {
+      return expect(
+        testUtils
+          .executeGenerator(generator)
+          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
+      ).to.be.rejectedWith(/No datasources found/);
+    });
+  });
+});
+
+// Sandbox constants
+const MODEL_ENDPOINT_PATH = 'src/model-endpoints';
+const INDEX_FILE = path.join(SANDBOX_PATH, MODEL_ENDPOINT_PATH, 'index.ts');
+
+function assertApplicationTsFileUpdated() {
+  const expectedAppFile = path.join(SANDBOX_PATH, 'src', 'application.ts');
+  assert.fileContent(
+    expectedAppFile,
+    /import {CrudRestComponent} from '@loopback\/rest-crud';/,
+  );
+  assert.fileContent(expectedAppFile, /this\.component\(CrudRestComponent\);/);
+}


### PR DESCRIPTION
The PR adds `lb4 rest-crud` command to generate `src/model-endpoints/<model>.rest-config.ts`.

It prompts for selection of a datasource and one or more models, similar as `lb4 repository`.

TODO: 

- ~add tests~ (done)
- ~add docs~ (done)
- ~implement the logic to update `application.ts` to register `CrudRestComponent`.~ (done)

Implements https://github.com/strongloop/loopback-next/issues/2739

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
