### PR TITLE
fix(cli): make yarn related tests conditional on the yarn availablity

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -224,9 +224,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
         type: 'confirm',
         name: 'yarn',
         message: g.f('Yarn is available. Do you prefer to use it by default?'),
-        when:
-          !this.options.packageManager &&
-          this.spawnCommandSync('yarn', ['help'], {stdio: false}).status === 0,
+        when: !this.options.packageManager && utils.isYarnAvailable(),
         default: false,
       },
     ];

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const stream = require('stream');
+const {spawnSync} = require('child_process');
 const readline = require('readline');
 const semver = require('semver');
 const regenerate = require('regenerate');
@@ -718,6 +719,18 @@ function wrapText(text, maxLineLength = 80) {
 
 exports.wrapLine = wrapLine;
 exports.wrapText = wrapText;
+
+/**
+ * Check if `yarn` is installed
+ */
+let yarnInstalled = undefined;
+function isYarnAvailable() {
+  if (yarnInstalled == null) {
+    yarnInstalled = spawnSync('yarn', ['help'], {stdio: false}).status === 0;
+  }
+  return yarnInstalled;
+}
+exports.isYarnAvailable = isYarnAvailable;
 
 // literal strings with artifacts directory locations
 exports.repositoriesDir = 'repositories';

--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -10,7 +10,7 @@ const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const bootstrapCommandFactory = require('@lerna/bootstrap');
 const build = require('@loopback/build');
-
+const utils = require('../../lib/utils');
 const appGenerator = path.join(__dirname, '../../generators/app');
 const rootDir = path.join(__dirname, '../../../..');
 const sandboxDir = path.join(rootDir, 'sandbox');
@@ -74,12 +74,10 @@ describe('app-generator (SLOW)', function () {
   });
 });
 
-build.runShell('yarn', ['help'], {stdio: 'ignore'}).on('close', code => {
-  if (code === 0) return describe('app-generator with Yarn (SLOW)', yarnTest);
-  return describe.skip;
-});
+const isYarnAvailable = utils.isYarnAvailable();
+const yarnTest = isYarnAvailable ? describe : describe.skip;
 
-function yarnTest() {
+yarnTest('app-generator with Yarn (SLOW)', () => {
   const appProps = {
     name: '@loopback/sandbox-yarn-app',
     description: 'My sandbox app with Yarn for LoopBack 4',
@@ -136,7 +134,7 @@ function yarnTest() {
     build.clean(['node', 'run-clean', appProps.outdir]);
     process.chdir(process.cwd());
   });
-}
+});
 
 async function lernaBootstrap(packageManager, ...scopes) {
   const cmd = bootstrapCommandFactory({

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -10,7 +10,8 @@ const yeoman = require('yeoman-environment');
 const testUtils = require('../../test-utils');
 const sinon = require('sinon');
 const path = require('path');
-const deps = require('../../../lib/utils').getDependencies();
+const utils = require('../../../lib/utils');
+const deps = utils.getDependencies();
 const expect = require('@loopback/testlab').expect;
 
 module.exports = function (projGenerator, props, projectType) {
@@ -520,13 +521,37 @@ module.exports = function (projGenerator, props, projectType) {
       });
     });
 
-    describe('set yarn packageManager', () => {
+    const isYarnAvailable = utils.isYarnAvailable();
+    const yarnTest = isYarnAvailable ? describe : describe.skip;
+    yarnTest('set yarn packageManager', () => {
       before(() => {
         return helpers.run(projGenerator).withOptions({
           packageManager: 'yarn',
         });
       });
       it('check .yo-rc.json', () => {
+        assert.file('.yo-rc.json');
+        assert.jsonFileContent('.yo-rc.json', {
+          '@loopback/cli': {
+            packageManager: 'yarn',
+          },
+        });
+      });
+    });
+
+    yarnTest('test yarn prompt', () => {
+      before(() => {
+        return helpers.run(projGenerator).withPrompts(
+          Object.assign(
+            {
+              yarn: true,
+            },
+            props,
+          ),
+        );
+      });
+
+      it('check .yo-rc.json for yarn', () => {
         assert.file('.yo-rc.json');
         assert.jsonFileContent('.yo-rc.json', {
           '@loopback/cli': {
@@ -546,28 +571,6 @@ module.exports = function (projGenerator, props, projectType) {
         return expect(result).to.be.rejectedWith(
           /Package manager 'invalidPkgManager' is not supported\. Use npm or yarn\./,
         );
-      });
-    });
-
-    describe('test yarn prompt', () => {
-      before(() => {
-        return helpers.run(projGenerator).withPrompts(
-          Object.assign(
-            {
-              yarn: true,
-            },
-            props,
-          ),
-        );
-      });
-
-      it('check .yo-rc.json', () => {
-        assert.file('.yo-rc.json');
-        assert.jsonFileContent('.yo-rc.json', {
-          '@loopback/cli': {
-            packageManager: 'yarn',
-          },
-        });
       });
     });
 


### PR DESCRIPTION
`npm run test` fails for `packages/cli` if `yarn` is not installed. This PR tests if `yarn` is available before run yarn related tests.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
