### PR TITLE
fix(docs): remove remote connector

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -742,19 +742,6 @@ children:
       url: Push-connector.html
       output: 'web, pdf'
 
-    - title: 'Remote connector'
-      url: Remote-connector.html
-      output: 'web, pdf'
-      children:
-
-      - title: 'Remote connector example'
-        url: Remote-connector-example.html
-        output: 'web, pdf'
-
-      - title: 'Strong Remoting'
-        url: Strong-Remoting.html
-        output: 'web, pdf'
-
     - title: 'REST connector'
       url: REST-connector.html
       output: 'web, pdf'


### PR DESCRIPTION
From Slack conversation, @bajtos pointed out that the remote connector is not supported in LB4. 

The other part of the change is in PR https://github.com/strongloop/loopback.io/pull/971. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
