### PR TITLE
Add yarn support for generated projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 sudo: false
 language: node_js
+
+os:
+  - linux
+
 node_js:
   - "10"
   - "12"
   - "14"
-
-os:
-  - linux
 
 script:
   - npm run postinstall
@@ -14,17 +15,27 @@ script:
   - npm run test:ci
 
 env: TASK=test
+
+cache:
+  yarn: true
+
+before_install: npm i -g yarn
+
 install: npm ci --ignore-scripts
 
 after_success:
   - if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ $(echo $TRAVIS_NODE_VERSION | cut -d'.' -f1) == "10" ]]; then npm run coverage:ci; fi
 
-matrix:
+branches:
+  only:
+    - master
+
+jobs:
   include:
     - node_js: "12"
       os: osx
-      # using the default script to build & run the tests
 
+      # using the default script to build & run the tests
     - node_js: "12"
       os: linux
       env: TASK=code-lint
@@ -34,16 +45,19 @@ matrix:
       script:
         - lerna bootstrap
         - npm run lint
+
     - node_js: "12"
       os: linux
       env: TASK=commit-lint
       script: commitlint-travis
+
     - node_js: "12"
       os: linux
       env: TASK=verify-docs
       # The default npm for node v12.16.1 (npm v6.13.4) fails with cb() never called
       before_install: npm i -g npm
       script: ./bin/verify-doc-changes.sh
+
     - node_js: "12"
       os: linux
       env:
@@ -53,6 +67,7 @@ matrix:
       script:
         - lerna bootstrap --scope "@loopback/test-repository-mongodb" --include-dependencies
         - cd acceptance/repository-mongodb && npm test
+
     - node_js: "12"
       os: linux
       env:
@@ -69,6 +84,7 @@ matrix:
       script:
         - lerna bootstrap --scope "@loopback/test-repository-mysql" --include-dependencies
         - cd acceptance/repository-mysql && npm test
+
     - node_js: "12"
       os: linux
       env:
@@ -80,6 +96,7 @@ matrix:
         - lerna bootstrap --scope "@loopback/test-repository-postgresql" --include-dependencies
         - psql -U postgres -a -f acceptance/repository-postgresql/test/schema.sql
         - cd acceptance/repository-postgresql && npm test
+
     - node_js: "12"
       os: linux
       env:
@@ -89,6 +106,7 @@ matrix:
         - lerna bootstrap --scope "@loopback/test-repository-cloudant" --include-dependencies
         - cd acceptance/repository-cloudant && sh setup.sh
         - npm test
+
     - node_js: "12"
       os: linux
       env:
@@ -98,7 +116,3 @@ matrix:
       script:
         - lerna bootstrap --scope "@loopback/test-extension-logging-fluentd" --include-dependencies
         - cd acceptance/extension-logging-fluentd && npm test
-
-branches:
-  only:
-    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 
 os:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,8 @@ test_script:
   - npm run build
   - npm run mocha --scripts-prepend-node-path
 
+cache:
+  - "%LOCALAPPDATA%\\Yarn"
+
 build: off
 skip_branch_with_pr: true

--- a/packages/cli/generators/app/index.js
+++ b/packages/cli/generators/app/index.js
@@ -85,7 +85,7 @@ module.exports = class AppGenerator extends ProjectGenerator {
   }
 
   promptApplication() {
-    if (this.shouldExit()) return false;
+    if (this.shouldExit()) return;
     const prompts = [
       {
         type: 'input',
@@ -110,8 +110,13 @@ module.exports = class AppGenerator extends ProjectGenerator {
     return super.promptOptions();
   }
 
+  promptYarnInstall() {
+    if (this.shouldExit()) return;
+    return super.promptYarnInstall();
+  }
+
   buildAppClassMixins() {
-    if (this.shouldExit()) return false;
+    if (this.shouldExit()) return;
     const {repositories, services} = this.projectInfo || {};
     if (!repositories && !services) return;
 
@@ -157,7 +162,7 @@ module.exports = class AppGenerator extends ProjectGenerator {
     this.log(g.f('Next steps:'));
     this.log();
     this.log('$ cd ' + this.projectInfo.outdir);
-    this.log('$ npm start');
+    this.log(`$ ${this.options.packageManager || 'npm'} start`);
     this.log();
   }
 };

--- a/packages/cli/generators/datasource/index.js
+++ b/packages/cli/generators/datasource/index.js
@@ -320,7 +320,13 @@ module.exports = class DataSourceGenerator extends ArtifactGenerator {
       pkgs.push('@loopback/repository');
     }
 
-    if (pkgs.length) this.npmInstall(pkgs, {save: true});
+    if (pkgs.length === 0) return;
+
+    this.pkgManagerInstall(pkgs, {
+      npm: {
+        save: true,
+      },
+    });
   }
 
   async end() {

--- a/packages/cli/generators/extension/index.js
+++ b/packages/cli/generators/extension/index.js
@@ -27,19 +27,22 @@ module.exports = class ExtensionGenerator extends ProjectGenerator {
   }
 
   setOptions() {
+    if (this.shouldExit()) return;
     return super.setOptions();
   }
 
   promptProjectName() {
+    if (this.shouldExit()) return;
     return super.promptProjectName();
   }
 
   promptProjectDir() {
+    if (this.shouldExit()) return;
     return super.promptProjectDir();
   }
 
   promptComponent() {
-    if (this.shouldExit()) return false;
+    if (this.shouldExit()) return;
     const prompts = [
       {
         type: 'input',
@@ -56,7 +59,13 @@ module.exports = class ExtensionGenerator extends ProjectGenerator {
   }
 
   promptOptions() {
+    if (this.shouldExit()) return;
     return super.promptOptions();
+  }
+
+  promptYarnInstall() {
+    if (this.shouldExit()) return;
+    return super.promptYarnInstall();
   }
 
   scaffold() {

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -444,7 +444,8 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
           when: answers => {
             return (
               ![null, 'buffer', 'any'].includes(answers.type) &&
-              !answers.generated
+              !answers.generated &&
+              answers.required !== true
             );
           },
         },

--- a/packages/cli/generators/openapi/index.js
+++ b/packages/cli/generators/openapi/index.js
@@ -493,7 +493,14 @@ module.exports = class OpenApiGenerator extends BaseGenerator {
         this.log(err);
       }
     }
-    if (pkgs.length) this.npmInstall(pkgs, {save: true});
+
+    if (pkgs.length === 0) return;
+
+    this.pkgManagerInstall(pkgs, {
+      npm: {
+        save: true,
+      },
+    });
   }
 
   async end() {

--- a/packages/cli/generators/rest-crud/index.js
+++ b/packages/cli/generators/rest-crud/index.js
@@ -369,7 +369,13 @@ module.exports = class RestCrudGenerator extends ArtifactGenerator {
       pkgs.push(`@loopback/rest-crud@${version}`);
     }
 
-    if (pkgs.length) this.npmInstall(pkgs, {save: true});
+    if (pkgs.length === 0) return;
+
+    this.pkgManagerInstall(pkgs, {
+      npm: {
+        save: true,
+      },
+    });
   }
 
   async end() {

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -335,7 +335,14 @@ module.exports = class ServiceGenerator extends ArtifactGenerator {
     if (!deps['@loopback/service-proxy']) {
       pkgs.push('@loopback/service-proxy');
     }
-    if (pkgs.length) this.npmInstall(pkgs, {save: true});
+
+    if (pkgs.length === 0) return;
+
+    this.pkgManagerInstall(pkgs, {
+      npm: {
+        save: true,
+      },
+    });
   }
 
   async end() {

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -217,13 +217,35 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     });
   }
 
+  promptYarnInstall() {
+    if (this.shouldExit()) return false;
+    const prompts = [
+      {
+        type: 'confirm',
+        name: 'yarn',
+        message: g.f('Yarn is available. Do you prefer to use it by default?'),
+        when:
+          !this.options.packageManager &&
+          this.spawnCommandSync('yarn', ['help'], {stdio: false}).status === 0,
+        default: false,
+      },
+    ];
+
+    return this.prompt(prompts).then(props => {
+      if (props.yarn) {
+        this.options.packageManager = 'yarn';
+      }
+    });
+  }
+
   scaffold() {
     if (this.shouldExit()) return false;
 
     this.destinationRoot(this.projectInfo.outdir);
 
-    // Store original cli version in .yo.rc.json
+    // Store information for cli operation in .yo.rc.json
     this.config.set('version', cliVersion);
+    this.config.set('packageManager', this.options.packageManager || 'npm');
 
     // First copy common files from ../../project/templates
     this.copyTemplatedFiles(

--- a/packages/cli/lib/version-helper.js
+++ b/packages/cli/lib/version-helper.js
@@ -163,7 +163,7 @@ function updateDependencies(generator) {
     chalk.red('Upgrading dependencies may break the current project.'),
   );
   generator.fs.writeJSON(generator.destinationPath('package.json'), pkg);
-  generator.npmInstall();
+  generator.pkgManagerInstall();
 }
 
 /**

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -142,6 +142,7 @@ function testFormat() {
         skipInstall: false,
         // Disable npm log and progress bar
         npmInstall: {silent: true, progress: false},
+        yarnInstall: {silent: true},
         // Disable npm stdio
         spawn: {
           stdio: 'ignore',

--- a/packages/cli/test/integration/generators/copyright-monorepo.integration.js
+++ b/packages/cli/test/integration/generators/copyright-monorepo.integration.js
@@ -38,7 +38,11 @@ describe('lb4 copyright for monorepo', function () {
           additionalFiles: SANDBOX_FILES,
         }),
       )
-      .withOptions({gitOnly: false, owner: 'ACME Inc.', license: 'MIT'});
+      .withOptions({
+        gitOnly: false,
+        owner: 'ACME Inc.',
+        license: 'MIT',
+      });
     assertHeader(
       ['packages/pkg1/src/application.ts', 'packages/pkg1/lib/no-header.js'],
       `// Copyright ACME Inc. ${year}. All Rights Reserved.`,

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -61,7 +61,11 @@ describe('lb4 copyright', function () {
           additionalFiles: SANDBOX_FILES,
         }),
       )
-      .withOptions({owner: 'ACME Inc.', license: 'ISC', gitOnly: false});
+      .withOptions({
+        owner: 'ACME Inc.',
+        license: 'ISC',
+        gitOnly: false,
+      });
 
     assertHeader(
       ['src/application.ts', 'lib/no-header.js'],

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -136,6 +136,13 @@ module.exports = function (projGenerator, props, projectType) {
           assert(helpText.match(/--vscode/));
           assert(helpText.match(/# Use preconfigured VSCode settings/));
         });
+
+        it('has packageManager option set up', () => {
+          const gen = testUtils.testSetUpGen(projGenerator);
+          const helpText = gen.help();
+          assert(helpText.match(/--packageManager/));
+          assert(helpText.match(/# Change the default package manager/));
+        });
       });
     });
 
@@ -493,6 +500,73 @@ module.exports = function (projGenerator, props, projectType) {
         assert.jsonFileContent('package.json', {
           name: props.name,
           description: props.name,
+        });
+      });
+    });
+
+    describe('set npm packageManager', () => {
+      before(() => {
+        return helpers.run(projGenerator).withOptions({
+          packageManager: 'npm',
+        });
+      });
+      it('check .yo-rc.json', () => {
+        assert.file('.yo-rc.json');
+        assert.jsonFileContent('.yo-rc.json', {
+          '@loopback/cli': {
+            packageManager: 'npm',
+          },
+        });
+      });
+    });
+
+    describe('set yarn packageManager', () => {
+      before(() => {
+        return helpers.run(projGenerator).withOptions({
+          packageManager: 'yarn',
+        });
+      });
+      it('check .yo-rc.json', () => {
+        assert.file('.yo-rc.json');
+        assert.jsonFileContent('.yo-rc.json', {
+          '@loopback/cli': {
+            packageManager: 'yarn',
+          },
+        });
+      });
+    });
+
+    describe('set invalid packageManager', () => {
+      it('get invalid error', () => {
+        const result = testUtils
+          .executeGenerator(projGenerator)
+          .withOptions({packageManager: 'invalidPkgManager'})
+          .toPromise();
+
+        return expect(result).to.be.rejectedWith(
+          /Package manager 'invalidPkgManager' is not supported\. Use npm or yarn\./,
+        );
+      });
+    });
+
+    describe('test yarn prompt', () => {
+      before(() => {
+        return helpers.run(projGenerator).withPrompts(
+          Object.assign(
+            {
+              yarn: true,
+            },
+            props,
+          ),
+        );
+      });
+
+      it('check .yo-rc.json', () => {
+        assert.file('.yo-rc.json');
+        assert.jsonFileContent('.yo-rc.json', {
+          '@loopback/cli': {
+            packageManager: 'yarn',
+          },
         });
       });
     });


### PR DESCRIPTION
One of the commits ignores the prompt when checking required in a model.
The other adds the functionality of using different package managers.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
