### PR TITLE
feat(cli): add client side service proxy generation for `lb4 openapi` command

### DIFF
--- a/docs/site/OpenAPI-generator.md
+++ b/docs/site/OpenAPI-generator.md
@@ -10,7 +10,15 @@ permalink: /doc/en/lb4/OpenAPI-generator.html
 
 ### Synopsis
 
-Generates artifacts from an OpenAPI spec into a LoopBack application.
+Generates models and types from an OpenAPI spec for a LoopBack application. It
+supports both server and client sides. Controllers are generated for the server
+side while service proxies and datasources with
+[`loopback-connector-openapi`](https://loopback.io/doc/en/lb4/OpenAPI-connector.html)
+are created for the client side.
+
+This command allows us to generate skeleton implementations of an OpenAPI spec
+and/or strongly-typed service proxies to access the endpoint conforming to the
+spec.
 
 ```sh
 lb4 openapi [<url>] [options]
@@ -22,6 +30,11 @@ lb4 openapi [<url>] [options]
 - `--validate`: Validate the OpenAPI spec. Default: `false`.
 - `--promote-anonymous-schemas`: Promote anonymous schemas as models classes.
   Default: `false`.
+- `--client`: Generate client-side service proxies for the OpenAPI spec Default:
+  `false`.
+- `--datasource`: A valid datasource name
+- `--positional`: A flag to control if service methods use positional parameters
+  or an object with named properties. Default: `true`.
 
 ### Arguments
 
@@ -39,14 +52,21 @@ Please note Swagger 2.0 specs are converted to OpenAPI 3.0 internally using
 
 The tool will prompt you for:
 
+- **Please select the datasource** You can select an existing datasource with
+  `openapi` connector when `--client` is specified.
 - **URL or file path of the OpenAPI spec** If the url or file path is supplied
   from the command line, the prompt is skipped.
 - **Select controllers to be generated** You can select what controllers will be
   generated based on OpenAPI tags.
+- **DataSource name: openapi** Provide the datasource name for the OpenAPI
+  service if `--client` is specified. If a datasource is selected, the prompt is
+  skipped.
 
 ### Generated artifacts
 
-The command generates the following artifacts:
+#### Models and types
+
+The command generates the following model classes and TypeScript types:
 
 1.  For each schema under `components.schemas`, a model class or type
     declaration is generated as `src/models/<model-or-type-name>.model.ts`.
@@ -280,6 +300,8 @@ export type PerformSearchResponseBody = {
    generated as `src/controllers/<tag-name>.controller.ts` to hold all
    operations with the same tag.
 
+#### Server-side controllers
+
 Controller class names are derived from tag names. The `x-controller-name`
 property of an operation can be used to customize the controller name. Method
 names are derived from `operationId`s. They can be configured using
@@ -370,6 +392,146 @@ export class AccountController {
 }
 ```
 
+#### Client-side datasource and service proxies
+
+If `--client` is specified, a datasource is generated to configure the
+connection to the endpoint that exposes an OpenAPI spec.
+
+{% include code-caption.html content="src/datasources/test2.datasource.config.json"
+%}
+
+```json
+{
+  "name": "test2",
+  "connector": "openapi",
+  "spec": "customer.yaml",
+  "validate": false,
+  "positional": true
+}
+```
+
+{% include code-caption.html content="src/datasources/test2.datasource.ts"
+%}
+
+```ts
+import {
+  inject,
+  lifeCycleObserver,
+  LifeCycleObserver,
+  ValueOrPromise,
+} from '@loopback/core';
+import {juggler} from '@loopback/repository';
+import config from './test2.datasource.config.json';
+
+@lifeCycleObserver('datasource')
+export class Test2DataSource extends juggler.DataSource
+  implements LifeCycleObserver {
+  static dataSourceName = 'test2';
+
+  constructor(
+    @inject('datasources.config.test2', {optional: true})
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+
+  /**
+   * Start the datasource when application is started
+   */
+  start(): ValueOrPromise<void> {
+    // Add your logic here to be invoked when the application is started
+  }
+
+  /**
+   * Disconnect the datasource when application is stopped. This allows the
+   * application to be shut down gracefully.
+   */
+  stop(): ValueOrPromise<void> {
+    return super.disconnect();
+  }
+}
+```
+
+For each tag, a service interface and proxy are generated to provide
+strongly-typed access to the endpoints.
+
+{% include code-caption.html content="src/services/customer.service.ts"
+%}
+
+````ts
+import {getService} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {Test2DataSource} from '../datasources';
+
+import {Customer} from '../models/customer.model';
+
+/**
+ * The service interface is generated from OpenAPI spec with operations tagged
+ * by Customer
+ * Customer resource
+ */
+export interface CustomerService {
+  /**
+   * Returns all customers (\/* customers *\/)
+   *
+   * @param _if if condition
+   * @param limit maximum number of results to return
+   * @param accessToken Access token (\/* access_token *\/)
+   * @returns customer response
+   */
+  getCustomers(
+    _if: string[],
+    limit: number,
+    accessToken: string,
+  ): Promise<Customer[]>;
+
+  /**
+   * Creates a new customer
+   *
+   * @param _requestBody Customer to add
+   * @param accessToken Access token (\/* access_token *\/)
+   * @returns customer response
+   */
+  createCustomer(
+    _requestBody: Customer,
+    accessToken: string,
+  ): Promise<Customer>;
+
+  // If `--no-positional` is supplied, we generate an object as the params:
+  /**
+   * ```ts
+   * createCustomer(params: {
+   *   _requestBody: Customer;
+   *   accessToken: string;
+   * }): Promise<Customer>;
+   * ```
+   */
+
+  /**
+   * Returns a customer based on a single ID
+   *
+   * @param customerId ID of customer to fetch
+   * @returns customer response
+   */
+  findCustomerById(customerId: number): Promise<Customer>;
+}
+
+export class CustomerServiceProvider implements Provider<CustomerService> {
+  constructor(
+    // test2 must match the name property in the datasource json file
+    @inject('datasources.test2')
+    protected dataSource: Test2DataSource = new Test2DataSource(),
+  ) {}
+
+  async value(): Promise<CustomerService> {
+    const service = await getService<{apis: Record<string, CustomerService>}>(
+      this.dataSource,
+    );
+    return service.apis['Customer'];
+  }
+}
+```
+
 ### OpenAPI Examples
 
 Try out the following specs or your own with `lb4 openapi`:
@@ -381,3 +543,4 @@ Try out the following specs or your own with `lb4 openapi`:
 
 For more real world OpenAPI specs, see
 [https://api.apis.guru/v2/list.json](https://api.apis.guru/v2/list.json).
+````

--- a/packages/cli/generators/copyright/license.js
+++ b/packages/cli/generators/copyright/license.js
@@ -6,6 +6,7 @@
 const path = require('path');
 const {FSE} = require('./fs');
 const {getYears} = require('./git');
+const {wrapText} = require('../../lib/utils');
 const spdxLicenses = require('spdx-license-list/full');
 const spdxLicenseList = {};
 for (const id in spdxLicenses) {
@@ -91,37 +92,6 @@ async function updateLicense(projectRoot, pkg, options) {
       years: await getYears(projectRoot),
     }),
   );
-}
-
-/**
- * Wrap a single line
- * @param {string} line Text for the a line
- * @param {number} maxLineLength - Maximum line length before wrapping
- */
-function wrapLine(line, maxLineLength) {
-  if (line === '') return line;
-  let lineLength = 0;
-  const words = line.split(/\s+/g);
-  return words.reduce((result, word) => {
-    if (lineLength + word.length >= maxLineLength) {
-      lineLength = word.length;
-      return `${result}\n${word}`;
-    } else {
-      lineLength += word.length + (result ? 1 : 0);
-      return result ? `${result} ${word}` : `${word}`;
-    }
-  }, '');
-}
-
-/**
- * Wrap the text into lines respecting the max line length
- * @param {string} text - Text string
- * @param {number} maxLineLength - Maximum line length before wrapping
- */
-function wrapText(text, maxLineLength = 80) {
-  let lines = text.split('\n');
-  lines = lines.map(line => wrapLine(line, maxLineLength));
-  return lines.join('\n');
 }
 
 exports.renderLicense = renderLicense;

--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -6,14 +6,19 @@
 'use strict';
 
 const BaseGenerator = require('../../lib/base-generator');
-const {debug, debugJson} = require('./utils');
+const {debug, debugJson, validateUrlOrFile, escapeComment} = require('./utils');
 const {loadAndBuildSpec} = require('./spec-loader');
-const {validateUrlOrFile, escapeComment} = require('./utils');
-const {getControllerFileName} = require('./spec-helper');
+const utils = require('../../lib/utils');
+const {parse} = require('url');
+const path = require('path');
+const semver = require('semver');
+const {getControllerFileName, getServiceFileName} = require('./spec-helper');
 
 const updateIndex = require('../../lib/update-index');
 const MODEL = 'models';
 const CONTROLLER = 'controllers';
+const DATASOURCE = 'datasources';
+const SERVICE = 'services';
 const g = require('../../lib/globalize');
 
 module.exports = class OpenApiGenerator extends BaseGenerator {
@@ -42,6 +47,28 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
       type: Boolean,
     });
 
+    this.option('server', {
+      description: g.f('Generate server-side controllers for the OpenAPI spec'),
+      required: false,
+      default: true,
+      type: Boolean,
+    });
+
+    this.option('client', {
+      description: g.f(
+        'Generate client-side service proxies for the OpenAPI spec',
+      ),
+      required: false,
+      default: false,
+      type: Boolean,
+    });
+
+    this.option('datasource', {
+      type: String,
+      required: false,
+      description: g.f('A valid datasource name for the OpenAPI endpoint'),
+    });
+
     this.option('promote-anonymous-schemas', {
       description: g.f('Promote anonymous schemas as models'),
       required: false,
@@ -56,8 +83,117 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
     return super.checkLoopBackProject();
   }
 
+  async promptDataSourceName() {
+    if (this.shouldExit()) return false;
+    if (this.options.client !== true) return;
+
+    debug('Prompting for a datasource');
+
+    // grab the datasourcename from the command line
+    const dsClass = this.options.datasource
+      ? utils.toClassName(this.options.datasource) + 'DataSource'
+      : '';
+
+    debug(`command line datasource is ${dsClass}`);
+
+    const dataSourcesDir = this.destinationPath(
+      `${utils.sourceRootDir}/${utils.datasourcesDir}`,
+    );
+
+    const dataSourceClasses = await utils.getArtifactList(
+      dataSourcesDir,
+      'datasource',
+      true,
+    );
+
+    // List all data sources
+    const dataSourceList = dataSourceClasses.map(ds => ({
+      className: ds,
+    }));
+    debug('datasourceList from %s', dataSourcesDir, dataSourceList);
+
+    // Find openapi data sources
+    const openApiDataSources = dataSourceList.filter(ds => {
+      debug(`data source inspecting item: ${ds.className}`);
+      const datasourceJSONFile = path.join(
+        dataSourcesDir,
+        utils.dataSourceToJSONFileName(ds.className),
+      );
+
+      debug(`reading ${datasourceJSONFile}`);
+      const dsObj = this.fs.readJSON(datasourceJSONFile);
+      if (
+        dsObj.connector === 'openapi' ||
+        dsObj.connector === 'loopback-connector-openapi'
+      ) {
+        ds.usePositionalParams = dsObj.positional;
+        ds.name = dsObj.name;
+        ds.className = utils.toClassName(dsObj.name) + 'DataSource';
+        ds.specPath = dsObj.spec;
+        return true;
+      }
+    });
+
+    debug('Data sources using openapi connector', openApiDataSources);
+
+    if (openApiDataSources.length === 0) {
+      return;
+    }
+
+    const matchedDs = openApiDataSources.find(ds => ds.className === dsClass);
+    if (matchedDs) {
+      this.dataSourceInfo = {
+        name: matchedDs.name,
+        className: matchedDs.className,
+        usePositionalParams: matchedDs.usePositionalParams,
+        specPath: matchedDs.specPath,
+      };
+      this.log(
+        'Datasource %s - %s found for OpenAPI: %s',
+        this.options.datasource,
+        this.dataSourceInfo.className,
+        this.dataSourceInfo.specPath,
+      );
+      return;
+    }
+
+    const answers = await this.prompt([
+      {
+        type: 'list',
+        name: 'dataSource',
+        message: g.f('Please select the datasource'),
+        choices: openApiDataSources.map(ds => ({
+          name: `${ds.name} - ${ds.className}`,
+          value: ds,
+        })),
+        default: `${openApiDataSources[0].name} - ${openApiDataSources[0].className}`,
+        validate: utils.validateClassName,
+      },
+    ]);
+
+    debug('Datasource selected', answers);
+    if (answers && answers.dataSource) {
+      this.dataSourceInfo = {
+        name: answers.dataSource.name,
+        className: answers.dataSource.className,
+        usePositionalParams: answers.dataSource.usePositionalParams,
+        specPath: answers.dataSource.specPath,
+      };
+      this.log(
+        'Datasource %s - %s selected: %s',
+        this.dataSourceInfo.name,
+        this.dataSourceInfo.className,
+        this.dataSourceInfo.specPath,
+      );
+    }
+  }
+
   async askForSpecUrlOrPath() {
     if (this.shouldExit()) return;
+    if (this.dataSourceInfo && this.dataSourceInfo.specPath) {
+      this.url = this.dataSourceInfo.specPath;
+      return;
+    }
     const prompts = [
       {
         name: 'url',
@@ -93,8 +229,16 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
   async selectControllers() {
     if (this.shouldExit()) return;
     const choices = this.controllerSpecs.map(c => {
+      const names = [];
+      if (this.options.server !== false) {
+        names.push(c.className);
+      }
+      if (this.options.client === true) {
+        names.push(c.serviceClassName);
+      }
+      const name = c.tag ? `[${c.tag}] ${names.join(' ')}` : names.join(' ');
       return {
-        name: c.tag ? `[${c.tag}] ${c.className}` : c.className,
+        name,
         value: c.className,
         checked: true,
       };
@@ -102,7 +246,9 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
     const prompts = [
       {
         name: 'controllerSelections',
-        message: g.f('Select controllers to be generated:'),
+        message: g.f(
+          'Select controllers and/or service proxies to be generated:',
+        ),
         type: 'checkbox',
         choices: choices,
         // Require at least one item to be selected
@@ -117,17 +263,11 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
     this.selectedControllers = this.controllerSpecs.filter(c =>
       selections.some(a => a === c.className),
     );
-    this.selectedControllers.forEach(
-      c => (c.fileName = getControllerFileName(c.tag || c.className)),
-    );
-  }
-
-  async scaffold() {
-    if (this.shouldExit()) return false;
-    this._generateModels();
-    await this._updateIndex(MODEL);
-    this._generateControllers();
-    await this._updateIndex(CONTROLLER);
+    this.selectedServices = this.selectedControllers;
+    this.selectedControllers.forEach(c => {
+      c.fileName = getControllerFileName(c.tag || c.className);
+      c.serviceFileName = getServiceFileName(c.tag || c.serviceClassName);
+    });
   }
 
   _generateControllers() {
@@ -144,6 +284,72 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
         debug('Copying artifact to: %s', dest);
       }
       this.copyTemplatedFiles(source, dest, mixinEscapeComment(c));
+    }
+  }
+
+  async _generateDataSource() {
+    const jsonFile = this.dataSourceInfo.jsonFileName;
+    const jsonTemplatePath = this.templatePath(
+      'src/datasources/datasource.config.json.ejs',
+    );
+    if (debug.enabled) {
+      debug(`Artifact output filename set to: ${jsonFile}`);
+    }
+    let dest = this.destinationPath(`src/datasources/${jsonFile}`);
+    if (debug.enabled) {
+      debug('Copying artifact to: %s', dest);
+    }
+
+    let specPath = this.url;
+    const parsed = parse(this.url);
+    if (parsed.protocol == null) {
+      specPath = path.relative(this.destinationRoot(), this.url);
+    }
+    this.dataSourceInfo.specPath = specPath;
+
+    this.copyTemplatedFiles(jsonTemplatePath, dest, this.dataSourceInfo);
+
+    const classTemplatePath = this.templatePath(
+      'src/datasources/datasource.ts.ejs',
+    );
+    const dataSourceFile = this.dataSourceInfo.outFile;
+    if (debug.enabled) {
+      debug(`Artifact output filename set to: ${dataSourceFile}`);
+    }
+    dest = this.destinationPath(`src/datasources/${dataSourceFile}`);
+    if (debug.enabled) {
+      debug('Copying artifact to: %s', dest);
+    }
+    const context = {...this.dataSourceInfo};
+    let dsClass = context.className;
+    dsClass = dsClass.endsWith('DataSource')
+      ? dsClass.substring(0, dsClass.length - 'DataSource'.length)
+      : dsClass;
+    context.className = dsClass;
+    this.copyTemplatedFiles(classTemplatePath, dest, context);
+    this.dataSources = [{fileName: dataSourceFile}];
+  }
+
+  _generateServiceProxies() {
+    const source = this.templatePath(
+      'src/services/service-proxy-template.ts.ejs',
+    );
+    for (const c of this.selectedControllers) {
+      const file = c.serviceFileName;
+      if (debug.enabled) {
+        debug(`Artifact output filename set to: ${file}`);
+      }
+      const dest = this.destinationPath(`src/services/${file}`);
+      if (debug.enabled) {
+        debug('Copying artifact to: %s', dest);
+      }
+      const context = {
+        ...mixinEscapeComment(c),
+        usePositionalParams: this.dataSourceInfo.usePositionalParams,
+        dataSourceName: this.dataSourceInfo.name,
+        dataSourceClassName: this.dataSourceInfo.className,
+      };
+      this.copyTemplatedFiles(source, dest, context);
     }
   }
 
@@ -167,26 +373,111 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
 
   // update index file for models and controllers
   async _updateIndex(dir) {
-    if (dir === MODEL) {
-      const targetDir = this.destinationPath(`src/${MODEL}`);
-      for (const m of this.modelSpecs) {
+    const update = async files => {
+      const targetDir = this.destinationPath(`src/${dir}`);
+      for (const f of files) {
         // Check all files being generated to ensure they succeeded
-        const status = this.conflicter.generationStatus[m.fileName];
+        const status = this.conflicter.generationStatus[f];
         if (status !== 'skip' && status !== 'identical') {
-          await updateIndex(targetDir, m.fileName);
+          await updateIndex(targetDir, f, this.fs);
         }
       }
+    };
+    let files = undefined;
+    switch (dir) {
+      case MODEL:
+        files = this.modelSpecs.map(m => m.fileName);
+        break;
+      case CONTROLLER:
+        files = this.selectedControllers.map(m => m.fileName);
+        break;
+      case SERVICE:
+        files = this.selectedServices.map(m => m.serviceFileName);
+        break;
+      case DATASOURCE:
+        files = this.dataSources.map(m => m.fileName);
+        break;
     }
-    if (dir === CONTROLLER) {
-      const targetDir = this.destinationPath(`src/${CONTROLLER}`);
-      for (const c of this.selectedControllers) {
-        // Check all files being generated to ensure they succeeded
-        const status = this.conflicter.generationStatus[c.fileName];
-        if (status !== 'skip' && status !== 'identical') {
-          await updateIndex(targetDir, c.fileName);
-        }
+
+    if (files != null) {
+      await update(files);
+    }
+  }
+
+  async promptNewDataSourceName() {
+    if (this.shouldExit()) return false;
+    if (this.options.client !== true) return;
+    // skip if the data source already exists
+    if (this.dataSourceInfo && this.dataSourceInfo.name) return;
+
+    this.dataSourceInfo = {
+      name: this.options.datasource || 'openapi',
+      usePositionalParams: this.options.positional !== false,
+    };
+
+    debug('Prompting for artifact name');
+    const prompts = [
+      {
+        type: 'input',
+        name: 'dataSourceName',
+        // capitalization
+        message: g.f('DataSource name:'),
+        default: 'openapi',
+        validate: utils.validateClassName,
+        when: !this.options.datasource,
+      },
+    ];
+
+    const answers = await this.prompt(prompts);
+    if (answers != null && answers.dataSourceName) {
+      this.dataSourceInfo.name = answers.dataSourceName;
+    }
+
+    // Setting up data for templates
+    this.dataSourceInfo.className =
+      utils.toClassName(this.dataSourceInfo.name) + 'DataSource';
+    this.dataSourceInfo.fileName = utils.toFileName(this.dataSourceInfo.name);
+    this.dataSourceInfo.jsonFileName = `${this.dataSourceInfo.fileName}.datasource.config.json`;
+    this.dataSourceInfo.outFile = `${this.dataSourceInfo.fileName}.datasource.ts`;
+  }
+
+  async scaffold() {
+    if (this.shouldExit()) return false;
+    this._generateModels();
+    await this._updateIndex(MODEL);
+    if (this.options.server !== false) {
+      this._generateControllers();
+      await this._updateIndex(CONTROLLER);
+    }
+    if (this.options.client === true) {
+      if (this.dataSourceInfo.outFile) {
+        await this._generateDataSource();
+        await this._updateIndex(DATASOURCE);
+      }
+      this._generateServiceProxies();
+      await this._updateIndex(SERVICE);
+    }
+  }
+
+  install() {
+    if (this.shouldExit()) return false;
+    debug('install npm dependencies');
+    const pkgJson = this.packageJson || {};
+    const deps = pkgJson.dependencies || {};
+    const pkgs = [];
+    const connectorVersionRange = deps['loopback-connector-openapi'];
+    if (!connectorVersionRange) {
+      // No dependency found for loopback-connector-openapi
+      pkgs.push('loopback-connector-openapi');
+    } else {
+      // `loopback-connector-openapi` exists - make sure its version range
+      // is >= 4.1.0
+      const minVersion = semver.minVersion(connectorVersionRange);
+      if (semver.lt(minVersion, '4.1.0')) {
+        pkgs.push('loopback-connector-openapi');
       }
     }
+    if (pkgs.length) this.npmInstall(pkgs, {save: true});
   }
 
   async end() {

--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -344,7 +344,27 @@ function buildMethodSpec(controllerSpec, op, options) {
       names[argName] = 1;
     }
     registerAnonymousSchema([methodName, argName], paramSpec.schema, options);
-    const paramType = mapSchemaType(paramSpec.schema, options);
+    let propSchema = paramSpec.schema;
+    if (propSchema == null) {
+      /*
+        {
+          name: 'where',
+          in: 'query',
+          content: { 'application/json': { schema: [Object] } }
+        }
+        */
+      const content = paramSpec.content;
+      const json = content && content['application/json'];
+      propSchema = json && json.schema;
+      if (propSchema == null && content) {
+        for (const m of content) {
+          propSchema = content[m].schema;
+          if (propSchema) break;
+        }
+      }
+    }
+    propSchema = propSchema || {type: 'string'};
+    const paramType = mapSchemaType(propSchema, options);
     addImportsForType(paramType);
     if (Array.isArray(_comments)) {
       _comments.push(`@param ${argName} ${paramSpec.description || ''}`);

--- a/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/controllers/controller-template.ts.ejs
@@ -10,17 +10,28 @@ imports.forEach(i => {
 
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
- * by <%- tag %>
- * <%- escapeComment(description) %>
+ * by <%- tag || '<no-tag>' %>.
+ *
+<%_ const _comment = escapeComment(description);
+    if (_comment) {
+-%>
+ * <%- _comment %>
+<%_ } -%>
  */
 export class <%- className %> {
   constructor() {}
 
   <%_ for (const m of methods) { -%>
   /**
-  <%_ for (const c of m.comments) { -%>
-   * <%- escapeComment(c) %>
-  <%_ } -%>
+  <%_ for (const c of m.comments) {
+        const _comment = escapeComment(c);
+        if (_comment) {
+  -%>
+   * <%- _comment %>
+  <%_   } else { -%>
+   *
+  <%_   }
+    } -%>
    */
   <%- m.decoration %>
   <%- m.signature %> {

--- a/packages/cli/generators/openapi/templates/src/datasources/datasource.config.json.ejs
+++ b/packages/cli/generators/openapi/templates/src/datasources/datasource.config.json.ejs
@@ -1,0 +1,7 @@
+{
+  "name": "<%= name %>",
+  "connector": "openapi",
+  "spec": "<%= specPath %>",
+  "validate": false,
+  "positional": <%= usePositionalParams !== false %>
+}

--- a/packages/cli/generators/openapi/templates/src/datasources/datasource.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/datasources/datasource.ts.ejs
@@ -1,0 +1,1 @@
+<%- include('../../../../datasource/templates/datasource.ts.ejs', locals); %>

--- a/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/models/model-template.ts.ejs
@@ -32,7 +32,13 @@ export class <%- className %> {
 
   <%_ for (const p of _properties) { -%>
   /**
-   * <%- escapeComment(p.description) %>
+  <%_ const _comment = escapeComment(p.description);
+    if (_comment) {
+  -%>
+   * <%- _comment %>
+  <%_ } else { -%>
+   *
+  <%_ } -%>
    */
   <%- p.decoration %>
   <%- p.signature %>

--- a/packages/cli/generators/openapi/templates/src/services/service-proxy-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/services/service-proxy-template.ts.ejs
@@ -1,0 +1,55 @@
+import {getService} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {<%= dataSourceClassName %>} from '../datasources';
+
+<%_
+imports.forEach(i => {
+-%>
+<%- i %>
+<%_
+});
+-%>
+
+/**
+ * The service interface is generated from OpenAPI spec with operations tagged
+ * by <%- tag || '<no-tag>' %>.
+<%_ const _comment = escapeComment(description);
+  if (_comment) {
+-%>
+ * <%- _comment %>
+<%_ } -%>
+ */
+export interface <%- serviceClassName %> {
+  <%_ for (const m of methods) { -%>
+  /**
+  <%_ for (const c of m.comments) {
+    const _comment = escapeComment(c);
+    if (_comment) {
+  -%>
+   * <%- _comment %>
+  <%_ }
+   } -%>
+   */
+  <%_ if (usePositionalParams !== false) { -%>
+  <%- m.signatureForInterface %>;
+  <%_ } else { -%>
+  <%- m.signatureForNamedParams %>;
+  <%_ } -%>
+
+  <%_ } -%>
+}
+
+export class <%= serviceClassName %>Provider implements Provider<<%= serviceClassName %>> {
+  constructor(
+    // <%= dataSourceName %> must match the name property in the datasource json file
+    @inject('datasources.<%= dataSourceName %>')
+    protected dataSource: <%= dataSourceClassName %> = new <%= dataSourceClassName %>(),
+  ) {}
+
+  async value(): Promise<<%= serviceClassName %>> {
+    const service = await getService<{apis: {<%= tag || 'default' %>: <%= serviceClassName %>}}>(
+      this.dataSource,
+    );
+    return service.apis['<%= tag || 'default' %>'];
+  }
+}

--- a/packages/cli/generators/openapi/utils.js
+++ b/packages/cli/generators/openapi/utils.js
@@ -36,7 +36,7 @@ function isExtension(key) {
  */
 function debugJson(msg, obj) {
   if (debug.enabled) {
-    debug('%s: %s', msg, JSON.stringify(obj, null, 2));
+    debug('%s: %s', msg, util.inspect(obj, {depth: 10}));
   }
 }
 

--- a/packages/cli/generators/openapi/utils.js
+++ b/packages/cli/generators/openapi/utils.js
@@ -178,7 +178,8 @@ function escapePropertyName(name) {
  */
 function escapeComment(comment) {
   comment = comment || '';
-  return comment.replace(/\/\*/g, '\\/*').replace(/\*\//g, '*\\/');
+  comment = comment.replace(/\/\*/g, '\\/*').replace(/\*\//g, '*\\/');
+  return utils.wrapText(comment, 76);
 }
 
 function toJsonStr(val) {

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -413,7 +413,7 @@ module.exports = class BaseGenerator extends Generator {
   }
 
   async _updateIndexFile(dir, file) {
-    await updateIndex(dir, file);
+    await updateIndex(dir, file, this.fs);
 
     // Output for users
     const updateDirRelPath = path.relative(

--- a/packages/cli/lib/update-index.js
+++ b/packages/cli/lib/update-index.js
@@ -6,18 +6,21 @@
 const debug = require('./debug')('update-index');
 
 const path = require('path');
-const util = require('util');
-const fs = require('fs');
-const appendFile = util.promisify(fs.appendFile);
-const readFile = util.promisify(fs.readFile);
-const exists = util.promisify(fs.exists);
+const fse = require('fs-extra');
+const defaultFs = {
+  read: fse.readFile,
+  write: fse.writeFile,
+  append: fse.appendFile,
+  exists: fse.exists,
+};
 
 /**
  *
  * @param {String} dir The directory in which index.ts is to be updated/created
  * @param {*} file The new file to be exported from index.ts
  */
-module.exports = async function (dir, file) {
+module.exports = async function (dir, file, fsApis) {
+  const {read, write, append, exists} = {...defaultFs, ...fsApis};
   debug(`Updating index with ${path.join(dir, file)}`);
   const indexFile = path.join(dir, 'index.ts');
   if (!file.endsWith('.ts')) {
@@ -27,10 +30,15 @@ module.exports = async function (dir, file) {
   let index = '';
   const indexExists = await exists(indexFile);
   if (indexExists) {
-    index = await readFile(indexFile);
+    index = await read(indexFile);
   }
   const content = `export * from './${file.slice(0, -3)}';\n`;
   if (!index.includes(content)) {
-    await appendFile(indexFile, content);
+    if (indexExists) {
+      await append(indexFile, content);
+    } else {
+      await fse.ensureDir(dir);
+      await write(indexFile, content);
+    }
   }
 };

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -678,6 +678,40 @@ exports.stringifyModelSettings = function (modelSettings) {
   return exports.stringifyObject({settings: modelSettings});
 };
 
+/**
+ * Wrap a single line
+ * @param {string} line Text for the a line
+ * @param {number} maxLineLength - Maximum line length before wrapping
+ */
+function wrapLine(line, maxLineLength) {
+  if (line === '') return line;
+  let lineLength = 0;
+  const words = line.split(/\s+/g);
+  return words.reduce((result, word) => {
+    if (lineLength + word.length >= maxLineLength) {
+      lineLength = word.length;
+      return `${result}\n${word}`;
+    } else {
+      lineLength += word.length + (result ? 1 : 0);
+      return result ? `${result} ${word}` : `${word}`;
+    }
+  }, '');
+}
+
+/**
+ * Wrap the text into lines respecting the max line length
+ * @param {string} text - Text string
+ * @param {number} maxLineLength - Maximum line length before wrapping
+ */
+function wrapText(text, maxLineLength = 80) {
+  let lines = text.split('\n');
+  lines = lines.map(line => wrapLine(line, maxLineLength));
+  return lines.join('\n');
+}
+
+exports.wrapLine = wrapLine;
+exports.wrapText = wrapText;
+
 // literal strings with artifacts directory locations
 exports.repositoriesDir = 'repositories';
 exports.datasourcesDir = 'datasources';

--- a/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
@@ -1,0 +1,1180 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`generates files with --client and --datasource for an existing datasource 1`] = `
+export * from './open-api.service';
+
+`;
+
+
+exports[`generates files with --client and --datasource for an existing datasource 2`] = `
+import {getService} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {PetStoreDataSource} from '../datasources';
+
+import {Pet} from '../models/pet.model';
+import {NewPet} from '../models/new-pet.model';
+
+/**
+ * The service interface is generated from OpenAPI spec with operations tagged
+ * by <no-tag>.
+ */
+export interface OpenApiService {
+  /**
+   * Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
+sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
+lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
+ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst.
+Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante
+molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor
+eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget
+eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac
+sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non
+augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed
+lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu
+condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus.
+In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus
+nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus
+ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean
+nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque
+mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero
+lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa
+ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium,
+pulvinar elit eu, euismod sapien.
+
+   * @param tags tags to filter by
+   * @param limit maximum number of results to return
+   * @returns pet response
+   */
+  findPets(params: { tags: string[]; limit: number }): Promise<Pet[]>;
+
+  /**
+   * Creates a new pet in the store. Duplicates are allowed
+   * @param _requestBody Pet to add to the store
+   * @returns pet response
+   */
+  addPet(params: { requestBody: NewPet }): Promise<Pet>;
+
+  /**
+   * Returns a user based on a single ID, if the user does not have access to the
+pet
+   * @param id ID of pet to fetch
+   * @returns pet response
+   */
+  findPetById(params: { id: number }): Promise<Pet>;
+
+  /**
+   * deletes a single pet based on the ID supplied
+   * @param id ID of pet to delete
+   */
+  deletePet(params: { id: number }): Promise<any>;
+
+}
+
+export class OpenApiServiceProvider implements Provider<OpenApiService> {
+  constructor(
+    // petStore must match the name property in the datasource json file
+    @inject('datasources.petStore')
+    protected dataSource: PetStoreDataSource = new PetStoreDataSource(),
+  ) {}
+
+  async value(): Promise<OpenApiService> {
+    const service = await getService<{apis: {default: OpenApiService}}>(
+      this.dataSource,
+    );
+    return service.apis['default'];
+  }
+}
+
+`;
+
+
+exports[`generates files with --client and --datasource for an existing datasource 3`] = `
+export * from './pet.model';
+export * from './new-pet.model';
+export * from './error.model';
+
+`;
+
+
+exports[`generates files with --client and --datasource for an existing datasource 4`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {NewPet} from './new-pet.model';
+/**
+ * The model type is generated from OpenAPI schema - Pet
+ * Pet
+ */
+export type Pet = NewPet & {
+  id: number;
+};
+
+
+`;
+
+
+exports[`generates files with --client and --datasource for an existing datasource 5`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - NewPet
+ * NewPet
+ */
+@model({name: 'NewPet'})
+export class NewPet {
+  constructor(data?: Partial<NewPet>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  name: string;
+
+  /**
+   *
+   */
+  @property()
+  tag?: string;
+
+}
+
+export interface NewPetRelations {
+  // describe navigational properties here
+}
+
+export type NewPetWithRelations = NewPet & NewPetRelations;
+
+
+
+`;
+
+
+exports[`generates files with --client and --datasource for an existing datasource 6`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - Error
+ * Error
+ */
+@model({name: 'Error'})
+export class Error {
+  constructor(data?: Partial<Error>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  code: number;
+
+  /**
+   *
+   */
+  @property({required: true})
+  message: string;
+
+}
+
+export interface ErrorRelations {
+  // describe navigational properties here
+}
+
+export type ErrorWithRelations = Error & ErrorRelations;
+
+
+
+`;
+
+
+exports[`generates files with --client for an existing datasource 1`] = `
+export * from './open-api.service';
+
+`;
+
+
+exports[`generates files with --client for an existing datasource 2`] = `
+import {getService} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {PetStoreDataSource} from '../datasources';
+
+import {Pet} from '../models/pet.model';
+import {NewPet} from '../models/new-pet.model';
+
+/**
+ * The service interface is generated from OpenAPI spec with operations tagged
+ * by <no-tag>.
+ */
+export interface OpenApiService {
+  /**
+   * Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
+sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
+lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
+ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst.
+Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante
+molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor
+eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget
+eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac
+sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non
+augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed
+lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu
+condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus.
+In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus
+nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus
+ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean
+nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque
+mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero
+lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa
+ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium,
+pulvinar elit eu, euismod sapien.
+
+   * @param tags tags to filter by
+   * @param limit maximum number of results to return
+   * @returns pet response
+   */
+  findPets(params: { tags: string[]; limit: number }): Promise<Pet[]>;
+
+  /**
+   * Creates a new pet in the store. Duplicates are allowed
+   * @param _requestBody Pet to add to the store
+   * @returns pet response
+   */
+  addPet(params: { requestBody: NewPet }): Promise<Pet>;
+
+  /**
+   * Returns a user based on a single ID, if the user does not have access to the
+pet
+   * @param id ID of pet to fetch
+   * @returns pet response
+   */
+  findPetById(params: { id: number }): Promise<Pet>;
+
+  /**
+   * deletes a single pet based on the ID supplied
+   * @param id ID of pet to delete
+   */
+  deletePet(params: { id: number }): Promise<any>;
+
+}
+
+export class OpenApiServiceProvider implements Provider<OpenApiService> {
+  constructor(
+    // petStore must match the name property in the datasource json file
+    @inject('datasources.petStore')
+    protected dataSource: PetStoreDataSource = new PetStoreDataSource(),
+  ) {}
+
+  async value(): Promise<OpenApiService> {
+    const service = await getService<{apis: {default: OpenApiService}}>(
+      this.dataSource,
+    );
+    return service.apis['default'];
+  }
+}
+
+`;
+
+
+exports[`generates files with --client for an existing datasource 3`] = `
+export * from './pet.model';
+export * from './new-pet.model';
+export * from './error.model';
+
+`;
+
+
+exports[`generates files with --client for an existing datasource 4`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {NewPet} from './new-pet.model';
+/**
+ * The model type is generated from OpenAPI schema - Pet
+ * Pet
+ */
+export type Pet = NewPet & {
+  id: number;
+};
+
+
+`;
+
+
+exports[`generates files with --client for an existing datasource 5`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - NewPet
+ * NewPet
+ */
+@model({name: 'NewPet'})
+export class NewPet {
+  constructor(data?: Partial<NewPet>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  name: string;
+
+  /**
+   *
+   */
+  @property()
+  tag?: string;
+
+}
+
+export interface NewPetRelations {
+  // describe navigational properties here
+}
+
+export type NewPetWithRelations = NewPet & NewPetRelations;
+
+
+
+`;
+
+
+exports[`generates files with --client for an existing datasource 6`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - Error
+ * Error
+ */
+@model({name: 'Error'})
+export class Error {
+  constructor(data?: Partial<Error>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  code: number;
+
+  /**
+   *
+   */
+  @property({required: true})
+  message: string;
+
+}
+
+export interface ErrorRelations {
+  // describe navigational properties here
+}
+
+export type ErrorWithRelations = Error & ErrorRelations;
+
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for client with --no-client 1`] = `
+export * from './open-api.controller';
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for client with --no-client 2`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+import {Pet} from '../models/pet.model';
+import {NewPet} from '../models/new-pet.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by <no-tag>.
+ *
+ */
+export class OpenApiController {
+  constructor() {}
+
+  /**
+   * Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
+sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
+lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
+ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst.
+Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante
+molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor
+eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget
+eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac
+sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non
+augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed
+lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu
+condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus.
+In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus
+nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus
+ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean
+nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque
+mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero
+lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa
+ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium,
+pulvinar elit eu, euismod sapien.
+
+   *
+   * @param tags tags to filter by
+   * @param limit maximum number of results to return
+   * @returns pet response
+   */
+  @operation('get', '/pets')
+  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Creates a new pet in the store. Duplicates are allowed
+   *
+   * @param _requestBody Pet to add to the store
+   * @returns pet response
+   */
+  @operation('post', '/pets')
+  async addPet(@requestBody() _requestBody: NewPet): Promise<Pet> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns a user based on a single ID, if the user does not have access to the
+pet
+   *
+   * @param id ID of pet to fetch
+   * @returns pet response
+   */
+  @operation('get', '/pets/{id}')
+  async findPetById(@param({name: 'id', in: 'path'}) id: number): Promise<Pet> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * deletes a single pet based on the ID supplied
+   *
+   * @param id ID of pet to delete
+   */
+  @operation('delete', '/pets/{id}')
+  async deletePet(@param({name: 'id', in: 'path'}) id: number): Promise<any> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for client with --no-client 3`] = `
+export * from './pet.model';
+export * from './new-pet.model';
+export * from './error.model';
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for client with --no-client 4`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {NewPet} from './new-pet.model';
+/**
+ * The model type is generated from OpenAPI schema - Pet
+ * Pet
+ */
+export type Pet = NewPet & {
+  id: number;
+};
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for client with --no-client 5`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - NewPet
+ * NewPet
+ */
+@model({name: 'NewPet'})
+export class NewPet {
+  constructor(data?: Partial<NewPet>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  name: string;
+
+  /**
+   *
+   */
+  @property()
+  tag?: string;
+
+}
+
+export interface NewPetRelations {
+  // describe navigational properties here
+}
+
+export type NewPetWithRelations = NewPet & NewPetRelations;
+
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for client with --no-client 6`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - Error
+ * Error
+ */
+@model({name: 'Error'})
+export class Error {
+  constructor(data?: Partial<Error>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  code: number;
+
+  /**
+   *
+   */
+  @property({required: true})
+  message: string;
+
+}
+
+export interface ErrorRelations {
+  // describe navigational properties here
+}
+
+export type ErrorWithRelations = Error & ErrorRelations;
+
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 1`] = `
+export * from './pet-store.datasource';
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 2`] = `
+import {
+  inject,
+  lifeCycleObserver,
+  LifeCycleObserver,
+  ValueOrPromise,
+} from '@loopback/core';
+import {juggler} from '@loopback/repository';
+import config from './pet-store.datasource.config.json';
+
+@lifeCycleObserver('datasource')
+export class PetStoreDataSource extends juggler.DataSource
+  implements LifeCycleObserver {
+  static dataSourceName = 'petStore';
+
+  constructor(
+    @inject('datasources.config.petStore', {optional: true})
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+
+  /**
+   * Start the datasource when application is started
+   */
+  start(): ValueOrPromise<void> {
+    // Add your logic here to be invoked when the application is started
+  }
+
+  /**
+   * Disconnect the datasource when application is stopped. This allows the
+   * application to be shut down gracefully.
+   */
+  stop(): ValueOrPromise<void> {
+    return super.disconnect();
+  }
+}
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 3`] = `
+export * from './open-api.service';
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 4`] = `
+import {getService} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {PetStoreDataSource} from '../datasources';
+
+import {Pet} from '../models/pet.model';
+import {NewPet} from '../models/new-pet.model';
+
+/**
+ * The service interface is generated from OpenAPI spec with operations tagged
+ * by <no-tag>.
+ */
+export interface OpenApiService {
+  /**
+   * Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
+sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
+lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
+ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst.
+Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante
+molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor
+eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget
+eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac
+sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non
+augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed
+lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu
+condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus.
+In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus
+nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus
+ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean
+nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque
+mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero
+lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa
+ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium,
+pulvinar elit eu, euismod sapien.
+
+   * @param tags tags to filter by
+   * @param limit maximum number of results to return
+   * @returns pet response
+   */
+  findPets(tags: string[], limit: number): Promise<Pet[]>;
+
+  /**
+   * Creates a new pet in the store. Duplicates are allowed
+   * @param _requestBody Pet to add to the store
+   * @returns pet response
+   */
+  addPet(_requestBody: NewPet): Promise<Pet>;
+
+  /**
+   * Returns a user based on a single ID, if the user does not have access to the
+pet
+   * @param id ID of pet to fetch
+   * @returns pet response
+   */
+  findPetById(id: number): Promise<Pet>;
+
+  /**
+   * deletes a single pet based on the ID supplied
+   * @param id ID of pet to delete
+   */
+  deletePet(id: number): Promise<any>;
+
+}
+
+export class OpenApiServiceProvider implements Provider<OpenApiService> {
+  constructor(
+    // petStore must match the name property in the datasource json file
+    @inject('datasources.petStore')
+    protected dataSource: PetStoreDataSource = new PetStoreDataSource(),
+  ) {}
+
+  async value(): Promise<OpenApiService> {
+    const service = await getService<{apis: {default: OpenApiService}}>(
+      this.dataSource,
+    );
+    return service.apis['default'];
+  }
+}
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 5`] = `
+export * from './pet.model';
+export * from './new-pet.model';
+export * from './error.model';
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 6`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {NewPet} from './new-pet.model';
+/**
+ * The model type is generated from OpenAPI schema - Pet
+ * Pet
+ */
+export type Pet = NewPet & {
+  id: number;
+};
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 7`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - NewPet
+ * NewPet
+ */
+@model({name: 'NewPet'})
+export class NewPet {
+  constructor(data?: Partial<NewPet>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  name: string;
+
+  /**
+   *
+   */
+  @property()
+  tag?: string;
+
+}
+
+export interface NewPetRelations {
+  // describe navigational properties here
+}
+
+export type NewPetWithRelations = NewPet & NewPetRelations;
+
+
+
+`;
+
+
+exports[`openapi-generator with --client does not generates files for server with --no-server 8`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - Error
+ * Error
+ */
+@model({name: 'Error'})
+export class Error {
+  constructor(data?: Partial<Error>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  code: number;
+
+  /**
+   *
+   */
+  @property({required: true})
+  message: string;
+
+}
+
+export interface ErrorRelations {
+  // describe navigational properties here
+}
+
+export type ErrorWithRelations = Error & ErrorRelations;
+
+
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 1`] = `
+export * from './open-api.controller';
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 2`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {operation, param, requestBody} from '@loopback/rest';
+import {Pet} from '../models/pet.model';
+import {NewPet} from '../models/new-pet.model';
+
+/**
+ * The controller class is generated from OpenAPI spec with operations tagged
+ * by <no-tag>.
+ *
+ */
+export class OpenApiController {
+  constructor() {}
+
+  /**
+   * Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
+sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
+lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
+ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst.
+Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante
+molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor
+eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget
+eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac
+sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non
+augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed
+lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu
+condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus.
+In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus
+nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus
+ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean
+nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque
+mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero
+lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa
+ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium,
+pulvinar elit eu, euismod sapien.
+
+   *
+   * @param tags tags to filter by
+   * @param limit maximum number of results to return
+   * @returns pet response
+   */
+  @operation('get', '/pets')
+  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Creates a new pet in the store. Duplicates are allowed
+   *
+   * @param _requestBody Pet to add to the store
+   * @returns pet response
+   */
+  @operation('post', '/pets')
+  async addPet(@requestBody() _requestBody: NewPet): Promise<Pet> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * Returns a user based on a single ID, if the user does not have access to the
+pet
+   *
+   * @param id ID of pet to fetch
+   * @returns pet response
+   */
+  @operation('get', '/pets/{id}')
+  async findPetById(@param({name: 'id', in: 'path'}) id: number): Promise<Pet> {
+    throw new Error('Not implemented');
+  }
+
+  /**
+   * deletes a single pet based on the ID supplied
+   *
+   * @param id ID of pet to delete
+   */
+  @operation('delete', '/pets/{id}')
+  async deletePet(@param({name: 'id', in: 'path'}) id: number): Promise<any> {
+    throw new Error('Not implemented');
+  }
+
+}
+
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 3`] = `
+export * from './pet-store.datasource';
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 4`] = `
+import {
+  inject,
+  lifeCycleObserver,
+  LifeCycleObserver,
+  ValueOrPromise,
+} from '@loopback/core';
+import {juggler} from '@loopback/repository';
+import config from './pet-store.datasource.config.json';
+
+@lifeCycleObserver('datasource')
+export class PetStoreDataSource extends juggler.DataSource
+  implements LifeCycleObserver {
+  static dataSourceName = 'petStore';
+
+  constructor(
+    @inject('datasources.config.petStore', {optional: true})
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+
+  /**
+   * Start the datasource when application is started
+   */
+  start(): ValueOrPromise<void> {
+    // Add your logic here to be invoked when the application is started
+  }
+
+  /**
+   * Disconnect the datasource when application is stopped. This allows the
+   * application to be shut down gracefully.
+   */
+  stop(): ValueOrPromise<void> {
+    return super.disconnect();
+  }
+}
+
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 5`] = `
+export * from './open-api.service';
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 6`] = `
+import {getService} from '@loopback/service-proxy';
+import {inject, Provider} from '@loopback/core';
+import {PetStoreDataSource} from '../datasources';
+
+import {Pet} from '../models/pet.model';
+import {NewPet} from '../models/new-pet.model';
+
+/**
+ * The service interface is generated from OpenAPI spec with operations tagged
+ * by <no-tag>.
+ */
+export interface OpenApiService {
+  /**
+   * Returns all pets from the system that the user has access to
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
+sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
+lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
+ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst.
+Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante
+molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor
+eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget
+eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac
+sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non
+augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed
+lacinia.
+
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu
+condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus.
+In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus
+nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus
+ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean
+nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque
+mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero
+lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa
+ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium,
+pulvinar elit eu, euismod sapien.
+
+   * @param tags tags to filter by
+   * @param limit maximum number of results to return
+   * @returns pet response
+   */
+  findPets(tags: string[], limit: number): Promise<Pet[]>;
+
+  /**
+   * Creates a new pet in the store. Duplicates are allowed
+   * @param _requestBody Pet to add to the store
+   * @returns pet response
+   */
+  addPet(_requestBody: NewPet): Promise<Pet>;
+
+  /**
+   * Returns a user based on a single ID, if the user does not have access to the
+pet
+   * @param id ID of pet to fetch
+   * @returns pet response
+   */
+  findPetById(id: number): Promise<Pet>;
+
+  /**
+   * deletes a single pet based on the ID supplied
+   * @param id ID of pet to delete
+   */
+  deletePet(id: number): Promise<any>;
+
+}
+
+export class OpenApiServiceProvider implements Provider<OpenApiService> {
+  constructor(
+    // petStore must match the name property in the datasource json file
+    @inject('datasources.petStore')
+    protected dataSource: PetStoreDataSource = new PetStoreDataSource(),
+  ) {}
+
+  async value(): Promise<OpenApiService> {
+    const service = await getService<{apis: {default: OpenApiService}}>(
+      this.dataSource,
+    );
+    return service.apis['default'];
+  }
+}
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 7`] = `
+export * from './pet.model';
+export * from './new-pet.model';
+export * from './error.model';
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 8`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {NewPet} from './new-pet.model';
+/**
+ * The model type is generated from OpenAPI schema - Pet
+ * Pet
+ */
+export type Pet = NewPet & {
+  id: number;
+};
+
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 9`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - NewPet
+ * NewPet
+ */
+@model({name: 'NewPet'})
+export class NewPet {
+  constructor(data?: Partial<NewPet>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  name: string;
+
+  /**
+   *
+   */
+  @property()
+  tag?: string;
+
+}
+
+export interface NewPetRelations {
+  // describe navigational properties here
+}
+
+export type NewPetWithRelations = NewPet & NewPetRelations;
+
+
+
+`;
+
+
+exports[`openapi-generator with --client generates all files for both server and client 10`] = `
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {model, property} from '@loopback/repository';
+
+/**
+ * The model class is generated from OpenAPI schema - Error
+ * Error
+ */
+@model({name: 'Error'})
+export class Error {
+  constructor(data?: Partial<Error>) {
+    if (data != null && typeof data === 'object') {
+      Object.assign(this, data);
+    }
+  }
+
+  /**
+   *
+   */
+  @property({required: true})
+  code: number;
+
+  /**
+   *
+   */
+  @property({required: true})
+  message: string;
+
+}
+
+export interface ErrorRelations {
+  // describe navigational properties here
+}
+
+export type ErrorWithRelations = Error & ErrorRelations;
+
+
+
+`;

--- a/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
@@ -53,9 +53,12 @@ pulvinar elit eu, euismod sapien.
 
    * @param tags tags to filter by
    * @param limit maximum number of results to return
+   * @param where 
    * @returns pet response
    */
-  findPets(params: { tags: string[]; limit: number }): Promise<Pet[]>;
+  findPets(params: { tags: string[]; limit: number; where: {
+  [additionalProperty: string]: any;
+} }): Promise<Pet[]>;
 
   /**
    * Creates a new pet in the store. Duplicates are allowed
@@ -249,9 +252,12 @@ pulvinar elit eu, euismod sapien.
 
    * @param tags tags to filter by
    * @param limit maximum number of results to return
+   * @param where 
    * @returns pet response
    */
-  findPets(params: { tags: string[]; limit: number }): Promise<Pet[]>;
+  findPets(params: { tags: string[]; limit: number; where: {
+  [additionalProperty: string]: any;
+} }): Promise<Pet[]>;
 
   /**
    * Creates a new pet in the store. Duplicates are allowed
@@ -447,10 +453,13 @@ pulvinar elit eu, euismod sapien.
    *
    * @param tags tags to filter by
    * @param limit maximum number of results to return
+   * @param where 
    * @returns pet response
    */
   @operation('get', '/pets')
-  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]> {
+  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number, @param({name: 'where', in: 'query'}) where: {
+  [additionalProperty: string]: any;
+}): Promise<Pet[]> {
     throw new Error('Not implemented');
   }
 
@@ -692,9 +701,12 @@ pulvinar elit eu, euismod sapien.
 
    * @param tags tags to filter by
    * @param limit maximum number of results to return
+   * @param where 
    * @returns pet response
    */
-  findPets(tags: string[], limit: number): Promise<Pet[]>;
+  findPets(tags: string[], limit: number, where: {
+  [additionalProperty: string]: any;
+}): Promise<Pet[]>;
 
   /**
    * Creates a new pet in the store. Duplicates are allowed
@@ -890,10 +902,13 @@ pulvinar elit eu, euismod sapien.
    *
    * @param tags tags to filter by
    * @param limit maximum number of results to return
+   * @param where 
    * @returns pet response
    */
   @operation('get', '/pets')
-  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]> {
+  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number, @param({name: 'where', in: 'query'}) where: {
+  [additionalProperty: string]: any;
+}): Promise<Pet[]> {
     throw new Error('Not implemented');
   }
 
@@ -1030,9 +1045,12 @@ pulvinar elit eu, euismod sapien.
 
    * @param tags tags to filter by
    * @param limit maximum number of results to return
+   * @param where 
    * @returns pet response
    */
-  findPets(tags: string[], limit: number): Promise<Pet[]>;
+  findPets(tags: string[], limit: number, where: {
+  [additionalProperty: string]: any;
+}): Promise<Pet[]>;
 
   /**
    * Creates a new pet in the store. Duplicates are allowed

--- a/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
@@ -55,10 +55,13 @@ pulvinar elit eu, euismod sapien.
    *
    * @param tags tags to filter by
    * @param limit maximum number of results to return
+   * @param where 
    * @returns pet response
    */
   @operation('get', '/pets')
-  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number): Promise<Pet[]> {
+  async findPets(@param({name: 'tags', in: 'query'}) tags: string[], @param({name: 'limit', in: 'query'}) limit: number, @param({name: 'where', in: 'query'}) where: {
+  [additionalProperty: string]: any;
+}): Promise<Pet[]> {
     throw new Error('Not implemented');
   }
 

--- a/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-petstore.integration.snapshots.js
@@ -7,21 +7,13 @@
 
 'use strict';
 
-exports[`openapi-generator specific files generates all the proper files 1`] = `
-export * from './pet.model';
-export * from './new-pet.model';
-export * from './error.model';
-
-`;
-
-
-exports[`openapi-generator specific files generates all the proper files 2`] = `
+exports[`openapi-generator petstore generates all the proper files 1`] = `
 export * from './open-api.controller';
 
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 3`] = `
+exports[`openapi-generator petstore generates all the proper files 2`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {operation, param, requestBody} from '@loopback/rest';
 import {Pet} from '../models/pet.model';
@@ -29,20 +21,38 @@ import {NewPet} from '../models/new-pet.model';
 
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
- * by 
- * 
+ * by <no-tag>.
+ *
  */
 export class OpenApiController {
   constructor() {}
 
   /**
    * Returns all pets from the system that the user has access to
-Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem
+sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio
+lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar
+ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst.
+Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante
+molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor
+eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget
+eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac
+sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non
+augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed
+lacinia.
 
-Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu
+condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus.
+In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus
+nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus
+ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean
+nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque
+mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero
+lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa
+ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium,
+pulvinar elit eu, euismod sapien.
 
-   * 
-
+   *
    * @param tags tags to filter by
    * @param limit maximum number of results to return
    * @returns pet response
@@ -53,9 +63,8 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
   }
 
   /**
-   * Creates a new pet in the store.  Duplicates are allowed
-   * 
-
+   * Creates a new pet in the store. Duplicates are allowed
+   *
    * @param _requestBody Pet to add to the store
    * @returns pet response
    */
@@ -65,9 +74,9 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
   }
 
   /**
-   * Returns a user based on a single ID, if the user does not have access to the pet
-   * 
-
+   * Returns a user based on a single ID, if the user does not have access to the
+pet
+   *
    * @param id ID of pet to fetch
    * @returns pet response
    */
@@ -78,8 +87,7 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
 
   /**
    * deletes a single pet based on the ID supplied
-   * 
-
+   *
    * @param id ID of pet to delete
    */
   @operation('delete', '/pets/{id}')
@@ -93,7 +101,15 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 4`] = `
+exports[`openapi-generator petstore generates all the proper files 3`] = `
+export * from './pet.model';
+export * from './new-pet.model';
+export * from './error.model';
+
+`;
+
+
+exports[`openapi-generator petstore generates all the proper files 4`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {NewPet} from './new-pet.model';
 /**
@@ -108,7 +124,7 @@ export type Pet = NewPet & {
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 5`] = `
+exports[`openapi-generator petstore generates all the proper files 5`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {model, property} from '@loopback/repository';
 
@@ -125,13 +141,13 @@ export class NewPet {
   }
 
   /**
-   * 
+   *
    */
   @property({required: true})
   name: string;
 
   /**
-   * 
+   *
    */
   @property()
   tag?: string;
@@ -149,7 +165,7 @@ export type NewPetWithRelations = NewPet & NewPetRelations;
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 6`] = `
+exports[`openapi-generator petstore generates all the proper files 6`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {model, property} from '@loopback/repository';
 
@@ -166,13 +182,13 @@ export class Error {
   }
 
   /**
-   * 
+   *
    */
   @property({required: true})
   code: number;
 
   /**
-   * 
+   *
    */
   @property({required: true})
   message: string;

--- a/packages/cli/snapshots/integration/generators/openapi-uspto-with-anonymous.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-uspto-with-anonymous.integration.snapshots.js
@@ -7,7 +7,14 @@
 
 'use strict';
 
-exports[`openapi-generator specific files generates all the proper files 1`] = `
+exports[`openapi-generator uspto with anonymous generates all the proper files 1`] = `
+export * from './metadata.controller';
+export * from './search.controller';
+
+`;
+
+
+exports[`openapi-generator uspto with anonymous generates all the proper files 2`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {operation, param, requestBody} from '@loopback/rest';
 import {PerformSearchRequestBody} from '../models/perform-search-request-body.model';
@@ -15,19 +22,27 @@ import {PerformSearchResponseBody} from '../models/perform-search-response-body.
 
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
- * by search
+ * by search.
+ *
  * Search a data set
  */
 export class SearchController {
   constructor() {}
 
   /**
-   * This API is based on Solr/Lucense Search. The data is indexed using SOLR. This GET API returns the list of all the searchable field names that are in the Solr Index. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the Solr/Lucene Syntax. Please refer https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the query syntax. List of field names that are searchable can be determined using above GET api.
-   * 
-
+   * This API is based on Solr/Lucense Search. The data is indexed using SOLR.
+This GET API returns the list of all the searchable field names that are in
+the Solr Index. Please see the 'fields' attribute which returns an array of
+field names. Each field or a combination of fields can be searched using the
+Solr/Lucene Syntax. Please refer
+https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the
+query syntax. List of field names that are searchable can be determined
+using above GET api.
+   *
    * @param _requestBody 
    * @param version Version of the dataset.
-   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * @param dataset Name of the dataset. In this case, the default value is
+oa_citations
    * @returns successful operation
    */
   @operation('post', '/{dataset}/{version}/records')
@@ -41,23 +56,23 @@ export class SearchController {
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 2`] = `
+exports[`openapi-generator uspto with anonymous generates all the proper files 3`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {operation, param, requestBody} from '@loopback/rest';
 import {DataSetList} from '../models/data-set-list.model';
 
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
- * by metadata
+ * by metadata.
+ *
  * Find out about the data sets
  */
 export class MetadataController {
   constructor() {}
 
   /**
-   * 
-   * 
-
+   *
+   *
    * @returns Returns a list of data sets
    */
   @operation('get', '/')
@@ -66,12 +81,16 @@ export class MetadataController {
   }
 
   /**
-   * This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
-   * 
-
-   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * This GET API returns the list of all the searchable field names that are in
+the oa_citations. Please see the 'fields' attribute which returns an array
+of field names. Each field or a combination of fields can be searched using
+the syntax options shown below.
+   *
+   * @param dataset Name of the dataset. In this case, the default value is
+oa_citations
    * @param version Version of the dataset.
-   * @returns The dataset api for the given version is found and it is accessible to consume.
+   * @returns The dataset api for the given version is found and it is accessible
+to consume.
    */
   @operation('get', '/{dataset}/{version}/fields')
   async listSearchableFields(@param({name: 'dataset', in: 'path'}) dataset: string, @param({name: 'version', in: 'path'}) version: string): Promise<string> {
@@ -84,7 +103,15 @@ export class MetadataController {
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 3`] = `
+exports[`openapi-generator uspto with anonymous generates all the proper files 4`] = `
+export * from './data-set-list.model';
+export * from './perform-search-request-body.model';
+export * from './perform-search-response-body.model';
+
+`;
+
+
+exports[`openapi-generator uspto with anonymous generates all the proper files 5`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {model, property} from '@loopback/repository';
 
@@ -101,7 +128,11 @@ export class PerformSearchRequestBody {
   }
 
   /**
-   * Uses Lucene Query Syntax in the format of propertyName:value, propertyName:[num1 TO num2] and date range format: propertyName:[yyyyMMdd TO yyyyMMdd]. In the response please see the 'docs' element which has the list of record objects. Each record structure would consist of all the fields and their corresponding values.
+   * Uses Lucene Query Syntax in the format of propertyName:value,
+propertyName:[num1 TO num2] and date range format: propertyName:[yyyyMMdd TO
+yyyyMMdd]. In the response please see the 'docs' element which has the list
+of record objects. Each record structure would consist of all the fields and
+their corresponding values.
    */
   @property({required: true})
   criteria: string = '*:*';
@@ -113,7 +144,9 @@ export class PerformSearchRequestBody {
   start?: number = 0;
 
   /**
-   * Specify number of rows to be returned. If you run the search with default values, in the response you will see 'numFound' attribute which will tell the number of records available in the dataset.
+   * Specify number of rows to be returned. If you run the search with default
+values, in the response you will see 'numFound' attribute which will tell
+the number of records available in the dataset.
    */
   @property()
   rows?: number = 100;
@@ -131,7 +164,7 @@ export type PerformSearchRequestBodyWithRelations = PerformSearchRequestBody & P
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 4`] = `
+exports[`openapi-generator uspto with anonymous generates all the proper files 6`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * The model type is generated from OpenAPI schema - {
@@ -147,20 +180,5 @@ export type PerformSearchResponseBody = {
 };
 }[];
 
-
-`;
-
-
-exports[`openapi-generator specific files generates all the proper files 5`] = `
-export * from './data-set-list.model';
-export * from './perform-search-request-body.model';
-export * from './perform-search-response-body.model';
-
-`;
-
-
-exports[`openapi-generator specific files generates all the proper files 6`] = `
-export * from './metadata.controller';
-export * from './search.controller';
 
 `;

--- a/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-uspto.integration.snapshots.js
@@ -7,25 +7,40 @@
 
 'use strict';
 
-exports[`openapi-generator specific files generates all the proper files 1`] = `
+exports[`openapi-generator uspto generates all the proper files 1`] = `
+export * from './metadata.controller';
+export * from './search.controller';
+
+`;
+
+
+exports[`openapi-generator uspto generates all the proper files 2`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {operation, param, requestBody} from '@loopback/rest';
 
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
- * by search
+ * by search.
+ *
  * Search a data set
  */
 export class SearchController {
   constructor() {}
 
   /**
-   * This API is based on Solr/Lucense Search. The data is indexed using SOLR. This GET API returns the list of all the searchable field names that are in the Solr Index. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the Solr/Lucene Syntax. Please refer https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the query syntax. List of field names that are searchable can be determined using above GET api.
-   * 
-
+   * This API is based on Solr/Lucense Search. The data is indexed using SOLR.
+This GET API returns the list of all the searchable field names that are in
+the Solr Index. Please see the 'fields' attribute which returns an array of
+field names. Each field or a combination of fields can be searched using the
+Solr/Lucene Syntax. Please refer
+https://lucene.apache.org/core/3_6_2/queryparsersyntax.html#Overview for the
+query syntax. List of field names that are searchable can be determined
+using above GET api.
+   *
    * @param _requestBody 
    * @param version Version of the dataset.
-   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * @param dataset Name of the dataset. In this case, the default value is
+oa_citations
    * @returns successful operation
    */
   @operation('post', '/{dataset}/{version}/records')
@@ -47,23 +62,23 @@ export class SearchController {
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 2`] = `
+exports[`openapi-generator uspto generates all the proper files 3`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {operation, param, requestBody} from '@loopback/rest';
 import {DataSetList} from '../models/data-set-list.model';
 
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
- * by metadata
+ * by metadata.
+ *
  * Find out about the data sets
  */
 export class MetadataController {
   constructor() {}
 
   /**
-   * 
-   * 
-
+   *
+   *
    * @returns Returns a list of data sets
    */
   @operation('get', '/')
@@ -72,12 +87,16 @@ export class MetadataController {
   }
 
   /**
-   * This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
-   * 
-
-   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * This GET API returns the list of all the searchable field names that are in
+the oa_citations. Please see the 'fields' attribute which returns an array
+of field names. Each field or a combination of fields can be searched using
+the syntax options shown below.
+   *
+   * @param dataset Name of the dataset. In this case, the default value is
+oa_citations
    * @param version Version of the dataset.
-   * @returns The dataset api for the given version is found and it is accessible to consume.
+   * @returns The dataset api for the given version is found and it is accessible
+to consume.
    */
   @operation('get', '/{dataset}/{version}/fields')
   async listSearchableFields(@param({name: 'dataset', in: 'path'}) dataset: string, @param({name: 'version', in: 'path'}) version: string): Promise<string> {
@@ -90,36 +109,35 @@ export class MetadataController {
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 3`] = `
+exports[`openapi-generator uspto generates all the proper files 4`] = `
 export * from './data-set-list.model';
 
 `;
 
 
-exports[`openapi-generator specific files generates all the proper files 4`] = `
+exports[`openapi-generator uspto skips controllers not selected 1`] = `
 export * from './metadata.controller';
-export * from './search.controller';
 
 `;
 
 
-exports[`openapi-generator specific files skips controllers not selected 1`] = `
+exports[`openapi-generator uspto skips controllers not selected 2`] = `
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {operation, param, requestBody} from '@loopback/rest';
 import {DataSetList} from '../models/data-set-list.model';
 
 /**
  * The controller class is generated from OpenAPI spec with operations tagged
- * by metadata
+ * by metadata.
+ *
  * Find out about the data sets
  */
 export class MetadataController {
   constructor() {}
 
   /**
-   * 
-   * 
-
+   *
+   *
    * @returns Returns a list of data sets
    */
   @operation('get', '/')
@@ -128,12 +146,16 @@ export class MetadataController {
   }
 
   /**
-   * This GET API returns the list of all the searchable field names that are in the oa_citations. Please see the 'fields' attribute which returns an array of field names. Each field or a combination of fields can be searched using the syntax options shown below.
-   * 
-
-   * @param dataset Name of the dataset. In this case, the default value is oa_citations
+   * This GET API returns the list of all the searchable field names that are in
+the oa_citations. Please see the 'fields' attribute which returns an array
+of field names. Each field or a combination of fields can be searched using
+the syntax options shown below.
+   *
+   * @param dataset Name of the dataset. In this case, the default value is
+oa_citations
    * @param version Version of the dataset.
-   * @returns The dataset api for the given version is found and it is accessible to consume.
+   * @returns The dataset api for the given version is found and it is accessible
+to consume.
    */
   @operation('get', '/{dataset}/{version}/fields')
   async listSearchableFields(@param({name: 'dataset', in: 'path'}) dataset: string, @param({name: 'version', in: 'path'}) version: string): Promise<string> {
@@ -146,13 +168,7 @@ export class MetadataController {
 `;
 
 
-exports[`openapi-generator specific files skips controllers not selected 2`] = `
+exports[`openapi-generator uspto skips controllers not selected 3`] = `
 export * from './data-set-list.model';
-
-`;
-
-
-exports[`openapi-generator specific files skips controllers not selected 3`] = `
-export * from './metadata.controller';
 
 `;

--- a/packages/cli/test/fixtures/openapi/3.0/customer.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/customer.yaml
@@ -74,7 +74,7 @@ paths:
       tags:
         - Customer
       description: Returns a customer based on a single ID
-      x-implementation: "return {id: id, 'first-name': 'John', last-name: 'Smith'};"
+      x-implementation: "return {id: customerId, 'first-name': 'John', 'last-name': 'Smith'};"
       operationId: find customer by id
       parameters:
         - name: customer-id

--- a/packages/cli/test/fixtures/openapi/3.0/index.js
+++ b/packages/cli/test/fixtures/openapi/3.0/index.js
@@ -1,0 +1,29 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+function mapFile(cwd, file) {
+  const dir = path.dirname(file);
+  const name = path.basename(file);
+  return {
+    path: dir,
+    file: name,
+    content: fs.readFileSync(path.join(cwd, file), {
+      encoding: 'utf-8',
+    }),
+  };
+}
+
+function discoverFiles(cwd) {
+  return glob
+    .sync('**/*.{js,ts,json,yaml}', {nodir: true, cwd})
+    .filter(f => f !== 'index.js')
+    .map(f => mapFile(cwd, f));
+}
+
+exports.SANDBOX_FILES = discoverFiles(path.join(__dirname));

--- a/packages/cli/test/fixtures/openapi/3.0/petstore-expanded.yaml
+++ b/packages/cli/test/fixtures/openapi/3.0/petstore-expanded.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: '3.0.0'
 info:
   version: 1.0.0
   title: Swagger Petstore
@@ -39,6 +39,14 @@ paths:
           schema:
             type: integer
             format: int32
+        - name: where
+          in: query
+          content:
+            'application/json':
+              schema:
+                type: object
+                title": TodoList.WhereFilter
+                additionalProperties: true
       responses:
         '200':
           description: pet response
@@ -128,7 +136,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/NewPet'
         - required:
-          - id
+            - id
           properties:
             id:
               type: integer
@@ -153,4 +161,3 @@ components:
           format: int32
         message:
           type: string
-

--- a/packages/cli/test/fixtures/openapi/3.0/src/datasources/index.ts
+++ b/packages/cli/test/fixtures/openapi/3.0/src/datasources/index.ts
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './pet-store.datasource';

--- a/packages/cli/test/fixtures/openapi/3.0/src/datasources/pet-store.datasource.config.json
+++ b/packages/cli/test/fixtures/openapi/3.0/src/datasources/pet-store.datasource.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "petStore",
+  "connector": "openapi",
+  "spec": "petstore-expanded.yaml",
+  "validate": false,
+  "positional": false
+}

--- a/packages/cli/test/fixtures/openapi/3.0/src/datasources/pet-store.datasource.ts
+++ b/packages/cli/test/fixtures/openapi/3.0/src/datasources/pet-store.datasource.ts
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  inject,
+  lifeCycleObserver,
+  LifeCycleObserver,
+  ValueOrPromise,
+} from '@loopback/core';
+import {juggler} from '@loopback/repository';
+import config from './pet-store.datasource.config.json';
+
+@lifeCycleObserver('datasource')
+export class PetStoreDataSource extends juggler.DataSource
+  implements LifeCycleObserver {
+  static dataSourceName = 'petStore';
+
+  constructor(
+    @inject('datasources.config.petStore', {optional: true})
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+
+  /**
+   * Start the datasource when application is started
+   */
+  start(): ValueOrPromise<void> {
+    // Add your logic here to be invoked when the application is started
+  }
+
+  /**
+   * Disconnect the datasource when application is stopped. This allows the
+   * application to be shut down gracefully.
+   */
+  stop(): ValueOrPromise<void> {
+    return super.disconnect();
+  }
+}

--- a/packages/cli/test/integration/generators/openapi-client.integration.js
+++ b/packages/cli/test/integration/generators/openapi-client.integration.js
@@ -75,7 +75,10 @@ describe('openapi-generator with --client', function () {
   });
 });
 
-it('generates files with --client for an existing datasource', async () => {
+it('generates files with --client for an existing datasource', async function () {
+  // These tests take longer to execute, they used to time out on Travis CI
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(10000);
   await testUtils
     .executeGenerator(generator)
     .inDir(sandbox.path, () =>

--- a/packages/cli/test/integration/generators/openapi-client.integration.js
+++ b/packages/cli/test/integration/generators/openapi-client.integration.js
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const path = require('path');
+const {TestSandbox} = require('@loopback/testlab');
+const {assertFilesToMatchSnapshot} = require('../../snapshots');
+
+const generator = path.join(__dirname, '../../../generators/openapi');
+const specPath = path.join(
+  __dirname,
+  '../../fixtures/openapi/3.0/petstore-expanded.yaml',
+);
+
+const SANDBOX_FILES = require('../../fixtures/openapi/3.0').SANDBOX_FILES;
+
+// Test Sandbox
+const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
+const testUtils = require('../../test-utils');
+
+const props = {
+  url: specPath,
+  dataSourceName: 'petStore',
+};
+
+describe('openapi-generator with --client', function () {
+  // These tests take longer to execute, they used to time out on Travis CI
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(10000);
+
+  before('reset sandbox', () => sandbox.reset());
+  afterEach('reset sandbox', () => sandbox.reset());
+
+  it('generates all files for both server and client', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+      .withPrompts(props)
+      .withOptions({client: true});
+
+    assertControllers();
+    assertDataSources();
+    assertServices();
+    assertModels();
+  });
+
+  it('does not generates files for client with --no-client', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+      .withPrompts(props)
+      .withOptions({client: false});
+
+    const options = {exists: false};
+    assertControllers();
+    assertDataSources(options);
+    assertServices(options);
+    assertModels();
+  });
+
+  it('does not generates files for server with --no-server', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
+      .withPrompts(props)
+      .withOptions({server: false, client: true});
+
+    assertControllers({exists: false});
+    assertDataSources();
+    assertServices();
+    assertModels();
+  });
+});
+
+it('generates files with --client for an existing datasource', async () => {
+  await testUtils
+    .executeGenerator(generator)
+    .inDir(sandbox.path, () =>
+      testUtils.givenLBProject(sandbox.path, {
+        additionalFiles: SANDBOX_FILES,
+      }),
+    )
+    .withPrompts({
+      dataSource: {
+        name: 'petStore',
+        className: 'PetStoreDataSource',
+        usePositionalParams: false,
+        specPath: 'petstore-expanded.yaml',
+      },
+    })
+    .withOptions({server: false, client: true});
+
+  assertControllers({exists: false});
+  assertServices();
+  assertModels();
+});
+
+it('generates files with --client and --datasource for an existing datasource', async () => {
+  await testUtils
+    .executeGenerator(generator)
+    .inDir(sandbox.path, () =>
+      testUtils.givenLBProject(sandbox.path, {additionalFiles: SANDBOX_FILES}),
+    )
+    .withOptions({server: false, client: true, datasource: 'petStore'});
+
+  assertControllers({exists: false});
+  assertServices();
+  assertModels();
+});
+
+function assertModels(options) {
+  assertFiles(
+    options,
+    'src/models/index.ts',
+    'src/models/pet.model.ts',
+    'src/models/new-pet.model.ts',
+    'src/models/error.model.ts',
+  );
+}
+
+function assertControllers(options) {
+  assertFiles(
+    options,
+    'src/controllers/index.ts',
+    'src/controllers/open-api.controller.ts',
+  );
+}
+
+function assertDataSources(options) {
+  assertFiles(
+    options,
+    'src/datasources/index.ts',
+    'src/datasources/pet-store.datasource.ts',
+  );
+}
+
+function assertServices(options) {
+  assertFiles(
+    options,
+    'src/services/index.ts',
+    'src/services/open-api.service.ts',
+  );
+}
+
+function assertFiles(options, ...files) {
+  options = {rootPath: sandbox.path, ...options};
+  assertFilesToMatchSnapshot(options, ...files);
+}

--- a/packages/cli/test/integration/generators/openapi-petstore.integration.js
+++ b/packages/cli/test/integration/generators/openapi-petstore.integration.js
@@ -6,9 +6,8 @@
 'use strict';
 
 const path = require('path');
-const assert = require('yeoman-assert');
 const {TestSandbox} = require('@loopback/testlab');
-const {expectFileToMatchSnapshot} = require('../../snapshots');
+const {assertFilesToMatchSnapshot} = require('../../snapshots');
 
 const generator = path.join(__dirname, '../../../generators/openapi');
 const specPath = path.join(
@@ -24,24 +23,13 @@ const props = {
   url: specPath,
 };
 
-describe('openapi-generator specific files', function () {
+describe('openapi-generator petstore', function () {
   // These tests take longer to execute, they used to time out on Travis CI
   // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
-  const modelIndex = path.resolve(sandbox.path, 'src/models/index.ts');
-  const controIndex = path.resolve(sandbox.path, 'src/controllers/index.ts');
-  const controller = path.resolve(
-    sandbox.path,
-    'src/controllers/open-api.controller.ts',
-  );
-  const petModel = path.resolve(sandbox.path, 'src/models/pet.model.ts');
-  const newPetModel = path.resolve(sandbox.path, 'src/models/new-pet.model.ts');
-  const errorModel = path.resolve(sandbox.path, 'src/models/error.model.ts');
-
-  after('reset sandbox', async () => {
-    await sandbox.reset();
-  });
+  before('reset sandbox', () => sandbox.reset());
+  afterEach('reset sandbox', () => sandbox.reset());
 
   it('generates all the proper files', async () => {
     await testUtils
@@ -49,22 +37,24 @@ describe('openapi-generator specific files', function () {
       .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withPrompts(props);
 
-    assert.file(modelIndex);
-    expectFileToMatchSnapshot(modelIndex);
+    const options = {};
+    assertFiles(
+      options,
+      'src/controllers/index.ts',
+      'src/controllers/open-api.controller.ts',
+    );
 
-    assert.file(controIndex);
-    expectFileToMatchSnapshot(controIndex);
-
-    assert.file(controller);
-    expectFileToMatchSnapshot(controller);
-
-    assert.file(petModel);
-    expectFileToMatchSnapshot(petModel);
-
-    assert.file(newPetModel);
-    expectFileToMatchSnapshot(newPetModel);
-
-    assert.file(errorModel);
-    expectFileToMatchSnapshot(errorModel);
+    assertFiles(
+      options,
+      'src/models/index.ts',
+      'src/models/pet.model.ts',
+      'src/models/new-pet.model.ts',
+      'src/models/error.model.ts',
+    );
   });
 });
+
+function assertFiles(options, ...files) {
+  options = {rootPath: sandbox.path, ...options};
+  assertFilesToMatchSnapshot(options, ...files);
+}

--- a/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
+++ b/packages/cli/test/integration/generators/openapi-uspto-with-anonymous.integration.js
@@ -6,9 +6,8 @@
 'use strict';
 
 const path = require('path');
-const assert = require('yeoman-assert');
 const {TestSandbox} = require('@loopback/testlab');
-const {expectFileToMatchSnapshot} = require('../../snapshots');
+const {assertFilesToMatchSnapshot} = require('../../snapshots');
 
 const generator = path.join(__dirname, '../../../generators/openapi');
 const specPath = path.join(__dirname, '../../fixtures/openapi/3.0/uspto.yaml');
@@ -21,29 +20,9 @@ const props = {
   url: specPath,
 };
 
-describe('openapi-generator specific files', () => {
-  const modelIndex = path.resolve(sandbox.path, 'src/models/index.ts');
-  const controIndex = path.resolve(sandbox.path, 'src/controllers/index.ts');
-  const searchController = path.resolve(
-    sandbox.path,
-    'src/controllers/search.controller.ts',
-  );
-  const metadataController = path.resolve(
-    sandbox.path,
-    'src/controllers/metadata.controller.ts',
-  );
-  const performSearchRequestBodyModel = path.resolve(
-    sandbox.path,
-    'src/models/perform-search-request-body.model.ts',
-  );
-  const performSearchResponseBodyModel = path.resolve(
-    sandbox.path,
-    'src/models/perform-search-response-body.model.ts',
-  );
-
-  after('reset sandbox', async () => {
-    await sandbox.reset();
-  });
+describe('openapi-generator uspto with anonymous', () => {
+  before('reset sandbox', () => sandbox.reset());
+  afterEach('reset sandbox', () => sandbox.reset());
 
   it('generates all the proper files', async () => {
     await testUtils
@@ -51,22 +30,25 @@ describe('openapi-generator specific files', () => {
       .inDir(sandbox.path, () => testUtils.givenLBProject(sandbox.path))
       .withArguments('--promote-anonymous-schemas')
       .withPrompts(props);
-    assert.file(searchController);
-    expectFileToMatchSnapshot(searchController);
 
-    assert.file(metadataController);
-    expectFileToMatchSnapshot(metadataController);
+    assertFiles(
+      {},
+      'src/controllers/index.ts',
+      'src/controllers/search.controller.ts',
+      'src/controllers/metadata.controller.ts',
+    );
 
-    assert.file(performSearchRequestBodyModel);
-    expectFileToMatchSnapshot(performSearchRequestBodyModel);
+    assertFiles(
+      {},
+      'src/models/index.ts',
 
-    assert.file(performSearchResponseBodyModel);
-    expectFileToMatchSnapshot(performSearchResponseBodyModel);
-
-    assert.file(modelIndex);
-    expectFileToMatchSnapshot(modelIndex);
-
-    assert.file(controIndex);
-    expectFileToMatchSnapshot(controIndex);
+      'src/models/perform-search-request-body.model.ts',
+      'src/models/perform-search-response-body.model.ts',
+    );
   });
 });
+
+function assertFiles(options, ...files) {
+  options = {rootPath: sandbox.path, ...options};
+  assertFilesToMatchSnapshot(options, ...files);
+}

--- a/packages/cli/test/snapshots.js
+++ b/packages/cli/test/snapshots.js
@@ -20,7 +20,31 @@ function expectFileToMatchSnapshot(filePath) {
   expectToMatchSnapshot(content);
 }
 
+/**
+ * Assert a list of files to match snapshots
+ * @param {object} options Options
+ *   - exists: assert the file exists or not
+ *   - rootPath: rootPath for file names
+ * @param  {...string} files
+ */
+function assertFilesToMatchSnapshot(options, ...files) {
+  options = {exists: true, ...options};
+  if (options.rootPath) {
+    files = files.map(f => path.resolve(options.rootPath, f));
+  }
+
+  for (const f of files) {
+    if (options.exists === false) {
+      assert.noFile(f);
+      break;
+    }
+    assert.file(f);
+    expectFileToMatchSnapshot(f);
+  }
+}
+
 module.exports = {
   expectToMatchSnapshot,
   expectFileToMatchSnapshot,
+  assertFilesToMatchSnapshot,
 };

--- a/packages/cli/test/unit/openapi/controller-spec.unit.js
+++ b/packages/cli/test/unit/openapi/controller-spec.unit.js
@@ -14,19 +14,20 @@ describe('openapi to controllers/models', () => {
   );
 
   it('generates models for customer', async () => {
-    const customerSepc = await loadAndBuildSpec(customer);
-    expect(customerSepc.controllerSpecs).to.eql([
+    const customerSpec = await loadAndBuildSpec(customer);
+    expect(customerSpec.controllerSpecs).to.eql([
       {
         tag: 'Customer',
         description: 'Customer resource',
         className: 'CustomerController',
+        serviceClassName: 'CustomerService',
         imports: ["import {Customer} from '../models/customer.model';"],
         methods: [
           {
             description: 'Returns all customers (/* customers */)',
             comments: [
               'Returns all customers (/* customers */)',
-              '\n',
+              '',
               '@param _if if condition',
               '@param limit maximum number of results to return',
               '@param accessToken Access token (/* access_token */)',
@@ -38,17 +39,25 @@ describe('openapi to controllers/models', () => {
               "string[], @param({name: 'limit', in: 'query'}) limit: number, " +
               "@param({name: 'access-token', in: 'query'}) accessToken: " +
               'string): Promise<Customer[]>',
+            signatureForInterface:
+              'getCustomers(_if: string[], limit: number, accessToken: string): Promise<Customer[]>',
+            signatureForNamedParams:
+              "getCustomers(params: { if: string[]; limit: number; 'access-token': string }): Promise<Customer[]>",
           },
           {
             description: 'Creates a new customer',
             comments: [
               'Creates a new customer',
-              '\n',
+              '',
               '@param _requestBody Customer to add',
               '@param accessToken Access token (/* access_token */)',
               '@returns customer response',
             ],
             decoration: "@operation('post', '/customers')",
+            signatureForInterface:
+              'createCustomer(_requestBody: Customer, accessToken: string): Promise<Customer>',
+            signatureForNamedParams:
+              "createCustomer(params: { requestBody: Customer; 'access-token': string }): Promise<Customer>",
             signature:
               'async createCustomer(@requestBody() _requestBody: Customer, ' +
               "@param({name: 'access-token', in: 'query'}) accessToken: " +
@@ -58,7 +67,7 @@ describe('openapi to controllers/models', () => {
             description: 'Returns a customer based on a single ID',
             comments: [
               'Returns a customer based on a single ID',
-              '\n',
+              '',
               '@param customerId ID of customer to fetch',
               '@returns customer response',
             ],
@@ -67,7 +76,11 @@ describe('openapi to controllers/models', () => {
               "async findCustomerById(@param({name: 'customer_id', " +
               "in: 'path'}) customerId: number): Promise<Customer>",
             implementation:
-              "return {id: id, 'first-name': 'John', last-name: 'Smith'};",
+              "return {id: customerId, 'first-name': 'John', 'last-name': 'Smith'};",
+            signatureForInterface:
+              'findCustomerById(customerId: number): Promise<Customer>',
+            signatureForNamedParams:
+              'findCustomerById(params: { customer_id: number }): Promise<Customer>',
           },
         ],
       },


### PR DESCRIPTION
This PR extends `lb4 openapi` with client-side service proxy code generation. The primary use case is to generate strongly-typed service proxies for REST apis that have Swagger 2.0 or OpenAPI 3.0 spec.

Usage:

`lb4 openapi --client`

It will prompt the user to give a datasource name and generate:

- models (models and types)
- services (for strongly-typed service providers per each tag)
- datasources (for openapi connector, can be supplied by `--datasource`)

The `--client` can be used with `--server`. By default, `client` is `false` and `server` is true. 

See docs at https://github.com/strongloop/loopback-next/blob/cli-openapi-client/docs/site/OpenAPI-generator.md

Depends on https://github.com/strongloop/loopback-connector-openapi/pull/10

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
