### PR TITLE
fix(cli): remove `All rights reserved.` from the header for LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: loopback-next
 This project is licensed under the MIT License, full text below.
 

--- a/acceptance/extension-logging-fluentd/LICENSE
+++ b/acceptance/extension-logging-fluentd/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/test-extension-logging-fluentd
 This project is licensed under the MIT License, full text below.
 

--- a/acceptance/repository-cloudant/LICENSE
+++ b/acceptance/repository-cloudant/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/test-repository-cloudant
 This project is licensed under the MIT License, full text below.
 

--- a/acceptance/repository-mongodb/LICENSE
+++ b/acceptance/repository-mongodb/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/test-repository-mongodb
 This project is licensed under the MIT License, full text below.
 

--- a/acceptance/repository-mysql/LICENSE
+++ b/acceptance/repository-mysql/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/test-repository-mysql
 This project is licensed under the MIT License, full text below.
 

--- a/acceptance/repository-postgresql/LICENSE
+++ b/acceptance/repository-postgresql/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/test-repository-postgresql
 This project is licensed under the MIT License, full text below.
 

--- a/benchmark/LICENSE
+++ b/benchmark/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/benchmark
 This project is licensed under the MIT License, full text below.
 

--- a/examples/access-control-migration/LICENSE
+++ b/examples/access-control-migration/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2020. All Rights Reserved.
+Copyright (c) IBM Corp. 2020.
 Node module: @loopback/example-access-control-migration
 This project is licensed under the MIT License, full text below.
 

--- a/examples/context/LICENSE
+++ b/examples/context/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/example-context
 This project is licensed under the MIT License, full text below.
 

--- a/examples/express-composition/LICENSE
+++ b/examples/express-composition/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/example-express-composition
 This project is licensed under the MIT License, full text below.
 

--- a/examples/greeter-extension/LICENSE
+++ b/examples/greeter-extension/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/example-greeter-extension
 This project is licensed under the MIT License, full text below.
 

--- a/examples/greeting-app/LICENSE
+++ b/examples/greeting-app/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/example-greeting-app
 This project is licensed under the MIT License, full text below.
 

--- a/examples/hello-world/LICENSE
+++ b/examples/hello-world/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/example-hello-world
 This project is licensed under the MIT License, full text below.
 

--- a/examples/lb3-application/LICENSE
+++ b/examples/lb3-application/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/example-lb3-application
 This project is licensed under the MIT License, full text below.
 

--- a/examples/log-extension/LICENSE
+++ b/examples/log-extension/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/example-log-extension
 This project is licensed under the MIT License, full text below.
 

--- a/examples/metrics-prometheus/LICENSE
+++ b/examples/metrics-prometheus/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/example-metrics-prometheus
 This project is licensed under the MIT License, full text below.
 

--- a/examples/rest-crud/LICENSE
+++ b/examples/rest-crud/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2020. All Rights Reserved.
+Copyright (c) IBM Corp. 2020.
 Node module: @loopback/example-rest-crud
 This project is licensed under the MIT License, full text below.
 

--- a/examples/rpc-server/LICENSE
+++ b/examples/rpc-server/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/example-rpc-server
 This project is licensed under the MIT License, full text below.
 

--- a/examples/soap-calculator/LICENSE
+++ b/examples/soap-calculator/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/example-soap-calculator
 This project is licensed under the MIT License, full text below.
 

--- a/examples/todo-list/LICENSE
+++ b/examples/todo-list/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/example-todo-list
 This project is licensed under the MIT License, full text below.
 

--- a/examples/todo/LICENSE
+++ b/examples/todo/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/example-todo
 This project is licensed under the MIT License, full text below.
 

--- a/extensions/apiconnect/LICENSE
+++ b/extensions/apiconnect/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2020. All Rights Reserved.
+Copyright (c) IBM Corp. 2020.
 Node module: @loopback/apiconnect
 This project is licensed under the MIT License, full text below.
 

--- a/extensions/authentication-passport/LICENSE
+++ b/extensions/authentication-passport/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/authentication-passport
 This project is licensed under the MIT License, full text below.
 

--- a/extensions/cron/LICENSE
+++ b/extensions/cron/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2020. All Rights Reserved.
+Copyright (c) IBM Corp. 2020.
 Node module: @loopback/cron
 This project is licensed under the MIT License, full text below.
 

--- a/extensions/health/LICENSE
+++ b/extensions/health/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/extension-health
 This project is licensed under the MIT License, full text below.
 

--- a/extensions/logging/LICENSE
+++ b/extensions/logging/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/extension-logging
 This project is licensed under the MIT License, full text below.
 

--- a/extensions/metrics/LICENSE
+++ b/extensions/metrics/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/extension-metrics
 This project is licensed under the MIT License, full text below.
 

--- a/packages/authentication/LICENSE
+++ b/packages/authentication/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/authentication
 This project is licensed under the MIT License, full text below.
 

--- a/packages/authorization/LICENSE
+++ b/packages/authorization/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018. All Rights Reserved.
+Copyright (c) IBM Corp. 2018.
 Node module: @loopback/authorization
 This project is licensed under the MIT License, full text below.
 

--- a/packages/boot/LICENSE
+++ b/packages/boot/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/boot
 This project is licensed under the MIT License, full text below.
 

--- a/packages/booter-lb3app/LICENSE
+++ b/packages/booter-lb3app/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/booter-lb3app
 This project is licensed under the MIT License, full text below.
 

--- a/packages/build/LICENSE
+++ b/packages/build/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/build
 This project is licensed under the MIT License, full text below.
 

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/cli
 This project is licensed under the MIT License, full text below.
 

--- a/packages/cli/generators/copyright/license.js
+++ b/packages/cli/generators/copyright/license.js
@@ -24,7 +24,7 @@ function renderLicense({name, owner, years, license}) {
     license = spdxLicenseList[license.toLowerCase()];
   }
   const text = replaceCopyRight(license.licenseText, {owner, years});
-  return `Copyright (c) ${owner} ${years}. All Rights Reserved.
+  return `Copyright (c) ${owner} ${years}.
 Node module: ${name}
 This project is licensed under the ${license.name}, full text below.
 

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -72,7 +72,7 @@ describe('lb4 copyright', function () {
     );
   });
 
-  it('updates LICENSE and package.json', async () => {
+  it('updates LICENSE and package.json for ISC', async () => {
     await testUtils
       .executeGenerator(generator)
       .inDir(sandbox.path, () =>
@@ -113,6 +113,78 @@ describe('lb4 copyright', function () {
     assert.fileContent(
       path.join(sandbox.path, 'LICENSE'),
       'Node module: myapp',
+    );
+    assert.fileContent(
+      path.join(sandbox.path, 'LICENSE'),
+      `Permission to use, copy, modify, and /or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above copyright
+notice and this permission notice appear in all copies.`,
+    );
+  });
+
+  it('updates LICENSE and package.json for MIT', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
+          excludePackageJSON: true,
+          additionalFiles: SANDBOX_FILES,
+        }),
+      )
+      .withOptions({
+        owner: 'IBM Corp.',
+        license: 'MIT',
+        gitOnly: false,
+        updateLicense: true,
+      });
+
+    assert.fileContent(
+      path.join(sandbox.path, 'package.json'),
+      '"license": "MIT"',
+    );
+    assert.fileContent(
+      path.join(sandbox.path, 'package.json'),
+      '"copyright.owner": "IBM Corp."',
+    );
+
+    /*
+    Copyright (c) ACME Inc. 2020. All Rights Reserved.
+    Node module: myapp
+    This project is licensed under the ISC License, full text below.
+    */
+    assert.fileContent(
+      path.join(sandbox.path, 'LICENSE'),
+      'This project is licensed under the MIT License, full text below.',
+    );
+    assert.fileContent(
+      path.join(sandbox.path, 'LICENSE'),
+      `Copyright (c) IBM Corp. ${year}.`,
+    );
+    assert.fileContent(
+      path.join(sandbox.path, 'LICENSE'),
+      'Node module: myapp',
+    );
+    assert.fileContent(
+      path.join(sandbox.path, 'LICENSE'),
+      `MIT License Copyright (c) IBM Corp. ${year}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`,
     );
   });
 });

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -100,7 +100,7 @@ describe('lb4 copyright', function () {
     /*
     Copyright (c) ACME Inc. 2020. All Rights Reserved.
     Node module: myapp
-
+    This project is licensed under the ISC License, full text below.
     */
     assert.fileContent(
       path.join(sandbox.path, 'LICENSE'),
@@ -108,7 +108,7 @@ describe('lb4 copyright', function () {
     );
     assert.fileContent(
       path.join(sandbox.path, 'LICENSE'),
-      `Copyright (c) ACME Inc. ${year}. All Rights Reserved.`,
+      `Copyright (c) ACME Inc. ${year}.`,
     );
     assert.fileContent(
       path.join(sandbox.path, 'LICENSE'),

--- a/packages/context/LICENSE
+++ b/packages/context/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/context
 This project is licensed under the MIT License, full text below.
 

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/core
 This project is licensed under the MIT License, full text below.
 

--- a/packages/eslint-config/LICENSE
+++ b/packages/eslint-config/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/eslint-config
 This project is licensed under the MIT License, full text below.
 

--- a/packages/http-caching-proxy/LICENSE
+++ b/packages/http-caching-proxy/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/http-caching-proxy
 This project is licensed under the MIT License, full text below.
 

--- a/packages/http-server/LICENSE
+++ b/packages/http-server/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/http-server
 This project is licensed under the MIT License, full text below.
 

--- a/packages/metadata/LICENSE
+++ b/packages/metadata/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/metadata
 This project is licensed under the MIT License, full text below.
 

--- a/packages/model-api-builder/LICENSE
+++ b/packages/model-api-builder/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/model-api-builder
 This project is licensed under the MIT License, full text below.
 

--- a/packages/openapi-spec-builder/LICENSE
+++ b/packages/openapi-spec-builder/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/openapi-spec-builder
 This project is licensed under the MIT License, full text below.
 

--- a/packages/openapi-v3/LICENSE
+++ b/packages/openapi-v3/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/openapi-v3
 This project is licensed under the MIT License, full text below.
 

--- a/packages/repository-json-schema/LICENSE
+++ b/packages/repository-json-schema/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/repository-json-schema
 This project is licensed under the MIT License, full text below.
 

--- a/packages/repository-tests/LICENSE
+++ b/packages/repository-tests/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/repository-tests
 This project is licensed under the MIT License, full text below.
 

--- a/packages/repository/LICENSE
+++ b/packages/repository/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/repository
 This project is licensed under the MIT License, full text below.
 

--- a/packages/rest-crud/LICENSE
+++ b/packages/rest-crud/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/rest-crud
 This project is licensed under the MIT License, full text below.
 

--- a/packages/rest-explorer/LICENSE
+++ b/packages/rest-explorer/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/rest-explorer
 This project is licensed under the MIT License, full text below.
 

--- a/packages/rest/LICENSE
+++ b/packages/rest/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/rest
 This project is licensed under the MIT License, full text below.
 

--- a/packages/security/LICENSE
+++ b/packages/security/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/security
 This project is licensed under the MIT License, full text below.
 

--- a/packages/service-proxy/LICENSE
+++ b/packages/service-proxy/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2018,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2018,2019.
 Node module: @loopback/service-proxy
 This project is licensed under the MIT License, full text below.
 

--- a/packages/testlab/LICENSE
+++ b/packages/testlab/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2017,2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2017,2019.
 Node module: @loopback/testlab
 This project is licensed under the MIT License, full text below.
 

--- a/packages/tsdocs/LICENSE
+++ b/packages/tsdocs/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) IBM Corp. 2019. All Rights Reserved.
+Copyright (c) IBM Corp. 2019.
 Node module: @loopback/tsdocs
 This project is licensed under the MIT License, full text below.
 


### PR DESCRIPTION
- Remove `All Rights Reserved.` from LICENSE files.
- Improve `lb4 copyright` command to wrap license text by 80 chars.

See https://github.com/strongloop/loopback-cli/issues/97

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
