### PR TITLE
docs(http-caching-proxy): mention alternative libraries

### DIFF
--- a/packages/http-caching-proxy/README.md
+++ b/packages/http-caching-proxy/README.md
@@ -24,7 +24,7 @@ caching and snapshots:
 
 - The first request is forwarded to the actual backend and the response is
   stored as a snapshot.
-- Subsequent requests are served by the proxy using the cached snaphost.
+- Subsequent requests are served by the proxy using the cached snapshot.
 - Snapshot older than a configured time are discarded and the first next request
   will fetch the real response from the backend.
 
@@ -88,6 +88,20 @@ await proxy.stop();
 
 See the auto-generated documentation at
 [loopback.io](https://loopback.io/doc/en/lb4/apidocs.http-caching-proxy.html)
+
+## Alternative solutions for HTTP-based integration testing
+
+A caching proxy is great if you want your tests to talk to the real backend
+service. There are many cases where such behavior is not desirable and the tests
+must run fully isolated. If that's your situation, then please consider using a
+tool that can record and replay HTTP interactions, for example:
+
+- [nock](https://www.npmjs.com/package/nock)
+- [Polly.JS](https://netflix.github.io/pollyjs/#/)
+
+Just make sure you have a process in place to verify that your recorded
+interactions are staying up to date with the actual behavior of the backend
+service!
 
 ## Contributions
 


### PR DESCRIPTION
Explain when the proxy is not the right tool for the job and offer two popular tools that can record and replay HTTP interactions: Polly.JS and nock.

(This is based on a conversation I had with a LB user looking for guidance.)

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
