### PR TITLE
feat(cli): uses `HttpErrors` for openapi service proxies

### DIFF
--- a/packages/cli/generators/openapi/templates/src/services/service-proxy-template.ts.ejs
+++ b/packages/cli/generators/openapi/templates/src/services/service-proxy-template.ts.ejs
@@ -1,6 +1,7 @@
 import util from 'util';
-import {getService} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
+import {HttpErrors} from '@loopback/rest';
+import {getService} from '@loopback/service-proxy';
 import {<%- dataSourceClassName %>} from '../datasources';
 
 <%_
@@ -92,8 +93,8 @@ function cast(proxy: Record<string, Function>): <%- serviceClassName %> {
       if (response.status < 400) {
         return response.body;
       }
-      const err = util.format('%O', response);
-      throw new Error(err);
+      const err = HttpErrors(response.status, response.statusText, response);
+      throw err;
     }
   }
   return methods as <%- serviceClassName %>;

--- a/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
@@ -15,8 +15,9 @@ export * from './open-api.service';
 
 exports[`generates files with --client and --datasource for an existing datasource 2`] = `
 import util from 'util';
-import {getService} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
+import {HttpErrors} from '@loopback/rest';
+import {getService} from '@loopback/service-proxy';
 import {PetStoreDataSource} from '../datasources';
 
 import {Pet} from '../models/pet.model';
@@ -141,8 +142,8 @@ function cast(proxy: Record<string, Function>): OpenApiService {
       if (response.status < 400) {
         return response.body;
       }
-      const err = util.format('%O', response);
-      throw new Error(err);
+      const err = HttpErrors(response.status, response.statusText, response);
+      throw err;
     }
   }
   return methods as OpenApiService;
@@ -272,8 +273,9 @@ export * from './open-api.service';
 
 exports[`generates files with --client for an existing datasource 2`] = `
 import util from 'util';
-import {getService} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
+import {HttpErrors} from '@loopback/rest';
+import {getService} from '@loopback/service-proxy';
 import {PetStoreDataSource} from '../datasources';
 
 import {Pet} from '../models/pet.model';
@@ -398,8 +400,8 @@ function cast(proxy: Record<string, Function>): OpenApiService {
       if (response.status < 400) {
         return response.body;
       }
-      const err = util.format('%O', response);
-      throw new Error(err);
+      const err = HttpErrors(response.status, response.statusText, response);
+      throw err;
     }
   }
   return methods as OpenApiService;
@@ -1077,8 +1079,9 @@ export * from './open-api.service';
 
 exports[`openapi-generator with --client does not generates files for server with --no-server 4`] = `
 import util from 'util';
-import {getService} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
+import {HttpErrors} from '@loopback/rest';
+import {getService} from '@loopback/service-proxy';
 import {PetStoreDataSource} from '../datasources';
 
 import {Pet} from '../models/pet.model';
@@ -1203,8 +1206,8 @@ function cast(proxy: Record<string, Function>): OpenApiService {
       if (response.status < 400) {
         return response.body;
       }
-      const err = util.format('%O', response);
-      throw new Error(err);
+      const err = HttpErrors(response.status, response.statusText, response);
+      throw err;
     }
   }
   return methods as OpenApiService;
@@ -1769,8 +1772,9 @@ export * from './open-api.service';
 
 exports[`openapi-generator with --client generates all files for both server and client 6`] = `
 import util from 'util';
-import {getService} from '@loopback/service-proxy';
 import {inject, Provider} from '@loopback/core';
+import {HttpErrors} from '@loopback/rest';
+import {getService} from '@loopback/service-proxy';
 import {PetStoreDataSource} from '../datasources';
 
 import {Pet} from '../models/pet.model';
@@ -1895,8 +1899,8 @@ function cast(proxy: Record<string, Function>): OpenApiService {
       if (response.status < 400) {
         return response.body;
       }
-      const err = util.format('%O', response);
-      throw new Error(err);
+      const err = HttpErrors(response.status, response.statusText, response);
+      throw err;
     }
   }
   return methods as OpenApiService;


### PR DESCRIPTION


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
