### PR TITLE
fix(docs): fix format in OpenAPI generator

### DIFF
--- a/docs/site/OpenAPI-generator.md
+++ b/docs/site/OpenAPI-generator.md
@@ -509,7 +509,7 @@ export class CustomerServiceProvider implements Provider<CustomerService> {
     return service.apis['Customer'];
   }
 }
-```
+````
 
 ### OpenAPI Examples
 
@@ -522,4 +522,3 @@ Try out the following specs or your own with `lb4 openapi`:
 
 For more real world OpenAPI specs, see
 [https://api.apis.guru/v2/list.json](https://api.apis.guru/v2/list.json).
-````


### PR DESCRIPTION
Fix the format issue in https://loopback.io/doc/en/lb4/OpenAPI-generator.html:
<img width="860" alt="Screen Shot 2020-05-06 at 10 01 38 PM" src="https://user-images.githubusercontent.com/25489897/81246302-348a8f00-8fe5-11ea-9b78-3df37b09445a.png">


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
