### PR TITLE
fix(boot): fix resolution of package.json for application metadata

### DIFF
--- a/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
@@ -27,10 +27,17 @@ describe('application metadata booter acceptance tests', () => {
   });
 
   async function getApp() {
+    // Add the following files
+    // - package.json
+    // - dist/application.js
     await sandbox.copyFile(resolve(__dirname, '../fixtures/package.json'));
-    await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
+    await sandbox.copyFile(
+      resolve(__dirname, '../fixtures/application.js'),
+      'dist/application.js',
+    );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(SANDBOX_PATH, 'dist/application.js'))
+      .BooterApp;
     app = new MyApp({
       rest: givenHttpServerConfig(),
     });

--- a/packages/boot/src/booters/application-metadata.booter.ts
+++ b/packages/boot/src/booters/application-metadata.booter.ts
@@ -27,7 +27,8 @@ export class ApplicationMetadataBooter implements Booter {
 
   async configure() {
     try {
-      const pkg = require(path.resolve(this.projectRoot, 'package.json'));
+      // `this.projectRoot` points to `<project>/dist`
+      const pkg = require(path.resolve(this.projectRoot, '../package.json'));
       this.app.setMetadata(pkg);
     } catch (err) {
       debug('package.json not found', err);


### PR DESCRIPTION
projectRoot is set to `dirname` of `application.js` (dist). We need to
resolve `package.json` in its parent folder.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
