### PR TITLE
build: improve errors printed by Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint": "node packages/build/bin/run-eslint --report-unused-disable-directives --cache .",
     "eslint:fix": "npm run eslint -- --fix",
     "prettier:cli": "node packages/build/bin/run-prettier \"**/*.ts\" \"**/*.js\" \"**/*.md\"",
-    "prettier:check": "npm run prettier:cli -- -l",
+    "prettier:check": "npm run prettier:cli -- --check",
     "prettier:fix": "npm run prettier:cli -- --write",
     "clean": "lerna run clean && node packages/build/bin/run-clean \"packages/*/dist\" \"extensions/*/dist\" \"examples/*/dist\" \"benchmark/dist\"",
     "clean:lerna": "lerna clean",


### PR DESCRIPTION
Use `--check` instead of `--list` when linting source code formatting.

The option `--list` produces very terse output which makes it difficult
to understand what's the problem and how to fix it:

```
> loopback-next@0.1.0 prettier:cli /Users/bajtos/src/loopback/next
> node packages/build/bin/run-prettier "**/*.ts" "**/*.js" "**/*.md" "-l"

packages/core/src/application.ts
```

The option `--check` is more verbose:

```
> loopback-next@0.1.0 prettier:cli /Users/bajtos/src/loopback/next
> node packages/build/bin/run-prettier "**/*.ts" "**/*.js" "**/*.md" "--check"

Checking formatting...
packages/core/src/application.ts
Code style issues found in the above file(s). Forgot to run Prettier?
```


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
