### PR TITLE
build: fix VSCode problem matcher for the build task 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -88,7 +88,10 @@
       "args": [
         "run",
         "-s",
-        "build"
+        "build",
+        "--",
+        "--pretty",
+        "false"
       ],
       "problemMatcher": "$tsc"
     },

--- a/packages/build/bin/compile-package.js
+++ b/packages/build/bin/compile-package.js
@@ -164,8 +164,10 @@ function validArgsForBuild(args) {
   });
   let validArgs = args;
   if (args.includes('-b') || args.includes('--build')) {
-    validArgs = filterArgs(args, arg => {
-      if (validBooleanOptions.includes(arg)) return 1;
+    validArgs = filterArgs(args, (arg, next) => {
+      if (validBooleanOptions.includes(arg)) {
+        return next === 'false' || next === 'true' ? 2 : 1;
+      }
       if (validValueOptions.includes(arg)) return 2;
       return 0;
     });
@@ -185,7 +187,7 @@ function filterArgs(args, filter) {
   const validArgs = [];
   let i = 0;
   while (i < args.length) {
-    const length = filter(args[i]);
+    const length = filter(args[i], args[i + 1]);
     if (length === 0) {
       i++;
     } else if (length === 1) {


### PR DESCRIPTION
TypeScript compiler enables `pretty` mode when using the build mode (project references). Unfortunately, pretty mode is not supported by VSCode's problem matcher and therefore VSCode is not able to parse the errors to populate the Problems window.

This change addes `--pretty false` arguments to `tsc` when invoked from VSCode task "Build project".

In order to make this work, I had to also fix `lb-tsc` to correctly recognize and pass boolean arguments with a value. Before this change, `lb-tsc -b --pretty false` would discard `--pretty false` arguments.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
