### PR TITLE
feat(context): provide resolution context metadata for factory functions with toDynamicValue()

### DIFF
--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -13,6 +13,12 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/benchmark": {
+			"version": "1.0.31",
+			"resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-1.0.31.tgz",
+			"integrity": "sha512-F6fVNOkGEkSdo/19yWYOwVKGvzbTeWkR/XQYBKtGBQ9oGRjBN9f/L4aJI4sDcVPJO58Y1CJZN8va9V2BhrZapA==",
+			"dev": true
+		},
 		"@types/byline": {
 			"version": "4.2.31",
 			"resolved": "https://registry.npmjs.org/@types/byline/-/byline-4.2.31.tgz",
@@ -174,6 +180,15 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
+		"benchmark": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+			"integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+			"requires": {
+				"lodash": "^4.17.4",
+				"platform": "^1.3.3"
+			}
 		},
 		"binary-extensions": {
 			"version": "2.0.0",
@@ -721,8 +736,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"log-symbols": {
 			"version": "3.0.0",
@@ -1015,6 +1029,11 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
+		},
+		"platform": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+			"integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
 		},
 		"pretty-bytes": {
 			"version": "5.3.0",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -19,6 +19,7 @@
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",
     "prestart": "npm run build",
     "benchmark:routing": "node ./dist/rest-routing/routing-table",
+    "benchmark:context": "node ./dist/context-binding/context-binding",
     "start": "node ."
   },
   "author": "IBM Corp.",
@@ -32,6 +33,7 @@
     "!*/__tests__"
   ],
   "dependencies": {
+    "@loopback/context": "^3.7.0",
     "@loopback/example-todo": "^3.3.0",
     "@loopback/openapi-spec-builder": "^2.1.3",
     "@loopback/rest": "^4.0.0",
@@ -40,6 +42,7 @@
     "@types/request-promise-native": "^1.0.17",
     "autocannon": "^4.6.0",
     "axios": "^0.19.2",
+    "benchmark": "^2.1.4",
     "byline": "^5.0.0",
     "debug": "^4.1.1",
     "path-to-regexp": "^6.1.0",
@@ -49,6 +52,7 @@
     "@loopback/build": "^5.3.1",
     "@loopback/testlab": "^3.1.3",
     "@types/autocannon": "^4.1.0",
+    "@types/benchmark": "^1.0.31",
     "@types/mocha": "^7.0.2",
     "@types/node": "^10.17.21",
     "mocha": "^7.1.2",

--- a/benchmark/src/context-binding/README.md
+++ b/benchmark/src/context-binding/README.md
@@ -1,0 +1,30 @@
+# Context binding benchmark
+
+This directory contains a simple benchmarking to measure the performance of
+different styles of context bindings.
+
+## Basic use
+
+```sh
+npm run -s benchmark:context
+```
+
+For example:
+
+```
+npm run -s benchmark:context
+```
+
+## Base lines
+
+| Test                      | Ops/sec   | Relative margin of error | Runs sampled | Count |
+| ------------------------- | --------- | ------------------------ | ------------ | ----- |
+| factory - getSync         | 1,282,238 | ±1.11%                   | 93           | 68537 |
+| factory - get             | 1,222,587 | ±1.19%                   | 87           | 66558 |
+| asyncFactory - get        | 362,457   | ±1.78%                   | 78           | 23284 |
+| staticProvider - getSync  | 484,494   | ±1.04%                   | 92           | 26260 |
+| staticProvider - get      | 475,130   | ±1.13%                   | 86           | 27435 |
+| asyncStaticProvider - get | 339,359   | ±1.43%                   | 86           | 19046 |
+| provider - getSync        | 368,127   | ±1.14%                   | 87           | 21162 |
+| provider - get            | 366,649   | ±0.86%                   | 86           | 21358 |
+| asyncProvider - get       | 291,054   | ±1.94%                   | 82           | 16557 |

--- a/benchmark/src/context-binding/context-binding.ts
+++ b/benchmark/src/context-binding/context-binding.ts
@@ -1,0 +1,136 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: @loopback/benchmark
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Context, inject, Provider, ValueFactory} from '@loopback/context';
+import Benchmark from 'benchmark';
+
+/**
+ * Option 1 - use a sync factory function
+ */
+const factory: ValueFactory = ({context}) => {
+  const user = context.getSync('user');
+  return `Hello, ${user}`;
+};
+
+/**
+ * Option 2 - use an async factory function
+ */
+const asyncFactory: ValueFactory = async ({context}) => {
+  const user = await context.get('user');
+  return `Hello, ${user}`;
+};
+
+/**
+ * Option 3 - use a value factory provider class with sync static value() method
+ * parameter injection
+ */
+class StaticGreetingProvider {
+  static value(@inject('user') user: string) {
+    return `Hello, ${user}`;
+  }
+}
+
+/**
+ * Option 4 - use a value factory provider class with async static value() method
+ * parameter injection
+ */
+class AsyncStaticGreetingProvider {
+  static value(@inject('user') user: string) {
+    return Promise.resolve(`Hello, ${user}`);
+  }
+}
+
+/**
+ * Option 5 - use a regular provider class with sync value()
+ */
+class GreetingProvider implements Provider<string> {
+  @inject('user')
+  private user: string;
+
+  value() {
+    return `Hello, ${this.user}`;
+  }
+}
+
+/**
+ * Option 6 - use a regular provider class with async value()
+ */
+class AsyncGreetingProvider implements Provider<string> {
+  @inject('user')
+  private user: string;
+
+  value() {
+    return Promise.resolve(`Hello, ${this.user}`);
+  }
+}
+
+setupContextBindings();
+
+function setupContextBindings() {
+  const ctx = new Context();
+  ctx.bind('user').to('John');
+  ctx.bind('greeting.syncFactory').toDynamicValue(factory);
+  ctx.bind('greeting.asyncFactory').toDynamicValue(asyncFactory);
+  ctx
+    .bind('greeting.syncStaticProvider')
+    .toDynamicValue(StaticGreetingProvider);
+  ctx
+    .bind('greeting.asyncStaticProvider')
+    .toDynamicValue(AsyncStaticGreetingProvider);
+  ctx.bind('greeting.syncProvider').toProvider(GreetingProvider);
+  ctx.bind('greeting.asyncProvider').toProvider(AsyncGreetingProvider);
+  return ctx;
+}
+
+function runBenchmark(ctx: Context) {
+  const options: Benchmark.Options = {
+    initCount: 1000,
+    onComplete: (e: Benchmark.Event) => {
+      const benchmark = e.target as Benchmark;
+      console.log('%s %d', benchmark, benchmark.count);
+    },
+  };
+  const suite = new Benchmark.Suite('context-bindings');
+  suite
+    .add(
+      'factory - getSync',
+      () => ctx.getSync('greeting.syncFactory'),
+      options,
+    )
+    .add('factory - get', () => ctx.get('greeting.syncFactory'), options)
+    .add('asyncFactory - get', () => ctx.get('greeting.asyncFactory'), options)
+    .add(
+      'staticProvider - getSync',
+      () => ctx.getSync('greeting.syncStaticProvider'),
+      options,
+    )
+    .add(
+      'staticProvider - get',
+      () => ctx.get('greeting.syncStaticProvider'),
+      options,
+    )
+    .add(
+      'asyncStaticProvider - get',
+      () => ctx.get('greeting.asyncStaticProvider'),
+      options,
+    )
+    .add(
+      'provider - getSync',
+      () => ctx.getSync('greeting.syncProvider'),
+      options,
+    )
+    .add('provider - get', () => ctx.get('greeting.syncProvider'), options)
+    .add(
+      'asyncProvider - get',
+      () => ctx.get('greeting.asyncProvider'),
+      options,
+    )
+    .run({async: true});
+}
+
+if (require.main === module) {
+  const ctx = setupContextBindings();
+  runBenchmark(ctx);
+}

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../examples/todo/tsconfig.json"
     },
     {
+      "path": "../packages/context/tsconfig.json"
+    },
+    {
       "path": "../packages/openapi-spec-builder/tsconfig.json"
     },
     {

--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -83,6 +83,47 @@ binding.toDynamicValue(() => new Date());
 binding.toDynamicValue(() => Promise.resolve('my-value'));
 ```
 
+The factory function can receive extra information about the context, binding,
+and resolution options.
+
+```ts
+import {ValueFactory} from '@loopback/context';
+
+// The factory function now have access extra metadata about the resolution
+const factory: ValueFactory<string> = resolutionCtx => {
+  return `Hello, ${resolutionCtx.context.name}#${
+    resolutionCtx.binding.key
+  } ${resolutionCtx.options.session?.getBindingPath()}`;
+};
+const b = ctx.bind('msg').toDynamicValue(factory);
+```
+
+Object destructuring can be used to further simplify a value factory function
+that needs to access `context`, `binding`, or `options`.
+
+```ts
+const factory: ValueFactory<string> = ({context, binding, options}) => {
+  return `Hello, ${context.name}#${
+    binding.key
+  } ${options.session?.getBindingPath()}`;
+};
+```
+
+An advanced form of value factory is a class that has a static `value` method
+that allows parameter injection.
+
+```ts
+import {inject} from '@loopback/context';
+
+class GreetingProvider {
+  static value(@inject('user') user: string) {
+    return `Hello, ${user}`;
+  }
+}
+
+const b = ctx.bind('msg').toDynamicValue(GreetingProvider);
+```
+
 #### A class
 
 The binding can represent an instance of a class, for example, a controller. A
@@ -118,6 +159,9 @@ class MyValueProvider implements Provider<string> {
 
 binding.toProvider(MyValueProvider);
 ```
+
+The provider class serves as the wrapper to declare dependency injections. If
+dependency is not needed, `toDynamicValue` can be used instead.
 
 #### An alias
 

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -40,8 +40,17 @@ const METHODS_KEY = MetadataAccessor.create<Injection, MethodDecorator>(
   'inject:methods',
 );
 
+// TODO(rfeng): We may want to align it with `ValueFactory` interface that takes
+// an argument of `ResolutionContext`.
 /**
- * A function to provide resolution of injected values
+ * A function to provide resolution of injected values.
+ *
+ * @example
+ * ```ts
+ * const resolver: ResolverFunction = (ctx, injection, session) {
+ *   return session.currentBinding?.key;
+ * }
+ * ```
  */
 export interface ResolverFunction {
   (
@@ -377,7 +386,7 @@ export namespace inject {
    * ```
    */
   export const context = function injectContext() {
-    return inject('', {decorator: '@inject.context'}, ctx => ctx);
+    return inject('', {decorator: '@inject.context'}, (ctx: Context) => ctx);
   };
 }
 

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -6,6 +6,7 @@
 import {DecoratorFactory} from '@loopback/metadata';
 import debugModule from 'debug';
 import {Binding} from './binding';
+import {Context} from './context';
 import {Injection} from './inject';
 import {BoundValue, tryWithFinally, ValueOrPromise} from './value-promise';
 
@@ -365,4 +366,22 @@ export function asResolutionOptions(
     return {session: optionsOrSession};
   }
   return optionsOrSession ?? {};
+}
+
+/**
+ * Contextual metadata for resolution
+ */
+export interface ResolutionContext<T = unknown> {
+  /**
+   * The context for resolution
+   */
+  readonly context: Context;
+  /**
+   * The binding to be resolved
+   */
+  readonly binding: Readonly<Binding<T>>;
+  /**
+   * The options used for resolution
+   */
+  readonly options: ResolutionOptions;
 }


### PR DESCRIPTION
A provider class can use dependency injection to receive resolution-related
metadata such as `context` and `binding`. But the overhead to wrap a factory
function is not desired for some use cases. This PR introduces a lightweight
alternative using `toDynamicValue` as follows:

1. Add a parameter to the factory function to receive resolution context
2. Support a specialized class with a static `value` method that allows
parameter injection.

Some benchmark tests are added to `benchmark` to measure performances for
various flavors of the dynamic value resolution for bindings.

See https://github.com/strongloop/loopback-next/tree/pass-ctx-to-dynamic-value/benchmark/src/context-binding for examples.

This change is backward compatible. Existing factory functions continue to work.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
