### PR TITLE
fix(repository-json-schema): avoid title inheritance

### DIFF
--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -13,8 +13,8 @@ import {
   resolveType,
 } from '@loopback/repository';
 import debugFactory from 'debug';
-import {JsonSchema} from './index';
 import {inspect} from 'util';
+import {JsonSchema} from './index';
 import {JSON_SCHEMA_KEY} from './keys';
 const debug = debugFactory('loopback:repository-json-schema:build-schema');
 
@@ -414,7 +414,6 @@ export function modelToJsonSchema<T extends object>(
   debug('Model settings', meta.settings);
 
   const title = buildSchemaTitle(ctor, meta, options);
-
   if (options.visited[title]) return options.visited[title];
 
   const result: JsonSchema = {title};
@@ -474,6 +473,10 @@ export function modelToJsonSchema<T extends object>(
       // Do not cascade `partial` to nested properties
       delete propOptions.partial;
     }
+    // `title` is the unique identity of a schema,
+    // it should be removed from the `options`
+    // when generating the relation or property schemas
+    delete propOptions.title;
 
     const propSchema = getJsonSchema(referenceType, propOptions);
 
@@ -502,13 +505,11 @@ export function modelToJsonSchema<T extends object>(
       const relMeta = meta.relations[r];
       const targetType = resolveType(relMeta.target);
 
+      // `title` is the unique identity of a schema,
+      // it should be removed from the `options`
+      // when generating the relation or property schemas
       const targetOptions = {...options};
-      if (targetOptions.title) {
-        // `title` is the unique identity of a schema,
-        // it should be removed from the `options`
-        // when generating the relation schemas
-        delete targetOptions.title;
-      }
+      delete targetOptions.title;
 
       const targetSchema = getJsonSchema(targetType, targetOptions);
       const targetRef = {$ref: `#/definitions/${targetSchema.title}`};


### PR DESCRIPTION
link to https://github.com/strongloop/loopback-next/issues/5088#issuecomment-617696920

https://github.com/strongloop/loopback-next/pull/5108 fixed the relation property's schema title, this PR also fixes it for the regular property.

Relation property:
```ts
 @hasMany(() => Child)
  children: Child[];
```

Regular property:
```ts
 @property.array(Child)
  children: Child[];
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
