### PR TITLE
feat(cli): add `--apiconnect` option to enable ApiConnectComponent

### DIFF
--- a/extensions/apiconnect/src/__tests__/acceptance/apiconnect.acceptance.ts
+++ b/extensions/apiconnect/src/__tests__/acceptance/apiconnect.acceptance.ts
@@ -6,8 +6,11 @@
 import {Application} from '@loopback/core';
 import {RestApplication, RestServer} from '@loopback/rest';
 import {expect} from '@loopback/testlab';
-import {ApiConnectBindings, ApiConnectComponent} from '../..';
-import {ApiConnectSpecOptions} from '../../apiconnect.spec-enhancer';
+import {
+  ApiConnectBindings,
+  ApiConnectComponent,
+  ApiConnectSpecOptions,
+} from '../..';
 
 describe('Extension for IBM API Connect - OASEnhancer', () => {
   let app: Application;

--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -49,6 +49,11 @@ module.exports = class AppGenerator extends ProjectGenerator {
       description: g.f('Include service-proxy imports and ServiceMixin'),
     });
 
+    this.option('apiconnect', {
+      type: Boolean,
+      description: g.f('Include ApiConnectComponent'),
+    });
+
     return super._setupGenerator();
   }
 

--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -11,6 +11,13 @@ import {RestApplication} from '@loopback/rest';
 <% if (project.services) { -%>
 import {ServiceMixin} from '@loopback/service-proxy';
 <% } -%>
+<% if (project.apiconnect) { -%>
+import {
+  ApiConnectBindings,
+  ApiConnectComponent,
+  ApiConnectSpecOptions,
+} from '@loopback/apiconnect';
+<% } -%>
 import path from 'path';
 import {MySequence} from './sequence';
 
@@ -37,6 +44,14 @@ export class <%= project.applicationName %> extends BootMixin(RestApplication) {
       path: '/explorer',
     });
     this.component(RestExplorerComponent);
+<%_ if (project.apiconnect) { -%>
+    this.component(ApiConnectComponent);
+    const apiConnectOptions: ApiConnectSpecOptions = {
+      targetUrl: 'http://localhost:3000/',
+    };
+    this.configure(ApiConnectBindings.API_CONNECT_SPEC_ENHANCER).to(
+      apiConnectOptions,
+<%_ } -%>
 
     this.projectRoot = __dirname;
     // Customize @loopback/boot Booter Conventions here

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -80,6 +80,9 @@
 <% if (project.repositories) { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
 <% } -%>
+<% if (project.apiconnect) { -%>
+    "@loopback/apiconnect": "<%= project.dependencies['@loopback/apiconnect'] -%>",
+<% } -%>
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
 <% if (project.services) { -%>
     "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -78,6 +78,9 @@
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
+<% if (project.apiconnect) { -%>
+    "@loopback/apiconnect": "<%= project.dependencies['@loopback/apiconnect'] -%>",
+<% } -%>
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
     "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",
 <% } else { -%>

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -114,9 +114,13 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       projectType: this.projectType,
       dependencies: utils.getDependencies(),
     };
-    this.projectOptions = ['name', 'description', 'outdir', 'private'].concat(
-      this.buildOptions,
-    );
+    this.projectOptions = [
+      'name',
+      'description',
+      'outdir',
+      'private',
+      'apiconnect',
+    ].concat(this.buildOptions);
     this.projectOptions.forEach(n => {
       if (typeof n === 'object') {
         n = n.name;

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -175,6 +175,32 @@ describe('app-generator with --applicationName', () => {
   });
 });
 
+describe('app-generator with --apiconnect', () => {
+  before(() => {
+    return helpers
+      .run(generator)
+      .withOptions({apiconnect: true})
+      .withPrompts(props);
+  });
+  it('adds imports for ApiConnectComponent', () => {
+    assert.fileContent(
+      'src/application.ts',
+      `
+import {
+  ApiConnectBindings,
+  ApiConnectComponent,
+  ApiConnectSpecOptions,
+} from '@loopback/apiconnect';
+`,
+    );
+    assert.fileContent(
+      'src/application.ts',
+      'this.component(ApiConnectComponent);',
+    );
+    assert.fileContent('package.json', '"@loopback/apiconnect"');
+  });
+});
+
 // The test takes about 1 min to install dependencies
 function testFormat() {
   before(function () {


### PR DESCRIPTION
Add `--apiconnect` option to generate a project that enables `ApiConnect` component.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
