### PR TITLE
fix(booter-lb3app): rename ds binding key

### DIFF
--- a/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
+++ b/packages/booter-lb3app/src/__tests__/acceptance/booter-lb3app.acceptance.ts
@@ -236,7 +236,7 @@ describe('booter-lb3app', () => {
     it('binds datasource to the context', async () => {
       const expected = require('../../../fixtures/app-with-model').dataSources
         .memory;
-      const dsBindings = app.findByTag('datasource');
+      const dsBindings = app.findByTag('lb3-datasource');
       const key = dsBindings[0].key;
       const ds = await app.get(key);
       expect(ds).to.eql(expected);

--- a/packages/booter-lb3app/src/lb3app.booter.ts
+++ b/packages/booter-lb3app/src/lb3app.booter.ts
@@ -69,7 +69,7 @@ export class Lb3AppBooter implements Booter {
         const ds = dataSources[key];
         if (visited.includes(ds)) return;
         visited.push(ds);
-        this.app.bind(`datasources.lb3-${key}`).to(ds).tag('datasource');
+        this.app.bind(`lb3-datasources.${key}`).to(ds).tag('lb3-datasource');
       });
     }
 


### PR DESCRIPTION
Rename the key from `datasources.lb3-{ds}` to `lb3-datasources.{ds}`

See https://github.com/strongloop/loopback-next/pull/3779#discussion_r327659012 for previous discussion.

Proposal to rename the binding key for datasources in order to match the proposed naming for lb3 models (see https://github.com/strongloop/loopback-next/pull/5251#discussion_r416616108).


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
