### PR TITLE
feat(context): relax parameter type for isProviderClass()

### DIFF
--- a/packages/context/src/binding-decorator.ts
+++ b/packages/context/src/binding-decorator.ts
@@ -14,7 +14,6 @@ import {
   isProviderClass,
   removeNameAndKeyTags,
 } from './binding-inspector';
-import {Provider} from './provider';
 import {Constructor} from './value-promise';
 
 /**
@@ -97,8 +96,8 @@ export namespace bind {
    */
   export function provider(
     ...specs: BindingSpec[]
-  ): (target: Constructor<Provider<unknown>>) => void {
-    return (target: Constructor<Provider<unknown>>) => {
+  ): (target: Constructor<unknown>) => void {
+    return (target: Constructor<unknown>) => {
       if (!isProviderClass(target)) {
         throw new Error(`Target ${target} is not a Provider`);
       }

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -57,9 +57,11 @@ export type BindingSpec<T = unknown> = BindingTemplate<T> | BindingScopeAndTags;
  * @typeParam T - Value type
  */
 export function isProviderClass<T>(
-  cls: Constructor<T | Provider<T>>,
+  cls: unknown,
 ): cls is Constructor<Provider<T>> {
-  return typeof cls?.prototype?.value === 'function';
+  return (
+    typeof cls === 'function' && typeof cls.prototype?.value === 'function'
+  );
 }
 
 /**

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -396,14 +396,11 @@ export function registerInterceptor(
       : LOCAL_INTERCEPTOR_NAMESPACE;
 
   let binding: Binding<Interceptor>;
-  if (isProviderClass(interceptor as Constructor<Provider<Interceptor>>)) {
-    binding = createBindingFromClass(
-      interceptor as Constructor<Provider<Interceptor>>,
-      {
-        defaultNamespace: namespace,
-        ...options,
-      },
-    );
+  if (isProviderClass(interceptor)) {
+    binding = createBindingFromClass(interceptor, {
+      defaultNamespace: namespace,
+      ...options,
+    });
     if (binding.tagMap[ContextTags.GLOBAL_INTERCEPTOR]) {
       global = true;
     }


### PR DESCRIPTION
This change makes it possible to test if a unknown value is provider class
without casting to Constructor first.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
