### PR TITLE
fix(rest): allow async custom keyword by setting {$async: true} to referenced schemas

### DIFF
--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -179,15 +179,18 @@ async function validateValueAgainstSchema(
 
 function createValidator(
   schema: SchemaObject,
-  globalSchemas?: SchemasObject,
+  globalSchemas: SchemasObject = {},
   options?: RequestBodyValidationOptions,
 ): ajv.ValidateFunction {
   const jsonSchema = convertToJsonSchema(schema);
 
-  const schemaWithRef = Object.assign({components: {}}, jsonSchema);
-  schemaWithRef.components = {
-    schemas: globalSchemas,
-  };
+  // Clone global schemas to set `$async: true` flag
+  const schemas: SchemasObject = {};
+  for (const name in globalSchemas) {
+    // See https://github.com/strongloop/loopback-next/issues/4939
+    schemas[name] = {...globalSchemas[name], $async: true};
+  }
+  const schemaWithRef = {components: {schemas}, ...jsonSchema};
 
   // FIXME(rfeng): We would prefer to inject the Ajv service
   const ajvInst = new AjvProvider(options).value();


### PR DESCRIPTION
The `$async: true` is not set on `components/schemas/<schema-name>/{}`.

Fixes https://github.com/strongloop/loopback-next/issues/4939

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
