### PR TITLE
[REST] Use the description field in Openapi

### DIFF
--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -333,7 +333,8 @@ describe('RestServer.getApiSpec()', () => {
 
   it('invokes info oas enhancers', async () => {
     const EXPECTED_SPEC_INFO = {
-      title: 'MyApp - LoopBack Test Application',
+      title: 'MyApp',
+      description: 'LoopBack Test Application',
       version: '1.0.1',
       contact: {
         name: 'Barney Rubble',
@@ -354,6 +355,7 @@ describe('RestServer.getApiSpec()', () => {
   it('invokes info oas enhancers with author object', async () => {
     const EXPECTED_SPEC_INFO = {
       title: 'MyApp',
+      description: '',
       version: '1.0.1',
       contact: {
         name: 'Barney Rubble',
@@ -370,6 +372,22 @@ describe('RestServer.getApiSpec()', () => {
         email: 'b@rubble.com',
         url: 'http://barnyrubble.tumblr.com/',
       },
+    });
+    const spec = await server.getApiSpec();
+    expect(spec.info).to.eql(EXPECTED_SPEC_INFO);
+  });
+
+  it('invokes info oas enhancers without author', async () => {
+    const EXPECTED_SPEC_INFO = {
+      title: 'MyApp',
+      description: '',
+      version: '1.0.1',
+      contact: {},
+    };
+    app.setMetadata({
+      name: 'MyApp',
+      version: '1.0.1',
+      description: '',
     });
     const spec = await server.getApiSpec();
     expect(spec.info).to.eql(EXPECTED_SPEC_INFO);

--- a/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
+++ b/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
@@ -43,13 +43,10 @@ export class InfoSpecEnhancer implements OASEnhancer {
     const contact: ContactObject = InfoSpecEnhancer.parseAuthor(
       this.pkg.author,
     );
-    let title = this.pkg.name;
-    if (this.pkg.description) {
-      title = `${title} - ${this.pkg.description}`;
-    }
     const patchSpec = {
       info: {
-        title,
+        title: this.pkg.name,
+        description: this.pkg.description,
         version: this.pkg.version,
         contact,
       },


### PR DESCRIPTION
# Before
![Screenshot 2020-04-07 at 15 04 19](https://user-images.githubusercontent.com/13822438/78672709-50651d00-78e1-11ea-9c97-f7480b30315d.png)

![Screenshot 2020-04-07 at 15 05 06](https://user-images.githubusercontent.com/13822438/78672731-578c2b00-78e1-11ea-8116-9810f5a1c158.png)

# Now
![Screenshot 2020-04-07 at 15 01 42](https://user-images.githubusercontent.com/13822438/78672751-5ce97580-78e1-11ea-9542-4306f8ff6cb3.png)

I wanted to include a config field in the package.json file. Something like:
```
"config": {
  "loopback": {
    "name": "LoopBack API",
    "contact": {
      "name": "Support",
      "email": "support@localhost"
    }
  },
  "commitizen": {
    "path": "./node_modules/cz-conventional-changelog"
  }
}
```

OR

```
"config": {
  "loopback": "./loopbackrc", (IN JSON FORMAT)
  "commitizen": {
    "path": "./node_modules/cz-conventional-changelog"
  }
}
```

The example:
```
info: {
  title: this.pkg.config.loopback.name || this.pkg.name,
  description: this.pkg.description,
  version: this.pkg.version,
  contact: this.pkg.config.loopback.contact || contact,
}
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
