### PR TITLE
feat(cli): remove `node_modules` before run `npm install` for `lb4 update`

### DIFF
--- a/packages/cli/lib/version-helper.js
+++ b/packages/cli/lib/version-helper.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const fse = require('fs-extra');
 const semver = require('semver');
 const chalk = require('chalk');
 const latestVersion = require('latest-version');
@@ -163,6 +164,10 @@ function updateDependencies(generator) {
     chalk.red('Upgrading dependencies may break the current project.'),
   );
   generator.fs.writeJSON(generator.destinationPath('package.json'), pkg);
+  // Remove `node_modules` force a fresh install
+  if (generator.command === 'update') {
+    fse.removeSync(generator.destinationPath('node_modules'));
+  }
   generator.pkgManagerInstall();
 }
 


### PR DESCRIPTION
Some users run into inconsistent `node_modules` after `lb4 update`. This PR removes `node_modules` to force a clean install.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
