### PR TITLE
feat(core): allow options for artifact registration on an application

### DIFF
--- a/packages/core/src/__tests__/unit/application-lifecycle.unit.ts
+++ b/packages/core/src/__tests__/unit/application-lifecycle.unit.ts
@@ -183,6 +183,15 @@ describe('Application life cycle', () => {
       expect(observer.status).to.equal('stopped');
     });
 
+    it('registers life cycle observers with options', async () => {
+      const app = new Application();
+      const binding = app.lifeCycleObserver(MyObserver, {
+        name: 'my-observer',
+        namespace: 'my-observers',
+      });
+      expect(binding.key).to.eql('my-observers.my-observer');
+    });
+
     it('honors @bind', async () => {
       @bind({
         tags: {

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -44,6 +44,14 @@ describe('Application', () => {
       );
     });
 
+    it('binds a controller with custom options', () => {
+      const binding = app.controller(MyController, {
+        name: 'my-controller',
+        namespace: 'my-controllers',
+      });
+      expect(binding.key).to.eql('my-controllers.my-controller');
+    });
+
     it('binds a singleton controller', () => {
       @bind({scope: BindingScope.SINGLETON})
       class MySingletonController {}
@@ -72,6 +80,14 @@ describe('Application', () => {
       expect(findKeysByTag(app, CoreTags.COMPONENT)).to.containEql(
         'components.my-component',
       );
+    });
+
+    it('binds a component with custom namespace', () => {
+      const binding = app.component(MyComponent, {
+        name: 'my-component',
+        namespace: 'my-components',
+      });
+      expect(binding.key).to.eql('my-components.my-component');
     });
 
     it('binds a transient component', () => {
@@ -207,6 +223,12 @@ describe('Application', () => {
       expect(result.constructor.name).to.equal(FakeServer.name);
     });
 
+    it('allows custom namespace', async () => {
+      const name = 'customName';
+      const binding = app.server(FakeServer, {name, namespace: 'my-servers'});
+      expect(binding.key).to.eql('my-servers.customName');
+    });
+
     it('allows binding of multiple servers as an array', async () => {
       const bindings = app.servers([FakeServer, AnotherServer]);
       expect(Array.from(bindings[0].tagNames)).to.containEql(CoreTags.SERVER);
@@ -235,6 +257,16 @@ describe('Application', () => {
       const binding = app.service(MyService, 'my-service');
       expect(Array.from(binding.tagNames)).to.containEql(CoreTags.SERVICE);
       expect(binding.key).to.equal('services.my-service');
+      expect(findKeysByTag(app, CoreTags.SERVICE)).to.containEql(binding.key);
+    });
+
+    it('binds a service with custom namespace', () => {
+      const binding = app.service(MyService, {
+        namespace: 'my-services',
+        name: 'my-service',
+      });
+      expect(Array.from(binding.tagNames)).to.containEql(CoreTags.SERVICE);
+      expect(binding.key).to.equal('my-services.my-service');
       expect(findKeysByTag(app, CoreTags.SERVICE)).to.containEql(binding.key);
     });
 

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -6,6 +6,7 @@
 import {
   Binding,
   BindingFilter,
+  BindingFromClassOptions,
   BindingTemplate,
   bindingTemplateFor,
   Constructor,
@@ -31,10 +32,9 @@ export type ServiceInterface = string | symbol | Function;
 /**
  * Options to register a service binding
  */
-export type ServiceOptions = {
-  name?: string;
+export interface ServiceOptions extends BindingFromClassOptions {
   interface?: ServiceInterface;
-};
+}
 
 /**
  * `@service` injects a service instance that matches the class or interface.
@@ -162,6 +162,7 @@ export function createServiceBinding<S>(
   const binding = createBindingFromClass(cls, {
     name,
     type: CoreTags.SERVICE,
+    ...options,
   }).apply(asService(options.interface ?? cls));
   return binding;
 }

--- a/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
+++ b/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
@@ -257,6 +257,15 @@ describe('RepositoryMixin dataSource', () => {
     expectDataSourceToBeBound(myApp, FooDataSource, 'bar');
   });
 
+  it('binds dataSource class using options', () => {
+    const myApp = new AppWithRepoMixin();
+    const binding = myApp.dataSource(FooDataSource, {
+      name: 'bar',
+      namespace: 'my-datasources',
+    });
+    expect(binding.key).to.eql('my-datasources.bar');
+  });
+
   it('binds dataSource class using Class name', () => {
     const myApp = new AppWithRepoMixin();
     myApp.dataSource(BarDataSource);

--- a/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
+++ b/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
@@ -27,6 +27,17 @@ describe('ServiceMixin', () => {
     await expectGeocoderToBeBound(myApp);
   });
 
+  it('binds service from app.serviceProvider() with options', async () => {
+    const myApp = new AppWithServiceMixin();
+    const binding = myApp.serviceProvider(GeocoderServiceProvider, {
+      name: 'geo',
+      namespace: 'my-services',
+      defaultScope: BindingScope.SINGLETON,
+    });
+    expect(binding.key).to.eql('my-services.geo');
+    expect(binding.scope).to.eql(BindingScope.SINGLETON);
+  });
+
   it('binds singleton service from app.serviceProvider()', async () => {
     @bind({scope: BindingScope.SINGLETON})
     class SingletonGeocoderServiceProvider extends GeocoderServiceProvider {}

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, Provider} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {Binding, BindingFromClassOptions, Provider} from '@loopback/context';
+import {Application, ServiceOptions} from '@loopback/core';
 
 /**
  * Interface for classes with `new` operator.
@@ -61,9 +61,9 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      */
     serviceProvider<S>(
       provider: Class<Provider<S>>,
-      name?: string,
+      nameOrOptions?: string | ServiceOptions,
     ): Binding<S> {
-      return this.service(provider, name);
+      return this.service(provider, nameOrOptions);
     }
 
     /**
@@ -87,8 +87,11 @@ export function ServiceMixin<T extends Class<any>>(superClass: T) {
      * app.component(ProductComponent);
      * ```
      */
-    public component(component: Class<unknown>, name?: string) {
-      super.component(component, name);
+    public component(
+      component: Class<unknown>,
+      nameOrOptions?: string | BindingFromClassOptions,
+    ) {
+      super.component(component, nameOrOptions);
       this.mountComponentServices(component);
     }
 


### PR DESCRIPTION
The new style allows extra options such as `namespace` to be customized.
One use case is that a sub application might boot artifacts into its own
namespace.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
