### PR TITLE
fix: remove restriction to Entities from DefaultKeyValueRepository

### DIFF
--- a/packages/repository/src/repositories/kv.repository.bridge.ts
+++ b/packages/repository/src/repositories/kv.repository.bridge.ts
@@ -5,7 +5,7 @@
 
 import legacy from 'loopback-datasource-juggler';
 import {DataObject, Options} from '../common-types';
-import {Entity} from '../model';
+import {Model} from '../model';
 import {KeyValueFilter, KeyValueRepository} from './kv.repository';
 import {ensurePromise, juggler} from './legacy-juggler-bridge';
 
@@ -22,7 +22,7 @@ if (!(Symbol as any).asyncIterator) {
 /**
  * An implementation of KeyValueRepository based on loopback-datasource-juggler
  */
-export class DefaultKeyValueRepository<T extends Entity>
+export class DefaultKeyValueRepository<T extends Model>
   implements KeyValueRepository<T> {
   /**
    * A legacy KeyValueModel class
@@ -34,7 +34,7 @@ export class DefaultKeyValueRepository<T extends Entity>
    * @param ds - Legacy DataSource
    */
   constructor(
-    private entityClass: typeof Entity & {prototype: T},
+    private entityClass: typeof Model & {prototype: T},
     ds: juggler.DataSource,
   ) {
     // KVModel class is placeholder to receive methods from KeyValueAccessObject


### PR DESCRIPTION
KeyValue repository does not require Entities, it can be used with any model. This was an intentional decision when implementing LB3 key-value APIs, to allow the key value to be provided outside of the data stored, thus enabling use cases like storing arbitrary data (including binary blobs) via the key-value API.

I have extracted this pull request from https://github.com/strongloop/loopback-next/pull/4949 to get it landed faster.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
