### PR TITLE
feat(core): improve application signal handler registration

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@loopback/metadata": "^2.0.3",
     "debug": "^4.1.1",
+    "@types/debug": "^4.1.5",
     "p-event": "^4.1.0",
     "tslib": "^1.11.1",
     "uuid": "^7.0.3"
@@ -29,7 +30,6 @@
     "@loopback/eslint-config": "^6.0.3",
     "@loopback/testlab": "^3.0.0",
     "@types/bluebird": "^3.5.30",
-    "@types/debug": "^4.1.5",
     "@types/node": "^10.17.19",
     "@types/uuid": "^7.0.2",
     "bluebird": "^3.7.2"


### PR DESCRIPTION
Key changes:
- only register shutdown listeners when the app starts
  - it does not make sense to register shutdown listener before the app starts
  - starts to use system resources in the constructor is not a good idea
- unregister process listeners upon explicit stop
- fix the test case to clean up process listeners
- improve debugging with context name prefix

Replace #5015 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
