### PR TITLE
feat(context): add `BindingKey.generate()` to generate unique binding keys

### DIFF
--- a/packages/context/src/__tests__/unit/binding-key.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-key.unit.ts
@@ -58,4 +58,24 @@ describe('BindingKey', () => {
       });
     });
   });
+
+  describe('generate', () => {
+    it('generates binding key without namespace', () => {
+      const key1 = BindingKey.generate().key;
+      expect(key1).to.match(
+        /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+      );
+      const key2 = BindingKey.generate().key;
+      expect(key1).to.not.eql(key2);
+    });
+
+    it('generates binding key with namespace', () => {
+      const key1 = BindingKey.generate('services').key;
+      expect(key1).to.match(
+        /^services\.[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
+      );
+      const key2 = BindingKey.generate('services').key;
+      expect(key1).to.not.eql(key2);
+    });
+  });
 });

--- a/packages/context/src/binding-key.ts
+++ b/packages/context/src/binding-key.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {v4} from 'uuid';
 export type BindingAddress<T = unknown> = string | BindingKey<T>;
 
 export class BindingKey<ValueType> {
@@ -118,5 +119,15 @@ export class BindingKey<ValueType> {
     const suffix = BindingKey.CONFIG_NAMESPACE;
     const bindingKey = key ? `${key}:${suffix}` : suffix;
     return bindingKey;
+  }
+
+  /**
+   * Generate a unique binding key with `uuid`
+   * @param namespace - Namespace for the binding
+   */
+  static generate<T>(namespace = ''): BindingKey<T> {
+    const prefix = namespace ? `${namespace}.` : '';
+    const uuid = v4();
+    return BindingKey.create(`${prefix}${uuid}`);
   }
 }


### PR DESCRIPTION
Some bindings are created as extensions to a given extension point. These
bindings use tags and their keys do not matter for discovery.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
