### PR TITLE
fix(cli): exclude `**/node_modules/**/*` from copyright header searching

### DIFF
--- a/packages/cli/generators/copyright/index.js
+++ b/packages/cli/generators/copyright/index.js
@@ -133,6 +133,7 @@ module.exports = class CopyrightGenerator extends BaseGenerator {
     answers = answers || {};
     const exclude = this.options.exclude || '';
     const excludePatterns = exclude.split(',').filter(p => p !== '');
+    excludePatterns.push('**/node_modules/**/*');
 
     this.headerOptions = {
       copyrightOwner: answers.owner || this.options.owner,

--- a/packages/cli/test/fixtures/copyright/single-package/index.js
+++ b/packages/cli/test/fixtures/copyright/single-package/index.js
@@ -4,4 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 // Use the same set of files (except index.js) in this folder
-exports.SANDBOX_FILES = require('../index')(__dirname);
+const files = require('../index')(__dirname);
+
+// add node_modules/third-party.js
+files.push({
+  path: 'node_modules',
+  file: 'third-party.js',
+  content: `module.exports = {}`,
+});
+exports.SANDBOX_FILES = files;

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -70,6 +70,14 @@ describe('lb4 copyright', function () {
       `// This file is licensed under the ${spdxLicenseList['isc'].name}.`,
       `// License text available at ${spdxLicenseList['isc'].url}`,
     );
+
+    assertNoHeader(
+      ['node_modules/third-party.js'],
+      `// Copyright ACME Inc. ${year}. All Rights Reserved.`,
+      '// Node module: myapp',
+      `// This file is licensed under the ${spdxLicenseList['isc'].name}.`,
+      `// License text available at ${spdxLicenseList['isc'].url}`,
+    );
   });
 
   it('updates copyright/license headers with options.exclude', async () => {
@@ -97,7 +105,7 @@ describe('lb4 copyright', function () {
     );
 
     assertNoHeader(
-      ['lib/no-header.js'],
+      ['lib/no-header.js', 'node_modules/third-party.js'],
       `// Copyright ACME Inc. ${year}. All Rights Reserved.`,
       '// Node module: myapp',
       `// This file is licensed under the ${spdxLicenseList['isc'].name}.`,


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
