### PR TITLE
fix: globalize app generator strings

### DIFF
--- a/packages/cli/intl/en/messages.json
+++ b/packages/cli/intl/en/messages.json
@@ -47,6 +47,7 @@
   "59a4c6df82c2bbaf50592ee55982fe64": "use @loopback/build helpers (e.g. lb-eslint)",
   "5a0085f46605278c8b83284484cfa858": "Group name for ordering the global interceptor",
   "5a5169e28fedd5752a79ae01155f47a1": "License name:",
+  "5b6e1e532844d265ddfe06d8a15bdeba": "Enable {0}",
   "5bdddebdf72c7027a9e24aa500a35dd7": "Default value {0}:",
   "5d0490e5ebfdca22d238997aa3882bb9": "Enter the OpenAPI spec url or file path:",
   "5dd3fd8d55f85cec0f63ef7c370df454": "Prompting for controller type",

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -183,8 +183,9 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     const choices = [];
     this.buildOptions.forEach(f => {
       if (this.options[f.name] == null) {
+        const name = g.f('Enable %s', f.name);
         choices.push({
-          name: `Enable ${f.name}: ${chalk.gray(f.description)}`,
+          name: `${name}: ${chalk.gray(f.description)}`,
           key: f.name,
           short: `Enable ${f.name}`,
           checked: true,


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/5121

After adding the translation as a test, it shows:
![image](https://user-images.githubusercontent.com/50331796/79894313-43612700-83d3-11ea-9fbe-981e008881b0.png)


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
