### PR TITLE
fix: relation schemas should not inherit `title` from the source model's schema

### DIFF
--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -501,7 +501,16 @@ export function modelToJsonSchema<T extends object>(
       result.properties = result.properties ?? {};
       const relMeta = meta.relations[r];
       const targetType = resolveType(relMeta.target);
-      const targetSchema = getJsonSchema(targetType, options);
+
+      const targetOptions = {...options};
+      if (targetOptions.title) {
+        // `title` is the unique identity of a schema,
+        // it should be removed from the `options`
+        // when generating the relation schemas
+        delete targetOptions.title;
+      }
+
+      const targetSchema = getJsonSchema(targetType, targetOptions);
       const targetRef = {$ref: `#/definitions/${targetSchema.title}`};
       const propDef = getNavigationalPropertyForRelation(relMeta, targetRef);
 


### PR DESCRIPTION
Fix https://github.com/strongloop/loopback-next/issues/5088

When building the relation schema, the `title` field should be omitted.
See details in comment https://github.com/strongloop/loopback-next/issues/5088#issuecomment-613069334

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
