### PR TITLE
feat(openapi-v3): relax `@api` to make `paths` optional with `{}` as the default

### DIFF
--- a/packages/openapi-v3/src/decorators/api.decorator.ts
+++ b/packages/openapi-v3/src/decorators/api.decorator.ts
@@ -26,10 +26,11 @@ import {OAI3Keys} from '../keys';
  * handled by this controller
  *
  */
-export function api(spec: ControllerSpec) {
+export function api(spec: Partial<ControllerSpec>) {
+  const controllerSpec: ControllerSpec = {paths: {}, ...spec};
   return ClassDecoratorFactory.createDecorator<ControllerSpec>(
     OAI3Keys.CLASS_KEY,
-    spec,
+    controllerSpec,
     {decoratorName: '@api'},
   );
 }

--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -524,7 +524,7 @@ describe('Routing', () => {
     const app = givenAnApplication();
     const server = await givenAServer(app);
 
-    @api({basePath: '/my', paths: {}})
+    @api({basePath: '/my'})
     class MyController {
       @get('/greet')
       greet(@param.query.string('name') name: string) {


### PR DESCRIPTION
The usage of `@api({basePath: '/customers'}) is now allowed without `paths`.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
