### PR TITLE
docs: remove summary frontmatter

### DIFF
--- a/docs/site/Creating-CRUD-REST-apis.md
+++ b/docs/site/Creating-CRUD-REST-apis.md
@@ -4,9 +4,6 @@ title: 'Creating CRUD REST APIs from a model'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-crud-rest-apis.html
-summary:
-  Use `@loopback/rest-crud` module to create CRUD REST APIs from a model and a
-  datasource
 ---
 
 Starting with a [model class](Model.md) and [datasource](DataSources.md),

--- a/docs/site/Creating-decorators.md
+++ b/docs/site/Creating-decorators.md
@@ -7,5 +7,4 @@ source: loopback-next
 file: packages/metadata/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-decorators.html
-summary: A tutorial to use `@loopback/metadata` module to create new decorators
 ---

--- a/docs/site/FAQ.md
+++ b/docs/site/FAQ.md
@@ -4,7 +4,6 @@ title: 'Frequently-asked questions'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/FAQ.html
-summary: LoopBack 4 is a completely new framework, also known as LoopBack-Next.
 ---
 
 ### What’s the vision behind LoopBack 4?

--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -4,7 +4,6 @@ title: 'Getting started'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Getting-started.html
-summary: Write and run a LoopBack 4 "Hello World" project in TypeScript.
 ---
 
 ## Prerequisites

--- a/docs/site/Roadmap.md
+++ b/docs/site/Roadmap.md
@@ -4,7 +4,6 @@ title: Roadmap
 keywords: LoopBack 4.0
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Roadmap.html
-summary: LoopBack 4.0 is the upcoming release.
 ---
 
 TBD.

--- a/docs/site/Running-cron-jobs.md
+++ b/docs/site/Running-cron-jobs.md
@@ -7,5 +7,4 @@ source: loopback-next
 file: extensions/cron/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Running-cron-jobs.html
-summary: Use `@loopback/cron` module to run cron jobs
 ---

--- a/docs/site/Self-hosted-REST-API-Explorer.md
+++ b/docs/site/Self-hosted-REST-API-Explorer.md
@@ -7,7 +7,4 @@ source: loopback-next
 file: packages/rest-explorer/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Self-hosted-rest-api-explorer.html
-summary:
-  A tutorial on using `@loopback/rest-explorer` to add a self-hosted REST API
-  Explorer
 ---

--- a/docs/site/Team.md
+++ b/docs/site/Team.md
@@ -4,7 +4,6 @@ title: Team
 keywords: LoopBack 4.0
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Team.html
-summary: The people working on LoopBack 4
 ---
 
 ## IBM

--- a/docs/site/Transactions.md
+++ b/docs/site/Transactions.md
@@ -6,7 +6,6 @@ keywords: LoopBack 4.0, LoopBack 4, Transactions, Transaction
 tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Using-database-transactions.html
-summary: Transactional API usage in LoopBack 4
 ---
 
 ## Overview

--- a/docs/site/deployment/Deploy-for-GDPR-readiness.md
+++ b/docs/site/deployment/Deploy-for-GDPR-readiness.md
@@ -6,7 +6,6 @@ tags: gdpr
 lang: en
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Deploy-for-GDPR-readiness.html
-summary: LoopBack considerations for GDPR readiness.
 ---
 
 ## Notice:

--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -4,7 +4,6 @@ title: 'Creating an Express Application with LoopBack REST API'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/express-with-lb4-rest-tutorial.html
-summary: A simple Express application with LoopBack 4 REST API
 ---
 
 ## Overview

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -5,7 +5,6 @@ toc: false
 keywords: LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/index.html
-summary: LoopBack is a platform for building APIs and microservices in Node.js
 ---
 
 {% include see-also.html title="GitHub Repo" content=' LoopBack 4 framework code

--- a/docs/site/soap-calculator-tutorial.md
+++ b/docs/site/soap-calculator-tutorial.md
@@ -7,5 +7,4 @@ source: loopback-next
 file: examples/soap-calculator/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial.html
-summary: LoopBack 4 SOAP Web Service Tutorial
 ---

--- a/docs/site/todo-list-tutorial.md
+++ b/docs/site/todo-list-tutorial.md
@@ -7,5 +7,4 @@ source: loopback-next
 file: examples/todo-list/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial.html
-summary: LoopBack 4 TodoList Application Tutorial
 ---

--- a/docs/site/todo-tutorial.md
+++ b/docs/site/todo-tutorial.md
@@ -7,5 +7,4 @@ source: loopback-next
 file: examples/todo/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial.html
-summary: LoopBack 4 Todo Application Tutorial
 ---

--- a/docs/site/tutorials/authentication/Authentication-Tutorial.md
+++ b/docs/site/tutorials/authentication/Authentication-Tutorial.md
@@ -4,7 +4,6 @@ title: 'How to secure your LoopBack 4 application with JWT authentication'
 keywords: LoopBack 4.0, LoopBack 4, Authentication, Tutorial
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Authentication-Tutorial.html
-summary: A LoopBack 4 application that uses JWT authentication
 ---
 
 ## Overview

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -4,9 +4,6 @@ title: "Add TodoList and TodoList's Todo Controller"
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-controller.html
-summary:
-  LoopBack 4 TodoList Application Tutorial - Add TodoList and TodoList's Todo
-  Controller
 ---
 
 ### Controllers with related models

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-has-one-relation.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-has-one-relation.md
@@ -4,7 +4,6 @@ title: 'Add TodoListImage Relation'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-has-one-relation.html
-summary: LoopBack 4 TodoList Application Tutorial - Add TodoListImage Relation
 ---
 
 We have that a `Todo` [`belongsTo`](../../BelongsTo-relation.md) a `TodoList`

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
@@ -4,7 +4,6 @@ title: 'Add TodoList Model'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-model.html
-summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Model
 ---
 
 ### Building a checklist for your Todo models

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-relations.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-relations.md
@@ -4,7 +4,6 @@ title: 'Add Model Relations'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-relations.html
-summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Repository
 ---
 
 ### Define the model relation

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
@@ -4,7 +4,6 @@ title: 'Add TodoList Repository'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-repository.html
-summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Repository
 ---
 
 ### Repositories with related models

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-sqldb.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-sqldb.md
@@ -4,8 +4,6 @@ title: 'Running on relational databases'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-sqldb.html
-summary:
-  LoopBack 4 TodoList Application Tutorial - Running on Relational Databases
 ---
 
 If you are running this example using a relational database, there are extra

--- a/docs/site/tutorials/todo/todo-tutorial-controller.md
+++ b/docs/site/tutorials/todo/todo-tutorial-controller.md
@@ -4,7 +4,6 @@ title: 'Add a Controller'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-controller.html
-summary: LoopBack 4 Todo Application Tutorial - Add a Controller
 ---
 
 ### Controllers

--- a/docs/site/tutorials/todo/todo-tutorial-datasource.md
+++ b/docs/site/tutorials/todo/todo-tutorial-datasource.md
@@ -4,7 +4,6 @@ title: 'Add a Datasource'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-datasource.html
-summary: LoopBack 4 Todo Application Tutorial - Add a Datasource
 ---
 
 ### Datasources

--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -4,8 +4,6 @@ title: 'Integrate with a geo-coding service'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-geocoding-service.html
-summary:
-  LoopBack 4 Todo Application Tutorial - Integrate with a geo-coding service
 ---
 
 ### Services

--- a/docs/site/tutorials/todo/todo-tutorial-model.md
+++ b/docs/site/tutorials/todo/todo-tutorial-model.md
@@ -4,7 +4,6 @@ title: 'Add the Todo Model'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-model.html
-summary: LoopBack 4 Todo Application Tutorial - Add the Todo Model
 ---
 
 ### Models

--- a/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
+++ b/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
@@ -4,7 +4,6 @@ title: 'Putting it all together'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-putting-it-together.html
-summary: LoopBack 4 Todo Application Tutorial - Putting it all together
 ---
 
 ### Putting it all together

--- a/docs/site/tutorials/todo/todo-tutorial-repository.md
+++ b/docs/site/tutorials/todo/todo-tutorial-repository.md
@@ -4,7 +4,6 @@ title: 'Add a Repository'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-repository.html
-summary: LoopBack 4 Todo Application Tutorial - Add a Repository
 ---
 
 ### Repositories

--- a/docs/site/tutorials/todo/todo-tutorial-scaffolding.md
+++ b/docs/site/tutorials/todo/todo-tutorial-scaffolding.md
@@ -4,7 +4,6 @@ title: 'Create your app scaffolding'
 keywords: LoopBack 4.0, LoopBack 4
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-scaffolding.html
-summary: LoopBack 4 Todo Application Tutorial - Create app scaffolding
 ---
 
 ### Create your app scaffolding


### PR DESCRIPTION
Let's not include summary frontmatter in LB4 docs. Most of the pages do not contain them, and those which do create redundant text as shown in the screenshot.

> LoopBack 4 Todo Application Tutorial - Integrate with a geo-coding service

![image](https://user-images.githubusercontent.com/950112/79087329-8a5c7600-7d5c-11ea-8d13-ba261d24802d.png)
