### PR TITLE
fix(cli) fix `lb4 app --apiconnect` to generate the correct code 

### DIFF
--- a/packages/cli/generators/app/templates/src/application.ts.ejs
+++ b/packages/cli/generators/app/templates/src/application.ts.ejs
@@ -51,6 +51,7 @@ export class <%= project.applicationName %> extends BootMixin(RestApplication) {
     };
     this.configure(ApiConnectBindings.API_CONNECT_SPEC_ENHANCER).to(
       apiConnectOptions,
+    );
 <%_ } -%>
 
     this.projectRoot = __dirname;

--- a/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
@@ -1,0 +1,484 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`app-generator specific files generates all the proper files 1`] = `
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {
+  RestExplorerBindings,
+  RestExplorerComponent,
+} from '@loopback/rest-explorer';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {ServiceMixin} from '@loopback/service-proxy';
+import path from 'path';
+import {MySequence} from './sequence';
+
+export class MyAppApplication extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Set up the custom sequence
+    this.sequence(MySequence);
+
+    // Set up default home page
+    this.static('/', path.join(__dirname, '../public'));
+
+    // Customize @loopback/rest-explorer configuration here
+    this.configure(RestExplorerBindings.COMPONENT).to({
+      path: '/explorer',
+    });
+    this.component(RestExplorerComponent);
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}
+
+`;
+
+
+exports[`app-generator specific files generates all the proper files 2`] = `
+const application = require('./dist');
+
+module.exports = application;
+
+if (require.main === module) {
+  // Run the application
+  const config = {
+    rest: {
+      port: +(process.env.PORT || 3000),
+      host: process.env.HOST,
+      // The \`gracePeriodForClose\` provides a graceful close for http/https
+      // servers with keep-alive clients. The default value is \`Infinity\`
+      // (don't force-close). If you want to immediately destroy all sockets
+      // upon stop, set its value to \`0\`.
+      // See https://www.npmjs.com/package/stoppable
+      gracePeriodForClose: 5000, // 5 seconds
+      openApiSpec: {
+        // useful when used with OpenAPI-to-GraphQL to locate your application
+        setServersFromRequest: true,
+      },
+    },
+  };
+  application.main(config).catch(err => {
+    console.error('Cannot start the application.', err);
+    process.exit(1);
+  });
+}
+
+`;
+
+
+exports[`app-generator specific files generates all the proper files 3`] = `
+import {MyAppApplication} from './application';
+import {ApplicationConfig} from '@loopback/core';
+
+export {MyAppApplication};
+
+export async function main(options: ApplicationConfig = {}) {
+  const app = new MyAppApplication(options);
+  await app.boot();
+  await app.start();
+
+  const url = app.restServer.url;
+  console.log(\`Server is running at \${url}\`);
+  console.log(\`Try \${url}/ping\`);
+
+  return app;
+}
+
+`;
+
+
+exports[`app-generator specific files generates all the proper files 4`] = `
+import {Request, RestBindings, get, ResponseObject} from '@loopback/rest';
+import {inject} from '@loopback/context';
+
+/**
+ * OpenAPI response for ping()
+ */
+const PING_RESPONSE: ResponseObject = {
+  description: 'Ping Response',
+  content: {
+    'application/json': {
+      schema: {
+        type: 'object',
+        title: 'PingResponse',
+        properties: {
+          greeting: {type: 'string'},
+          date: {type: 'string'},
+          url: {type: 'string'},
+          headers: {
+            type: 'object',
+            properties: {
+              'Content-Type': {type: 'string'},
+            },
+            additionalProperties: true,
+          },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * A simple controller to bounce back http requests
+ */
+export class PingController {
+  constructor(@inject(RestBindings.Http.REQUEST) private req: Request) {}
+
+  // Map to \`GET /ping\`
+  @get('/ping', {
+    responses: {
+      '200': PING_RESPONSE,
+    },
+  })
+  ping(): object {
+    // Reply with a greeting, the current time, the url, and request headers
+    return {
+      greeting: 'Hello from LoopBack',
+      date: new Date(),
+      url: this.req.url,
+      headers: Object.assign({}, this.req.headers),
+    };
+  }
+}
+
+`;
+
+
+exports[`app-generator specific files generates all the proper files 5`] = `
+import {Client, expect} from '@loopback/testlab';
+import {MyAppApplication} from '../..';
+import {setupApplication} from './test-helper';
+
+describe('PingController', () => {
+  let app: MyAppApplication;
+  let client: Client;
+
+  before('setupApplication', async () => {
+    ({app, client} = await setupApplication());
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  it('invokes GET /ping', async () => {
+    const res = await client.get('/ping?msg=world').expect(200);
+    expect(res.body).to.containEql({greeting: 'Hello from LoopBack'});
+  });
+});
+
+`;
+
+
+exports[`app-generator specific files generates all the proper files 6`] = `
+import {Client} from '@loopback/testlab';
+import {MyAppApplication} from '../..';
+import {setupApplication} from './test-helper';
+
+describe('HomePage', () => {
+  let app: MyAppApplication;
+  let client: Client;
+
+  before('setupApplication', async () => {
+    ({app, client} = await setupApplication());
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  it('exposes a default home page', async () => {
+    await client
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /text\\/html/);
+  });
+
+  it('exposes self-hosted explorer', async () => {
+    await client
+      .get('/explorer/')
+      .expect(200)
+      .expect('Content-Type', /text\\/html/)
+      .expect(/<title>LoopBack API Explorer/);
+  });
+});
+
+`;
+
+
+exports[`app-generator specific files generates all the proper files 7`] = `
+import {MyAppApplication} from '../..';
+import {
+  createRestAppClient,
+  givenHttpServerConfig,
+  Client,
+} from '@loopback/testlab';
+
+export async function setupApplication(): Promise<AppWithClient> {
+  const restConfig = givenHttpServerConfig({
+    // Customize the server configuration here.
+    // Empty values (undefined, '') will be ignored by the helper.
+    //
+    // host: process.env.HOST,
+    // port: +process.env.PORT,
+  });
+
+  const app = new MyAppApplication({
+    rest: restConfig,
+  });
+
+  await app.boot();
+  await app.start();
+
+  const client = createRestAppClient(app);
+
+  return {app, client};
+}
+
+export interface AppWithClient {
+  app: MyAppApplication;
+  client: Client;
+}
+
+`;
+
+
+exports[`app-generator specific files generates database migration script 1`] = `
+import {MyAppApplication} from './application';
+
+export async function migrate(args: string[]) {
+  const existingSchema = args.includes('--rebuild') ? 'drop' : 'alter';
+  console.log('Migrating schemas (%s existing schema)', existingSchema);
+
+  const app = new MyAppApplication();
+  await app.boot();
+  await app.migrateSchema({existingSchema});
+
+  // Connectors usually keep a pool of opened connections,
+  // this keeps the process running even after all work is done.
+  // We need to exit explicitly.
+  process.exit(0);
+}
+
+migrate(process.argv).catch(err => {
+  console.error('Cannot migrate database schema', err);
+  process.exit(1);
+});
+
+`;
+
+
+exports[`app-generator specific files generates docker files 1`] = `
+# Check out https://hub.docker.com/_/node to select a new base image
+FROM node:10-slim
+
+# Set to a non-root built-in user \`node\`
+USER node
+
+# Create app directory (with user \`node\`)
+RUN mkdir -p /home/node/app
+
+WORKDIR /home/node/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY --chown=node package*.json ./
+
+RUN npm install
+
+# Bundle app source code
+COPY --chown=node . .
+
+RUN npm run build
+
+# Bind to all network interfaces so that it can be mapped to the host OS
+ENV HOST=0.0.0.0 PORT=3000
+
+EXPOSE \${PORT}
+CMD [ "node", "." ]
+
+`;
+
+
+exports[`app-generator specific files generates docker files 2`] = `
+node_modules
+npm-debug.log
+/dist
+# Cache used by TypeScript's incremental build
+*.tsbuildinfo
+
+`;
+
+
+exports[`app-generator with --apiconnect adds imports for ApiConnectComponent 1`] = `
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {
+  RestExplorerBindings,
+  RestExplorerComponent,
+} from '@loopback/rest-explorer';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {ServiceMixin} from '@loopback/service-proxy';
+import {
+  ApiConnectBindings,
+  ApiConnectComponent,
+  ApiConnectSpecOptions,
+} from '@loopback/apiconnect';
+import path from 'path';
+import {MySequence} from './sequence';
+
+export class MyAppApplication extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Set up the custom sequence
+    this.sequence(MySequence);
+
+    // Set up default home page
+    this.static('/', path.join(__dirname, '../public'));
+
+    // Customize @loopback/rest-explorer configuration here
+    this.configure(RestExplorerBindings.COMPONENT).to({
+      path: '/explorer',
+    });
+    this.component(RestExplorerComponent);
+    this.component(ApiConnectComponent);
+    const apiConnectOptions: ApiConnectSpecOptions = {
+      targetUrl: 'http://localhost:3000/',
+    };
+    this.configure(ApiConnectBindings.API_CONNECT_SPEC_ENHANCER).to(
+      apiConnectOptions,
+    );
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}
+
+`;
+
+
+exports[`app-generator with --applicationName generates all the proper files 1`] = `
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {
+  RestExplorerBindings,
+  RestExplorerComponent,
+} from '@loopback/rest-explorer';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {ServiceMixin} from '@loopback/service-proxy';
+import path from 'path';
+import {MySequence} from './sequence';
+
+export class MyApp extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Set up the custom sequence
+    this.sequence(MySequence);
+
+    // Set up default home page
+    this.static('/', path.join(__dirname, '../public'));
+
+    // Customize @loopback/rest-explorer configuration here
+    this.configure(RestExplorerBindings.COMPONENT).to({
+      path: '/explorer',
+    });
+    this.component(RestExplorerComponent);
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}
+
+`;
+
+
+exports[`app-generator with --applicationName generates the application with RepositoryMixin 1`] = `
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {
+  RestExplorerBindings,
+  RestExplorerComponent,
+} from '@loopback/rest-explorer';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {ServiceMixin} from '@loopback/service-proxy';
+import path from 'path';
+import {MySequence} from './sequence';
+
+export class MyApp extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    // Set up the custom sequence
+    this.sequence(MySequence);
+
+    // Set up default home page
+    this.static('/', path.join(__dirname, '../public'));
+
+    // Customize @loopback/rest-explorer configuration here
+    this.configure(RestExplorerBindings.COMPONENT).to({
+      path: '/explorer',
+    });
+    this.component(RestExplorerComponent);
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}
+
+`;

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -21,6 +21,8 @@ const props = {
 };
 const {expect} = require('@loopback/testlab');
 
+const {assertFilesToMatchSnapshot} = require('../../snapshots');
+
 const tests = require('../lib/project-generator')(
   generator,
   props,
@@ -37,60 +39,15 @@ describe('app-generator specific files', () => {
     return helpers.run(generator).withPrompts(props);
   });
   it('generates all the proper files', () => {
-    assert.file('src/application.ts');
-    assert.fileContent(
+    assertFilesToMatchSnapshot(
+      {},
       'src/application.ts',
-      /class MyAppApplication extends BootMixin\(/,
-    );
-    assert.fileContent(
-      'src/application.ts',
-      /ServiceMixin\(RepositoryMixin\(RestApplication\)\)/,
-    );
-    assert.fileContent('src/application.ts', /constructor\(/);
-    assert.fileContent('src/application.ts', /this.projectRoot = __dirname/);
-
-    assert.file('index.js');
-    assert.fileContent('index.js', /openApiSpec: {/);
-    assert.fileContent('index.js', /setServersFromRequest: true/);
-
-    assert.file('src/index.ts');
-    assert.fileContent('src/index.ts', /new MyAppApplication/);
-    assert.fileContent('src/index.ts', /await app.start\(\);/);
-
-    assert.file('src/controllers/ping.controller.ts');
-    assert.fileContent(
+      'index.js',
+      'src/index.ts',
       'src/controllers/ping.controller.ts',
-      /export class PingController/,
-    );
-    assert.fileContent('src/controllers/ping.controller.ts', /@inject/);
-    assert.fileContent(
-      'src/controllers/ping.controller.ts',
-      /@get\('\/ping'\, \{/,
-    );
-    assert.fileContent('src/controllers/ping.controller.ts', /ping\(\)/);
-    assert.fileContent(
-      'src/controllers/ping.controller.ts',
-      /\'\@loopback\/rest\'/,
-    );
-    assert.fileContent(
       'src/__tests__/acceptance/ping.controller.acceptance.ts',
-      /describe\('PingController'/,
-    );
-    assert.fileContent(
       'src/__tests__/acceptance/home-page.acceptance.ts',
-      /describe\('HomePage'/,
-    );
-    assert.fileContent(
       'src/__tests__/acceptance/test-helper.ts',
-      /export async function setupApplication/,
-    );
-    assert.fileContent(
-      'src/__tests__/acceptance/test-helper.ts',
-      'process.env.HOST',
-    );
-    assert.fileContent(
-      'src/__tests__/acceptance/test-helper.ts',
-      '+process.env.PORT',
     );
     assert.jsonFileContent('.yo-rc.json', {
       '@loopback/cli': {
@@ -100,23 +57,11 @@ describe('app-generator specific files', () => {
   });
 
   it('generates database migration script', () => {
-    assert.fileContent(
-      'src/migrate.ts',
-      /import {MyAppApplication} from '\.\/application'/,
-    );
-
-    assert.fileContent(
-      'src/migrate.ts',
-      /const app = new MyAppApplication\(\);/,
-    );
-
-    assert.fileContent('src/migrate.ts', /export async function migrate/);
+    assertFilesToMatchSnapshot({}, 'src/migrate.ts');
   });
 
   it('generates docker files', () => {
-    assert.fileContent('Dockerfile', /FROM node:10-slim/);
-    assert.fileContent('.dockerignore', /node_modules/);
-    assert.fileContent('.dockerignore', '*.tsbuildinfo');
+    assertFilesToMatchSnapshot({}, 'Dockerfile', '.dockerignore');
 
     assert.fileContent('package.json', /"docker:build": "docker build/);
     assert.fileContent('package.json', /"docker:run": "docker run/);
@@ -163,15 +108,10 @@ describe('app-generator with --applicationName', () => {
       .withPrompts(props);
   });
   it('generates all the proper files', () => {
-    assert.file('src/application.ts');
-    assert.fileContent('src/application.ts', /class MyApp extends BootMixin\(/);
+    assertFilesToMatchSnapshot({}, 'src/application.ts');
   });
   it('generates the application with RepositoryMixin', () => {
-    assert.file('src/application.ts');
-    assert.fileContent(
-      'src/application.ts',
-      /RepositoryMixin\(RestApplication\)/,
-    );
+    assertFilesToMatchSnapshot({}, 'src/application.ts');
   });
 });
 
@@ -183,20 +123,7 @@ describe('app-generator with --apiconnect', () => {
       .withPrompts(props);
   });
   it('adds imports for ApiConnectComponent', () => {
-    assert.fileContent(
-      'src/application.ts',
-      `
-import {
-  ApiConnectBindings,
-  ApiConnectComponent,
-  ApiConnectSpecOptions,
-} from '@loopback/apiconnect';
-`,
-    );
-    assert.fileContent(
-      'src/application.ts',
-      'this.component(ApiConnectComponent);',
-    );
+    assertFilesToMatchSnapshot({}, 'src/application.ts');
     assert.fileContent('package.json', '"@loopback/apiconnect"');
   });
 });


### PR DESCRIPTION
`lb4 app --apiconnect` is broken as the generated `src/application.ts` is missing `);`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
