### PR TITLE
feat: remove Node.js 8.x polyfill for Symbol.asyncIterator

### DIFF
--- a/packages/context/src/context-subscription.ts
+++ b/packages/context/src/context-subscription.ts
@@ -5,6 +5,7 @@
 
 import debugFactory from 'debug';
 import {EventEmitter} from 'events';
+import {iterator, multiple} from 'p-event';
 import {Context} from './context';
 import {ContextEvent, ContextEventListener} from './context-event';
 import {
@@ -12,22 +13,8 @@ import {
   ContextEventType,
   ContextObserver,
 } from './context-observer';
-const debug = debugFactory('loopback:context:subscription');
 
-/**
- * Polyfill Symbol.asyncIterator as required by TypeScript for Node 8.x.
- * See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html
- */
-if (!Symbol.asyncIterator) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (Symbol as any).asyncIterator = Symbol.for('Symbol.asyncIterator');
-}
-/**
- * WARNING: This following import must happen after the polyfill. The
- * `auto-import` by an IDE such as VSCode may move the import before the
- * polyfill. It must be then fixed manually.
- */
-import {iterator, multiple} from 'p-event';
+const debug = debugFactory('loopback:context:subscription');
 
 /**
  * Subscription of context events. It's modeled after

--- a/packages/repository/src/repositories/kv.repository.bridge.ts
+++ b/packages/repository/src/repositories/kv.repository.bridge.ts
@@ -10,16 +10,6 @@ import {KeyValueFilter, KeyValueRepository} from './kv.repository';
 import {ensurePromise, juggler} from './legacy-juggler-bridge';
 
 /**
- * Polyfill for Symbol.asyncIterator
- * See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-if (!(Symbol as any).asyncIterator) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (Symbol as any).asyncIterator = Symbol.for('Symbol.asyncIterator');
-}
-
-/**
  * An implementation of KeyValueRepository based on loopback-datasource-juggler
  */
 export class DefaultKeyValueRepository<T extends Model>


### PR DESCRIPTION
Async iterators are a first-class feature in Node.js 10.x and newer, the polyfill is no longer needed.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
