### PR TITLE
Run LB3 tests from LB4 when LB3 is mounted on the LB4 app

### DIFF
--- a/examples/lb3-application/lb3app/common/models/coffee-shop.js
+++ b/examples/lb3-application/lb3app/common/models/coffee-shop.js
@@ -38,6 +38,6 @@ module.exports = function (CoffeeShop) {
   };
   CoffeeShop.remoteMethod('greet', {
     http: {path: '/greet', verb: 'get'},
-    returns: {type: 'string'},
+    returns: {arg: 'greeting', type: 'string'},
   });
 };

--- a/examples/lb3-application/lb3app/test/acceptance.js
+++ b/examples/lb3-application/lb3app/test/acceptance.js
@@ -1,0 +1,107 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/example-lb3-application
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const {supertest} = require('@loopback/testlab');
+const assert = require('assert');
+const {ExpressServer} = require('../../dist/server');
+const {CoffeeShopApplication} = require('../../dist/application');
+require('should');
+
+let app;
+
+function jsonForLB4(verb, url) {
+  // use the lb4 app's rest server
+  return supertest(app.restServer.url)
+    [verb](url)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/);
+}
+
+function jsonForExpressApp(verb, url) {
+  // use the express server, it mounts LoopBack 3 apis to
+  // base path '/api'
+  return supertest(app.server)
+    [verb]('/api' + url)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/);
+}
+
+function jsonForExternal(verb, url) {
+  // use the express server, its external apis doesn't have base path
+  return supertest(app.server)
+    [verb](url)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/);
+}
+
+describe('LoopBack 3 style acceptance tests - boot from Express server', function () {
+  before(async function () {
+    app = new ExpressServer();
+    await app.boot();
+    await app.start();
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  it('gets external route in application', function (done) {
+    jsonForExternal('get', '/ping').expect(200, function (err, res) {
+      assert.equal(res.text, 'pong');
+      done();
+    });
+  });
+
+  runTests(jsonForExpressApp);
+});
+
+describe('LoopBack 3 style acceptance tests - boot from LB4 app', function () {
+  before(async function () {
+    app = new CoffeeShopApplication();
+    await app.boot();
+    await app.start();
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  runTests(jsonForLB4);
+});
+
+function runTests(request) {
+  context('basic REST calls for LoopBack 3 application', () => {
+    it('creates and finds a CoffeeShop', function (done) {
+      request('post', '/CoffeeShops')
+        .send({
+          name: 'Coffee Shop',
+          city: 'Toronto',
+        })
+        .expect(200)
+        .end(function (err, res) {
+          assert(typeof res.body === 'object');
+          assert(res.body.name);
+          assert(res.body.city);
+          assert.equal(res.body.name, 'Coffee Shop');
+          assert.equal(res.body.city, 'Toronto');
+          done();
+        });
+    });
+
+    it("gets the CoffeeShop's status", function (done) {
+      request('get', '/CoffeeShops/status').expect(200, function (err, res) {
+        res.body.status.should.be.equalOneOf(
+          'We are open for business.',
+          'Sorry, we are closed. Open daily from 6am to 8pm.',
+        );
+        done();
+      });
+    });
+  });
+}

--- a/examples/lb3-application/lb3app/test/authentication.js
+++ b/examples/lb3-application/lb3app/test/authentication.js
@@ -1,0 +1,135 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/example-lb3-application
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+const lb3App = require('../server/server');
+const {supertest} = require('@loopback/testlab');
+const assert = require('assert');
+const {ExpressServer} = require('../../dist/server');
+const {CoffeeShopApplication} = require('../../dist/application');
+require('should');
+
+let app, User;
+
+function jsonForLB4(verb, url) {
+  // use the lb4 app's rest server
+  return supertest(app.restServer.url)
+    [verb](url)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/);
+}
+
+function jsonForExpressApp(verb, url) {
+  // use the express server, it mounts apis to base path '/api'
+  return supertest(app.server)
+    [verb]('/api' + url)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/);
+}
+
+/**
+ * The tests show running LoopBack 3 authentication tests mounted to
+ * an Express server.
+ * Make sure you start the express server first and stop it after tests done.
+ */
+describe('LoopBack 3 authentication - Express server', function () {
+  before(async function () {
+    User = lb3App.models.User;
+    app = new ExpressServer();
+    await app.boot();
+    await app.start();
+  });
+
+  after(async () => {
+    await User.destroyAll();
+    await app.stop();
+  });
+
+  runTests(jsonForExpressApp);
+});
+
+/**
+ * The tests show running LoopBack 3 authentication tests mounted to
+ * a LoopBack 4 application.
+ * Make sure you start the LoopBack 4 application first and stop it
+ * after tests done.
+ */
+describe('Loopback 3 authentication - LoopBack 4 app', function () {
+  before(async function () {
+    User = lb3App.models.User;
+    app = new CoffeeShopApplication();
+    await app.boot();
+    await app.start();
+  });
+
+  after(async () => {
+    await User.destroyAll();
+    await app.stop();
+  });
+
+  runTests(jsonForLB4);
+});
+
+function runTests(request) {
+  it('creates a User and logs them in and out', function (done) {
+    // create user
+    request('post', '/users')
+      .send({email: 'new@email.com', password: 'L00pBack!'})
+      .expect(200, function (err, user) {
+        assert.equal(user.body.email, 'new@email.com');
+        // login
+        request('post', '/users/login')
+          .send({
+            email: 'new@email.com',
+            password: 'L00pBack!',
+          })
+          .expect(200, function (err2, token) {
+            token.body.should.have.properties('ttl', 'userId', 'created', 'id');
+            assert.equal(token.body.userId, user.body.id);
+            // logout
+            request(
+              'post',
+              `/users/logout?access_token=${token.body.id}`,
+            ).expect(204);
+            done();
+          });
+      });
+  });
+
+  it('rejects anonymous requests to protected endpoints', function (done) {
+    request('get', '/CoffeeShops/greet').expect(401, function (err, res) {
+      assert.equal(res.body.error.code, 'AUTHORIZATION_REQUIRED');
+    });
+    done();
+  });
+
+  it('makes an authenticated request', function (done) {
+    // create user
+    User.create({email: 'new@gmail.com', password: 'L00pBack!'}, function (
+      err,
+      user,
+    ) {
+      user.email.should.be.equal('new@gmail.com');
+      // login
+      User.login({email: 'new@gmail.com', password: 'L00pBack!'}, function (
+        err2,
+        token,
+      ) {
+        assert.equal(typeof token, 'object');
+        assert.equal(token.userId, user.id);
+        // authenticate user with token
+        request('get', `/CoffeeShops/greet?access_token=${token.id}`).expect(
+          200,
+          function (err3, res) {
+            res.body.greeting.should.be.equal('Hello from this Coffee Shop');
+            done();
+          },
+        );
+      });
+    });
+  });
+}

--- a/examples/lb3-application/lb3app/test/integration.js
+++ b/examples/lb3-application/lb3app/test/integration.js
@@ -1,0 +1,75 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/example-lb3-application
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const assert = require('assert');
+const ExpressServer = require('../../dist/server').ExpressServer;
+const CoffeeShopApp = require('../../dist/application').CoffeeShopApplication;
+require('should');
+
+let CoffeeShop, app;
+
+describe('LoopBack 3 style integration tests - boot from LB4 app', function () {
+  before(async function () {
+    app = new CoffeeShopApp();
+    await app.boot();
+    await app.start();
+    CoffeeShop = await app.get('lb3-models.CoffeeShop');
+  });
+
+  after(async () => {
+    await CoffeeShop.destroyAll({name: 'Nook Shop'});
+    await app.stop();
+  });
+
+  runTests();
+});
+
+describe('LoopBack 3 style integration tests - boot from express', function () {
+  before(async () => {
+    app = new ExpressServer();
+    await app.boot();
+    await app.start();
+    CoffeeShop = await app.lbApp.get('lb3-models.CoffeeShop');
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  runTests();
+});
+
+function runTests() {
+  it('CoffeeShop.find', function (done) {
+    CoffeeShop.find({where: {name: 'Bel Cafe'}}, function (err, shop) {
+      shop[0].__data.name.should.be.equal('Bel Cafe');
+      shop[0].__data.city.should.be.equal('Vancouver');
+    });
+    done();
+  });
+
+  it('CoffeeShop.count', function (done) {
+    CoffeeShop.count({}, function (err, count) {
+      assert.equal(count, 6);
+    });
+    done();
+  });
+
+  it('CoffeeShop.create', function (done) {
+    CoffeeShop.create(
+      {
+        name: 'Nook Shop',
+        city: 'Toronto',
+      },
+      function (err, shop) {
+        shop.__data.name.should.be.equal('Nook Shop');
+        shop.__data.city.should.be.equal('Toronto');
+      },
+    );
+    done();
+  });
+}

--- a/examples/lb3-application/package-lock.json
+++ b/examples/lb3-application/package-lock.json
@@ -2465,6 +2465,60 @@
 				"nanoid": "^2.1.0"
 			}
 		},
+		"should": {
+			"version": "13.2.3",
+			"resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+			"integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+			"dev": true,
+			"requires": {
+				"should-equal": "^2.0.0",
+				"should-format": "^3.0.3",
+				"should-type": "^1.4.0",
+				"should-type-adaptors": "^1.0.1",
+				"should-util": "^1.0.0"
+			}
+		},
+		"should-equal": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+			"integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+			"dev": true,
+			"requires": {
+				"should-type": "^1.4.0"
+			}
+		},
+		"should-format": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+			"dev": true,
+			"requires": {
+				"should-type": "^1.3.0",
+				"should-type-adaptors": "^1.0.1"
+			}
+		},
+		"should-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+			"integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+			"dev": true
+		},
+		"should-type-adaptors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+			"integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+			"dev": true,
+			"requires": {
+				"should-type": "^1.3.0",
+				"should-util": "^1.0.0"
+			}
+		},
+		"should-util": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+			"integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+			"dev": true
+		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -19,7 +19,7 @@
     "eslint": "lb-eslint --report-unused-disable-directives .",
     "eslint:fix": "npm run eslint -- --fix",
     "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\" \"lb3app/test/*.js\"",
     "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
     "verify": "npm pack && tar xf loopback-lb3-application*.tgz && tree package && npm run clean",
     "migrate": "node ./dist/migrate",
@@ -62,7 +62,8 @@
     "@types/node": "^10.17.21",
     "eslint": "^7.0.0",
     "lodash": "^4.17.15",
-    "typescript": "~3.9.2"
+    "typescript": "~3.9.2",
+    "should": "^13.2.3"
   },
   "keywords": [
     "loopback",

--- a/examples/lb3-application/src/__tests__/acceptance/lb3app.acceptance.ts
+++ b/examples/lb3-application/src/__tests__/acceptance/lb3app.acceptance.ts
@@ -90,7 +90,7 @@ describe('CoffeeShopApplication', () => {
         .get(`/api/CoffeeShops/greet?access_token=${token.id}`)
         .expect(200);
 
-      expect(response.body.undefined).to.eql('Hello from this Coffee Shop');
+      expect(response.body.greeting).to.eql('Hello from this Coffee Shop');
     });
 
     it('rejects anonymous requests to protected endpoints', async () => {

--- a/examples/lb3-application/src/server.ts
+++ b/examples/lb3-application/src/server.ts
@@ -19,7 +19,7 @@ const helmet = require('helmet');
 export class ExpressServer {
   private app: express.Application;
   public readonly lbApp: CoffeeShopApplication;
-  private server?: http.Server;
+  public server?: http.Server;
   public url: String;
 
   constructor(options: ApplicationConfig = {}) {

--- a/packages/booter-lb3app/README.md
+++ b/packages/booter-lb3app/README.md
@@ -29,6 +29,12 @@ Register the component in Application's constructor:
 this.component(Lb3AppBooterComponent);
 ```
 
+By default, the LoopBack 3 models and datasources will be bond to the
+application with naming conventions as:
+
+- binding key for datasources: `lb3-datasources.{ds name}`
+- binding key for models: `lb3-models.{model name}`
+
 ## Contributions
 
 - [Guidelines](https://github.com/strongloop/loopback-next/blob/master/docs/CONTRIBUTING.md)


### PR DESCRIPTION
Implements https://github.com/strongloop/loopback-next/issues/5298 and https://github.com/strongloop/loopback-next/issues/5300

Based on the spike in https://github.com/strongloop/loopback-next/issues/5004
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
