### PR TITLE
feat(http-server): adds http/2 support

### DIFF
--- a/packages/testlab/src/http-server-config.ts
+++ b/packages/testlab/src/http-server-config.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {readFileSync} from 'fs';
+import http2 from 'http2';
 import {ServerOptions as HttpsServerOptions} from 'https';
 import {ListenOptions} from 'net';
 import path from 'path';
@@ -22,6 +23,16 @@ export interface HttpsOptions extends ListenOptions, HttpsServerOptions {
   protocol: 'https';
 }
 
+export interface Http2Options extends ListenOptions, http2.ServerOptions {
+  protocol: 'http2';
+}
+
+export interface Http2sOptions
+  extends ListenOptions,
+    http2.SecureServerOptions {
+  protocol: 'http2s';
+}
+
 export type HostPort = {
   host: string;
   port: number;
@@ -36,9 +47,9 @@ export type HostPort = {
  *
  * @param customConfig - Additional configuration options to apply.
  */
-export function givenHttpServerConfig<T extends HttpOptions | HttpsOptions>(
-  customConfig?: T,
-): HostPort & T {
+export function givenHttpServerConfig<
+  T extends HttpOptions | HttpsOptions | Http2Options | Http2sOptions
+>(customConfig?: T): HostPort & T {
   const defaults = {
     host: '127.0.0.1',
     port: 0,


### PR DESCRIPTION
Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
