### PR TITLE
fix(context): fix context subscription manager to not emit errors to its context if there is an error listener is in place

### DIFF
--- a/packages/context/src/__tests__/unit/context-observer.unit.ts
+++ b/packages/context/src/__tests__/unit/context-observer.unit.ts
@@ -173,7 +173,7 @@ describe('Context', () => {
     it('reports error if an observer fails', () => {
       ctx.bind('bar').to('bar-value');
       return expect(ctx.waitUntilObserversNotified()).to.be.rejectedWith(
-        'something wrong',
+        'something wrong - async',
       );
     });
 
@@ -239,7 +239,7 @@ describe('Context', () => {
         filter: binding => binding.key === 'bar',
         observe: async () => {
           await setImmediateAsync();
-          throw new Error('something wrong');
+          throw new Error('something wrong - async');
         },
       };
       ctx.subscribe(nonMatchingObserver);
@@ -282,7 +282,7 @@ describe('Context', () => {
     });
 
     it('reports error on current context if an observer fails', async () => {
-      const err = new Error('something wrong');
+      const err = new Error('something wrong - 1');
       server.subscribe((event, binding) => {
         if (binding.key === 'bar') {
           return Promise.reject(err);
@@ -290,12 +290,13 @@ describe('Context', () => {
       });
       server.bind('bar').to('bar-value');
       // Please note the following code registers an `error` listener on `server`
+      // so that error events are caught before it is reported as unhandled.
       const obj = await pEvent(server, 'error');
       expect(obj).to.equal(err);
     });
 
     it('reports error on the first context with error listeners on the chain', async () => {
-      const err = new Error('something wrong');
+      const err = new Error('something wrong - 2');
       server.subscribe((event, binding) => {
         if (binding.key === 'bar') {
           return Promise.reject(err);


### PR DESCRIPTION
The unhandled error is reported when context-observer.unit.ts is run by itself. The root cause is that ContextSubscriptionManager always emits errors to the context chain without checking if there is an error listener on itself.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
