### PR TITLE
feat(express): allow invokeMiddleware to take a `next` option

### DIFF
--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -213,7 +213,7 @@ export function invokeMiddleware(
     filter,
     compareBindingsByTag('group', orderedGroups),
   );
-  return _middlewareChain.invokeInterceptors();
+  return _middlewareChain.invokeInterceptors(options?.next);
 }
 
 /**

--- a/packages/express/src/providers/invoke-middleware.provider.ts
+++ b/packages/express/src/providers/invoke-middleware.provider.ts
@@ -12,6 +12,7 @@ import {
   Provider,
 } from '@loopback/core';
 import debugFactory from 'debug';
+import {DEFAULT_MIDDLEWARE_GROUP} from '../keys';
 import {invokeExpressMiddleware, invokeMiddleware} from '../middleware';
 import {
   DEFAULT_MIDDLEWARE_CHAIN,
@@ -39,7 +40,7 @@ export class InvokeMiddlewareProvider implements Provider<InvokeMiddleware> {
   @config()
   protected defaultOptions: InvokeMiddlewareOptions = {
     chain: DEFAULT_MIDDLEWARE_CHAIN,
-    orderedGroups: ['cors', 'apiSpec', ''],
+    orderedGroups: ['cors', 'apiSpec', DEFAULT_MIDDLEWARE_GROUP],
   };
 
   value(): InvokeMiddleware {

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -10,6 +10,7 @@ import {
   GenericInterceptorChain,
   InvocationContext,
   ValueOrPromise,
+  Next,
 } from '@loopback/core';
 import {Request, RequestHandler, Response} from 'express';
 import onFinished from 'on-finished';
@@ -119,6 +120,8 @@ export interface InvokeMiddlewareOptions {
    * An array of group names to denote the order of execution
    */
   orderedGroups?: string[];
+
+  next?: Next;
 }
 
 /**


### PR DESCRIPTION
`options.next` allows invokeMiddleware to be cascaded with another middleware
chain.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
