### PR TITLE
feat(core): allow extensionFilter to take a list of extension point names

### DIFF
--- a/packages/context/src/binding-filter.ts
+++ b/packages/context/src/binding-filter.ts
@@ -144,15 +144,16 @@ export const ANY_TAG_VALUE: TagValueMatcher = (tagValue, tagName, tagMap) =>
 /**
  * Create a tag value matcher function that returns `true` if the target tag
  * value equals to the item value or is an array that includes the item value.
- * @param itemValue - Tag item value
+ * @param itemValues - A list of tag item value
  */
-export function includesTagValue(itemValue: unknown): TagValueMatcher {
+export function includesTagValue(...itemValues: unknown[]): TagValueMatcher {
   return tagValue => {
-    return (
-      // The tag value equals the item value
-      tagValue === itemValue ||
-      // The tag value contains the item value
-      (Array.isArray(tagValue) && tagValue.includes(itemValue))
+    return itemValues.some(
+      itemValue =>
+        // The tag value equals the item value
+        tagValue === itemValue ||
+        // The tag value contains the item value
+        (Array.isArray(tagValue) && tagValue.includes(itemValue)),
     );
   };
 }

--- a/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
+++ b/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
@@ -251,13 +251,25 @@ describe('extension point', () => {
       ]);
     });
 
-    it('allows multiple extension points for extensionFilter', () => {
+    it('allows multiple extension points for extensionFor', () => {
       class MyExtension {}
       const binding = ctx.bind('my-extension').toClass(MyExtension);
       extensionFor('extensionPoint-1', 'extensionPoint-2')(binding);
       expect(extensionFilter('extensionPoint-1')(binding)).to.be.true();
       expect(extensionFilter('extensionPoint-2')(binding)).to.be.true();
       expect(extensionFilter('extensionPoint-3')(binding)).to.be.false();
+    });
+
+    it('allows multiple extension points for extensionFilter', () => {
+      class MyExtension {}
+      const binding = ctx.bind('my-extension').toClass(MyExtension);
+      extensionFor('extensionPoint-1', 'extensionPoint-2')(binding);
+      expect(
+        extensionFilter('extensionPoint-1', 'extensionPoint3')(binding),
+      ).to.be.true();
+      expect(
+        extensionFilter('extensionPoint-2', 'extensionPoint3')(binding),
+      ).to.be.true();
     });
 
     it('allows multiple extension points for @extensions', async () => {

--- a/packages/core/src/extension-point.ts
+++ b/packages/core/src/extension-point.ts
@@ -227,11 +227,13 @@ function inferExtensionPointName(
 /**
  * A factory function to create binding filter for extensions of a named
  * extension point
- * @param extensionPointName - Name of the extension point
+ * @param extensionPointNames - A list of names of extension points
  */
-export function extensionFilter(extensionPointName: string): BindingFilter {
+export function extensionFilter(
+  ...extensionPointNames: string[]
+): BindingFilter {
   return filterByTag({
-    [CoreTags.EXTENSION_FOR]: includesTagValue(extensionPointName),
+    [CoreTags.EXTENSION_FOR]: includesTagValue(...extensionPointNames),
   });
 }
 


### PR DESCRIPTION
We can now use `extensionFilter` to match one or more extension points for aggregation if needed.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
