### PR TITLE
chore: fix CODEOWNERS for build tooling

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -298,8 +298,8 @@
 #
 # - Issue label: Internal Tooling
 # - Primary owner(s): @raymondfeng
-# - Standby owner(s): @emonddr @raymondfeng
-/bin
+# - Standby owner(s): @emonddr
+/bin @emonddr @raymondfeng
 /packages/build @emonddr @raymondfeng
 /packages/eslint-config @emonddr @raymondfeng
 /packages/tsdocs @emonddr @raymondfeng


### PR DESCRIPTION
While reviewing https://github.com/strongloop/loopback-next/pull/5324, I noticed no code owner was picked for review. Closer inspection of the CODEOWNERS file shown that the entry for `/bin` did not contain any names. 

In this change, I am
- adding missing owners for `/bin` entry
- removing duplicate mention of Raymond in the comment

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
