### PR TITLE
chore(benchmark): increase timeout for benchmark tests

### DIFF
--- a/benchmark/src/__tests__/benchmark.integration.ts
+++ b/benchmark/src/__tests__/benchmark.integration.ts
@@ -19,7 +19,7 @@ const DUMMY_STATS: EndpointStats = {
 describe('Benchmark (SLOW)', function () {
   // Unfortunately, the todo app requires one second to start (or more on CI)
   // eslint-disable-next-line no-invalid-this
-  this.timeout(10000);
+  this.timeout(15000);
   it('works', async () => {
     const bench = new Benchmark();
     bench.cannonFactory = url => new AutocannonStub(url);

--- a/benchmark/src/__tests__/mocha.opts
+++ b/benchmark/src/__tests__/mocha.opts
@@ -1,2 +1,0 @@
---recursive
---require source-map-support/register


### PR DESCRIPTION
The CI build on Windows fails once a while due to benchmark timeout

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
