### PR TITLE
chore: remove codeowners of `/docs`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -84,11 +84,15 @@
 # Fall-back entry for files not assigned to any Functional Areas
 * @bajtos @raymondfeng
 
-# To keep things simple, we assign documentation to all core team members
-# For longer term, we may want to re-organize doc files around functional
-# areas (create a new subdirectory for each functional area), so that
-# we can assign more specific code owners to different doc pages.
-/docs @agnes512 @bajtos @deepakrkris @emonddr @jannyHou @hacksparrow @raymondfeng
+# To keep things simple, we don't assign any owners for the documentation.
+# When some doc pages are changed as part of a pull request changing the
+# implementation, then GitHub will assign the reviewers based on who is
+# owning the code being modified.
+# There will be no code owners assigned for pull requests changing
+# the documentation only. We can improve this situation in the future,
+# e.g. by re-organizing doc pages to align the file structure with functional
+# areas.
+/docs
 
 #
 # CLI (`lb4` infrastructure, commands not covered by functional areas below)


### PR DESCRIPTION
At the moment, whenever a pull request touches a doc file, all team members are assigned as code owners for review. This is not very practical, because almost every pull request adding a new feature with docs included is assigned to everybody.

In this proposal, I am changing CODEOWNERS configuration for `/docs` tree to have NO code owners at all. 
- When some doc pages are changed as part of a pull request changing the implementation, then GitHub will assign the reviewers based on who is owning the code being modified 👌 
- There will be no code owners assigned for pull requests changing the documentation only 🤷  We can improve this situation in the future, e.g. by re-organizing doc pages to align the file structure with functional areas.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
