### PR TITLE
feat(build): don't reject console logs when tests failed

### DIFF
--- a/packages/build/src/fail-on-console-logs.js
+++ b/packages/build/src/fail-on-console-logs.js
@@ -46,6 +46,10 @@ process.on('warning', warning => {
 });
 
 process.on('exit', code => {
+  // Don't complain about console logs when some of the tests have failed.
+  // It's a common practice to add temporary console logs while troubleshooting.
+  if (code) return;
+
   if (!warnings.length) {
     for (const w of warnings) {
       originalConsole.warn(w);


### PR DESCRIPTION
Improve `lb-mocha` to complain about invalid usage of console logs when some of the tests failed. It's a common practice to add temporary console logs while troubleshooting.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
