### PR TITLE
feat: remove hand-written datasource `stop()` method

### DIFF
--- a/docs/site/OpenAPI-generator.md
+++ b/docs/site/OpenAPI-generator.md
@@ -401,12 +401,7 @@ connection to the endpoint that exposes an OpenAPI spec.
 %}
 
 ```ts
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -417,6 +412,10 @@ const config = {
   positional: true,
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The `stop()` method is inherited from `juggler.DataSource`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class Test2DataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -428,21 +427,6 @@ export class Test2DataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }
 ```

--- a/examples/multi-tenancy/src/datasources/db.datasource.ts
+++ b/examples/multi-tenancy/src/datasources/db.datasource.ts
@@ -1,9 +1,4 @@
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -24,20 +19,5 @@ export class DbDataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }

--- a/examples/multi-tenancy/src/datasources/db1.datasource.ts
+++ b/examples/multi-tenancy/src/datasources/db1.datasource.ts
@@ -1,9 +1,4 @@
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -22,20 +17,5 @@ export class Db1DataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }

--- a/examples/multi-tenancy/src/datasources/db2.datasource.ts
+++ b/examples/multi-tenancy/src/datasources/db2.datasource.ts
@@ -1,9 +1,4 @@
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -22,20 +17,5 @@ export class Db2DataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }

--- a/examples/validation-app/src/datasources/ds.datasource.ts
+++ b/examples/validation-app/src/datasources/ds.datasource.ts
@@ -3,12 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -29,20 +24,5 @@ export class DsDataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }

--- a/packages/cli/generators/datasource/templates/datasource.ts.ejs
+++ b/packages/cli/generators/datasource/templates/datasource.ts.ejs
@@ -1,13 +1,12 @@
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = <%- dsConfigString %>;
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The `stop()` method is inherited from `juggler.DataSource`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class <%= className %>DataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -19,20 +18,5 @@ export class <%= className %>DataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }

--- a/packages/cli/snapshots/integration/generators/datasource.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/datasource.integration.snapshots.js
@@ -8,12 +8,7 @@
 'use strict';
 
 exports[`lb4 datasource integration basic datasource scaffolds correct file with args 1`] = `
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -23,6 +18,10 @@ const config = {
   file: undefined
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -34,21 +33,6 @@ export class DsDataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }
 
@@ -56,12 +40,7 @@ export class DsDataSource extends juggler.DataSource
 
 
 exports[`lb4 datasource integration basic datasource scaffolds correct file with input 1`] = `
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -71,6 +50,10 @@ const config = {
   file: undefined
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -83,33 +66,13 @@ export class DsDataSource extends juggler.DataSource
   ) {
     super(dsConfig);
   }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
-  }
 }
 
 `;
 
 
 exports[`lb4 datasource integration correctly coerces setting input of type number 1`] = `
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -124,6 +87,10 @@ const config = {
   schema: undefined
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -136,33 +103,13 @@ export class DsDataSource extends juggler.DataSource
   ) {
     super(dsConfig);
   }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
-  }
 }
 
 `;
 
 
 exports[`lb4 datasource integration correctly coerces setting input of type object and array 1`] = `
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -179,6 +126,10 @@ const config = {
   crud: false
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -191,33 +142,13 @@ export class DsDataSource extends juggler.DataSource
   ) {
     super(dsConfig);
   }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
-  }
 }
 
 `;
 
 
 exports[`lb4 datasource integration scaffolds correct file with cloudant input 1`] = `
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -230,6 +161,10 @@ const config = {
   modelIndex: undefined
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class DsDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -241,21 +176,6 @@ export class DsDataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }
 

--- a/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/openapi-client.integration.snapshots.js
@@ -1022,12 +1022,7 @@ export * from './pet-store.datasource';
 
 
 exports[`openapi-generator with --client does not generates files for server with --no-server 2`] = `
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -1038,6 +1033,10 @@ const config = {
   positional: true
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class PetStoreDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -1049,21 +1048,6 @@ export class PetStoreDataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }
 
@@ -1715,12 +1699,7 @@ export * from './pet-store.datasource';
 
 
 exports[`openapi-generator with --client generates all files for both server and client 4`] = `
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -1731,6 +1710,10 @@ const config = {
   positional: true
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The \`stop()\` method is inherited from \`juggler.DataSource\`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class PetStoreDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -1742,21 +1725,6 @@ export class PetStoreDataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }
 

--- a/packages/cli/test/fixtures/openapi/3.0/src/datasources/pet-store.datasource.ts
+++ b/packages/cli/test/fixtures/openapi/3.0/src/datasources/pet-store.datasource.ts
@@ -3,12 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  inject,
-  lifeCycleObserver,
-  LifeCycleObserver,
-  ValueOrPromise,
-} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {juggler} from '@loopback/repository';
 
 const config = {
@@ -19,6 +14,10 @@ const config = {
   positional: false,
 };
 
+// Observe application's life cycle to disconnect the datasource when
+// application is stopped. This allows the application to be shut down
+// gracefully. The `stop()` method is inherited from `juggler.DataSource`.
+// Learn more at https://loopback.io/doc/en/lb4/Life-cycle.html
 @lifeCycleObserver('datasource')
 export class PetStoreDataSource extends juggler.DataSource
   implements LifeCycleObserver {
@@ -30,20 +29,5 @@ export class PetStoreDataSource extends juggler.DataSource
     dsConfig: object = config,
   ) {
     super(dsConfig);
-  }
-
-  /**
-   * Start the datasource when application is started
-   */
-  start(): ValueOrPromise<void> {
-    // Add your logic here to be invoked when the application is started
-  }
-
-  /**
-   * Disconnect the datasource when application is stopped. This allows the
-   * application to be shut down gracefully.
-   */
-  stop(): ValueOrPromise<void> {
-    return super.disconnect();
   }
 }


### PR DESCRIPTION
Use the `stop()` method provided by `juggler.DataSource` instead.

See also #5220

~~CI builds are failing now and that's expected, because this PR requires a newer version of juggler, I'll rebase it on top of a newer master once the relevant RenovateBot's pull request is landed.~~

@raymondfeng @agnes512 let's continue our discussion from https://github.com/strongloop/loopback-next/pull/5261 in this pull request please.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
