### PR TITLE
feat(context): allows bindings with singleton/context scopes to be refreshed

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -270,6 +270,28 @@ export class Binding<T = BoundValue> extends EventEmitter {
   }
 
   /**
+   * Invalidate the binding cache so that its value will be reloaded next time.
+   * This is useful to force reloading a singleton when its configuration or
+   * dependencies are changed.
+   * **WARNING**: The state held in the cached value will be gone.
+   *
+   * @param ctx - Context object
+   */
+  refresh(ctx: Context) {
+    if (!this._cache) return;
+    if (this.scope === BindingScope.SINGLETON) {
+      // Cache the value
+      const ownerCtx = ctx.getOwnerContext(this.key);
+      if (ownerCtx != null) {
+        this._cache.delete(ownerCtx);
+      }
+    } else if (this.scope === BindingScope.CONTEXT) {
+      // Cache the value at the current context
+      this._cache.delete(ctx);
+    }
+  }
+
+  /**
    * This is an internal function optimized for performance.
    * Users should use `@inject(key)` or `ctx.get(key)` instead.
    *


### PR DESCRIPTION
This makes it possible to reload singleton/context scoped bindings when its
configuration or dependencies are changed. For example, a logging provider
can be refreshed to pick up a new logging level. The same functionality can
be achieved with transient scope but with much more overheads.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
