### PR TITLE
feat(repository): adding hasManyThrough (through model) to hasMany and its helpers

### DIFF
--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-has-many-through-metadata.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/resolve-has-many-through-metadata.unit.ts
@@ -1,0 +1,327 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {
+  Entity,
+  HasManyDefinition,
+  model,
+  ModelDefinition,
+  property,
+  RelationType,
+} from '../../../..';
+import {
+  createTargetConstraint,
+  createThroughConstraint,
+  HasManyThroughResolvedDefinition,
+  resolveHasManyThroughMetadata,
+} from '../../../../relations/has-many/has-many-through.helpers';
+
+describe('HasManyThroughHelpers', () => {
+  context('createThroughConstraint', () => {
+    it('can create constraint for searching through models', () => {
+      const resolved = resolvedMetadata as HasManyThroughResolvedDefinition;
+      const result = createThroughConstraint(resolved, 1);
+      expect(result).to.containEql({categoryId: 1});
+    });
+  });
+  context('createTargetConstraint', () => {
+    it('can create constraint for searching target models', () => {
+      const through1 = createCategoryProductLink({
+        id: 1,
+        categoryId: 2,
+        productId: 9,
+      });
+      const through2 = createCategoryProductLink({
+        id: 2,
+        categoryId: 2,
+        productId: 8,
+      });
+      const resolved = resolvedMetadata as HasManyThroughResolvedDefinition;
+
+      // single through model
+      let result = createTargetConstraint(resolved, [through1]);
+      expect(result).to.containEql({id: 9});
+      // multiple through models
+      result = createTargetConstraint(resolved, [through1, through2]);
+      expect(result).to.containEql({id: {inq: [9, 8]}});
+    });
+  });
+  context('resolveHasManyThroughMetadata', () => {
+    it('throws if the wrong metadata type is used', async () => {
+      const metadata: unknown = {
+        name: 'category',
+        type: RelationType.hasOne,
+        targetsMany: false,
+        source: Category,
+        target: () => Product,
+      };
+
+      expect(() => {
+        resolveHasManyThroughMetadata(metadata as HasManyDefinition);
+      }).to.throw(
+        /Invalid hasOne definition for Category#category: relation type must be HasMany/,
+      );
+    });
+
+    it('throws if the through is not provided', async () => {
+      const metadata: unknown = {
+        name: 'category',
+        type: RelationType.hasMany,
+        targetsMany: true,
+        source: Category,
+        target: () => Product,
+      };
+
+      expect(() => {
+        resolveHasManyThroughMetadata(metadata as HasManyDefinition);
+      }).to.throw(
+        /Invalid hasMany definition for Category#category: through must be specified/,
+      );
+    });
+
+    it('throws if the through is not resolvable', async () => {
+      const metadata: unknown = {
+        name: 'category',
+        type: RelationType.hasMany,
+        targetsMany: true,
+        source: Category,
+        through: {model: 'random'},
+        target: () => Product,
+      };
+
+      expect(() => {
+        resolveHasManyThroughMetadata(metadata as HasManyDefinition);
+      }).to.throw(
+        /Invalid hasMany definition for Category#category: through.model must be a type resolver/,
+      );
+    });
+
+    describe('resolves through.keyTo/keyFrom', () => {
+      it('resolves metadata with complete hasManyThrough definition', () => {
+        const metadata = {
+          name: 'products',
+          type: RelationType.hasMany,
+          targetsMany: true,
+          source: Category,
+          keyFrom: 'id',
+          target: () => Product,
+          keyTo: 'id',
+
+          through: {
+            model: () => CategoryProductLink,
+            keyFrom: 'categoryId',
+            keyTo: 'productId',
+          },
+        };
+        const meta = resolveHasManyThroughMetadata(
+          metadata as HasManyDefinition,
+        );
+
+        expect(meta).to.eql(resolvedMetadata);
+      });
+
+      it('infers through.keyFrom if it is not provided', () => {
+        const metadata = {
+          name: 'products',
+          type: RelationType.hasMany,
+          targetsMany: true,
+          source: Category,
+          keyFrom: 'id',
+          target: () => Product,
+          keyTo: 'id',
+
+          through: {
+            model: () => CategoryProductLink,
+            // no through.keyFrom
+            keyTo: 'productId',
+          },
+        };
+        const meta = resolveHasManyThroughMetadata(
+          metadata as HasManyDefinition,
+        );
+
+        expect(meta).to.eql(resolvedMetadata);
+      });
+
+      it('infers through.keyTo if it is not provided', () => {
+        const metadata = {
+          name: 'products',
+          type: RelationType.hasMany,
+          targetsMany: true,
+          source: Category,
+          keyFrom: 'id',
+          target: () => Product,
+          keyTo: 'id',
+
+          through: {
+            model: () => CategoryProductLink,
+            keyFrom: 'categoryId',
+            // no through.keyTo
+          },
+        };
+
+        const meta = resolveHasManyThroughMetadata(
+          metadata as HasManyDefinition,
+        );
+
+        expect(meta).to.eql(resolvedMetadata);
+      });
+
+      it('throws if through.keyFrom is not provided in through', async () => {
+        const metadata = {
+          name: 'categories',
+          type: RelationType.hasMany,
+          targetsMany: true,
+          source: Category,
+          keyFrom: 'id',
+          target: () => Product,
+          keyTo: 'id',
+
+          through: {
+            model: () => InvalidThrough,
+            keyTo: 'productId',
+          },
+        };
+
+        expect(() => {
+          resolveHasManyThroughMetadata(metadata as HasManyDefinition);
+        }).to.throw(
+          /Invalid hasMany definition for Category#categories: through model InvalidThrough is missing definition of source foreign key/,
+        );
+      });
+
+      it('throws if through.keyTo is not provided in through', async () => {
+        const metadata = {
+          name: 'categories',
+          type: RelationType.hasMany,
+          targetsMany: true,
+          source: Category,
+          keyFrom: 'id',
+          target: () => Product,
+          keyTo: 'id',
+
+          through: {
+            model: () => InvalidThrough2,
+            keyFrom: 'categoryId',
+          },
+        };
+
+        expect(() => {
+          resolveHasManyThroughMetadata(metadata as HasManyDefinition);
+        }).to.throw(
+          /Invalid hasMany definition for Category#categories: through model InvalidThrough2 is missing definition of target foreign key/,
+        );
+      });
+
+      it('throws if the tarhet model does not have the id property', async () => {
+        const metadata = {
+          name: 'categories',
+          type: RelationType.hasMany,
+          targetsMany: true,
+          source: Category,
+          keyFrom: 'id',
+          target: () => InvalidProduct,
+          keyTo: 'id',
+
+          through: {
+            model: () => CategoryProductLink,
+            keyFrom: 'categoryId',
+            keyTo: 'productId',
+          },
+        };
+
+        expect(() => {
+          resolveHasManyThroughMetadata(metadata as HasManyDefinition);
+        }).to.throw(
+          'Invalid hasMany definition for Category#categories: target model InvalidProduct does not have any primary key (id property)',
+        );
+      });
+    });
+  });
+  /******  HELPERS *******/
+
+  @model()
+  class Category extends Entity {
+    @property({id: true})
+    id: number;
+
+    constructor(data: Partial<Category>) {
+      super(data);
+    }
+  }
+
+  @model()
+  class Product extends Entity {
+    @property({id: true})
+    id: number;
+
+    constructor(data: Partial<Product>) {
+      super(data);
+    }
+  }
+
+  @model()
+  class InvalidProduct extends Entity {
+    @property({id: false})
+    random: number;
+    constructor(data: Partial<InvalidProduct>) {
+      super(data);
+    }
+  }
+
+  @model()
+  class CategoryProductLink extends Entity {
+    @property({id: true})
+    id: number;
+    @property()
+    categoryId: number;
+    @property()
+    productId: number;
+
+    constructor(data: Partial<Product>) {
+      super(data);
+    }
+  }
+
+  const resolvedMetadata = {
+    name: 'products',
+    type: 'hasMany',
+    targetsMany: true,
+    source: Category,
+    keyFrom: 'id',
+    target: () => Product,
+    keyTo: 'id',
+    through: {
+      model: () => CategoryProductLink,
+      keyFrom: 'categoryId',
+      keyTo: 'productId',
+    },
+  };
+
+  class InvalidThrough extends Entity {}
+  InvalidThrough.definition = new ModelDefinition('InvalidThrough')
+    .addProperty('id', {
+      type: 'number',
+      id: true,
+      required: true,
+    })
+    // lack through.keyFrom
+    .addProperty('productId', {type: 'number'});
+
+  class InvalidThrough2 extends Entity {}
+  InvalidThrough2.definition = new ModelDefinition('InvalidThrough2')
+    .addProperty('id', {
+      type: 'number',
+      id: true,
+      required: true,
+    })
+    // lack through.keyTo
+    .addProperty('categoryId', {type: 'number'});
+
+  function createCategoryProductLink(properties: Partial<CategoryProductLink>) {
+    return new CategoryProductLink(properties);
+  }
+});

--- a/packages/repository/src/relations/has-many/has-many-through.helpers.ts
+++ b/packages/repository/src/relations/has-many/has-many-through.helpers.ts
@@ -1,0 +1,193 @@
+import debugFactory from 'debug';
+import {camelCase} from 'lodash';
+import {
+  DataObject,
+  Entity,
+  HasManyDefinition,
+  InvalidRelationError,
+  isTypeResolver,
+} from '../..';
+import {resolveHasManyMetaHelper} from './has-many.helpers';
+
+const debug = debugFactory('loopback:repository:has-many-through-helpers');
+
+export type HasManyThroughResolvedDefinition = HasManyDefinition & {
+  keyTo: string;
+  keyFrom: string;
+  through: {
+    keyTo: string;
+    keyFrom: string;
+  };
+};
+
+/**
+ * Creates constraint used to query target
+ * @param relationMeta - hasManyThrough metadata to resolve
+ * @param throughInstances - Instances of through entities used to constrain the target
+ * @internal
+ *
+ * @example
+ * ```ts
+ * const resolvedMetadata = {
+ *  // .. other props
+ *  keyFrom: 'id',
+ *  keyTo: 'id',
+ *  through: {
+ *    model: () => CategoryProductLink,
+ *    keyFrom: 'categoryId',
+ *    keyTo: 'productId',
+ *  },
+ * };
+
+ * createTargetConstraint(resolvedMetadata, [
+      {
+        id: 2,
+        categoryId: 2,
+        productId: 8,
+      }, {
+        id: 2,
+        categoryId: 2,
+        productId: 9,
+      }
+  ]);
+ * ```
+ */
+export function createTargetConstraint<
+  Target extends Entity,
+  Through extends Entity
+>(
+  relationMeta: HasManyThroughResolvedDefinition,
+  throughInstances: Through[],
+): DataObject<Target> {
+  const targetPrimaryKey = relationMeta.keyTo;
+  const targetFkName = relationMeta.through.keyTo;
+  const fkValues = throughInstances.map(
+    (throughInstance: Through) =>
+      throughInstance[targetFkName as keyof Through],
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const constraint: any = {
+    [targetPrimaryKey]: fkValues.length === 1 ? fkValues[0] : {inq: fkValues},
+  };
+  return constraint;
+}
+
+/**
+ * Creates constraint used to query through model
+ *
+ * @param relationMeta - hasManyThrough metadata to resolve
+ * @param fkValue - Value of the foreign key of the source model used to constrain through
+ * @param targetInstance - Instance of target entity used to constrain through
+ * @internal
+ *
+ * @example
+ * ```ts
+ * const resolvedMetadata = {
+ *  // .. other props
+ *  keyFrom: 'id',
+ *  keyTo: 'id',
+ *  through: {
+ *    model: () => CategoryProductLink,
+ *    keyFrom: 'categoryId',
+ *    keyTo: 'productId',
+ *  },
+ * };
+ * createThroughConstraint(resolvedMetadata, 1);
+ * ```
+ */
+export function createThroughConstraint<Through extends Entity, ForeignKeyType>(
+  relationMeta: HasManyThroughResolvedDefinition,
+  fkValue: ForeignKeyType,
+): DataObject<Through> {
+  const sourceFkName = relationMeta.through.keyFrom;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const constraint: any = {[sourceFkName]: fkValue};
+  return constraint;
+}
+
+/**
+ * Resolves given hasMany metadata if target is specified to be a resolver.
+ * Mainly used to infer what the `keyTo` property should be from the target's
+ * belongsTo metadata
+ * @param relationMeta - hasManyThrough metadata to resolve
+ * @internal
+ */
+export function resolveHasManyThroughMetadata(
+  relationMeta: HasManyDefinition,
+): HasManyThroughResolvedDefinition {
+  // some checks and relationMeta.keyFrom are handled in here
+  relationMeta = resolveHasManyMetaHelper(relationMeta);
+
+  if (!relationMeta.through) {
+    const reason = 'through must be specified';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+  if (!isTypeResolver(relationMeta.through?.model)) {
+    const reason = 'through.model must be a type resolver';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const throughModel = relationMeta.through.model();
+  const throughModelProperties = throughModel.definition?.properties;
+
+  const targetModel = relationMeta.target();
+  const targetModelProperties = targetModel.definition?.properties;
+
+  // check if metadata is already complete
+  if (
+    relationMeta.through.keyTo &&
+    throughModelProperties[relationMeta.through.keyTo] &&
+    relationMeta.through.keyFrom &&
+    throughModelProperties[relationMeta.through.keyFrom] &&
+    relationMeta.keyTo &&
+    targetModelProperties[relationMeta.keyTo]
+  ) {
+    // The explict cast is needed because of a limitation of type inference
+    return relationMeta as HasManyThroughResolvedDefinition;
+  }
+
+  const sourceModel = relationMeta.source;
+
+  debug(
+    'Resolved model %s from given metadata: %o',
+    targetModel.modelName,
+    targetModel,
+  );
+
+  debug(
+    'Resolved model %s from given metadata: %o',
+    throughModel.modelName,
+    throughModel,
+  );
+
+  const sourceFkName =
+    relationMeta.through.keyFrom ?? camelCase(sourceModel.modelName + '_id');
+  if (!throughModelProperties[sourceFkName]) {
+    const reason = `through model ${throughModel.name} is missing definition of source foreign key`;
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const targetFkName =
+    relationMeta.through.keyTo ?? camelCase(targetModel.modelName + '_id');
+  if (!throughModelProperties[targetFkName]) {
+    const reason = `through model ${throughModel.name} is missing definition of target foreign key`;
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const targetPrimaryKey =
+    relationMeta.keyTo ?? targetModel.definition.idProperties()[0];
+  if (!targetPrimaryKey || !targetModelProperties[targetPrimaryKey]) {
+    const reason = `target model ${targetModel.modelName} does not have any primary key (id property)`;
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  return Object.assign(relationMeta, {
+    keyTo: targetPrimaryKey,
+    keyFrom: relationMeta.keyFrom!,
+    through: {
+      ...relationMeta.through,
+      keyTo: targetFkName,
+      keyFrom: sourceFkName,
+    },
+  });
+}

--- a/packages/repository/src/relations/has-many/has-many.helpers.ts
+++ b/packages/repository/src/relations/has-many/has-many.helpers.ts
@@ -30,41 +30,18 @@ export type HasManyResolvedDefinition = HasManyDefinition & {
 export function resolveHasManyMetadata(
   relationMeta: HasManyDefinition,
 ): HasManyResolvedDefinition {
-  if ((relationMeta.type as RelationType) !== RelationType.hasMany) {
-    const reason = 'relation type must be HasMany';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
-
-  if (!isTypeResolver(relationMeta.target)) {
-    const reason = 'target must be a type resolver';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
+  // some checks and relationMeta.keyFrom are handled in here
+  relationMeta = resolveHasManyMetaHelper(relationMeta);
 
   const targetModel = relationMeta.target();
   const targetModelProperties =
     targetModel.definition && targetModel.definition.properties;
 
   const sourceModel = relationMeta.source;
-  if (!sourceModel || !sourceModel.modelName) {
-    const reason = 'source model must be defined';
-    throw new InvalidRelationError(reason, relationMeta);
-  }
 
-  // keyFrom defaults to id property
-  let keyFrom;
-  if (
-    relationMeta.keyFrom &&
-    relationMeta.source.definition.properties[relationMeta.keyFrom]
-  ) {
-    keyFrom = relationMeta.keyFrom;
-  } else {
-    keyFrom = sourceModel.getIdProperties()[0];
-  }
-  // Make sure that if it already keys to the foreign key property,
-  // the key exists in the target model
   if (relationMeta.keyTo && targetModelProperties[relationMeta.keyTo]) {
     // The explicit cast is needed because of a limitation of type inference
-    return Object.assign(relationMeta, {keyFrom}) as HasManyResolvedDefinition;
+    return relationMeta as HasManyResolvedDefinition;
   }
 
   debug(
@@ -81,7 +58,44 @@ export function resolveHasManyMetadata(
   }
 
   return Object.assign(relationMeta, {
-    keyFrom,
     keyTo: defaultFkName,
   } as HasManyResolvedDefinition);
+}
+
+/**
+ * A helper to check relation type and the existence of the source/target models
+ * and set up keyFrom
+ * for HasMany(Through) relations
+ * @param relationMeta
+ *
+ * @returns relationMeta that has set up keyFrom
+ */
+export function resolveHasManyMetaHelper(
+  relationMeta: HasManyDefinition,
+): HasManyDefinition {
+  if ((relationMeta.type as RelationType) !== RelationType.hasMany) {
+    const reason = 'relation type must be HasMany';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  if (!isTypeResolver(relationMeta.target)) {
+    const reason = 'target must be a type resolver';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+
+  const sourceModel = relationMeta.source;
+  if (!sourceModel || !sourceModel.modelName) {
+    const reason = 'source model must be defined';
+    throw new InvalidRelationError(reason, relationMeta);
+  }
+  let keyFrom;
+  if (
+    relationMeta.keyFrom &&
+    relationMeta.source.definition.properties[relationMeta.keyFrom]
+  ) {
+    keyFrom = relationMeta.keyFrom;
+  } else {
+    keyFrom = sourceModel.getIdProperties()[0];
+  }
+  return Object.assign(relationMeta, {keyFrom}) as HasManyDefinition;
 }

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -52,6 +52,10 @@ export interface RelationDefinitionBase {
   target: TypeResolver<Entity, typeof Entity>;
 }
 
+/**
+ * HasManyDefinition defines one-to-many relations and also possible defines
+ * many-to-many relations with through models.
+ */
 export interface HasManyDefinition extends RelationDefinitionBase {
   type: RelationType.hasMany;
   targetsMany: true;
@@ -69,49 +73,40 @@ export interface HasManyDefinition extends RelationDefinitionBase {
    */
   keyTo?: string;
   keyFrom?: string;
-}
-
-/**
- * A `hasManyThrough` relation defines a many-to-many connection with another model.
- * This relation indicates that the declaring model can be matched with zero or more
- * instances of another model by proceeding through a third model.
- *
- * Warning: The hasManyThrough interface is experimental and is subject to change.
- * If backwards-incompatible changes are made, a new major version may not be
- * released.
- */
-export interface HasManyThroughDefinition extends RelationDefinitionBase {
-  type: RelationType.hasMany;
-  targetsMany: true;
 
   /**
-   * The foreign key in the source model, e.g. Customer#id.
+   * Description of the through model of the hasManyThrough relation.
+   *
+   * A `hasManyThrough` relation defines a many-to-many connection with another model.
+   * This relation indicates that the declaring model can be matched with zero or more
+   * instances of another model by proceeding through a third model.
+   *
+   * E.g a Category has many Products, and a Product can have many Categories.
+   * CategoryProductLink can be the through model.
+   * Such a through model has information of foreign keys of the source model(Category) and the target model(Product).
+   *
+   * Warning: The hasManyThrough interface is experimental and is subject to change.
+   * If backwards-incompatible changes are made, a new major version may not be
+   * released.
    */
-  keyFrom: string;
-
-  /**
-   * The primary key of the target model, e.g Seller#id.
-   */
-  keyTo: string;
-
-  through: {
+  through?: {
     /**
      * The through model of this relation.
      *
-     * E.g. when a Customer has many Order instances and a Seller has many Order instances,
-     * then Order is through.
+     * E.g. when a Category has many CategoryProductLink instances and a Product has many CategoryProductLink instances,
+     * then CategoryProductLink is through.
      */
     model: TypeResolver<Entity, typeof Entity>;
 
     /**
-     * The foreign key of the source model defined in the through model, e.g. Order#customerId
+     * The foreign key of the source model defined in the through model, e.g. CategoryProductLink#categoryId
      */
-    keyFrom: string;
+    keyFrom?: string;
 
     /**
-     * The foreign key of the target model defined in the through model, e.g. Order#sellerId
+     * The foreign key of the target model defined in the through model, e.g. CategoryProductLink#productId
      */
-    keyTo: string;
+    keyTo?: string;
   };
 }
 
@@ -153,7 +148,6 @@ export interface HasOneDefinition extends RelationDefinitionBase {
  */
 export type RelationMetadata =
   | HasManyDefinition
-  | HasManyThroughDefinition
   | BelongsToDefinition
   | HasOneDefinition
   // TODO(bajtos) add other relation types and remove RelationDefinitionBase once


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Extract hasManyThrough relation definition and its helpers from #4438 

Adding unit tests for `hasManyThrough.help`

Changes: 
- Move the through member to `HasManyDefinition` and get rid of `hasManyThroughDefinition`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
