### PR TITLE
chore(cli): remove inquirer@7.0.x

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,6 @@
     "debug": "^4.1.1",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
-    "inquirer": "~7.0.7",
     "inquirer-autocomplete-prompt": "^1.0.2",
     "json5": "^2.1.3",
     "latest-version": "^5.1.0",


### PR DESCRIPTION
Test if inquirer@7.1.x works with windows.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
