### PR TITLE
feat(context): force interceptor functions to return a value

### DIFF
--- a/packages/context/src/__tests__/unit/interceptor.unit.ts
+++ b/packages/context/src/__tests__/unit/interceptor.unit.ts
@@ -266,7 +266,7 @@ describe('globalInterceptors', () => {
   });
 
   it('generates binding key for the interceptor function', () => {
-    const binding = registerInterceptor(ctx, () => {});
+    const binding = registerInterceptor(ctx, () => undefined);
     expect(binding.key).to.match(
       new RegExp(`interceptors.${UUID_PATTERN.source}`, 'i'),
     );

--- a/packages/context/src/interceptor-chain.ts
+++ b/packages/context/src/interceptor-chain.ts
@@ -13,27 +13,54 @@ import {transformValueOrPromise, ValueOrPromise} from './value-promise';
 const debug = debugFactory('loopback:context:interceptor-chain');
 
 /**
+ * Any type except `void`. We use this type to enforce that interceptor functions
+ * always return a value (including undefined or null).
+ */
+export type NonVoid = string | number | boolean | null | undefined | object;
+
+/**
  * The `next` function that can be used to invoke next generic interceptor in
  * the chain
  */
-export type Next = () => ValueOrPromise<InvocationResult>;
+export type Next = () => ValueOrPromise<NonVoid>;
 
 /**
  * An interceptor function to be invoked in a chain for the given context.
  * It serves as the base interface for various types of interceptors, such
  * as method invocation interceptor or request/response processing interceptor.
  *
+ * We choose `NonVoid` as the return type to avoid possible bugs that an
+ * interceptor forgets to return the value from `next()`. For example, the code
+ * below will fail to compile.
+ *
+ * ```ts
+ * const myInterceptor: Interceptor = async (ctx, next) {
+ *   // preprocessing
+ *   // ...
+ *
+ *   // There is a subtle bug that the result from `next()` is not further
+ *   // returned back to the upstream interceptors
+ *   const result = await next();
+ *
+ *   // postprocessing
+ *   // ...
+ *   // We must have `return ...` here
+ *   // either return `result` or another value if the interceptor decides to
+ *   // have its own response
+ * }
+ * ```
+ *
  * @typeParam C - `Context` class or a subclass of `Context`
  * @param context - Context object
  * @param next - A function to proceed with downstream interceptors or the
  * target operation
  *
- * @returns The invocation result as a value (sync) or promise (async)
+ * @returns The invocation result as a value (sync) or promise (async).
  */
 export type GenericInterceptor<C extends Context = Context> = (
   context: C,
   next: Next,
-) => ValueOrPromise<InvocationResult>;
+) => ValueOrPromise<NonVoid>;
 
 /**
  * Interceptor function or a binding key that resolves a generic interceptor

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -441,7 +441,9 @@ describe('Application', () => {
       });
     });
 
-    function logInterceptor(ctx: InvocationContext, next: Next) {}
+    function logInterceptor(ctx: InvocationContext, next: Next) {
+      return undefined;
+    }
 
     @bind(asGlobalInterceptor())
     class LogInterceptorProvider implements Provider<Interceptor> {


### PR DESCRIPTION
The `NonVoid` return type prohibits an interceptor function from having
void return type. This is important that an interceptor should either
return the value from downstream interceptors or a value from its own.

For example, the code will fail to compile.
```ts
 const myInterceptor: Interceptor = async (ctx, next) {
    // preprocessing
    // ...
 
    // subtle bug that the returned value from `next` is not returned
    // back to the upstream interceptors
    next();
 
   // postprocessing
    // ...
    // We must have `return ...` here
 }
```

Related to #5339 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
