### PR TITLE
feat: allow `jsonSchema` for model definitions

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -97,6 +97,21 @@ export class Customer {
 }
 ```
 
+The `@model` decorator can take `jsonSchema` to customize the JSON schema
+inferred for the model class. For example,
+
+```ts
+@model({
+  jsonSchema: {
+    title: 'Customer',
+    required: ['email'],
+  },
+})
+export class Customer {
+  // ...
+}
+```
+
 ## Model Discovery
 
 LoopBack can automatically create model definitions by discovering the schema of
@@ -464,7 +479,7 @@ Here are general attributes for property definitions:
       <th>Description</th>
     </tr>
   </thead>
-  <tbody>    
+  <tbody>
     <tr>
       <td><code>default</code></td>
       <td>No</td>
@@ -585,7 +600,7 @@ id property settings that can be used for auto-migration / auto-update:
       <th>Description</th>
     </tr>
   </thead>
-  <tbody>   
+  <tbody>
     <tr>
       <td><code>generated</code></td>
       <td>No</td>
@@ -631,8 +646,8 @@ the database:
       <th width="100">Type</th>
       <th width="540">Description</th>
     </tr>
-  </thead>    
-  <tbody>    
+  </thead>
+  <tbody>
     <tr>
       <td><code>[connector name].schema</code></td>
       <td>String</td>
@@ -656,8 +671,8 @@ columns in the database:
       <th width="100">Type</th>
       <th width="540">Description</th>
     </tr>
-  </thead>    
-  <tbody>    
+  </thead>
+  <tbody>
     <tr>
       <td><code>columnName</code></td>
       <td>String</td>
@@ -908,7 +923,7 @@ class Product extends Entity {
 
 ## JSON Schema Inference
 
-Use the `@loopback/repository-json-schema module` to build a JSON schema from a
+Use the `@loopback/repository-json-schema` module to build a JSON schema from a
 decorated model. Type information is inferred from the `@model` and `@property`
 decorators. The `@loopback/repository-json-schema` module contains the
 `getJsonSchema` function to access the metadata stored by the decorators to

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -20,6 +20,7 @@ import {
   metaToJsonProperty,
   modelToJsonSchema,
   stringTypeToWrapper,
+  JsonSchema,
 } from '../..';
 
 describe('build-schema', () => {
@@ -215,6 +216,39 @@ describe('build-schema', () => {
   });
 
   describe('modelToJsonSchema', () => {
+    it('allows jsonSchema in model definition', () => {
+      @model({
+        jsonSchema: {
+          title: 'report-state',
+          required: ['color'],
+        } as JsonSchema,
+      })
+      class ReportState extends Model {
+        @property({
+          type: 'string',
+        })
+        benchmarkId?: string;
+
+        @property({
+          type: 'string',
+        })
+        color: string;
+
+        constructor(data?: Partial<ReportState>) {
+          super(data);
+        }
+      }
+      const schema = modelToJsonSchema(ReportState, {});
+      expect(schema.properties).to.containEql({
+        benchmarkId: {type: 'string'},
+        color: {type: 'string'},
+      });
+      expect(schema.required).to.eql(['color']);
+      expect(schema.title).to.eql('report-state');
+      // No circular references in definitions
+      expect(schema.definitions).to.be.undefined();
+    });
+
     it('allows recursive model definition', () => {
       @model()
       class ReportState extends Model {

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {getModelRelations, Model, model} from '@loopback/repository';
-import {JSONSchema6 as JsonSchema, JSONSchema6Definition} from 'json-schema';
+import {JSONSchema7 as JsonSchema, JSONSchema7Definition} from 'json-schema';
 
 export interface FilterSchemaOptions {
   /**
@@ -67,7 +67,7 @@ export function getFilterJsonSchemaFor(
   } else {
     excluded = options.exclude ?? [];
   }
-  const properties: Record<string, JSONSchema6Definition> = {
+  const properties: Record<string, JSONSchema7Definition> = {
     offset: {
       type: 'integer',
       minimum: 0,

--- a/packages/repository-json-schema/src/index.ts
+++ b/packages/repository-json-schema/src/index.ts
@@ -14,10 +14,7 @@
  * @packageDocumentation
  */
 
-export {Model} from '@loopback/repository';
+export {JsonSchema, Model} from '@loopback/repository';
 export * from './build-schema';
 export * from './filter-json-schema';
 export * from './keys';
-export {JsonSchema};
-
-import {JSONSchema6 as JsonSchema} from 'json-schema';

--- a/packages/repository-json-schema/src/keys.ts
+++ b/packages/repository-json-schema/src/keys.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {MetadataAccessor} from '@loopback/metadata';
-import {JSONSchema6 as JSONSchema} from 'json-schema';
+import {JsonSchema} from './index';
 
 /**
  * Metadata key used to set or retrieve repository JSON Schema
  */
 export const JSON_SCHEMA_KEY = MetadataAccessor.create<
-  {[key: string]: JSONSchema},
+  {[key: string]: JsonSchema},
   ClassDecorator
 >('loopback:json-schema');

--- a/packages/repository/package-lock.json
+++ b/packages/repository/package-lock.json
@@ -18,6 +18,12 @@
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
 			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
 		},
+		"@types/json-schema": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+			"dev": true
+		},
 		"@types/lodash": {
 			"version": "4.14.150",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -22,6 +22,7 @@
     "@loopback/eslint-config": "^6.0.3",
     "@loopback/testlab": "^3.0.1",
     "@types/bson": "^4.0.2",
+    "@types/json-schema": "^7.0.4",
     "@types/lodash": "^4.14.150",
     "@types/node": "^10.17.21",
     "bson": "4.0.4"

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -18,6 +18,7 @@
  * @packageDocumentation
  */
 
+export {JSONSchema7 as JsonSchema} from 'json-schema';
 export * from './common-types';
 export * from './connectors';
 export * from './datasource';

--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {AnyObject, DataObject, Options} from './common-types';
+import {JsonSchema} from './index';
 import {RelationMetadata} from './relations';
 import {TypeResolver} from './type-resolver';
 import {Type} from './types';
@@ -15,6 +16,10 @@ import {Type} from './types';
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface JsonSchemaWithExtensions extends JsonSchema {
+  [attributes: string]: any;
+}
 
 export type PropertyType =
   | string
@@ -30,7 +35,7 @@ export interface PropertyDefinition {
   type: PropertyType; // For example, 'string', String, or {}
   id?: boolean | number;
   json?: PropertyForm;
-  jsonSchema?: {[attribute: string]: any};
+  jsonSchema?: JsonSchemaWithExtensions;
   store?: PropertyForm;
   itemType?: PropertyType; // type of array
   [attribute: string]: any; // Other attributes
@@ -61,6 +66,7 @@ export interface ModelDefinitionSyntax {
   properties?: {[name: string]: PropertyDefinition | PropertyType};
   settings?: {[name: string]: any};
   relations?: RelationDefinitionMap;
+  jsonSchema?: JsonSchemaWithExtensions;
   [attribute: string]: any;
 }
 


### PR DESCRIPTION
With `lb4 openapi` command, I would like to populate `jsonSchema` for models/properties so that generated controllers/models will have schemas from the spec.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
