### PR TITLE
feat(repository): to object preserves prototype

### DIFF
--- a/packages/repository/src/__tests__/acceptance/repository.acceptance.ts
+++ b/packages/repository/src/__tests__/acceptance/repository.acceptance.ts
@@ -113,6 +113,18 @@ describe('Repository in Thinking in LoopBack', () => {
     expect(stored).to.containDeep(user);
   });
 
+  it('toObject preserves the prototype of properties', async () => {
+    const DATE = new Date('2020-05-01');
+    const created = await repo.create({
+      createdAt: DATE,
+    });
+
+    expect(created.toObject()).to.deepEqual({
+      id: 1,
+      createdAt: DATE,
+    });
+  });
+
   function givenProductRepository() {
     const db = new DataSource({
       connector: 'memory',

--- a/packages/repository/src/__tests__/fixtures/models/product.model.ts
+++ b/packages/repository/src/__tests__/fixtures/models/product.model.ts
@@ -20,6 +20,11 @@ export class Product extends Entity {
   @property({type: 'string'})
   slug: string;
 
+  @property({
+    type: 'date',
+  })
+  createdAt: Date;
+
   constructor(data?: Partial<Product>) {
     super(data);
   }

--- a/packages/repository/src/__tests__/unit/model/model.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/model.unit.ts
@@ -21,6 +21,7 @@ describe('model', () => {
     .addProperty('lastName', STRING)
     .addProperty('address', 'object')
     .addProperty('phones', 'array')
+    .addProperty('createdAt', Date)
     .addSetting('id', 'id');
 
   const realmCustomerDef = new ModelDefinition('RealmCustomer');
@@ -83,6 +84,7 @@ describe('model', () => {
     email: string;
     firstName: string;
     lastName: string;
+    createdAt?: Date;
     address?: Address;
     phones?: Phone[];
 
@@ -136,6 +138,24 @@ describe('model', () => {
     const customer = new Customer();
     customer.id = '123';
     customer.email = 'xyz@example.com';
+    customer.address = new Address({
+      street: '123 A St',
+      city: 'San Jose',
+      state: 'CA',
+      zipCode: '95131',
+    });
+    customer.phones = [
+      new Phone({label: 'home', number: '111-222-3333'}),
+      new Phone({label: 'work', number: '111-222-5555'}),
+    ];
+    return customer;
+  }
+
+  function createCustomerWithContactAndDate(date: Date) {
+    const customer = new Customer();
+    customer.id = '123';
+    customer.email = 'xyz@example.com';
+    customer.createdAt = date;
     customer.address = new Address({
       street: '123 A St',
       city: 'San Jose',
@@ -332,12 +352,14 @@ describe('model', () => {
   });
 
   it('converts to plain object recursively', () => {
-    const customer = createCustomerWithContact();
+    const aDate = new Date();
+    const customer = createCustomerWithContactAndDate(aDate);
     Object.assign(customer, {unknown: 'abc'});
     Object.assign(customer.address, {unknown: 'xyz'});
     expect(customer.toObject()).to.eql({
       id: '123',
       email: 'xyz@example.com',
+      createdAt: aDate,
       address: {
         street: '123 A St',
         city: 'San Jose',
@@ -352,6 +374,7 @@ describe('model', () => {
     expect(customer.toObject({ignoreUnknownProperties: false})).to.eql({
       id: '123',
       email: 'xyz@example.com',
+      createdAt: aDate,
       unknown: 'abc',
       address: {
         street: '123 A St',


### PR DESCRIPTION
Implements https://github.com/strongloop/loopback-next/issues/3607
Discussion see https://github.com/strongloop/loopback-next/issues/3607#issuecomment-624050020

The new conversion rules are:

> toObject() preserves type of Date, ObjectID and other non-model values. Of course, if a model instance has a property set to a value of another Model, that property must be recursively converted via toObject to a plain object.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
