### PR TITLE
fix(example-express-composition): use an assinged port number for testing

### DIFF
--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -155,8 +155,9 @@ import {ApplicationConfig} from '@loopback/core';
 import express from 'express';
 
 export class ExpressServer {
-  private app: express.Application;
-  private lbApp: NoteApplication;
+  public readonly app: express.Application;
+  public readonly lbApp: NoteApplication;
+  private server?: http.Server;
 
   constructor(options: ApplicationConfig = {}) {
     this.app = express();
@@ -223,8 +224,9 @@ Express application:
 import pEvent from 'p-event';
 
 export class ExpressServer {
-  private app: express.Application;
-  private lbApp: NoteApplication;
+  public readonly app: express.Application;
+  public readonly lbApp: NoteApplication;
+  private server?: http.Server;
 
   constructor(options: ApplicationConfig = {}) {
     //...
@@ -236,7 +238,7 @@ export class ExpressServer {
 
   public async start() {
     await this.lbApp.start();
-    const port = this.lbApp.restServer.config.port || 3000;
+    const port = this.lbApp.restServer.config.port ?? 3000;
     const host = this.lbApp.restServer.config.host || '127.0.0.1';
     this.server = this.app.listen(port, host);
     await pEvent(this.server, 'listening');

--- a/examples/express-composition/.eslintrc.js
+++ b/examples/express-composition/.eslintrc.js
@@ -1,0 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/example-express-composition
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = {
+  extends: ['@loopback/eslint-config'],
+};

--- a/examples/express-composition/src/__tests__/acceptance/test-helper.ts
+++ b/examples/express-composition/src/__tests__/acceptance/test-helper.ts
@@ -15,7 +15,7 @@ export async function setupExpressApplication(): Promise<AppWithClient> {
 
   const lbApp = server.lbApp;
 
-  const client = supertest('http://127.0.0.1:3000');
+  const client = supertest(server.app);
 
   return {server, client, lbApp};
 }

--- a/examples/express-composition/src/server.ts
+++ b/examples/express-composition/src/server.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import {NoteApplication} from './application';
 
 export class ExpressServer {
-  private app: express.Application;
+  public readonly app: express.Application;
   public readonly lbApp: NoteApplication;
   private server?: http.Server;
 
@@ -40,7 +40,7 @@ export class ExpressServer {
 
   public async start() {
     await this.lbApp.start();
-    const port = this.lbApp.restServer.config.port || 3000;
+    const port = this.lbApp.restServer.config.port ?? 3000;
     const host = this.lbApp.restServer.config.host ?? '127.0.0.1';
     this.server = this.app.listen(port, host);
     await pEvent(this.server, 'listening');


### PR DESCRIPTION
Avoid hard-coded port 3000 for testing.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
