### PR TITLE
fix(cli): remove project references from examples

### DIFF
--- a/packages/cli/test/integration/generators/example.integration.js
+++ b/packages/cli/test/integration/generators/example.integration.js
@@ -8,6 +8,7 @@
 const assert = require('yeoman-assert');
 const expect = require('@loopback/testlab').expect;
 const path = require('path');
+const {readJsonSync} = require('fs-extra');
 
 const generator = path.join(__dirname, '../../../generators/example');
 const baseTests = require('../lib/base-generator')(generator);
@@ -86,5 +87,29 @@ describe('lb4 example', function () {
           expect(err).to.match(/Invalid example name/);
         },
       );
+  });
+
+  it('removes project references from tsconfig', () => {
+    return testUtils
+      .executeGenerator(generator)
+      .withPrompts({name: VALID_EXAMPLE})
+      .then(() => {
+        const tsconfigFile = 'tsconfig.json';
+        const expectedConfig = readJsonSync(
+          require.resolve(
+            `../../../../../examples/${VALID_EXAMPLE}/${tsconfigFile}`,
+          ),
+        );
+        delete expectedConfig.references;
+        expectedConfig.compilerOptions.composite = false;
+
+        assert.file(tsconfigFile);
+
+        // IMPORTANT! We cannot use `assert.jsonFileContent` here
+        // because the helper only checks if the file contains all expected
+        // properties, it does not verify there is no additional data.
+        const actualConfig = readJsonSync(tsconfigFile);
+        expect(actualConfig).to.deepEqual(expectedConfig);
+      });
   });
 });


### PR DESCRIPTION
In strongloop/loopback-next#5155, we reworked our typescript setup to leverage composite mode and project references. This breaks our example applications when they are checked out standalone, typically via `lb4 example`.

```sh
$ lb4 example todo
(...)
$ cd loopback4-example-todo
$ npm t
(...)
> lb-tsc

error TS6053: File '/private/packages/http-caching-proxy/tsconfig.json' not found.
error TS6053: File '/private/packages/testlab/tsconfig.json' not found.
(...)
Found 10 errors.
```

This patch fixes the problem by introducing a new step to `lb4 example` command where we remove `references` and `compilerOptions.composite` field from `tsconfig.json` file.

Implements https://github.com/strongloop/loopback-next/issues/2609.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
