### PR TITLE
feat: populate x-typescript-type for openapi schema

### DIFF
--- a/packages/openapi-v3/src/__tests__/unit/decorators/query.decorator.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/decorators/query.decorator.unit.ts
@@ -32,6 +32,7 @@ describe('sugar decorators for filter and where', () => {
             schema: {
               type: 'object',
               title: 'MyModel.Filter',
+              'x-typescript-type': '@loopback/repository#Filter<MyModel>',
               properties: {
                 fields: {
                   title: 'MyModel.Fields',
@@ -67,6 +68,7 @@ describe('sugar decorators for filter and where', () => {
             schema: {
               type: 'object',
               title: 'MyModel.Filter',
+              'x-typescript-type': '@loopback/repository#Filter<MyModel>',
               properties: {
                 fields: {
                   title: 'MyModel.Fields',
@@ -109,6 +111,7 @@ describe('sugar decorators for filter and where', () => {
             schema: {
               type: 'object',
               title: 'MyModel.Filter',
+              'x-typescript-type': '@loopback/repository#Filter<MyModel>',
               properties: {
                 fields: {
                   title: 'MyModel.Fields',
@@ -139,6 +142,7 @@ describe('sugar decorators for filter and where', () => {
             schema: {
               type: 'object',
               title: 'MyModel.WhereFilter',
+              'x-typescript-type': '@loopback/repository#Where<MyModel>',
               additionalProperties: true,
             },
           },

--- a/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
+++ b/packages/openapi-v3/src/__tests__/unit/filter-schema.unit.ts
@@ -22,6 +22,7 @@ describe('filterSchema', () => {
     expect(MyUserModel.definition.name).to.eql('my-user-model');
     expect(schema).to.eql({
       title: 'my-user-model.Filter',
+      'x-typescript-type': '@loopback/repository#Filter<MyUserModel>',
       properties: {
         where: {
           type: 'object',
@@ -51,6 +52,7 @@ describe('filterSchema', () => {
     expect(MyUserModel.definition.name).to.eql('my-user-model');
     expect(schema).to.eql({
       title: 'my-user-model.Filter',
+      'x-typescript-type': '@loopback/repository#Filter<MyUserModel>',
       properties: {
         fields: {
           type: 'object',
@@ -84,6 +86,7 @@ describe('filterSchema', () => {
     expect(CustomUserModel.definition.name).to.eql('CustomUserModel');
     expect(schema).to.eql({
       title: 'CustomUserModel.Filter',
+      'x-typescript-type': '@loopback/repository#Filter<CustomUserModel>',
       properties: {
         where: {
           type: 'object',

--- a/packages/openapi-v3/src/filter-schema.ts
+++ b/packages/openapi-v3/src/filter-schema.ts
@@ -9,6 +9,7 @@ import {
   getWhereJsonSchemaFor,
   Model,
 } from '@loopback/repository-json-schema';
+import {isSchemaObject} from 'openapi3-ts';
 import {jsonToSchemaObject} from './json-to-schema';
 import {SchemaObject} from './types';
 
@@ -28,6 +29,11 @@ export function getFilterSchemaFor(
 ): SchemaObject {
   const jsonSchema = getFilterJsonSchemaFor(modelCtor, options);
   const schema = jsonToSchemaObject(jsonSchema);
+  if (isSchemaObject(schema)) {
+    schema[
+      'x-typescript-type'
+    ] = `@loopback/repository#Filter<${modelCtor.name}>`;
+  }
   return schema;
 }
 
@@ -43,5 +49,10 @@ export function getFilterSchemaFor(
 export function getWhereSchemaFor(modelCtor: typeof Model): SchemaObject {
   const jsonSchema = getWhereJsonSchemaFor(modelCtor);
   const schema = jsonToSchemaObject(jsonSchema);
+  if (isSchemaObject(schema)) {
+    schema[
+      'x-typescript-type'
+    ] = `@loopback/repository#Where<${modelCtor.name}>`;
+  }
   return schema;
 }

--- a/packages/openapi-v3/src/json-to-schema.ts
+++ b/packages/openapi-v3/src/json-to-schema.ts
@@ -138,6 +138,11 @@ export function jsonToSchemaObject(
   }
 
   delete result[converted];
+  // Check if the description contains information about TypeScript type
+  const matched = result.description?.match(/^\(tsType: (.+), schemaOptions:/);
+  if (matched) {
+    result['x-typescript-type'] = matched[1];
+  }
   return result;
 }
 

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -468,7 +468,8 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomTypePartial: {
               title: 'CustomTypePartial',
-              description: "(Schema options: { partial: 'deep' })",
+              description:
+                "(tsType: Partial<CustomType>, schemaOptions: { partial: 'deep' })",
               properties: {
                 prop: {
                   type: 'string',
@@ -566,7 +567,8 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomTypePartial: {
               title: 'CustomTypePartial',
-              description: "(Schema options: { partial: 'deep' })",
+              description:
+                "(tsType: Partial<CustomType>, schemaOptions: { partial: 'deep' })",
               properties: {
                 prop: {
                   type: 'string',
@@ -975,7 +977,9 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
-            description: `(Schema options: { includeRelations: true })`,
+            description:
+              `(tsType: ProductWithRelations, ` +
+              `schemaOptions: { includeRelations: true })`,
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -993,7 +997,9 @@ describe('build-schema', () => {
         },
         additionalProperties: false,
         title: 'CategoryWithRelations',
-        description: `(Schema options: { includeRelations: true })`,
+        description:
+          `(tsType: CategoryWithRelations, ` +
+          `schemaOptions: { includeRelations: true })`,
       };
       const jsonSchema = getJsonSchema(Category, {includeRelations: true});
       expect(jsonSchema).to.deepEqual(expectedSchema);
@@ -1018,7 +1024,9 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
-            description: `(Schema options: { includeRelations: true })`,
+            description:
+              `(tsType: ProductWithRelations, ` +
+              `schemaOptions: { includeRelations: true })`,
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -1037,7 +1045,9 @@ describe('build-schema', () => {
         },
         additionalProperties: false,
         title: 'CategoryWithoutPropWithRelations',
-        description: `(Schema options: { includeRelations: true })`,
+        description:
+          `(tsType: CategoryWithoutPropWithRelations, ` +
+          `schemaOptions: { includeRelations: true })`,
       };
 
       // To check for case when there are no other properties than relational
@@ -1209,7 +1219,9 @@ describe('build-schema', () => {
             description: {type: 'string'},
           },
           additionalProperties: false,
-          description: `(Schema options: { exclude: [ 'id' ] })`,
+          description:
+            `(tsType: Omit<Product, 'id'>, ` +
+            `schemaOptions: { exclude: [ 'id' ] })`,
         });
       });
 
@@ -1231,7 +1243,9 @@ describe('build-schema', () => {
             description: {type: 'string'},
           },
           additionalProperties: false,
-          description: `(Schema options: { exclude: [ 'id', 'name' ] })`,
+          description:
+            `(tsType: Omit<Product, 'id' | 'name'>, ` +
+            `schemaOptions: { exclude: [ 'id', 'name' ] })`,
         });
       });
 
@@ -1276,7 +1290,8 @@ describe('build-schema', () => {
         expect(optionalIdSchema.required).to.deepEqual(['name']);
         expect(optionalIdSchema.title).to.equal('ProductOptional_id_');
         expect(optionalIdSchema.description).to.endWith(
-          `(Schema options: { optional: [ 'id' ] })`,
+          `(tsType: @loopback/repository-json-schema#Optional<Product, 'id'>, ` +
+            `schemaOptions: { optional: [ 'id' ] })`,
         );
       });
 
@@ -1293,7 +1308,8 @@ describe('build-schema', () => {
           'ProductOptional_id-name_',
         );
         expect(optionalIdAndNameSchema.description).to.endWith(
-          `(Schema options: { optional: [ 'id', 'name' ] })`,
+          `(tsType: @loopback/repository-json-schema#Optional<Product, 'id' | 'name'>, ` +
+            `schemaOptions: { optional: [ 'id', 'name' ] })`,
         );
       });
 
@@ -1319,7 +1335,8 @@ describe('build-schema', () => {
         expect(optionalNameSchema.required).to.deepEqual(['id']);
         expect(optionalNameSchema.title).to.equal('ProductOptional_name_');
         expect(optionalNameSchema.description).to.endWith(
-          `(Schema options: { optional: [ 'name' ] })`,
+          `(tsType: @loopback/repository-json-schema#Optional<Product, 'name'>,` +
+            ` schemaOptions: { optional: [ 'name' ] })`,
         );
 
         optionalNameSchema = getJsonSchema(Product, {
@@ -1329,7 +1346,8 @@ describe('build-schema', () => {
         expect(optionalNameSchema.required).to.deepEqual(['id']);
         expect(optionalNameSchema.title).to.equal('ProductOptional_name_');
         expect(optionalNameSchema.description).to.endWith(
-          `(Schema options: { optional: [ 'name' ] })`,
+          `(tsType: @loopback/repository-json-schema#Optional<Product, 'name'>, ` +
+            `schemaOptions: { optional: [ 'name' ] })`,
         );
       });
 
@@ -1359,7 +1377,9 @@ describe('build-schema', () => {
           'ProductOptional_name_Excluding_id_',
         );
         expect(bothOptionsSchema.description).to.endWith(
-          `(Schema options: { exclude: [ 'id' ], optional: [ 'name' ] })`,
+          `(tsType: @loopback/repository-json-schema#` +
+            `Optional<Omit<Product, 'id'>, 'name'>, ` +
+            `schemaOptions: { exclude: [ 'id' ], optional: [ 'name' ] })`,
         );
       });
     });

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -17,10 +17,10 @@ import {expect} from '@loopback/testlab';
 import {
   buildModelCacheKey,
   getNavigationalPropertyForRelation,
+  JsonSchema,
   metaToJsonProperty,
   modelToJsonSchema,
   stringTypeToWrapper,
-  JsonSchema,
 } from '../..';
 
 describe('build-schema', () => {
@@ -330,7 +330,8 @@ describe('build-schema', () => {
       expect(schema.definitions).to.containEql({
         ChildWithRelations: {
           title: 'ChildWithRelations',
-          description: '(Schema options: { includeRelations: true })',
+          description:
+            '(tsType: ChildWithRelations, schemaOptions: { includeRelations: true })',
           properties: {name: {type: 'string'}},
           additionalProperties: false,
         },

--- a/packages/repository-json-schema/src/index.ts
+++ b/packages/repository-json-schema/src/index.ts
@@ -18,3 +18,25 @@ export {JsonSchema, Model} from '@loopback/repository';
 export * from './build-schema';
 export * from './filter-json-schema';
 export * from './keys';
+
+/**
+ * Optional
+ * @desc From `T` make a set of properties by key `K` become optional
+ * @example
+ *    type Props = {
+ *      name: string;
+ *      age: number;
+ *      visible: boolean;
+ *    };
+ *
+ *    // Expect: { name?: string; age?: number; visible?: boolean; }
+ *    type Props = Optional<Props>;
+ *
+ *    // Expect: { name: string; age?: number; visible?: boolean; }
+ *    type Props = Optional<Props, 'age' | 'visible'>;
+ */
+export type Optional<T extends object, K extends keyof T = keyof T> = Omit<
+  T,
+  K
+> &
+  Partial<Pick<T, K>>;

--- a/packages/repository/src/common-types.ts
+++ b/packages/repository/src/common-types.ts
@@ -101,6 +101,7 @@ export interface Count {
 export const CountSchema = {
   type: 'object',
   title: 'loopback.Count',
+  'x-typescript-type': '@loopback/repository#Count',
   properties: {count: {type: 'number'}},
 };
 


### PR DESCRIPTION
The `x-typescript-type` can help client code generation tool such as `lb4 openapi --client` to use the built-in TypeScript types.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
