### PR TITLE
feat(rest): add info spec enhancer to build `info` for OpenAPI spec from application metadata

### DIFF
--- a/packages/rest/src/__tests__/unit/rest.server/fixtures/info.spec.extension.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/fixtures/info.spec.extension.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {bind} from '@loopback/core';
-import debugModule from 'debug';
+import debugFactory from 'debug';
 import {inspect} from 'util';
 import {
   asSpecEnhancer,
@@ -13,14 +13,14 @@ import {
   OpenApiSpec,
 } from '../../../..';
 
-const debug = debugModule('loopback:openapi:spec-enhancer');
+const debug = debugFactory('loopback:openapi:spec-enhancer');
 
 /**
  * A spec enhancer to add OpenAPI info spec
  */
 @bind(asSpecEnhancer)
-export class InfoSpecEnhancer implements OASEnhancer {
-  name = 'info';
+export class TestInfoSpecEnhancer implements OASEnhancer {
+  name = 'info-test';
 
   modifySpec(spec: OpenApiSpec): OpenApiSpec {
     const InfoPatchSpec = {

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -14,7 +14,7 @@ import {
   RestServer,
 } from '../../..';
 import {RestTags} from '../../../keys';
-import {InfoSpecEnhancer} from './fixtures/info.spec.extension';
+import {TestInfoSpecEnhancer} from './fixtures/info.spec.extension';
 
 describe('RestServer.getApiSpec()', () => {
   let app: Application;
@@ -326,7 +326,51 @@ describe('RestServer.getApiSpec()', () => {
       title: 'LoopBack Test Application',
       version: '1.0.1',
     };
-    server.add(createBindingFromClass(InfoSpecEnhancer));
+    server.add(createBindingFromClass(TestInfoSpecEnhancer));
+    const spec = await server.getApiSpec();
+    expect(spec.info).to.eql(EXPECTED_SPEC_INFO);
+  });
+
+  it('invokes info oas enhancers', async () => {
+    const EXPECTED_SPEC_INFO = {
+      title: 'MyApp - LoopBack Test Application',
+      version: '1.0.1',
+      contact: {
+        name: 'Barney Rubble',
+        email: 'b@rubble.com',
+        url: 'http://barnyrubble.tumblr.com/',
+      },
+    };
+    app.setMetadata({
+      name: 'MyApp',
+      description: 'LoopBack Test Application',
+      version: '1.0.1',
+      author: 'Barney Rubble <b@rubble.com> (http://barnyrubble.tumblr.com/)',
+    });
+    const spec = await server.getApiSpec();
+    expect(spec.info).to.eql(EXPECTED_SPEC_INFO);
+  });
+
+  it('invokes info oas enhancers with author object', async () => {
+    const EXPECTED_SPEC_INFO = {
+      title: 'MyApp',
+      version: '1.0.1',
+      contact: {
+        name: 'Barney Rubble',
+        email: 'b@rubble.com',
+        url: 'http://barnyrubble.tumblr.com/',
+      },
+    };
+    app.setMetadata({
+      name: 'MyApp',
+      version: '1.0.1',
+      description: '',
+      author: {
+        name: 'Barney Rubble',
+        email: 'b@rubble.com',
+        url: 'http://barnyrubble.tumblr.com/',
+      },
+    });
     const spec = await server.getApiSpec();
     expect(spec.info).to.eql(EXPECTED_SPEC_INFO);
   });

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -17,6 +17,7 @@ export * from './rest.component';
 export * from './rest.server';
 export * from './router';
 export * from './sequence';
+export * from './spec-enhancers/info.spec-enhancer';
 export * from './types';
 export * from './validation/request-body.validator';
 export * from './writer';

--- a/packages/rest/src/rest.component.ts
+++ b/packages/rest/src/rest.component.ts
@@ -3,7 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, Constructor, inject} from '@loopback/context';
+import {
+  Binding,
+  Constructor,
+  createBindingFromClass,
+  inject,
+} from '@loopback/context';
 import {
   Application,
   Component,
@@ -37,6 +42,7 @@ import {
   RestServerConfig,
 } from './rest.server';
 import {DefaultSequence} from './sequence';
+import {InfoSpecEnhancer} from './spec-enhancers/info.spec-enhancer';
 
 export class RestComponent implements Component {
   providers: ProviderMap = {
@@ -76,6 +82,7 @@ export class RestComponent implements Component {
       StreamBodyParser,
       RestBindings.REQUEST_BODY_PARSER_STREAM,
     ),
+    createBindingFromClass(InfoSpecEnhancer),
   ];
   servers: {
     [name: string]: Constructor<Server>;

--- a/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
+++ b/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
@@ -1,0 +1,95 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  bind,
+  BindingScope,
+  inject,
+  JSONObject,
+  JSONValue,
+} from '@loopback/context';
+import {ApplicationMetadata, CoreBindings} from '@loopback/core';
+import {
+  asSpecEnhancer,
+  ContactObject,
+  mergeOpenAPISpec,
+  OASEnhancer,
+  OpenApiSpec,
+} from '@loopback/openapi-v3';
+import debugFactory from 'debug';
+
+const debug = debugFactory('loopback:openapi:spec-enhancer:info');
+
+/**
+ * An OpenAPI spec enhancer to populate `info` with application metadata
+ * (package.json).
+ */
+@bind(asSpecEnhancer, {scope: BindingScope.SINGLETON})
+export class InfoSpecEnhancer implements OASEnhancer {
+  name = 'info';
+
+  constructor(
+    @inject(CoreBindings.APPLICATION_METADATA, {optional: true})
+    readonly pkg?: ApplicationMetadata,
+  ) {}
+
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    if (this.pkg == null) {
+      debug('Application metadata is not found. Skipping spec enhancing.');
+      return spec;
+    }
+    const contact: ContactObject = InfoSpecEnhancer.parseAuthor(
+      this.pkg.author,
+    );
+    let title = this.pkg.name;
+    if (this.pkg.description) {
+      title = `${title} - ${this.pkg.description}`;
+    }
+    const patchSpec = {
+      info: {
+        title,
+        version: this.pkg.version,
+        contact,
+      },
+    };
+    debug('Enhancing OpenAPI spec with %j', patchSpec);
+    return mergeOpenAPISpec(spec, patchSpec);
+  }
+
+  /**
+   * Parse package.json
+   * {@link https://docs.npmjs.com/files/package.json#people-fields-author-contributors | author}
+   *
+   * @param author - Author string or object from package.json
+   */
+  private static parseAuthor(author: JSONValue) {
+    let contact: ContactObject = {};
+    if (author == null) {
+      contact = {};
+    } else if (typeof author === 'string') {
+      // "Barney Rubble <b@rubble.com> (http://barnyrubble.tumblr.com/)"
+      const emailRegex = /<([^<>]+)>/; // <email>
+      const urlRegex = /\(([^()]+)\)/; // (url)
+      const nameRegex = /([^<>()]+)/;
+      contact = {
+        name: nameRegex.exec(author)?.[1]?.trim(),
+        email: emailRegex.exec(author)?.[1]?.trim(),
+        url: urlRegex.exec(author)?.[1]?.trim(),
+      };
+    } else if (typeof author === 'object') {
+      const authorObj = author as JSONObject;
+      contact = {
+        name: authorObj.name as string,
+        email: authorObj.email as string,
+        url: authorObj.url as string,
+      };
+    }
+    // Remove undefined/null values
+    for (const p in contact) {
+      if (contact[p] == null) delete contact[p];
+    }
+    return contact;
+  }
+}


### PR DESCRIPTION
See https://github.com/strongloop/loopback4-example-shopping/pull/611

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
