### PR TITLE
fix(cli): add previously undeclared dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,6 @@
     "sinon": "^9.0.2",
     "strong-globalize-cli": "7.0.1",
     "yeoman-assert": "^3.1.1",
-    "yeoman-environment": "^2.10.0",
     "yeoman-test": "~2.6.0"
   },
   "dependencies": {
@@ -82,6 +81,7 @@
     "url-slug": "^2.3.1",
     "validate-npm-package-name": "^3.0.0",
     "write-file-atomic": "^3.0.3",
+    "yeoman-environment": "^2.10.0",
     "yeoman-generator": "^4.10.1"
   },
   "scripts": {


### PR DESCRIPTION
Fix issue with Yarn plug'n'play. `yeoman-environment` is required by [`lib/cli.js`](https://github.com/strongloop/loopback-next/blob/b13b3386a06332b71b33a64f5bc2ab9b4544cc8a/packages/cli/lib/cli.js#L12) but not declared in `dependencies` field in [`package.json`](https://github.com/strongloop/loopback-next/blob/b13b3386a06332b71b33a64f5bc2ab9b4544cc8a/packages/cli/package.json#L84).

> Error: @loopback/cli tried to access yeoman-environment, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [X] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] <s>Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)</s>
- [ ] <s>API Documentation in code was updated</s>
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] <s>Affected artifact templates in `packages/cli` were updated</s>
- [ ] <s>Affected example projects in `examples/*` were updated</s>

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
