### PR TITLE
feat(build): change the default compilation target to ES2018 (Node.js 10.x)

### DIFF
--- a/packages/build/config/tsconfig.common.json
+++ b/packages/build/config/tsconfig.common.json
@@ -16,7 +16,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "target": "es2017",
+    "target": "es2018",
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true


### PR DESCRIPTION
Now that we no longer support Node.js 8.x (see #4619), we can configure TypeScript compiler to emit code leveraging newer language constructs available in Node.js 10.x.

See also 9424b40 which added support for ES2018/Node.js 10.x target back in the days where we were producing custom `dist` versions for each target Node.js version supported.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
