### PR TITLE
test(cron): use events to synchronize timing for assertions

### DIFF
--- a/extensions/cron/package-lock.json
+++ b/extensions/cron/package-lock.json
@@ -65,6 +65,30 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"p-event": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
+			"integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
+			"dev": true,
+			"requires": {
+				"p-timeout": "^2.0.1"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-timeout": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"dev": true,
+			"requires": {
+				"p-finally": "^1.0.0"
+			}
+		},
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -27,7 +27,8 @@
     "@loopback/build": "^5.2.0",
     "@loopback/eslint-config": "^6.0.4",
     "@loopback/testlab": "^3.1.1",
-    "@types/node": "^10.17.21"
+    "@types/node": "^10.17.21",
+    "p-event": "^4.1.0"
   },
   "keywords": [
     "LoopBack",


### PR DESCRIPTION
Timeout-based tests are not reliable. Switch to explicit events for coordination. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
