### PR TITLE
fix: minor fixes to middleware group and binding template

### DIFF
--- a/packages/express/src/middleware-interceptor.ts
+++ b/packages/express/src/middleware-interceptor.ts
@@ -408,7 +408,7 @@ export function createMiddlewareInterceptorBinding<CFG>(
 ) {
   options = {
     global: true,
-    group: 'middleware',
+    group: DEFAULT_MIDDLEWARE_GROUP,
     ...options,
   };
   const namespace = options.global

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -127,7 +127,7 @@ export function registerExpressMiddleware<CFG>(
  */
 export function asMiddleware(
   options: MiddlewareBindingOptions = {},
-): BindingTemplate<Middleware> {
+): BindingTemplate {
   return function middlewareBindingTemplate(binding) {
     binding
       .apply(extensionFor(options.chain ?? DEFAULT_MIDDLEWARE_CHAIN))

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -20,7 +20,7 @@ import {
 } from '@loopback/context';
 import {extensionFilter, extensionFor} from '@loopback/core';
 import debugFactory from 'debug';
-import {MIDDLEWARE_NAMESPACE} from './keys';
+import {DEFAULT_MIDDLEWARE_GROUP, MIDDLEWARE_NAMESPACE} from './keys';
 import {
   createInterceptor,
   defineInterceptorProvider,
@@ -131,7 +131,7 @@ export function asMiddleware(
   return function middlewareBindingTemplate(binding) {
     binding
       .apply(extensionFor(options.chain ?? DEFAULT_MIDDLEWARE_CHAIN))
-      .tag({group: options.group ?? ''});
+      .tag({group: options.group ?? DEFAULT_MIDDLEWARE_GROUP});
   };
 }
 


### PR DESCRIPTION
1. Consistently use `DEFAULT_MIDDLEWARE_GROUP`
2. Change return type to `BindingTemplate` for `asMiddleware`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
