### PR TITLE
feat: improve internal build scripts

### DIFF
--- a/bin/build-docs-site.sh
+++ b/bin/build-docs-site.sh
@@ -37,7 +37,7 @@ rm -rf sandbox/loopback.io/
 git clone --depth 1 https://github.com/strongloop/loopback.io.git sandbox/loopback.io
 
 # Add loopback.io-workflow-scripts with @loopback/docs linked
-lerna bootstrap --no-ci --scope loopback.io-workflow-scripts --include-filtered-dependencies
+lerna bootstrap --no-ci --scope loopback.io-workflow-scripts --include-dependencies
 
 pushd $REPO_ROOT/sandbox/loopback.io/ >/dev/null
 

--- a/bin/config-lerna-scopes.js
+++ b/bin/config-lerna-scopes.js
@@ -9,15 +9,16 @@
  */
 'use strict';
 
-const getPackages = require('@lerna/project').getPackages;
+const {getPackages} = require('@lerna/project');
+
 module.exports = {
   rules: {
     // https://github.com/marionebl/commitlint/blob/master/docs/reference-rules.md
-    'scope-enum': async ctx => [2, 'always', await listPackages(ctx)],
+    'scope-enum': async ctx => [2, 'always', await getPackageNames(ctx)],
   },
 };
 
-async function listPackages(context) {
+async function getPackageNames(context) {
   const ctx = context || {};
   const cwd = ctx.cwd || process.cwd();
   // List all lerna packages
@@ -25,7 +26,25 @@ async function listPackages(context) {
 
   // Get a list of names. Npm scopes will be removed, for example,
   // @loopback/core -> core
-  return packages
-    .map(pkg => pkg.name)
-    .map(name => (name.charAt(0) === '@' ? name.split('/')[1] : name));
+  return packages.map(getShortName);
+}
+
+/**
+ * Get short name of a package. The NPM scope will be removed if it exists.
+ * For example, the short name of `@loopback/core` is `core`.
+ * @param {Package} pkg - Lerna project
+ */
+function getShortName(pkg) {
+  const name = pkg.name;
+  return name.startsWith('@') ? name.split('/')[1] : name;
+}
+
+if (require.main === module) {
+  getPackageNames().then(
+    names => console.log('Scopes: %s', names),
+    err => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
 }

--- a/bin/rebuild-package-locks.js
+++ b/bin/rebuild-package-locks.js
@@ -26,7 +26,10 @@ async function removePackageLocks(project, ...scopes) {
   const rootPath = project.rootPath;
   const pkgRoots = [];
   const matchedPackages = filterPackages(packages, scopes, [], true, true);
-  if (matchedPackages.length === 0) return;
+  if (matchedPackages.length === 0) {
+    console.error('No matching packages found for %s', scopes);
+    return pkgRoots;
+  }
   for (const pkg of matchedPackages) {
     pkgRoots.push(pkg.location);
   }
@@ -57,9 +60,9 @@ async function removePackageLocks(project, ...scopes) {
 async function rebuildPackageLocks(...scopes) {
   const project = new Project(process.cwd());
 
-  const removed = await removePackageLocks(project, ...scopes);
-  if (removed.length === 0) return;
   if (scopes.length) {
+    const removed = await removePackageLocks(project, ...scopes);
+    if (removed.length === 0) return;
     const args = [];
     scopes.forEach(s => args.push('--scope', s));
 

--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -585,36 +585,39 @@ node bin/create-package.js
 
 The script does the following steps:
 
-1.  Determine the location and package name.
+1. Determine the parentDir and package name.
 
-    The first argument of the command can be one of the following:
+   The first argument can be one of the following:
 
-    - package-name
-    - @loopback/package-name
-    - extensions/package-name
-    - packages/package-name
+   - package-name
+   - @loopback/package-name
+   - extensions/package-name
+   - packages/package-name
 
-    If the location is not specified, it tries to guess by the current directory
-    and falls back to `extensions`.
+If the parentDir is not specified, it tries to guess by the current directory
+and falls back to `extensions`.
 
-2.  Run `lb4 extension` to scaffold the project without `npm install`. If
-    `--yes` or `-y` is provide by the command, interactive prompts are skipped.
+2. Run `lb4 extension` to scaffold the project without `npm install`. If
+   `--interactive` or `-i` is NOT provided by the command, interactive prompts
+   are skipped.
 
-3.  Tidy up the project
+3. Fix up the project
 
-    - Remove unused files
-    - Improve `package.json`
+   - Remove unused files
+   - Improve `package.json`
 
-4.  Run `lerna bootstrap --scope <full-package-name>` to link its local
-    dependencies.
+4. Run `lb4 copyright` to update `LICENSE` and copyright headers for `*.ts` and
+   `*.js`.
 
-5.  Run `update-ts-project-refs` to update TypeScript project references
+5. Run `lerna bootstrap --scope <full-package-name>` to link its local
+   dependencies.
 
-6.  Remind to update `CODEOWNERS` and `docs/site/MONOREPO.md`
+6. Run `update-ts-project-refs` to update TypeScript project references
 
-If you would like to do it manually, follow steps below:
+7. Remind to update `CODEOWNERS` and `docs/site/MONOREPO.md` If you would like
+   to do it manually, follow steps below:
 
-To add a new package, create a folder in
+To add a new package by hand, create a folder in
 [`packages`](https://github.com/strongloop/loopback-next/tree/master/packages)
 as the root directory of your module. For example,
 


### PR DESCRIPTION
Tidy up internal build scripts:

1. Use `--include-dependencies` for `lerna bootstrap --scope <scope> --include-dependencies` as `--include-filtered-dependencies` is deprecated.

2. Check local packages instead of hard-coded `@loopback/*` to make sure `package-lock.json` does not have entries for local packages.

3. Report errors if provided scopes does not match any packages for `rebuild-package-locks.js`

4. Allow printing out of valid commit scopes 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
