### PR TITLE
docs: oauth2 provider migration

### DIFF
--- a/docs/site/migration/auth/oauth2.md
+++ b/docs/site/migration/auth/oauth2.md
@@ -6,12 +6,23 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-oauth2.html
 ---
 
-{% include tip.html content="
-Missing instructions for your LoopBack 3 use case? Please report a [Migration docs issue](https://github.com/strongloop/loopback-next/issues/new?labels=question,Migration,Docs&template=Migration_docs.md) on GitHub to let us know.
-" %}
+[`loopback-component-oauth2`](https://github.com/strongloop/loopback-component-oauth2)
+is used to setup a LoopBack application as an [OAuth 2.0](https://oauth.net/2/)
+server. It can be applied when people implement their LoopBack application as an
+OAuth 2.0 provider. For example, the API gateway application.
 
-{% include note.html content="
-This is a placeholder page, the task of adding content is tracked by the
-following GitHub issue:
-[loopback-next#3959](https://github.com/strongloop/loopback-next/issues/3959)
-" %}
+As of now, LoopBack 4 focuses on redirecting to third-party OAuth2 providers
+like [Google](https://developers.google.com/identity/protocols/oauth2) or
+[Facebook](https://developers.facebook.com/docs/facebook-login/) for
+authentication and authorization, instead of turning itself into an OAuth 2.0
+provider. And given the complexity of
+[`loopback-component-oauth2`](https://github.com/strongloop/loopback-component-oauth2),
+we decide to defer the migration guide for it.
+
+We have a simplified OAuth 2.0 server implementation in extension
+[authentication-passport](https://github.com/strongloop/loopback-next/blob/master/extensions/authentication-passport)'s
+test fixtures, which sets up an Express application as an OAuth 2.0 provider.
+You can find the code in file
+[mock-oauth2-social-app.ts](https://github.com/strongloop/loopback-next/blob/master/extensions/authentication-passport/src/__tests__/acceptance/fixtures/mock-oauth2-social-app.ts).
+At this moment people who are interested to create such a provider can use it as
+a reference.


### PR DESCRIPTION
After discussing with @raymondfeng and @deepakrkris we decided to update the documentations as this stage and postpone the migration guide. Thanks for the thoughtful suggestions!

Will close https://github.com/strongloop/loopback-next/issues/5184 after landing.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
