### PR TITLE
fix(repository): updateById behaves like updateAll when called with a…

### DIFF
--- a/packages/repository/src/__tests__/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -609,6 +609,13 @@ describe('DefaultCrudRepository', () => {
     );
   });
 
+  it('throws error when provided an empty id', async () => {
+    const repo = new DefaultCrudRepository(Note, ds);
+    await expect(repo.updateById(undefined, {title: 't4'})).to.be.rejectedWith(
+      'Invalid Argument: id cannot be undefined',
+    );
+  });
+
   it('implements Repository.updateAll()', async () => {
     const repo = new DefaultCrudRepository(Note, ds);
     await repo.create({title: 't3', content: 'c3'});

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -17,7 +17,7 @@ import {
 } from '../common-types';
 import {EntityNotFoundError} from '../errors';
 import {Entity, Model, PropertyType} from '../model';
-import {Filter, Inclusion, Where, FilterExcludingWhere} from '../query';
+import {Filter, FilterExcludingWhere, Inclusion, Where} from '../query';
 import {
   BelongsToAccessor,
   BelongsToDefinition,
@@ -458,6 +458,9 @@ export class DefaultCrudRepository<
     data: DataObject<T>,
     options?: Options,
   ): Promise<void> {
+    if (id === undefined) {
+      throw new Error('Invalid Argument: id cannot be undefined');
+    }
     const idProp = this.modelClass.definition.idName();
     const where = {} as Where<T>;
     (where as AnyObject)[idProp] = id;


### PR DESCRIPTION
…n undefined value for id

DefaultCrudRepository.updateById behaves like updateAll when it is called with undefined as id value , and as a side effect instead of trying to update a single row/model it updates all the rows. undefined is not a valid value for id, hence the function should throw an appropriate error when undefined is passed in.
I added an argument value check for id, in the updateById function, throws an error, and added a test to unit tests to check for this behaviour.

Fixes #5319

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
