### PR TITLE
refactor: use sandbox.path instead of SANDBOX to access the sandbox directory

### DIFF
--- a/examples/file-transfer/README.md
+++ b/examples/file-transfer/README.md
@@ -55,8 +55,9 @@ browser. You can try to upload a few files using the web UI or API explorer.
 
 ![upload-download](upload-download.png)
 
-The uploaded files will be stored in `.sandbox` folder under the application
-root directory.
+By default, the uploaded files will be stored in `.sandbox` folder under the
+application root directory. The directory can be configured via
+`fileStorageDirectory` of application config.
 
 ## Contributions
 

--- a/examples/file-transfer/src/__tests__/acceptance/file-upload.acceptance.ts
+++ b/examples/file-transfer/src/__tests__/acceptance/file-upload.acceptance.ts
@@ -48,7 +48,7 @@ describe('file upload acceptance - multipart/form-data', () => {
   });
 
   async function givenAClient() {
-    ({app, client} = await setupApplication());
+    ({app, client} = await setupApplication(sandbox.path));
   }
 
   async function resetSandbox() {

--- a/examples/file-transfer/src/__tests__/acceptance/test-helper.ts
+++ b/examples/file-transfer/src/__tests__/acceptance/test-helper.ts
@@ -12,7 +12,9 @@ import {
 import path from 'path';
 import {FileUploadApplication} from '../..';
 
-export async function setupApplication(): Promise<AppWithClient> {
+export async function setupApplication(
+  fileStorageDirectory?: string,
+): Promise<AppWithClient> {
   const restConfig = givenHttpServerConfig({
     // Customize the server configuration here.
     // Empty values (undefined, '') will be ignored by the helper.
@@ -23,6 +25,7 @@ export async function setupApplication(): Promise<AppWithClient> {
 
   const app = new FileUploadApplication({
     rest: restConfig,
+    fileStorageDirectory,
   });
 
   await app.boot();
@@ -38,8 +41,7 @@ export interface AppWithClient {
   client: Client;
 }
 
-const SANDBOX = path.resolve(__dirname, '../../../.sandbox');
 export function getSandbox() {
-  const sandbox = new TestSandbox(SANDBOX);
+  const sandbox = new TestSandbox(path.resolve(__dirname, '../../../.sandbox'));
   return sandbox;
 }

--- a/examples/file-transfer/src/application.ts
+++ b/examples/file-transfer/src/application.ts
@@ -32,7 +32,7 @@ export class FileUploadApplication extends BootMixin(RestApplication) {
     this.component(RestExplorerComponent);
 
     // Configure file upload with multer options
-    this.configureFileUpload();
+    this.configureFileUpload(options.fileStorageDirectory);
 
     this.projectRoot = __dirname;
     // Customize @loopback/boot Booter Conventions here
@@ -49,11 +49,11 @@ export class FileUploadApplication extends BootMixin(RestApplication) {
   /**
    * Configure `multer` options for file upload
    */
-  protected configureFileUpload() {
+  protected configureFileUpload(destination?: string) {
     const multerOptions: multer.Options = {
       storage: multer.diskStorage({
         // Upload files to `.sandbox`
-        destination: path.join(__dirname, '../.sandbox'),
+        destination: destination ?? path.join(__dirname, '../.sandbox'),
         // Use the original file name as is
         filename: (req, file, cb) => {
           cb(null, file.originalname);

--- a/examples/file-transfer/src/controllers/index.ts
+++ b/examples/file-transfer/src/controllers/index.ts
@@ -3,4 +3,5 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+export * from './file-download.controller';
 export * from './file-upload.controller';

--- a/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
@@ -10,8 +10,7 @@ import {BooterApp} from '../fixtures/application';
 
 describe('application metadata booter acceptance tests', () => {
   let app: BooterApp;
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
@@ -36,7 +35,7 @@ describe('application metadata booter acceptance tests', () => {
       'dist/application.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'dist/application.js'))
+    const MyApp = require(resolve(sandbox.path, 'dist/application.js'))
       .BooterApp;
     app = new MyApp({
       rest: givenHttpServerConfig(),

--- a/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
@@ -13,8 +13,7 @@ import {BooterApp} from '../fixtures/application';
 
 describe('controller booter acceptance tests', () => {
   let app: BooterApp;
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
@@ -40,7 +39,7 @@ describe('controller booter acceptance tests', () => {
       'controllers/multiple.controller.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(sandbox.path, 'application.js')).BooterApp;
     app = new MyApp({
       rest: givenHttpServerConfig(),
     });

--- a/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
@@ -14,8 +14,7 @@ import {ProductRepository} from '../fixtures/product.repository';
 
 describe('CRUD rest builder acceptance tests', () => {
   let app: BooterApp;
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(givenAppWithDataSource);

--- a/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
@@ -26,8 +26,7 @@ import {
 
 describe('model API booter acceptance tests', () => {
   let app: BooterApp;
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(givenAppWithDataSource);

--- a/packages/boot/src/__tests__/integration/controller.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/controller.booter.integration.ts
@@ -8,8 +8,7 @@ import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
 describe('controller booter integration tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   // Remnants from Refactor -- need to add these to core
   const CONTROLLERS_PREFIX = 'controllers';
@@ -39,7 +38,7 @@ describe('controller booter integration tests', () => {
       'controllers/multiple.controller.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(sandbox.path, 'application.js')).BooterApp;
     app = new MyApp();
   }
 });

--- a/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
@@ -8,8 +8,7 @@ import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
 describe('datasource booter integration tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   const DATASOURCES_PREFIX = 'datasources';
   const DATASOURCES_TAG = 'datasource';
@@ -35,7 +34,7 @@ describe('datasource booter integration tests', () => {
       'datasources/db.datasource.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(sandbox.path, 'application.js')).BooterApp;
     app = new MyApp();
   }
 });

--- a/packages/boot/src/__tests__/integration/interceptor.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/interceptor.booter.integration.ts
@@ -13,8 +13,7 @@ import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
 describe('interceptor script booter integration tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   let app: BooterApp;
 
@@ -76,7 +75,7 @@ describe('interceptor script booter integration tests', () => {
       'interceptors/non-global-interceptor.interceptor.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(sandbox.path, 'application.js')).BooterApp;
     app = new MyApp();
   }
 });

--- a/packages/boot/src/__tests__/integration/lifecycle-observer.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/lifecycle-observer.booter.integration.ts
@@ -14,8 +14,7 @@ import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
 describe('lifecycle script booter integration tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   const OBSERVER_PREFIX = CoreBindings.LIFE_CYCLE_OBSERVERS;
   const OBSERVER_TAG = CoreTags.LIFE_CYCLE_OBSERVER;
@@ -47,7 +46,7 @@ describe('lifecycle script booter integration tests', () => {
       'observers/lifecycle-observer.observer.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(sandbox.path, 'application.js')).BooterApp;
     app = new MyApp();
   }
 });

--- a/packages/boot/src/__tests__/integration/repository.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/repository.booter.integration.ts
@@ -8,8 +8,7 @@ import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
 describe('repository booter integration tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   // Remnants from Refactor -- need to add these to core
   const REPOSITORIES_PREFIX = 'repositories';
@@ -39,7 +38,7 @@ describe('repository booter integration tests', () => {
       'repositories/multiple.repository.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(sandbox.path, 'application.js')).BooterApp;
     app = new MyApp();
   }
 });

--- a/packages/boot/src/__tests__/integration/service.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/service.booter.integration.ts
@@ -8,8 +8,7 @@ import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
 describe('service booter integration tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   const SERVICES_PREFIX = 'services';
   const SERVICES_TAG = 'service';
@@ -62,7 +61,7 @@ describe('service booter integration tests', () => {
       'services/bindable-classes.service.js',
     );
 
-    const MyApp = require(resolve(SANDBOX_PATH, 'application.js')).BooterApp;
+    const MyApp = require(resolve(sandbox.path, 'application.js')).BooterApp;
     app = new MyApp();
   }
 });

--- a/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/booter-utils.unit.ts
@@ -8,8 +8,7 @@ import {resolve} from 'path';
 import {discoverFiles, isClass, loadClassesFromFiles} from '../../..';
 
 describe('booter-utils unit tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../../.sandbox'));
 
   beforeEach('reset sandbox', () => sandbox.reset());
 
@@ -18,26 +17,26 @@ describe('booter-utils unit tests', () => {
 
     it('discovers files matching a nested glob pattern', async () => {
       const expected = [
-        resolve(SANDBOX_PATH, 'empty.artifact.js'),
-        resolve(SANDBOX_PATH, 'nested/multiple.artifact.js'),
+        resolve(sandbox.path, 'empty.artifact.js'),
+        resolve(sandbox.path, 'nested/multiple.artifact.js'),
       ];
       const glob = '/**/*.artifact.js';
 
-      const files = await discoverFiles(glob, SANDBOX_PATH);
+      const files = await discoverFiles(glob, sandbox.path);
       expect(files.sort()).to.eql(expected.sort());
     });
 
     it('discovers files matching a non-nested glob pattern', async () => {
-      const expected = [resolve(SANDBOX_PATH, 'empty.artifact.js')];
+      const expected = [resolve(sandbox.path, 'empty.artifact.js')];
       const glob = '/*.artifact.js';
 
-      const files = await discoverFiles(glob, SANDBOX_PATH);
+      const files = await discoverFiles(glob, sandbox.path);
       expect(files).to.eql(expected);
     });
 
     it('discovers no files for a unknown glob', async () => {
       const glob = '/xyz';
-      const files = await discoverFiles(glob, SANDBOX_PATH);
+      const files = await discoverFiles(glob, sandbox.path);
       expect(files).to.be.eql([]);
     });
 
@@ -64,7 +63,7 @@ describe('booter-utils unit tests', () => {
       await sandbox.copyFile(
         resolve(__dirname, '../../fixtures/multiple.artifact.js'),
       );
-      const files = [resolve(SANDBOX_PATH, 'multiple.artifact.js')];
+      const files = [resolve(sandbox.path, 'multiple.artifact.js')];
       const NUM_CLASSES = 2; // Number of classes in above file
 
       const classes = loadClassesFromFiles(files, sandbox.path);
@@ -77,7 +76,7 @@ describe('booter-utils unit tests', () => {
       await sandbox.copyFile(
         resolve(__dirname, '../../fixtures/empty.artifact.js'),
       );
-      const files = [resolve(SANDBOX_PATH, 'empty.artifact.js')];
+      const files = [resolve(sandbox.path, 'empty.artifact.js')];
 
       const classes = loadClassesFromFiles(files, sandbox.path);
       expect(classes).to.be.an.Array();
@@ -85,7 +84,7 @@ describe('booter-utils unit tests', () => {
     });
 
     it('throws an error given a non-existent file', async () => {
-      const files = [resolve(SANDBOX_PATH, 'fake.artifact.js')];
+      const files = [resolve(sandbox.path, 'fake.artifact.js')];
       expect(() => loadClassesFromFiles(files, sandbox.path)).to.throw(
         /Cannot find module/,
       );

--- a/packages/boot/src/__tests__/unit/booters/controller.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/controller.booter.unit.ts
@@ -9,8 +9,7 @@ import {resolve} from 'path';
 import {ControllerBooter, ControllerDefaults} from '../../..';
 
 describe('controller booter unit tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../../.sandbox'));
 
   const CONTROLLERS_PREFIX = 'controllers';
   const CONTROLLERS_TAG = 'controller';
@@ -21,7 +20,7 @@ describe('controller booter unit tests', () => {
   beforeEach(getApp);
 
   it(`constructor uses ControllerDefaults for 'options' if none are given`, () => {
-    const booterInst = new ControllerBooter(app, SANDBOX_PATH);
+    const booterInst = new ControllerBooter(app, sandbox.path);
     expect(booterInst.options).to.deepEqual(ControllerDefaults);
   });
 
@@ -34,7 +33,7 @@ describe('controller booter unit tests', () => {
       nested: ControllerDefaults.nested,
     });
 
-    const booterInst = new ControllerBooter(app, SANDBOX_PATH, options);
+    const booterInst = new ControllerBooter(app, sandbox.path, options);
     expect(booterInst.options).to.deepEqual(expected);
   });
 
@@ -46,11 +45,11 @@ describe('controller booter unit tests', () => {
     await sandbox.copyFile(
       resolve(__dirname, '../../fixtures/multiple.artifact.js'),
     );
-    const booterInst = new ControllerBooter(app, SANDBOX_PATH);
+    const booterInst = new ControllerBooter(app, sandbox.path);
     const NUM_CLASSES = 2; // 2 classes in above file.
 
     // Load uses discovered property
-    booterInst.discovered = [resolve(SANDBOX_PATH, 'multiple.artifact.js')];
+    booterInst.discovered = [resolve(sandbox.path, 'multiple.artifact.js')];
     await booterInst.load();
 
     const ctrls = app.findByTag(CONTROLLERS_TAG);

--- a/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/datasource.booter.unit.ts
@@ -13,8 +13,7 @@ import {resolve} from 'path';
 import {DataSourceBooter, DataSourceDefaults} from '../../..';
 
 describe('datasource booter unit tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../../.sandbox'));
 
   const DATASOURCES_PREFIX = 'datasources';
   const DATASOURCES_TAG = 'datasource';
@@ -38,10 +37,10 @@ describe('datasource booter unit tests', () => {
 
     const booterInst = new DataSourceBooter(
       normalApp as ApplicationWithRepositories,
-      SANDBOX_PATH,
+      sandbox.path,
     );
 
-    booterInst.discovered = [resolve(SANDBOX_PATH, 'datasource.artifact.js')];
+    booterInst.discovered = [resolve(sandbox.path, 'datasource.artifact.js')];
     await booterInst.load();
 
     sinon.assert.calledOnce(stub);
@@ -53,7 +52,7 @@ describe('datasource booter unit tests', () => {
   });
 
   it(`uses DataSourceDefaults for 'options' if none are given`, () => {
-    const booterInst = new DataSourceBooter(app, SANDBOX_PATH);
+    const booterInst = new DataSourceBooter(app, sandbox.path);
     expect(booterInst.options).to.deepEqual(DataSourceDefaults);
   });
 
@@ -66,7 +65,7 @@ describe('datasource booter unit tests', () => {
       nested: DataSourceDefaults.nested,
     });
 
-    const booterInst = new DataSourceBooter(app, SANDBOX_PATH, options);
+    const booterInst = new DataSourceBooter(app, sandbox.path, options);
     expect(booterInst.options).to.deepEqual(expected);
   });
 
@@ -75,10 +74,10 @@ describe('datasource booter unit tests', () => {
     await sandbox.copyFile(
       resolve(__dirname, '../../fixtures/datasource.artifact.js'),
     );
-    const booterInst = new DataSourceBooter(app, SANDBOX_PATH);
+    const booterInst = new DataSourceBooter(app, sandbox.path);
     const NUM_CLASSES = 1; // 1 class in above file.
 
-    booterInst.discovered = [resolve(SANDBOX_PATH, 'datasource.artifact.js')];
+    booterInst.discovered = [resolve(sandbox.path, 'datasource.artifact.js')];
     await booterInst.load();
 
     const datasources = app.findByTag(DATASOURCES_TAG);

--- a/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/repository.booter.unit.ts
@@ -13,8 +13,7 @@ import {resolve} from 'path';
 import {RepositoryBooter, RepositoryDefaults} from '../../..';
 
 describe('repository booter unit tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../../.sandbox'));
 
   const REPOSITORIES_PREFIX = 'repositories';
   const REPOSITORIES_TAG = 'repository';
@@ -38,11 +37,11 @@ describe('repository booter unit tests', () => {
 
     const booterInst = new RepositoryBooter(
       normalApp as ApplicationWithRepositories,
-      SANDBOX_PATH,
+      sandbox.path,
     );
 
     // Load uses discovered property
-    booterInst.discovered = [resolve(SANDBOX_PATH, 'multiple.artifact.js')];
+    booterInst.discovered = [resolve(sandbox.path, 'multiple.artifact.js')];
     await booterInst.load();
 
     sinon.assert.calledOnce(stub);
@@ -54,7 +53,7 @@ describe('repository booter unit tests', () => {
   });
 
   it(`uses RepositoryDefaults for 'options' if none are give`, () => {
-    const booterInst = new RepositoryBooter(app, SANDBOX_PATH);
+    const booterInst = new RepositoryBooter(app, sandbox.path);
     expect(booterInst.options).to.deepEqual(RepositoryDefaults);
   });
 
@@ -67,7 +66,7 @@ describe('repository booter unit tests', () => {
       nested: RepositoryDefaults.nested,
     });
 
-    const booterInst = new RepositoryBooter(app, SANDBOX_PATH, options);
+    const booterInst = new RepositoryBooter(app, sandbox.path, options);
     expect(booterInst.options).to.deepEqual(expected);
   });
 
@@ -79,11 +78,11 @@ describe('repository booter unit tests', () => {
     await sandbox.copyFile(
       resolve(__dirname, '../../fixtures/multiple.artifact.js'),
     );
-    const booterInst = new RepositoryBooter(app, SANDBOX_PATH);
+    const booterInst = new RepositoryBooter(app, sandbox.path);
     const NUM_CLASSES = 2; // 2 classes in above file.
 
     // Load uses discovered property
-    booterInst.discovered = [resolve(SANDBOX_PATH, 'multiple.artifact.js')];
+    booterInst.discovered = [resolve(sandbox.path, 'multiple.artifact.js')];
     await booterInst.load();
 
     const repos = app.findByTag(REPOSITORIES_TAG);

--- a/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
+++ b/packages/boot/src/__tests__/unit/booters/service.booter.unit.ts
@@ -10,8 +10,7 @@ import {resolve} from 'path';
 import {ServiceBooter, ServiceDefaults} from '../../..';
 
 describe('service booter unit tests', () => {
-  const SANDBOX_PATH = resolve(__dirname, '../../../.sandbox');
-  const sandbox = new TestSandbox(SANDBOX_PATH);
+  const sandbox = new TestSandbox(resolve(__dirname, '../../../.sandbox'));
 
   const SERVICES_PREFIX = 'services';
   const SERVICES_TAG = 'service';
@@ -35,11 +34,11 @@ describe('service booter unit tests', () => {
 
     const booterInst = new ServiceBooter(
       normalApp as ApplicationWithServices,
-      SANDBOX_PATH,
+      sandbox.path,
     );
 
     booterInst.discovered = [
-      resolve(SANDBOX_PATH, 'service-provider.artifact.js'),
+      resolve(sandbox.path, 'service-provider.artifact.js'),
     ];
     await booterInst.load();
 
@@ -47,7 +46,7 @@ describe('service booter unit tests', () => {
   });
 
   it(`uses ServiceDefaults for 'options' if none are given`, () => {
-    const booterInst = new ServiceBooter(app, SANDBOX_PATH);
+    const booterInst = new ServiceBooter(app, sandbox.path);
     expect(booterInst.options).to.deepEqual(ServiceDefaults);
   });
 
@@ -60,7 +59,7 @@ describe('service booter unit tests', () => {
       nested: ServiceDefaults.nested,
     });
 
-    const booterInst = new ServiceBooter(app, SANDBOX_PATH, options);
+    const booterInst = new ServiceBooter(app, sandbox.path, options);
     expect(booterInst.options).to.deepEqual(expected);
   });
 
@@ -69,11 +68,11 @@ describe('service booter unit tests', () => {
     await sandbox.copyFile(
       resolve(__dirname, '../../fixtures/service-provider.artifact.js'),
     );
-    const booterInst = new ServiceBooter(app, SANDBOX_PATH);
+    const booterInst = new ServiceBooter(app, sandbox.path);
     const NUM_CLASSES = 1; // 1 class in above file.
 
     booterInst.discovered = [
-      resolve(SANDBOX_PATH, 'service-provider.artifact.js'),
+      resolve(sandbox.path, 'service-provider.artifact.js'),
     ];
     await booterInst.load();
 

--- a/packages/cli/test/integration/generators/clone-example.integration.js
+++ b/packages/cli/test/integration/generators/clone-example.integration.js
@@ -17,8 +17,7 @@ const path = require('path');
 const readFile = promisify(fs.readFile);
 
 const VALID_EXAMPLE = 'todo';
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 describe('cloneExampleFromGitHub (SLOW)', function () {
   // eslint-disable-next-line no-invalid-this
@@ -27,7 +26,7 @@ describe('cloneExampleFromGitHub (SLOW)', function () {
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('extracts project files', async () => {
-    const outDir = await downloadAndExtractExample(VALID_EXAMPLE, SANDBOX_PATH);
+    const outDir = await downloadAndExtractExample(VALID_EXAMPLE, sandbox.path);
     const actualFiles = await glob('**', {
       cwd: outDir,
       ignore: 'node_modules/**',

--- a/packages/cli/test/integration/generators/controller.integration.js
+++ b/packages/cli/test/integration/generators/controller.integration.js
@@ -21,8 +21,7 @@ const testUtils = require('../../test-utils');
 const {expectFileToMatchSnapshot} = require('../../snapshots');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // CLI Inputs
 const basicCLIInput = {
@@ -37,7 +36,7 @@ const restCLIInput = {
 
 // Expected File Name
 const filePath = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   '/src/controllers/product-review.controller.ts',
 );
 
@@ -52,8 +51,8 @@ describe('lb4 controller', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludePackageJSON: true}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludePackageJSON: true}),
         )
         .withPrompts(basicCLIInput),
     ).to.be.rejectedWith(/No package.json found in/);
@@ -63,8 +62,8 @@ describe('lb4 controller', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: true}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludeLoopbackCore: true}),
         )
         .withPrompts(basicCLIInput),
     ).to.be.rejectedWith(/No `@loopback\/core` package found/);
@@ -74,7 +73,7 @@ describe('lb4 controller', () => {
     it('scaffolds correct file with input', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withPrompts(basicCLIInput);
 
       checkBasicContents();
@@ -83,7 +82,7 @@ describe('lb4 controller', () => {
     it('scaffolds correct file with args', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withArguments('productReview');
 
       assert.file(filePath);
@@ -104,8 +103,8 @@ describe('lb4 controller', () => {
     it('creates REST CRUD template with valid input - id omitted', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             includeDummyModel: true,
             includeDummyRepository: true,
           }),
@@ -118,8 +117,8 @@ describe('lb4 controller', () => {
     it('creates REST CRUD template with valid input', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             includeDummyModel: true,
             includeDummyRepository: true,
           }),
@@ -135,8 +134,8 @@ describe('lb4 controller', () => {
       it('defaults correctly', async () => {
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               includeDummyModel: true,
               includeDummyRepository: true,
             }),
@@ -153,8 +152,8 @@ describe('lb4 controller', () => {
 
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               includeDummyModel: true,
               includeDummyRepository: true,
             }),
@@ -176,8 +175,8 @@ describe('lb4 controller', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               includeDummyRepository: true,
             }),
           )
@@ -196,8 +195,8 @@ describe('lb4 controller', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {includeDummyModel: true}),
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {includeDummyModel: true}),
           )
           .withPrompts(noRepositoryInput),
       ).to.be.rejectedWith(/No repositories found in /);
@@ -207,8 +206,8 @@ describe('lb4 controller', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               excludeModelsDir: true,
               includeDummyRepository: true,
             }),
@@ -221,8 +220,8 @@ describe('lb4 controller', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               excludeRepositoriesDir: true,
               includeDummyModel: true,
             }),

--- a/packages/cli/test/integration/generators/copyright-monorepo.integration.js
+++ b/packages/cli/test/integration/generators/copyright-monorepo.integration.js
@@ -17,8 +17,7 @@ const testUtils = require('../../test-utils');
 const {spdxLicenseList} = require('../../../generators/copyright/license');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const year = new Date().getFullYear();
 
@@ -33,8 +32,8 @@ describe('lb4 copyright for monorepo', function () {
   it('updates copyright/license headers', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () =>
-        testUtils.givenLBProject(SANDBOX_PATH, {
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
           excludePackageJSON: true,
           additionalFiles: SANDBOX_FILES,
         }),
@@ -72,7 +71,7 @@ function assertHeader(fileNames, ...expected) {
     fileNames = [fileNames];
   }
   for (const f of fileNames) {
-    const file = path.join(SANDBOX_PATH, f);
+    const file = path.join(sandbox.path, f);
     for (const line of expected) {
       assert.fileContent(file, line);
     }

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -17,8 +17,7 @@ const SANDBOX_FILES = require('../../fixtures/copyright/single-package')
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const year = new Date().getFullYear();
 
@@ -35,8 +34,8 @@ describe('lb4 copyright', function () {
   it.skip('updates copyright/license headers with prompts', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () =>
-        testUtils.givenLBProject(SANDBOX_PATH, {
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
           excludePackageJSON: true,
           additionalFiles: SANDBOX_FILES,
         }),
@@ -56,8 +55,8 @@ describe('lb4 copyright', function () {
   it('updates copyright/license headers with options', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () =>
-        testUtils.givenLBProject(SANDBOX_PATH, {
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
           excludePackageJSON: true,
           additionalFiles: SANDBOX_FILES,
         }),
@@ -76,8 +75,8 @@ describe('lb4 copyright', function () {
   it('updates LICENSE and package.json', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () =>
-        testUtils.givenLBProject(SANDBOX_PATH, {
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
           excludePackageJSON: true,
           additionalFiles: SANDBOX_FILES,
         }),
@@ -90,11 +89,11 @@ describe('lb4 copyright', function () {
       });
 
     assert.fileContent(
-      path.join(SANDBOX_PATH, 'package.json'),
+      path.join(sandbox.path, 'package.json'),
       '"license": "ISC"',
     );
     assert.fileContent(
-      path.join(SANDBOX_PATH, 'package.json'),
+      path.join(sandbox.path, 'package.json'),
       '"copyright.owner": "ACME Inc."',
     );
 
@@ -104,15 +103,15 @@ describe('lb4 copyright', function () {
 
     */
     assert.fileContent(
-      path.join(SANDBOX_PATH, 'LICENSE'),
+      path.join(sandbox.path, 'LICENSE'),
       'This project is licensed under the ISC License, full text below.',
     );
     assert.fileContent(
-      path.join(SANDBOX_PATH, 'LICENSE'),
+      path.join(sandbox.path, 'LICENSE'),
       `Copyright (c) ACME Inc. ${year}. All Rights Reserved.`,
     );
     assert.fileContent(
-      path.join(SANDBOX_PATH, 'LICENSE'),
+      path.join(sandbox.path, 'LICENSE'),
       'Node module: myapp',
     );
   });
@@ -123,7 +122,7 @@ function assertHeader(fileNames, ...expected) {
     fileNames = [fileNames];
   }
   for (const f of fileNames) {
-    const file = path.join(SANDBOX_PATH, f);
+    const file = path.join(sandbox.path, f);
     for (const line of expected) {
       assert.fileContent(file, line);
     }

--- a/packages/cli/test/integration/generators/datasource.integration.js
+++ b/packages/cli/test/integration/generators/datasource.integration.js
@@ -20,8 +20,7 @@ const testUtils = require('../../test-utils');
 const {expectFileToMatchSnapshot} = require('../../snapshots');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // CLI Inputs
 const basicCLIInput = {
@@ -58,16 +57,16 @@ const expectedComplexJSONOutput = {
 
 // Expected File Name
 const expectedTSFile = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   'src/datasources/ds.datasource.ts',
 );
 
 const expectedJSONFile = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   'src/datasources/ds.datasource.config.json',
 );
 
-const expectedIndexFile = path.join(SANDBOX_PATH, 'src/datasources/index.ts');
+const expectedIndexFile = path.join(sandbox.path, 'src/datasources/index.ts');
 
 // Base Tests
 describe('datasource-generator extending BaseGenerator', baseTests);
@@ -80,8 +79,8 @@ describe('lb4 datasource integration', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludePackageJSON: true}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludePackageJSON: true}),
         )
         .withPrompts(basicCLIInput),
     ).to.be.rejectedWith(/No package.json found in/);
@@ -91,8 +90,8 @@ describe('lb4 datasource integration', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: true}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludeLoopbackCore: true}),
         )
         .withPrompts(basicCLIInput),
     ).to.be.rejectedWith(/No `@loopback\/core` package found/);
@@ -102,7 +101,7 @@ describe('lb4 datasource integration', () => {
     it('scaffolds correct file with input', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withPrompts(basicCLIInput);
 
       checkBasicDataSourceFiles();
@@ -113,7 +112,7 @@ describe('lb4 datasource integration', () => {
     it('scaffolds correct file with args', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withArguments('ds');
 
       checkBasicDataSourceFiles();
@@ -124,7 +123,7 @@ describe('lb4 datasource integration', () => {
   it('scaffolds correct file with cloudant input', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts(cloudantCLIInput);
 
     checkBasicDataSourceFiles();
@@ -134,7 +133,7 @@ describe('lb4 datasource integration', () => {
   it('correctly coerces setting input of type number', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts(numberCLIInput);
 
     checkBasicDataSourceFiles();
@@ -147,7 +146,7 @@ describe('lb4 datasource integration', () => {
   it('correctly coerces setting input of type object and array', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts(complexCLIInput);
 
     checkBasicDataSourceFiles();
@@ -159,7 +158,7 @@ function checkBasicDataSourceFiles() {
   assert.file(expectedTSFile);
   assert.file(expectedJSONFile);
   assert.file(expectedIndexFile);
-  assert.noFile(path.join(SANDBOX_PATH, 'node_modules/memory'));
+  assert.noFile(path.join(sandbox.path, 'node_modules/memory'));
 
   expectFileToMatchSnapshot(expectedTSFile);
 

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -25,9 +25,8 @@ const basicModelFileChecks = require('../lib/file-check').basicModelFileChecks;
 // tests/unit/discovery/import-discovered-model.test.ts
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
 const SANDBOX_FILES = require('../../fixtures/discover').SANDBOX_FILES;
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // CLI Inputs
 const baseOptions = {
@@ -54,25 +53,25 @@ const missingDataSourceOptions = {
 
 // Expected File Name
 const defaultExpectedTestModel = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   'src/models/test.model.ts',
 );
 const defaultExpectedSchemaModel = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   'src/models/schema.model.ts',
 );
 const defaultExpectedViewModel = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   'src/models/view.model.ts',
 );
 const defaultExpectedNamingModel = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   'src/models/naming.model.ts',
 );
 
-const defaultExpectedIndexFile = path.join(SANDBOX_PATH, 'src/models/index.ts');
-const movedExpectedTestModel = path.join(SANDBOX_PATH, 'src/test.model.ts');
-const movedExpectedIndexFile = path.join(SANDBOX_PATH, 'src/index.ts');
+const defaultExpectedIndexFile = path.join(sandbox.path, 'src/models/index.ts');
+const movedExpectedTestModel = path.join(sandbox.path, 'src/test.model.ts');
+const movedExpectedIndexFile = path.join(sandbox.path, 'src/index.ts');
 
 // Base Tests
 /*describe('discover-generator extending BaseGenerator', baseTests);
@@ -90,8 +89,8 @@ describe('lb4 discover integration', () => {
       this.timeout(10000);
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -105,8 +104,8 @@ describe('lb4 discover integration', () => {
     it('uses a different --outDir if provided', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -119,8 +118,8 @@ describe('lb4 discover integration', () => {
     it('excludes models based on the --views and --schema options', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -134,8 +133,8 @@ describe('lb4 discover integration', () => {
     it('keeps model property names the same as the db column names', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -149,8 +148,8 @@ describe('lb4 discover integration', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )

--- a/packages/cli/test/integration/generators/import-lb3-models.integration.js
+++ b/packages/cli/test/integration/generators/import-lb3-models.integration.js
@@ -12,8 +12,7 @@ const generator = path.join(__dirname, '../../../generators/import-lb3-models');
 const {expectFileToMatchSnapshot} = require('../../snapshots');
 const testUtils = require('../../test-utils');
 
-const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // In this test suite we invoke the full generator with mocked prompts
 // and inspect the generated model file(s).
@@ -48,14 +47,14 @@ describe('lb4 import-lb3-models', function () {
   it('imports CoffeeShop model from lb3-example app', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withArguments(COFFEE_SHOP_EXAMPLE)
       .withPrompts({
         modelNames: ['CoffeeShop'],
       });
 
     // The default outDir is "src/models"
-    const outDir = path.join(SANDBOX_PATH, 'src/models');
+    const outDir = path.join(sandbox.path, 'src/models');
 
     // Verify the source code generated for the model
     expectFileToMatchSnapshot(`${outDir}/coffee-shop.model.ts`);
@@ -65,11 +64,11 @@ describe('lb4 import-lb3-models', function () {
   });
 
   it('honours `outDir` option', async () => {
-    const outDir = path.join(SANDBOX_PATH, 'my-models');
+    const outDir = path.join(sandbox.path, 'my-models');
 
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withArguments(COFFEE_SHOP_EXAMPLE)
       .withPrompts({
         modelNames: ['CoffeeShop'],
@@ -85,7 +84,7 @@ describe('lb4 import-lb3-models', function () {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withArguments(COFFEE_SHOP_EXAMPLE)
         .withPrompts({
           modelNames: ['ModelDoesNotExist'],
@@ -97,11 +96,11 @@ describe('lb4 import-lb3-models', function () {
   });
 
   it('imports a model inheriting from a custom base class', async () => {
-    const outDir = path.join(SANDBOX_PATH, 'models-with-inheritance');
+    const outDir = path.join(sandbox.path, 'models-with-inheritance');
 
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withArguments(APP_USING_MODEL_INHERITANCE)
       .withPrompts({
         modelNames: ['Customer'],

--- a/packages/cli/test/integration/generators/interceptor.integration.js
+++ b/packages/cli/test/integration/generators/interceptor.integration.js
@@ -15,14 +15,13 @@ const testUtils = require('../../test-utils');
 const {expectFileToMatchSnapshot} = require('../../snapshots');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // Sandbox constants
 const SCRIPT_APP_PATH = 'src/interceptors';
-const INDEX_FILE = path.join(SANDBOX_PATH, SCRIPT_APP_PATH, 'index.ts');
+const INDEX_FILE = path.join(sandbox.path, SCRIPT_APP_PATH, 'index.ts');
 const GENERATED_FILE = path.join(
-  SANDBOX_PATH,
+  sandbox.path,
   SCRIPT_APP_PATH,
   'my-interceptor.interceptor.ts',
 );
@@ -36,8 +35,8 @@ describe('lb4 interceptor', () => {
     it('generates a basic interceptor from command line arguments', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -49,8 +48,8 @@ describe('lb4 interceptor', () => {
     it('generates a basic interceptor from CLI with group', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -62,8 +61,8 @@ describe('lb4 interceptor', () => {
     it('generates a interceptor from a config file', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -75,8 +74,8 @@ describe('lb4 interceptor', () => {
     it('generates a non-global interceptor from CLI', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -88,8 +87,8 @@ describe('lb4 interceptor', () => {
     it('generates a non-global interceptor with prompts', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )

--- a/packages/cli/test/integration/generators/local-service.integration.js
+++ b/packages/cli/test/integration/generators/local-service.integration.js
@@ -17,8 +17,7 @@ const SANDBOX_FILES = require('../../fixtures/service').SANDBOX_FILES;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 describe('lb4 service (local)', () => {
   beforeEach('reset sandbox', async () => {
@@ -31,7 +30,7 @@ describe('lb4 service (local)', () => {
         testUtils
           .executeGenerator(generator)
           .withArguments('myService --type xyz')
-          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
+          .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path)),
       ).to.be.rejectedWith(/Invalid service type\: xyz/);
     });
   });
@@ -40,14 +39,14 @@ describe('lb4 service (local)', () => {
     it('generates a basic local service class from command line arguments', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('myTest --type class');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'my-test.service.ts',
       );
@@ -64,15 +63,15 @@ describe('lb4 service (local)', () => {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'my-test.service.ts',
       );
@@ -85,14 +84,14 @@ describe('lb4 service (local)', () => {
     it('generates a basic local service provider from command line arguments', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('myService --type provider');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'my-service.service.ts',
       );
@@ -113,15 +112,15 @@ describe('lb4 service (local)', () => {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'my-service.service.ts',
       );
@@ -139,4 +138,4 @@ describe('lb4 service (local)', () => {
 
 // Sandbox constants
 const SERVICE_APP_PATH = 'src/services';
-const INDEX_FILE = path.join(SANDBOX_PATH, SERVICE_APP_PATH, 'index.ts');
+const INDEX_FILE = path.join(sandbox.path, SERVICE_APP_PATH, 'index.ts');

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -19,9 +19,8 @@ const testUtils = require('../../test-utils');
 const basicModelFileChecks = require('../lib/file-check').basicModelFileChecks;
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
 const DISCOVER_SANDBOX_FILES = require('../../fixtures/discover').SANDBOX_FILES;
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // Basic CLI Input
 const basicCLIInput = {
@@ -29,8 +28,8 @@ const basicCLIInput = {
 };
 
 // Expected File Paths & File Contents
-const expectedIndexFile = path.join(SANDBOX_PATH, 'src/models/index.ts');
-const expectedModelFile = path.join(SANDBOX_PATH, 'src/models/test.model.ts');
+const expectedIndexFile = path.join(sandbox.path, 'src/models/index.ts');
+const expectedModelFile = path.join(sandbox.path, 'src/models/test.model.ts');
 
 // Base Tests
 describe('model-generator extending BaseGenerator', baseTests);
@@ -43,8 +42,8 @@ describe('lb4 model integration', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludePackageJSON: true}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludePackageJSON: true}),
         )
         .withPrompts(basicCLIInput),
     ).to.be.rejectedWith(/No package.json found in/);
@@ -54,8 +53,8 @@ describe('lb4 model integration', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: true}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludeLoopbackCore: true}),
         )
         .withPrompts(basicCLIInput),
     ).to.be.rejectedWith(/No `@loopback\/core` package found/);
@@ -65,8 +64,8 @@ describe('lb4 model integration', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {excludeLoopbackCore: false}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {excludeLoopbackCore: false}),
         )
         .withArguments('myNewModel --base InvalidModel'),
     ).to.be.rejectedWith(/Model was not found in/);
@@ -75,7 +74,7 @@ describe('lb4 model integration', () => {
   it('run if passed a valid base model from command line', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withArguments('test --base Model');
 
     assert.file(expectedModelFile);
@@ -87,8 +86,8 @@ describe('lb4 model integration', () => {
     this.timeout(3000);
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () =>
-        testUtils.givenLBProject(SANDBOX_PATH, {
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
           additionalFiles: DISCOVER_SANDBOX_FILES,
         }),
       )
@@ -100,8 +99,8 @@ describe('lb4 model integration', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: DISCOVER_SANDBOX_FILES,
           }),
         )
@@ -113,7 +112,7 @@ describe('lb4 model integration', () => {
     it('scaffolds correct files with input', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withPrompts({
           name: 'test',
           propName: null,
@@ -125,9 +124,9 @@ describe('lb4 model integration', () => {
     it('creates "src/models" directory if it does not exist', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, async () => {
-          testUtils.givenLBProject(SANDBOX_PATH);
-          await remove(path.resolve(SANDBOX_PATH, 'src/models'));
+        .inDir(sandbox.path, async () => {
+          testUtils.givenLBProject(sandbox.path);
+          await remove(path.resolve(sandbox.path, 'src/models'));
         })
         .withPrompts({
           name: 'test',
@@ -140,7 +139,7 @@ describe('lb4 model integration', () => {
     it('scaffolds correct files with model base class', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withPrompts({
           name: 'test',
           propName: null,
@@ -166,8 +165,8 @@ describe('lb4 model integration', () => {
     it('scaffolds correct files with model custom class', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {includeDummyModel: true}),
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {includeDummyModel: true}),
         )
         .withPrompts({
           name: 'test',
@@ -193,7 +192,7 @@ describe('lb4 model integration', () => {
     it('scaffolds model with strict setting disabled', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withPrompts({
           name: 'test',
           propName: null,
@@ -226,7 +225,7 @@ describe('lb4 model integration', () => {
     it('scaffolds empty model relation interface and relation type', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withPrompts({
           name: 'test',
           propName: null,
@@ -254,7 +253,7 @@ describe('lb4 model integration', () => {
     it('scaffolds correct files with args', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withArguments('test')
         .withPrompts({
           propName: null,
@@ -269,7 +268,7 @@ describe('model generator using --config option', () => {
   it('create models with valid json', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withArguments(['--config', '{"name":"test", "base":"Entity"}', '--yes']);
 
     basicModelFileChecks(expectedModelFile, expectedIndexFile);
@@ -279,7 +278,7 @@ describe('model generator using --config option', () => {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withArguments([
           '--config',
           '{"name":"test", "base":"InvalidBaseModel"}',
@@ -292,7 +291,7 @@ describe('model generator using --config option', () => {
     it('creates a model with valid settings', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+        .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
         .withArguments([
           '--config',
           '{"name":"test", "base":"Entity", \

--- a/packages/cli/test/integration/generators/observer.integration.js
+++ b/packages/cli/test/integration/generators/observer.integration.js
@@ -16,8 +16,7 @@ const SANDBOX_FILES = require('../../fixtures/observer').SANDBOX_FILES;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 describe('lb4 observer', () => {
   beforeEach('reset sandbox', async () => {
@@ -28,8 +27,8 @@ describe('lb4 observer', () => {
     it('generates a basic observer from command line arguments', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -40,8 +39,8 @@ describe('lb4 observer', () => {
     it('generates a basic observer from CLI with group', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -52,8 +51,8 @@ describe('lb4 observer', () => {
     it('generates a observer from a config file', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -65,11 +64,11 @@ describe('lb4 observer', () => {
 
 // Sandbox constants
 const SCRIPT_APP_PATH = 'src/observers';
-const INDEX_FILE = path.join(SANDBOX_PATH, SCRIPT_APP_PATH, 'index.ts');
+const INDEX_FILE = path.join(sandbox.path, SCRIPT_APP_PATH, 'index.ts');
 
 function verifyGeneratedScript(group = '') {
   const expectedFile = path.join(
-    SANDBOX_PATH,
+    sandbox.path,
     SCRIPT_APP_PATH,
     'my-observer.observer.ts',
   );

--- a/packages/cli/test/integration/generators/openapi-petstore.integration.js
+++ b/packages/cli/test/integration/generators/openapi-petstore.integration.js
@@ -17,8 +17,7 @@ const specPath = path.join(
 );
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 const testUtils = require('../../test-utils');
 
 const props = {
@@ -30,15 +29,15 @@ describe('openapi-generator specific files', function () {
   // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
-  const modelIndex = path.resolve(SANDBOX_PATH, 'src/models/index.ts');
-  const controIndex = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const modelIndex = path.resolve(sandbox.path, 'src/models/index.ts');
+  const controIndex = path.resolve(sandbox.path, 'src/controllers/index.ts');
   const controller = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/controllers/open-api.controller.ts',
   );
-  const petModel = path.resolve(SANDBOX_PATH, 'src/models/pet.model.ts');
-  const newPetModel = path.resolve(SANDBOX_PATH, 'src/models/new-pet.model.ts');
-  const errorModel = path.resolve(SANDBOX_PATH, 'src/models/error.model.ts');
+  const petModel = path.resolve(sandbox.path, 'src/models/pet.model.ts');
+  const newPetModel = path.resolve(sandbox.path, 'src/models/new-pet.model.ts');
+  const errorModel = path.resolve(sandbox.path, 'src/models/error.model.ts');
 
   after('reset sandbox', async () => {
     await sandbox.reset();
@@ -47,7 +46,7 @@ describe('openapi-generator specific files', function () {
   it('generates all the proper files', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts(props);
 
     assert.file(modelIndex);

--- a/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
@@ -14,8 +14,7 @@ const generator = path.join(__dirname, '../../../generators/openapi');
 const specPath = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 const testUtils = require('../../test-utils');
 
 const props = {
@@ -23,22 +22,22 @@ const props = {
 };
 
 describe('openapi-generator specific files', () => {
-  const modelIndex = path.resolve(SANDBOX_PATH, 'src/models/index.ts');
-  const controIndex = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const modelIndex = path.resolve(sandbox.path, 'src/models/index.ts');
+  const controIndex = path.resolve(sandbox.path, 'src/controllers/index.ts');
   const searchController = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/controllers/search.controller.ts',
   );
   const metadataController = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/controllers/metadata.controller.ts',
   );
   const performSearchRequestBodyModel = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/models/perform-search-request-body.model.ts',
   );
   const performSearchResponseBodyModel = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/models/perform-search-response-body.model.ts',
   );
 
@@ -49,7 +48,7 @@ describe('openapi-generator specific files', () => {
   it('generates all the proper files', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withArguments('--promote-anonymous-schemas')
       .withPrompts(props);
     assert.file(searchController);

--- a/packages/cli/test/integration/generators/openapi-uspto.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto.integration.js
@@ -14,8 +14,7 @@ const generator = path.join(__dirname, '../../../generators/openapi');
 const specPath = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 const testUtils = require('../../test-utils');
 
 const props = {
@@ -23,14 +22,14 @@ const props = {
 };
 
 describe('openapi-generator specific files', () => {
-  const modelIndex = path.resolve(SANDBOX_PATH, 'src/models/index.ts');
-  const controIndex = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const modelIndex = path.resolve(sandbox.path, 'src/models/index.ts');
+  const controIndex = path.resolve(sandbox.path, 'src/controllers/index.ts');
   const searchController = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/controllers/search.controller.ts',
   );
   const metadataController = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/controllers/metadata.controller.ts',
   );
   after('reset sandbox', async () => {
@@ -40,7 +39,7 @@ describe('openapi-generator specific files', () => {
   it('generates all the proper files', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts(props);
     assert.file(searchController);
     expectFileToMatchSnapshot(searchController);
@@ -58,7 +57,7 @@ describe('openapi-generator specific files', () => {
   it('skips controllers not selected', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts({
         url: specPath,
         controllerSelections: ['MetadataController'],

--- a/packages/cli/test/integration/generators/relation.belongs-to.integration.js
+++ b/packages/cli/test/integration/generators/relation.belongs-to.integration.js
@@ -15,11 +15,10 @@ const {SANDBOX_FILES, SourceEntries} = require('../../fixtures/relation');
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 const MODEL_APP_PATH = 'src/models';
 const CONTROLLER_PATH = 'src/controllers';
 const REPOSITORY_APP_PATH = 'src/repositories';
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const sourceFileName = [
   'order.model.ts',
@@ -52,8 +51,8 @@ describe('lb4 relation', function () {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -72,8 +71,8 @@ describe('lb4 relation', function () {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: [
               // no model/repository files in this project
             ],
@@ -93,8 +92,8 @@ describe('lb4 relation', function () {
 
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () =>
-        testUtils.givenLBProject(SANDBOX_PATH, {
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
           additionalFiles: [
             SourceEntries.CustomerModelWithOrdersProperty,
             SourceEntries.OrderModelModelWithCustomerIdProperty,
@@ -106,7 +105,7 @@ describe('lb4 relation', function () {
       .withPrompts(prompt);
 
     const expectedFile = path.join(
-      SANDBOX_PATH,
+      sandbox.path,
       MODEL_APP_PATH,
       'order.model.ts',
     );
@@ -135,8 +134,8 @@ describe('lb4 relation', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -145,7 +144,7 @@ describe('lb4 relation', function () {
 
       it('has correct default imports', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
@@ -177,8 +176,8 @@ describe('lb4 relation', function () {
       await sandbox.reset();
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -186,15 +185,15 @@ describe('lb4 relation', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(promptList[0]);
 
       const sourceFilePath = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         MODEL_APP_PATH,
         sourceFileName[0],
       );
@@ -231,8 +230,8 @@ describe('lb4 relation', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -241,7 +240,7 @@ describe('lb4 relation', function () {
 
       it('relation name should be my_customer', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
@@ -278,8 +277,8 @@ describe('lb4 relation', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -288,7 +287,7 @@ describe('lb4 relation', function () {
 
       it('new controller file created', async () => {
         const filePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           CONTROLLER_PATH,
           controllerFileName[i],
         );
@@ -297,7 +296,7 @@ describe('lb4 relation', function () {
 
       it('checks controller content with belongsTo relation', async () => {
         const filePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           CONTROLLER_PATH,
           controllerFileName[i],
         );
@@ -307,7 +306,7 @@ describe('lb4 relation', function () {
 
       it('the new controller file added to index.ts file', async () => {
         const indexFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           CONTROLLER_PATH,
           'index.ts',
         );
@@ -353,8 +352,8 @@ describe('lb4 relation', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -367,7 +366,7 @@ describe('lb4 relation', function () {
           ' repository file with different inputs',
         async () => {
           const sourceFilePath = path.join(
-            SANDBOX_PATH,
+            sandbox.path,
             REPOSITORY_APP_PATH,
             repositoryFileName[i],
           );

--- a/packages/cli/test/integration/generators/relation.has-many.integration.js
+++ b/packages/cli/test/integration/generators/relation.has-many.integration.js
@@ -15,12 +15,11 @@ const {SANDBOX_FILES, SourceEntries} = require('../../fixtures/relation');
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 const MODEL_APP_PATH = 'src/models';
 const CONTROLLER_PATH = 'src/controllers';
 const REPOSITORY_APP_PATH = 'src/repositories';
 
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const sourceFileName = [
   'customer.model.ts',
@@ -59,8 +58,8 @@ describe('lb4 relation HasMany', function () {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -82,8 +81,8 @@ describe('lb4 relation HasMany', function () {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: [
               SourceEntries.CustomerModelWithOrdersProperty,
               SourceEntries.OrderModel,
@@ -112,8 +111,8 @@ describe('lb4 relation HasMany', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: [
                 SourceEntries.CustomerModel,
                 SourceEntries.OrderModel,
@@ -160,8 +159,8 @@ describe('lb4 relation HasMany', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -170,7 +169,7 @@ describe('lb4 relation HasMany', function () {
 
       it('has correct default imports', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
@@ -213,8 +212,8 @@ describe('lb4 relation HasMany', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -223,12 +222,12 @@ describe('lb4 relation HasMany', function () {
 
       it('relation name should be myOrders', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
         const targetFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           targetFileName[i],
         );
@@ -274,8 +273,8 @@ describe('lb4 relation HasMany', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -284,12 +283,12 @@ describe('lb4 relation HasMany', function () {
 
       it('add the keyTo to the source model', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
         const targetFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           targetFileName[i],
         );
@@ -328,8 +327,8 @@ describe('lb4 relation HasMany', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -338,7 +337,7 @@ describe('lb4 relation HasMany', function () {
 
       it('new controller file has been created', async () => {
         const filePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           CONTROLLER_PATH,
           controllerFileName[i],
         );
@@ -347,7 +346,7 @@ describe('lb4 relation HasMany', function () {
 
       it('checks controller content with hasMany relation', async () => {
         const filePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           CONTROLLER_PATH,
           controllerFileName[i],
         );
@@ -389,8 +388,8 @@ describe('lb4 relation HasMany', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -403,7 +402,7 @@ describe('lb4 relation HasMany', function () {
           ' repository file with different inputs',
         async () => {
           const sourceFilePath = path.join(
-            SANDBOX_PATH,
+            sandbox.path,
             REPOSITORY_APP_PATH,
             repositoryFileName[i],
           );

--- a/packages/cli/test/integration/generators/relation.has-one.integration.js
+++ b/packages/cli/test/integration/generators/relation.has-one.integration.js
@@ -15,12 +15,11 @@ const {SANDBOX_FILES, SourceEntries} = require('../../fixtures/relation');
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 const MODEL_APP_PATH = 'src/models';
 const CONTROLLER_PATH = 'src/controllers';
 const REPOSITORY_APP_PATH = 'src/repositories';
 
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const sourceFileName = [
   'customer.model.ts',
@@ -59,8 +58,8 @@ describe('lb4 relation HasOne', function () {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -82,8 +81,8 @@ describe('lb4 relation HasOne', function () {
     return expect(
       testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: [
               SourceEntries.CustomerModelWithAddressProperty,
               SourceEntries.AddressModel,
@@ -112,8 +111,8 @@ describe('lb4 relation HasOne', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: [
                 SourceEntries.CustomerModel,
                 SourceEntries.AddressModel,
@@ -160,8 +159,8 @@ describe('lb4 relation HasOne', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -170,7 +169,7 @@ describe('lb4 relation HasOne', function () {
 
       it('has correct default imports', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
@@ -213,8 +212,8 @@ describe('lb4 relation HasOne', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -223,12 +222,12 @@ describe('lb4 relation HasOne', function () {
 
       it('relation name should be myAddress', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
         const targetFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           targetFileName[i],
         );
@@ -274,8 +273,8 @@ describe('lb4 relation HasOne', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -284,12 +283,12 @@ describe('lb4 relation HasOne', function () {
 
       it('add the keyTo to the source model', async () => {
         const sourceFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           sourceFileName[i],
         );
         const targetFilePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           MODEL_APP_PATH,
           targetFileName[i],
         );
@@ -328,8 +327,8 @@ describe('lb4 relation HasOne', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -338,7 +337,7 @@ describe('lb4 relation HasOne', function () {
 
       it('new controller file has been created', async () => {
         const filePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           CONTROLLER_PATH,
           controllerFileName[i],
         );
@@ -347,7 +346,7 @@ describe('lb4 relation HasOne', function () {
 
       it('checks controller content with hasOne relation', async () => {
         const filePath = path.join(
-          SANDBOX_PATH,
+          sandbox.path,
           CONTROLLER_PATH,
           controllerFileName[i],
         );
@@ -389,8 +388,8 @@ describe('lb4 relation HasOne', function () {
         await sandbox.reset();
         await testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -403,7 +402,7 @@ describe('lb4 relation HasOne', function () {
           ' repository file with different inputs',
         async () => {
           const sourceFilePath = path.join(
-            SANDBOX_PATH,
+            sandbox.path,
             REPOSITORY_APP_PATH,
             repositoryFileName[i],
           );

--- a/packages/cli/test/integration/generators/relation.integration.js
+++ b/packages/cli/test/integration/generators/relation.integration.js
@@ -16,9 +16,8 @@ const SANDBOX_FILES4 = require('../../fixtures/relation').SANDBOX_FILES4;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
 const CONTROLLER_PATH = 'src/controllers';
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 // In this test suite, we test scenarios that apply to all relation types
 // See `relation-{type}.integration.ts` files for test cases specific
@@ -37,8 +36,8 @@ describe('lb4 relation', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -53,8 +52,8 @@ describe('lb4 relation', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -68,8 +67,8 @@ describe('lb4 relation', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -85,8 +84,8 @@ describe('lb4 relation', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -100,8 +99,8 @@ describe('lb4 relation', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -120,8 +119,8 @@ describe('lb4 relation', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -140,14 +139,14 @@ describe('lb4 relation', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(prompt);
       const expectedControllerIndexFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         CONTROLLER_PATH,
         'index.ts',
       );
@@ -169,14 +168,14 @@ describe('lb4 relation', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES4,
           }),
         )
         .withPrompts(prompt);
       const expectedControllerIndexFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         CONTROLLER_PATH,
         'index.ts',
       );

--- a/packages/cli/test/integration/generators/remote-service.integration.js
+++ b/packages/cli/test/integration/generators/remote-service.integration.js
@@ -17,8 +17,7 @@ const SANDBOX_FILES = require('../../fixtures/service').SANDBOX_FILES;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 describe('lb4 service (remote)', () => {
   beforeEach('reset sandbox', async () => {
@@ -30,7 +29,7 @@ describe('lb4 service (remote)', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
+          .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path)),
       ).to.be.rejectedWith(/No datasources found/);
     });
 
@@ -38,8 +37,8 @@ describe('lb4 service (remote)', () => {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -52,14 +51,14 @@ describe('lb4 service (remote)', () => {
     it('generates a basic soap service from command line arguments', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('myService --datasource myds');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'my-service.service.ts',
       );
@@ -78,14 +77,14 @@ describe('lb4 service (remote)', () => {
     it('generates a soap service from a config file', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('--config mysoapconfig.json');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'multi-word-service.service.ts',
       );
@@ -116,15 +115,15 @@ describe('lb4 service (remote)', () => {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'my-service.service.ts',
       );
@@ -148,15 +147,15 @@ describe('lb4 service (remote)', () => {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'myservice.service.ts',
       );
@@ -174,14 +173,14 @@ describe('lb4 service (remote)', () => {
     it('generates a basic rest service from a config file', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('--config myrestconfig.json');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'myservice.service.ts',
       );
@@ -199,14 +198,14 @@ describe('lb4 service (remote)', () => {
     it('generates a basic rest service from command line arguments', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('myservice --datasource restdb');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'myservice.service.ts',
       );
@@ -230,15 +229,15 @@ describe('lb4 service (remote)', () => {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         SERVICE_APP_PATH,
         'myservice.service.ts',
       );
@@ -267,4 +266,4 @@ describe('lb4 service (remote)', () => {
 
 // Sandbox constants
 const SERVICE_APP_PATH = 'src/services';
-const INDEX_FILE = path.join(SANDBOX_PATH, SERVICE_APP_PATH, 'index.ts');
+const INDEX_FILE = path.join(sandbox.path, SERVICE_APP_PATH, 'index.ts');

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -17,8 +17,7 @@ const SANDBOX_FILES = require('../../fixtures/repository').SANDBOX_FILES;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 describe('lb4 repository', function () {
   // eslint-disable-next-line no-invalid-this
@@ -38,20 +37,20 @@ describe('lb4 repository', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedMultiWordFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'multi-word.repository.ts',
       );
       const expectedDefaultModelFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'default-model.repository.ts',
       );
@@ -96,15 +95,15 @@ describe('lb4 repository', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'multi-word.repository.ts',
       );
@@ -125,14 +124,14 @@ describe('lb4 repository', function () {
     it('generates a custom name repository', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('myrepo --datasource dbmem --model MultiWord');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'myrepo.repository.ts',
       );
@@ -150,14 +149,14 @@ describe('lb4 repository', function () {
     it('generates a crud repository from a config file', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('--config myconfig.json');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'decorator-defined.repository.ts',
       );
@@ -186,15 +185,15 @@ describe('lb4 repository', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'invalid-id.repository.ts',
       );
@@ -221,8 +220,8 @@ describe('lb4 repository', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -238,8 +237,8 @@ describe('lb4 repository', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -251,7 +250,7 @@ describe('lb4 repository', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
+          .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path)),
       ).to.be.rejectedWith(/No datasources found/);
     });
   });
@@ -263,15 +262,15 @@ describe('lb4 repository', function () {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(basicPrompt)
         .withArguments(' --model DefaultModel');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'default-model.repository.ts',
       );
@@ -295,15 +294,15 @@ describe('lb4 repository', function () {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(basicPrompt)
         .withArguments(' --model Model1NameWithNum1');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'model-1-name-with-num1.repository.ts',
       );
@@ -335,8 +334,8 @@ describe('lb4 repository', function () {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             // Only use the sqlite3 datasource
             additionalFiles: files,
           }),
@@ -344,7 +343,7 @@ describe('lb4 repository', function () {
         .withPrompts(basicPrompt)
         .withArguments(' --model DefaultModel');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'default-model.repository.ts',
       );
@@ -357,15 +356,15 @@ describe('lb4 repository', function () {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(basicPrompt)
         .withArguments(' --model DefaultModel');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'default-model.repository.ts',
       );
@@ -393,14 +392,14 @@ describe('lb4 repository', function () {
     it('generates a crud repository from decorator defined model', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('--datasource dbmem --model DecoratorDefined');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'decorator-defined.repository.ts',
       );
@@ -422,8 +421,8 @@ describe('lb4 repository', function () {
     it('generates a crud repository from custom base class', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -431,7 +430,7 @@ describe('lb4 repository', function () {
           '--datasource dbmem --model DecoratorDefined --repositoryBaseClass DefaultModelRepository',
         );
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'decorator-defined.repository.ts',
       );
@@ -460,8 +459,8 @@ describe('lb4 repository', function () {
     it('generates a kv repository from default model', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -469,7 +468,7 @@ describe('lb4 repository', function () {
           '--datasource dbkv --model DefaultModel --repositoryBaseClass DefaultKeyValueRepository',
         );
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'default-model.repository.ts',
       );
@@ -491,8 +490,8 @@ describe('lb4 repository', function () {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
@@ -501,7 +500,7 @@ describe('lb4 repository', function () {
           '--model DecoratorDefined --repositoryBaseClass DefaultKeyValueRepository',
         );
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         REPOSITORY_APP_PATH,
         'decorator-defined.repository.ts',
       );
@@ -522,4 +521,4 @@ describe('lb4 repository', function () {
 
 // Sandbox constants
 const REPOSITORY_APP_PATH = 'src/repositories';
-const INDEX_FILE = path.join(SANDBOX_PATH, REPOSITORY_APP_PATH, 'index.ts');
+const INDEX_FILE = path.join(sandbox.path, REPOSITORY_APP_PATH, 'index.ts');

--- a/packages/cli/test/integration/generators/rest-crud.integration.js
+++ b/packages/cli/test/integration/generators/rest-crud.integration.js
@@ -17,8 +17,7 @@ const SANDBOX_FILES = require('../../fixtures/rest-crud').SANDBOX_FILES;
 const testUtils = require('../../test-utils');
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '..', '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 describe('lb4 rest-crud', function () {
   // eslint-disable-next-line no-invalid-this
@@ -38,20 +37,20 @@ describe('lb4 rest-crud', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedMultiWordFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         MODEL_ENDPOINT_PATH,
         'multi-word.rest-config.ts',
       );
       const expectedDefaultModelFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         MODEL_ENDPOINT_PATH,
         'default-model.rest-config.ts',
       );
@@ -85,15 +84,15 @@ describe('lb4 rest-crud', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(multiItemPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         MODEL_ENDPOINT_PATH,
         'multi-word.rest-config.ts',
       );
@@ -117,15 +116,15 @@ describe('lb4 rest-crud', function () {
 
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withPrompts(singleModelPrompt);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         MODEL_ENDPOINT_PATH,
         'multi-word.rest-config.ts',
       );
@@ -148,15 +147,15 @@ describe('lb4 rest-crud', function () {
       };
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withOptions(options);
 
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         MODEL_ENDPOINT_PATH,
         'multi-word.rest-config.ts',
       );
@@ -174,14 +173,14 @@ describe('lb4 rest-crud', function () {
     it('generates a rest-crud model endpoint from a config file', async () => {
       await testUtils
         .executeGenerator(generator)
-        .inDir(SANDBOX_PATH, () =>
-          testUtils.givenLBProject(SANDBOX_PATH, {
+        .inDir(sandbox.path, () =>
+          testUtils.givenLBProject(sandbox.path, {
             additionalFiles: SANDBOX_FILES,
           }),
         )
         .withArguments('--config myconfig.json');
       const expectedFile = path.join(
-        SANDBOX_PATH,
+        sandbox.path,
         MODEL_ENDPOINT_PATH,
         'decorator-defined.rest-config.ts',
       );
@@ -204,8 +203,8 @@ describe('lb4 rest-crud', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -221,8 +220,8 @@ describe('lb4 rest-crud', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () =>
-            testUtils.givenLBProject(SANDBOX_PATH, {
+          .inDir(sandbox.path, () =>
+            testUtils.givenLBProject(sandbox.path, {
               additionalFiles: SANDBOX_FILES,
             }),
           )
@@ -234,7 +233,7 @@ describe('lb4 rest-crud', function () {
       return expect(
         testUtils
           .executeGenerator(generator)
-          .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH)),
+          .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path)),
       ).to.be.rejectedWith(/No datasources found/);
     });
   });
@@ -242,10 +241,10 @@ describe('lb4 rest-crud', function () {
 
 // Sandbox constants
 const MODEL_ENDPOINT_PATH = 'src/model-endpoints';
-const INDEX_FILE = path.join(SANDBOX_PATH, MODEL_ENDPOINT_PATH, 'index.ts');
+const INDEX_FILE = path.join(sandbox.path, MODEL_ENDPOINT_PATH, 'index.ts');
 
 function assertApplicationTsFileUpdated() {
-  const expectedAppFile = path.join(SANDBOX_PATH, 'src', 'application.ts');
+  const expectedAppFile = path.join(sandbox.path, 'src', 'application.ts');
   assert.fileContent(
     expectedAppFile,
     /import {CrudRestComponent} from '@loopback\/rest-crud';/,

--- a/packages/cli/test/integration/generators/swagger-petstore.integration.js
+++ b/packages/cli/test/integration/generators/swagger-petstore.integration.js
@@ -17,8 +17,7 @@ const testlab = require('@loopback/testlab');
 const TestSandbox = testlab.TestSandbox;
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '../.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 const testUtils = require('../../test-utils');
 
 const props = {
@@ -26,15 +25,15 @@ const props = {
 };
 
 describe('openapi-generator specific files', () => {
-  const index = path.resolve(SANDBOX_PATH, 'src/controllers/index.ts');
+  const index = path.resolve(sandbox.path, 'src/controllers/index.ts');
   const controller = path.resolve(
-    SANDBOX_PATH,
+    sandbox.path,
     'src/controllers/open-api.controller.ts',
   );
 
-  const petModel = path.resolve(SANDBOX_PATH, 'src/models/pet.model.ts');
-  const newPetModel = path.resolve(SANDBOX_PATH, 'src/models/new-pet.model.ts');
-  const errorModel = path.resolve(SANDBOX_PATH, 'src/models/error.model.ts');
+  const petModel = path.resolve(sandbox.path, 'src/models/pet.model.ts');
+  const newPetModel = path.resolve(sandbox.path, 'src/models/new-pet.model.ts');
+  const errorModel = path.resolve(sandbox.path, 'src/models/error.model.ts');
 
   after('reset sandbox', async () => {
     await sandbox.reset();
@@ -43,7 +42,7 @@ describe('openapi-generator specific files', () => {
   it('generates all the proper files', async () => {
     await testUtils
       .executeGenerator(generator)
-      .inDir(SANDBOX_PATH, () => testUtils.givenLBProject(SANDBOX_PATH))
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts(props);
     assert.file(controller);
 

--- a/packages/cli/test/unit/update-index.unit.js
+++ b/packages/cli/test/unit/update-index.unit.js
@@ -15,32 +15,31 @@ const expect = testlab.expect;
 const TestSandbox = testlab.TestSandbox;
 
 // Test Sandbox
-const SANDBOX_PATH = path.resolve(__dirname, '.sandbox');
-const sandbox = new TestSandbox(SANDBOX_PATH);
-const expectedFile = path.join(SANDBOX_PATH, 'index.ts');
+const sandbox = new TestSandbox(path.resolve(__dirname, '.sandbox'));
+const expectedFile = path.join(sandbox.path, 'index.ts');
 
 describe('update-index unit tests', () => {
   beforeEach('reset sandbox', () => sandbox.reset());
 
   it('creates index.ts when not present', async () => {
-    await updateIndex(SANDBOX_PATH, 'test.ts');
+    await updateIndex(sandbox.path, 'test.ts');
     assert.file(expectedFile);
     assert.fileContent(expectedFile, /export \* from '.\/test';/);
   });
 
   it('appends to existing index.ts when present', async () => {
     await writeFileAsync(
-      path.join(SANDBOX_PATH, 'index.ts'),
+      path.join(sandbox.path, 'index.ts'),
       `export * from './first';\n`,
     );
-    await updateIndex(SANDBOX_PATH, 'test.ts');
+    await updateIndex(sandbox.path, 'test.ts');
     assert.file(expectedFile);
     assert.fileContent(expectedFile, /export \* from '.\/first'/);
     assert.fileContent(expectedFile, /export \* from '.\/test'/);
   });
 
   it('throws an error when given a non-ts file', async () => {
-    await expect(updateIndex(SANDBOX_PATH, 'test.js')).to.be.rejectedWith(
+    await expect(updateIndex(sandbox.path, 'test.js')).to.be.rejectedWith(
       /test.js must be a TypeScript \(.ts\) file/,
     );
   });


### PR DESCRIPTION
Step 1 for #5011 

Refactor test sandbox usage to use `sandbox.path` to access the sandbox directory as we'll create unique subdirs for different sandbox instances.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
