### PR TITLE
feat(repository): extract helper `rejectNavigationalPropertiesInData`

### DIFF
--- a/packages/repository/src/__tests__/unit/model/model.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/model.unit.ts
@@ -5,9 +5,11 @@
 
 import {expect} from '@loopback/testlab';
 import {
+  BelongsToDefinition,
   Entity,
   HasManyDefinition,
   ModelDefinition,
+  rejectNavigationalPropertiesInData,
   RelationType,
   STRING,
 } from '../../../';
@@ -432,6 +434,43 @@ describe('model', () => {
       id: '123',
       email: 'xyz@example.com',
       firstName: 'Test User',
+    });
+  });
+
+  describe('rejectNavigationalPropertiesInData', () => {
+    class Order extends Entity {
+      static definition = new ModelDefinition('Order')
+        .addProperty('id', {type: 'string', id: true})
+        .addRelation(<BelongsToDefinition>{
+          name: 'customer',
+          type: RelationType.belongsTo,
+          targetsMany: false,
+          source: Order,
+          target: () => User,
+          keyFrom: 'customerId',
+        });
+
+      id: string;
+      customerId: string;
+
+      customer?: User;
+    }
+
+    it('accepts data with no navigational properties', () => {
+      rejectNavigationalPropertiesInData(Order, {id: '1'});
+    });
+
+    it('rejects data with a navigational property', () => {
+      expect(() =>
+        rejectNavigationalPropertiesInData(Order, {
+          id: '1',
+          customer: {
+            id: '2',
+            email: 'test@example.com',
+            firstName: 'a customer',
+          },
+        }),
+      ).to.throw(/Navigational properties are not allowed in model data/);
     });
   });
 });

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -11,12 +11,18 @@ import {
   Command,
   Count,
   DataObject,
+  DeepPartial,
   NamedParameters,
   Options,
   PositionalParameters,
 } from '../common-types';
 import {EntityNotFoundError} from '../errors';
-import {Entity, Model, PropertyType} from '../model';
+import {
+  Entity,
+  Model,
+  PropertyType,
+  rejectNavigationalPropertiesInData,
+} from '../model';
 import {Filter, FilterExcludingWhere, Inclusion, Where} from '../query';
 import {
   BelongsToAccessor,
@@ -109,8 +115,8 @@ export class DefaultCrudRepository<
 
   /**
    * Constructor of DefaultCrudRepository
-   * @param entityClass - Legacy entity class
-   * @param dataSource - Legacy data source
+   * @param entityClass - LoopBack 4 entity class
+   * @param dataSource - Legacy juggler data source
    */
   constructor(
     // entityClass should have type "typeof T", but that's not supported by TSC
@@ -590,27 +596,10 @@ export class DefaultCrudRepository<
     const data: AnyObject =
       typeof entity.toJSON === 'function' ? entity.toJSON() : {...entity};
     */
+    const data: DeepPartial<R> = new this.entityClass(entity);
 
-    const data: AnyObject = new this.entityClass(entity);
+    rejectNavigationalPropertiesInData(this.entityClass, data);
 
-    const def = this.entityClass.definition;
-    const props = def.properties;
-    for (const r in def.relations) {
-      const relName = def.relations[r].name;
-      if (relName in data) {
-        let invalidNameMsg = '';
-        if (relName in props) {
-          invalidNameMsg =
-            ` The error might be invoked by belongsTo relations, please make sure the relation name is not the same as` +
-            ` the property name.`;
-        }
-        throw new Error(
-          `Navigational properties are not allowed in model data (model "${this.entityClass.modelName}"` +
-            ` property "${relName}"), please remove it.` +
-            invalidNameMsg,
-        );
-      }
-    }
     return data;
   }
 


### PR DESCRIPTION
Extract the code for rejecting navigational properites into a standalone helper function that can be used from other repository implementations too.

I have extracted this pull request from #5222

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
