### PR TITLE
fix: remove email connector from sidebar

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -743,10 +743,6 @@ children:
     output: 'web'
     children:
 
-    - title: 'Email connector'
-      url: Email-connector.html
-      output: 'web, pdf'
-
     - title: 'JSON RPC connector'
       url: JSON-RPC-connector.html
       output: 'web, pdf'


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Fixes https://github.com/strongloop/loopback-next/issues/5409

Since LB3 email connector does not work in LoopBack 4 (see discussion https://github.com/strongloop/loopback-next/issues/1979), we're removing the email connector from the LB4 sidebar.  

#1979 has the workaround and potential documentation around how to send emails in LB4. 

Once this PR lands and the change is published, I'll submit another PR in loopback.io to clean up the md files. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
