### PR TITLE
Replace eslint rule `no-invalid-this` with TypeScript-aware one

### DIFF
--- a/acceptance/extension-logging-fluentd/src/__tests__/acceptance/fluent.acceptance.ts
+++ b/acceptance/extension-logging-fluentd/src/__tests__/acceptance/fluent.acceptance.ts
@@ -11,16 +11,14 @@ import {readLog} from '../fixtures/fluentd.docker';
 
 const sleep = promisify(setTimeout);
 
-describe('LoggingComponent', function () {
+describe('LoggingComponent', function (this: Mocha.Suite) {
   let app: Application;
 
-  // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
   beforeEach(givenAppWithCustomConfig);
 
-  /* eslint-disable no-invalid-this */
-  it('binds a fluent sender', async function () {
+  it('binds a fluent sender', async function (this: Mocha.Context) {
     if (process.env.FLUENTD_SERVICE_PORT_TCP == null) return this.skip();
     const sender = await app.get(LoggingBindings.FLUENT_SENDER);
     sender.emit({greeting: 'Hello, LoopBack!'});
@@ -28,7 +26,7 @@ describe('LoggingComponent', function () {
     await expectLogsToMatch(/LoopBack\s+\{"greeting"\:"Hello, LoopBack!"\}/);
   });
 
-  it('binds a winston transport for fluent', async function () {
+  it('binds a winston transport for fluent', async function (this: Mocha.Context) {
     if (process.env.FLUENTD_SERVICE_PORT_TCP == null) return this.skip();
     const logger = await app.get(LoggingBindings.WINSTON_LOGGER);
     logger.log('info', 'Hello, LoopBack!');
@@ -38,7 +36,7 @@ describe('LoggingComponent', function () {
     );
   });
 
-  it('throws error if fluent is not configured', async function () {
+  it('throws error if fluent is not configured', async function (this: Mocha.Context) {
     if (process.env.FLUENTD_SERVICE_PORT_TCP == null) return this.skip();
 
     // Remove the configuration for fluent sender

--- a/acceptance/extension-logging-fluentd/src/__tests__/fixtures/fluentd.docker.ts
+++ b/acceptance/extension-logging-fluentd/src/__tests__/fixtures/fluentd.docker.ts
@@ -33,11 +33,10 @@ async function startFluentd() {
 
 let fluentd: StartedTestContainer | undefined;
 
-/* eslint-disable no-invalid-this */
 /**
  * Root-level before hook to start Fluentd container
  */
-before(async function () {
+before(async function (this: Mocha.Context) {
   // Do not run with non-linux CI
   if (process.env.CI && process.platform !== 'linux') return;
   this.timeout(30 * 1000);
@@ -49,7 +48,7 @@ before(async function () {
 /**
  * Root-level before hook to stop Fluentd container
  */
-after(async function () {
+after(async function (this: Mocha.Context) {
   this.timeout(30 * 1000);
   if (fluentd) await fluentd.stop();
 });

--- a/benchmark/src/__tests__/benchmark.integration.ts
+++ b/benchmark/src/__tests__/benchmark.integration.ts
@@ -16,9 +16,8 @@ const DUMMY_STATS: EndpointStats = {
   requestsPerSecond: 1000,
 };
 
-describe('Benchmark (SLOW)', function () {
+describe('Benchmark (SLOW)', function (this: Mocha.Suite) {
   // Unfortunately, the todo app requires one second to start (or more on CI)
-  // eslint-disable-next-line no-invalid-this
   this.timeout(15000);
   it('works', async () => {
     const bench = new Benchmark();

--- a/examples/context/src/__tests__/acceptance/examples.acceptance.ts
+++ b/examples/context/src/__tests__/acceptance/examples.acceptance.ts
@@ -18,10 +18,9 @@ describe('context examples', () => {
 
   before(disableConsoleOutput);
 
-  it('runs all examples', async function () {
+  it('runs all examples', async function (this: Mocha.Context) {
     // For some reason, travis CI on mac reports timeout for some builds
     // Error: Timeout of 2000ms exceeded.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(5000);
     const expectedLogs = loadExpectedLogs();
     await main();

--- a/examples/passport-login/src/__tests__/acceptance/passport-login.acceptance.ts
+++ b/examples/passport-login/src/__tests__/acceptance/passport-login.acceptance.ts
@@ -3,14 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Client, supertest, expect} from '@loopback/testlab';
 import {MockTestOauth2SocialApp} from '@loopback/mock-oauth2-provider';
-import {ExpressServer} from '../../server';
-import {User, UserIdentity} from '../../models';
-import {startApplication} from '../../';
-import * as url from 'url';
-import qs from 'qs';
+import {Client, expect, supertest} from '@loopback/testlab';
 import * as path from 'path';
+import qs from 'qs';
+import * as url from 'url';
+import {startApplication} from '../../';
+import {User, UserIdentity} from '../../models';
+import {ExpressServer} from '../../server';
 const oauth2Providers = require(path.resolve(
   __dirname,
   '../../../data/oauth2-test-provider',
@@ -40,8 +40,7 @@ describe('example-passport-login acceptance test', () => {
    */
   before(MockTestOauth2SocialApp.startMock);
   after(MockTestOauth2SocialApp.stopMock);
-  before(async function setupApplication() {
-    // eslint-disable-next-line no-invalid-this
+  before(async function setupApplication(this: Mocha.Context) {
     this.timeout(6000);
     server = await startApplication(oauth2Providers);
     client = supertest('http://127.0.0.1:3000');

--- a/examples/soap-calculator/src/__tests__/acceptance/application.acceptance.ts
+++ b/examples/soap-calculator/src/__tests__/acceptance/application.acceptance.ts
@@ -6,11 +6,10 @@
 import {Client, createRestAppClient, expect} from '@loopback/testlab';
 import {SoapCalculatorApplication} from '../../application';
 
-describe('Application', function () {
+describe('Application', function (this: Mocha.Suite) {
   let app: SoapCalculatorApplication;
   let client: Client;
 
-  // eslint-disable-next-line no-invalid-this
   this.timeout(30000);
 
   before(givenAnApplication);

--- a/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
+++ b/examples/soap-calculator/src/__tests__/integration/services/calculator.service.integration.ts
@@ -11,12 +11,11 @@ import {
 } from '../../../services/calculator.service';
 import {givenAConnectedDataSource} from '../../helpers';
 
-describe('CalculatorService', function () {
+describe('CalculatorService', function (this: Mocha.Suite) {
   let calculatorService: CalculatorService;
 
   // The calculator soap server is hosted in the cloud and it takes some time
   // to wake up and respond to api requests
-  // eslint-disable-next-line no-invalid-this
   this.timeout(30000);
 
   before(givenACalculatorService);

--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -38,8 +38,7 @@ describe('TodoApplication', () => {
   after(() => app.stop());
 
   let available = true;
-  before(async function () {
-    // eslint-disable-next-line no-invalid-this
+  before(async function (this: Mocha.Context) {
     this.timeout(30 * 1000);
     const service = await app.get<Geocoder>('services.Geocoder');
     available = await isGeoCoderServiceAvailable(service);
@@ -54,10 +53,9 @@ describe('TodoApplication', () => {
     await todoRepo.deleteAll();
   });
 
-  it('creates a todo', async function () {
+  it('creates a todo', async function (this: Mocha.Context) {
     // Set timeout to 30 seconds as `post /todos` triggers geocode look up
     // over the internet and it takes more than 2 seconds
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30000);
     const todo = givenTodo();
     const response = await client.post('/todos').send(todo).expect(200);
@@ -86,11 +84,9 @@ describe('TodoApplication', () => {
     await client.post('/todos').send(todo).expect(422);
   });
 
-  it('creates an address-based reminder', async function () {
-    // eslint-disable-next-line no-invalid-this
+  it('creates an address-based reminder', async function (this: Mocha.Context) {
     if (!available) return this.skip();
     // Increase the timeout to accommodate slow network connections
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30000);
 
     const todo = givenTodo({remindAtAddress: aLocation.address});
@@ -103,11 +99,9 @@ describe('TodoApplication', () => {
     expect(result).to.containEql(todo);
   });
 
-  it('returns 400 if it cannot find an address', async function () {
-    // eslint-disable-next-line no-invalid-this
+  it('returns 400 if it cannot find an address', async function (this: Mocha.Context) {
     if (!available) return this.skip();
     // Increase the timeout to accommodate slow network connections
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30000);
 
     const todo = givenTodo({remindAtAddress: 'this address does not exist'});

--- a/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
+++ b/examples/todo/src/__tests__/integration/services/geocoder.service.integration.ts
@@ -14,8 +14,7 @@ import {
   isGeoCoderServiceAvailable,
 } from '../../helpers';
 
-describe('GeoLookupService', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('GeoLookupService', function (this: Mocha.Suite) {
   this.timeout(30 * 1000);
 
   let cachingProxy: HttpCachingProxy;
@@ -30,8 +29,7 @@ describe('GeoLookupService', function () {
     available = await isGeoCoderServiceAvailable(service);
   });
 
-  it('resolves an address to a geo point', async function () {
-    // eslint-disable-next-line no-invalid-this
+  it('resolves an address to a geo point', async function (this: Mocha.Context) {
     if (!available) return this.skip();
 
     const points = await service.geocode(aLocation.address);

--- a/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
+++ b/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
@@ -16,8 +16,7 @@ import {
   ContextExplorerConfig,
 } from '../..';
 
-describe('Context Explorer (acceptance)', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('Context Explorer (acceptance)', function (this: Mocha.Suite) {
   this.timeout(5000);
   let app: RestApplication;
   let request: Client;

--- a/packages/build/test/integration/scripts.integration.js
+++ b/packages/build/test/integration/scripts.integration.js
@@ -10,8 +10,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const utils = require('../../bin/utils');
 
-describe('build', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('build', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
   const cwd = process.cwd();
   const projectDir = path.resolve(__dirname, './fixtures');
@@ -243,8 +242,7 @@ describe('build', function () {
   });
 });
 
-describe('mocha', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('mocha', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
   const cwd = process.cwd();
   const projectDir = path.resolve(__dirname, './fixtures');

--- a/packages/cli/smoke-test/openapi/real-world-apis.smoke.js
+++ b/packages/cli/smoke-test/openapi/real-world-apis.smoke.js
@@ -30,7 +30,9 @@ let realWorldAPIs = [
 ];
 
 describe('Real-world APIs', () => {
-  before(async function () {
+  before(prepareRealWorldApis);
+  /** @this {Mocha.Context} */
+  async function prepareRealWorldApis() {
     // Set env var `APIS` to `*` to test against apis.guru directory
     if (process.env.APIS !== 'all') return;
 
@@ -46,7 +48,6 @@ describe('Real-world APIs', () => {
     }
 
     // This hook sometimes takes several seconds, due to the large download
-    // eslint-disable-next-line no-invalid-this
     this.timeout(10000);
 
     // Download a list of over 1500 real-world Swagger APIs from apis.guru
@@ -78,10 +79,9 @@ describe('Real-world APIs', () => {
         realWorldAPIs.push(api);
       }
     }
-  });
+  }
 
-  it('generates all the proper files', async function () {
-    // eslint-disable-next-line no-invalid-this
+  it('generates all the proper files', /** @this {Mocha.Context} */ async function () {
     this.timeout(0);
     let count = 0;
     for (const api of realWorldAPIs) {

--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -22,9 +22,10 @@ describe('app-generator (SLOW)', function () {
     outdir: path.join(sandboxDir, 'sandbox-app'),
   };
 
-  before('scaffold a new application', async function createAppProject() {
+  before('scaffold a new application', createAppProject);
+  /** @this {Mocha.Context} */
+  async function createAppProject() {
     // Increase the timeout to 1 minute to accommodate slow CI build machines
-    // eslint-disable-next-line no-invalid-this
     this.timeout(60 * 1000);
     await helpers
       .run(appGenerator)
@@ -32,21 +33,21 @@ describe('app-generator (SLOW)', function () {
       // Mark it private to prevent accidental npm publication
       .withOptions({private: true})
       .withPrompts(appProps);
-  });
+  }
 
-  before('install dependencies', async function installDependencies() {
+  before('install dependencies', installDependencies);
+  /** @this {Mocha.Context} */
+  async function installDependencies() {
     // Run `lerna bootstrap --scope @loopback/sandbox-app --include-filtered-dependencies`
     // WARNING: It takes a while to run `lerna bootstrap`
-    // eslint-disable-next-line no-invalid-this
     this.timeout(15 * 60 * 1000);
     process.chdir(rootDir);
     await lernaBootstrap(null, appProps.name);
-  });
+  }
 
-  it('passes `npm test` for the generated project', function () {
+  it('passes `npm test` for the generated project', /** @this {Mocha.Context} */ function () {
     // Increase the timeout to 5 minutes,
     // the tests can take more than 2 seconds to run.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(5 * 60 * 1000);
 
     return new Promise((resolve, reject) => {
@@ -63,15 +64,16 @@ describe('app-generator (SLOW)', function () {
     });
   });
 
-  after(function () {
+  after(cleanup);
+  /** @this {Mocha.Context} */
+  function cleanup() {
     // Increase the timeout to accommodate slow CI build machines
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30 * 1000);
 
     process.chdir(rootDir);
     build.clean(['node', 'run-clean', appProps.outdir]);
     process.chdir(process.cwd());
-  });
+  }
 });
 
 const isYarnAvailable = utils.isYarnAvailable();
@@ -84,9 +86,10 @@ yarnTest('app-generator with Yarn (SLOW)', () => {
     outdir: path.join(sandboxDir, 'sandbox-yarn-app'),
   };
 
-  before('scaffold a new application', async function createAppProject() {
+  before('scaffold a new application', createAppProject);
+  /** @this {Mocha.Context} */
+  async function createAppProject() {
     // Increase the timeout to 1 minute to accommodate slow CI build machines
-    // eslint-disable-next-line no-invalid-this
     this.timeout(60 * 1000);
     await helpers
       .run(appGenerator)
@@ -98,21 +101,21 @@ yarnTest('app-generator with Yarn (SLOW)', () => {
         private: true,
       })
       .withPrompts(appProps);
-  });
+  }
 
-  before('install dependencies', async function installDependencies() {
+  before('install dependencies', installDependencies);
+  /** @this {Mocha.Context} */
+  async function installDependencies() {
     // Run `lerna bootstrap --scope @loopback/sandbox-app --include-filtered-dependencies`
     // WARNING: It takes a while to run `lerna bootstrap`
-    // eslint-disable-next-line no-invalid-this
     this.timeout(15 * 60 * 1000);
     process.chdir(rootDir);
     await lernaBootstrap('yarn', appProps.name);
-  });
+  }
 
-  it('passes `yarn test` for the generated project', function () {
+  it('passes `yarn test` for the generated project', /** @this {Mocha.Context} */ function () {
     // Increase the timeout to 5 minutes,
     // the tests can take more than 2 seconds to run.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(5 * 60 * 1000);
 
     return new Promise((resolve, reject) => {
@@ -129,15 +132,16 @@ yarnTest('app-generator with Yarn (SLOW)', () => {
     });
   });
 
-  after(function () {
+  after(cleanup);
+  /** @this {Mocha.Context} */
+  function cleanup() {
     // Increase the timeout to accommodate slow CI build machines
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30 * 1000);
 
     process.chdir(rootDir);
     build.clean(['node', 'run-clean', appProps.outdir]);
     process.chdir(process.cwd());
-  });
+  }
 });
 
 async function lernaBootstrap(packageManager, ...scopes) {

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -129,8 +129,9 @@ describe('app-generator with --apiconnect', () => {
 
 // The test takes about 1 min to install dependencies
 function testFormat() {
-  before(function () {
-    // eslint-disable-next-line no-invalid-this
+  before(createAppAndInstallDeps);
+  /** @this {Mocha.Context} */
+  function createAppAndInstallDeps() {
     this.timeout(90 * 1000);
     return helpers
       .run(generator)
@@ -148,7 +149,7 @@ function testFormat() {
         },
       })
       .withPrompts(props);
-  });
+  }
   it('generates all the proper files', () => {
     assert.file('src/application.ts');
     assert.fileContent('src/application.ts', /class MyApp extends BootMixin\(/);
@@ -206,7 +207,7 @@ describe('app-generator with default values', () => {
 });
 
 /** For testing the support of tilde path as the input of project path.
- * Use differnt paths to test out the support of `~` when the test runs outside of home dir.
+ * Use different paths to test out the support of `~` when the test runs outside of home dir.
  */
 describe('app-generator with tilde project path', () => {
   const rootDir = path.join(__dirname, '../../../../../');
@@ -230,9 +231,10 @@ describe('app-generator with tilde project path', () => {
     outdir: pathWithTilde,
   };
 
-  before(async function () {
+  before(givenScaffoldedApp);
+  /** @this {Mocha.Context} */
+  async function givenScaffoldedApp() {
     // Increase the timeout to accommodate slow CI build machines
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30 * 1000);
     // check it with full path. tilde-path-app should not exist at this point
     assert.equal(fs.existsSync(sandbox), false);
@@ -242,14 +244,17 @@ describe('app-generator with tilde project path', () => {
       // Mark it private to prevent accidental npm publication
       .withOptions({private: true})
       .withPrompts(tildePathProps);
-  });
+  }
+
   it('scaffold a new application for tilde-path-app', async () => {
     // tilde-path-app should be created at this point
     assert.equal(fs.existsSync(sandbox), true);
   });
-  after(function () {
+
+  after(cleanup);
+  /** @this {Mocha.Context} */
+  function cleanup() {
     // Increase the timeout to accommodate slow CI build machines
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30 * 1000);
 
     // Handle special case - Skipping... not inside the project root directory.
@@ -260,5 +265,5 @@ describe('app-generator with tilde project path', () => {
     }
     build.clean(['node', 'run-clean', sandbox]);
     process.chdir(cwd);
-  });
+  }
 });

--- a/packages/cli/test/integration/generators/clone-example.integration.js
+++ b/packages/cli/test/integration/generators/clone-example.integration.js
@@ -19,8 +19,7 @@ const readFile = promisify(fs.readFile);
 const VALID_EXAMPLE = 'todo';
 const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
-describe('cloneExampleFromGitHub (SLOW)', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('cloneExampleFromGitHub (SLOW)', /** @this {Mocha.Suite} */ function () {
   this.timeout(20000);
 
   beforeEach('reset sandbox', () => sandbox.reset());

--- a/packages/cli/test/integration/generators/copyright-git.integration.js
+++ b/packages/cli/test/integration/generators/copyright-git.integration.js
@@ -21,8 +21,7 @@ const testUtils = require('../../test-utils');
 let year = new Date().getFullYear();
 if (year !== 2020) year = `2020,${year}`;
 
-describe('lb4 copyright with git', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 copyright with git', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   before('add files not tracked by git', async () => {

--- a/packages/cli/test/integration/generators/copyright-monorepo.integration.js
+++ b/packages/cli/test/integration/generators/copyright-monorepo.integration.js
@@ -21,8 +21,7 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const year = new Date().getFullYear();
 
-describe('lb4 copyright for monorepo', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 copyright for monorepo', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   beforeEach('reset sandbox', async () => {

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -21,8 +21,7 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
 const year = new Date().getFullYear();
 
-describe('lb4 copyright', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 copyright', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   beforeEach('reset sandbox', async () => {

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -84,8 +84,7 @@ describe('lb4 discover integration', () => {
       await sandbox.mkdir('dist/datasources');
     });
 
-    it('generates all models without prompts using --all --dataSource', async function () {
-      // eslint-disable-next-line no-invalid-this
+    it('generates all models without prompts using --all --dataSource', /** @this {Mocha.Context} */ async function () {
       this.timeout(10000);
       await testUtils
         .executeGenerator(generator)

--- a/packages/cli/test/integration/generators/example.integration.js
+++ b/packages/cli/test/integration/generators/example.integration.js
@@ -17,8 +17,7 @@ const testUtils = require('../../test-utils');
 const ALL_EXAMPLES = require('../../../generators/example').getAllExamples();
 const VALID_EXAMPLE = 'todo';
 
-describe('lb4 example', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 example', /** @this {Mocha.Suite} */ function () {
   this.timeout(10000);
 
   describe('correctly extends BaseGenerator', baseTests);

--- a/packages/cli/test/integration/generators/import-lb3-models.integration.js
+++ b/packages/cli/test/integration/generators/import-lb3-models.integration.js
@@ -35,12 +35,13 @@ const APP_USING_MODEL_INHERITANCE = require.resolve(
 describe('lb4 import-lb3-models', function () {
   require('../lib/base-generator')(generator, {args: ['path-to-lb3-app']})();
 
-  before(function preloadCoffeeShopExampleApp() {
+  before(preloadCoffeeShopExampleApp);
+  /** @this {Mocha.Context} */
+  function preloadCoffeeShopExampleApp() {
     // The CoffeeShop example app takes some time to load :(
-    // eslint-disable-next-line no-invalid-this
     this.timeout(10000);
     return loadLb3App(COFFEE_SHOP_EXAMPLE);
-  });
+  }
 
   beforeEach('reset sandbox', () => sandbox.reset());
 

--- a/packages/cli/test/integration/generators/model.integration.js
+++ b/packages/cli/test/integration/generators/model.integration.js
@@ -80,9 +80,8 @@ describe('lb4 model integration', () => {
     assert.file(expectedModelFile);
   });
 
-  it('discovers a model from a datasource', async function () {
+  it('discovers a model from a datasource', /** @this {Mocha.Context} */ async function () {
     // This test takes a bit longer to finish on Windows.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(3000);
     await testUtils
       .executeGenerator(generator)

--- a/packages/cli/test/integration/generators/openapi-client.integration.js
+++ b/packages/cli/test/integration/generators/openapi-client.integration.js
@@ -26,9 +26,8 @@ const props = {
   dataSourceName: 'petStore',
 };
 
-describe('openapi-generator with --client', function () {
+describe('openapi-generator with --client', /** @this {Mocha.Suite} */ function () {
   // These tests take longer to execute, they used to time out on Travis CI
-  // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
   before('reset sandbox', () => sandbox.reset());
@@ -88,9 +87,8 @@ describe('openapi-generator with --client', function () {
   });
 });
 
-it('generates files with --client for an existing datasource', async function () {
+it('generates files with --client for an existing datasource', /** @this {Mocha.Context} */ async function () {
   // These tests take longer to execute, they used to time out on Travis CI
-  // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
   await testUtils
     .executeGenerator(generator)

--- a/packages/cli/test/integration/generators/openapi-petstore.integration.js
+++ b/packages/cli/test/integration/generators/openapi-petstore.integration.js
@@ -23,9 +23,8 @@ const props = {
   url: specPath,
 };
 
-describe('openapi-generator petstore', function () {
+describe('openapi-generator petstore', /** @this {Mocha.Suite} */ function () {
   // These tests take longer to execute, they used to time out on Travis CI
-  // eslint-disable-next-line no-invalid-this
   this.timeout(10000);
 
   before('reset sandbox', () => sandbox.reset());

--- a/packages/cli/test/integration/generators/relation.belongs-to.integration.js
+++ b/packages/cli/test/integration/generators/relation.belongs-to.integration.js
@@ -36,8 +36,7 @@ const repositoryFileName = [
   'order-class-type.repository.ts',
 ];
 
-describe('lb4 relation', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 relation', /** @this {Mocha.Suite} */ function () {
   this.timeout(50000);
 
   it("rejects relation when destination model doesn't have primary Key", async () => {

--- a/packages/cli/test/integration/generators/relation.has-many.integration.js
+++ b/packages/cli/test/integration/generators/relation.has-many.integration.js
@@ -42,8 +42,7 @@ const repositoryFileName = [
   'customer-class-type.repository.ts',
 ];
 
-describe('lb4 relation HasMany', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 relation HasMany', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   it('rejects relation when the corresponding repository does not exist', async () => {

--- a/packages/cli/test/integration/generators/relation.has-one.integration.js
+++ b/packages/cli/test/integration/generators/relation.has-one.integration.js
@@ -42,8 +42,7 @@ const repositoryFileName = [
   'customer-class-type.repository.ts',
 ];
 
-describe('lb4 relation HasOne', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 relation HasOne', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   it('rejects relation when the corresponding repository does not exist', async () => {

--- a/packages/cli/test/integration/generators/relation.integration.js
+++ b/packages/cli/test/integration/generators/relation.integration.js
@@ -23,8 +23,7 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 // See `relation-{type}.integration.ts` files for test cases specific
 // to different relation types.
 
-describe('lb4 relation', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 relation', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   beforeEach('reset sandbox', async () => {

--- a/packages/cli/test/integration/generators/repository.integration.js
+++ b/packages/cli/test/integration/generators/repository.integration.js
@@ -19,8 +19,7 @@ const testUtils = require('../../test-utils');
 // Test Sandbox
 const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
-describe('lb4 repository', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 repository', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   beforeEach('reset sandbox', async () => {

--- a/packages/cli/test/integration/generators/rest-crud.integration.js
+++ b/packages/cli/test/integration/generators/rest-crud.integration.js
@@ -20,8 +20,7 @@ const {expectFileToMatchSnapshot} = require('../../snapshots');
 // Test Sandbox
 const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 
-describe('lb4 rest-crud', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('lb4 rest-crud', /** @this {Mocha.Suite} */ function () {
   this.timeout(30000);
 
   beforeEach('reset sandbox', async () => {

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -15,10 +15,9 @@ const deps = utils.getDependencies();
 const expect = require('@loopback/testlab').expect;
 
 module.exports = function (projGenerator, props, projectType) {
-  return function () {
-    // Increase the timeout to 60 seconds to accomodate
+  return /** @this {Mocha.Context} */ function () {
+    // Increase the timeout to 60 seconds to accommodate
     // for possibly slow CI build machines
-    // eslint-disable-next-line no-invalid-this
     this.timeout(60 * 1000);
 
     describe('help', () => {

--- a/packages/cli/test/snapshot-matcher.js
+++ b/packages/cli/test/snapshot-matcher.js
@@ -46,11 +46,12 @@ function initializeSnapshots(snapshotDir) {
   let currentTest;
   let snapshotErrors = false;
 
-  beforeEach(function setupSnapshots() {
-    // eslint-disable-next-line no-invalid-this
+  /** @this {Mocha.Context} */
+  function setupSnapshots() {
     currentTest = this.currentTest;
     currentTest.__snapshotCounter = 1;
-  });
+  }
+  beforeEach(setupSnapshots);
 
   if (!process.env.UPDATE_SNAPSHOTS) {
     process.on('exit', function printSnapshotHelp() {

--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -108,7 +108,8 @@ module.exports = {
     'no-new-wrappers': 'error', // tslint:no-construct
     // 'no-redeclare': 'error', // tslint:no-duplicate-variable
 
-    'no-invalid-this': 'error',
+    'no-invalid-this': 'off',
+    '@typescript-eslint/no-invalid-this': ['error'],
     '@typescript-eslint/no-misused-new': 'error',
     'no-shadow': 'error', // tslint:no-shadowed-variable
     'no-throw-literal': 'error', // tslint:no-string-throw

--- a/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
+++ b/packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts
@@ -44,9 +44,8 @@ describe('HttpCachingProxy', () => {
     expect(proxy.url).to.match(/not-running/);
   });
 
-  it('proxies HTTP requests', async function () {
+  it('proxies HTTP requests', async function (this: Mocha.Context) {
     // Increase the timeout to accommodate slow network connections
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30000);
 
     await givenRunningProxy();
@@ -58,9 +57,8 @@ describe('HttpCachingProxy', () => {
     expect(result.body).to.containEql('example');
   });
 
-  it('reports error for HTTP requests', async function () {
+  it('reports error for HTTP requests', async function (this: Mocha.Context) {
     // Increase the timeout to accommodate slow network connections
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30000);
 
     await givenRunningProxy({logError: false});
@@ -86,9 +84,8 @@ describe('HttpCachingProxy', () => {
     ).to.be.rejectedWith(/502 - "Error: timeout of 1ms exceeded/);
   });
 
-  it('proxies HTTPs requests (no tunneling)', async function () {
+  it('proxies HTTPs requests (no tunneling)', async function (this: Mocha.Context) {
     // Increase the timeout to accommodate slow network connections
-    // eslint-disable-next-line no-invalid-this
     this.timeout(30000);
 
     await givenRunningProxy();
@@ -188,9 +185,8 @@ describe('HttpCachingProxy', () => {
     expect(result2.body).to.equal(2);
   });
 
-  it('handles the case where backend service is not running', async function () {
+  it('handles the case where backend service is not running', async function (this: Mocha.Context) {
     // This test takes a bit longer to finish on windows.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(3000);
     await givenRunningProxy({logError: false});
 

--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -41,9 +41,8 @@ describe('HttpServer (integration)', () => {
     await supertest(server.url).get('/').expect(200);
   });
 
-  it('stops server', async function () {
+  it('stops server', async function (this: Mocha.Context) {
     // This test takes a bit longer to finish on windows.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(3000);
     const serverOptions = givenHttpServerConfig();
     server = new HttpServer(dummyRequestHandler, serverOptions);
@@ -52,9 +51,8 @@ describe('HttpServer (integration)', () => {
     await expect(httpGetAsync(server.url)).to.be.rejectedWith(/ECONNREFUSED/);
   });
 
-  it('stops server with grace period and inflight request', async function () {
+  it('stops server with grace period and inflight request', async function (this: Mocha.Context) {
     // This test takes a bit longer to finish on windows.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(3000);
     const serverOptions = givenHttpServerConfig() as HttpServerOptions;
     serverOptions.gracePeriodForClose = 1000;
@@ -80,9 +78,8 @@ describe('HttpServer (integration)', () => {
     await expect(httpGetAsync(server.url)).to.be.rejectedWith(/ECONNREFUSED/);
   });
 
-  it('stops server with shorter grace period and inflight request', async function () {
+  it('stops server with shorter grace period and inflight request', async function (this: Mocha.Context) {
     // This test takes a bit longer to finish on windows.
-    // eslint-disable-next-line no-invalid-this
     this.timeout(3000);
     const serverOptions = givenHttpServerConfig() as HttpServerOptions;
     serverOptions.gracePeriodForClose = 10;

--- a/packages/repository-tests/src/helpers.repository-tests.ts
+++ b/packages/repository-tests/src/helpers.repository-tests.ts
@@ -24,8 +24,6 @@ export function withCrudCtx(
   fn: (context: CrudTestContext) => PromiseLike<unknown> | void,
 ): Mocha.AsyncFunc | Mocha.Func {
   return function (this: Mocha.Context) {
-    // See https://github.com/typescript-eslint/typescript-eslint/issues/604
-    // eslint-disable-next-line no-invalid-this
     return fn.call(this, getCrudContext(this));
   };
 }

--- a/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
+++ b/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
@@ -16,8 +16,7 @@ const MONOREPO_ROOT = path.join(__dirname, '../../../fixtures/monorepo');
 const APIDOCS_ROOT = path.join(MONOREPO_ROOT, 'docs/apidocs');
 const SITE_APIDOCS_ROOT = path.join(MONOREPO_ROOT, 'docs/site/apidocs');
 
-describe('tsdocs', function () {
-  // eslint-disable-next-line no-invalid-this
+describe('tsdocs', function (this: Mocha.Suite) {
   this.timeout(10000);
 
   const API_MD_FILES = [


### PR DESCRIPTION
See https://github.com/typescript-eslint/typescript-eslint/issues/604

The first commit changes our eslint config, the second removes `eslint-disable` comments that are no longer necessary 🎉 

**BREAKING CHANGE**

In code accessing `this` variable, eslint-ignore comment for `no-invalid-this` will no longer work. You can either change those comments to disable `@typescript-eslint/no-invalid-this`, or better tell TypeScript what is the type of `this` in your function.

A TypeScript example:

```ts
describe('my mocha suite', function(this: Mocha.Suite) {
  this.timeout(1000);
  it('is slow', function(this: Mocha.Context) {
    this.timeout(2000);
  });
})
```

A JavaScript example:

```js
describe('my mocha suite', /** @this {Mocha.Suite} */ function() {
  this.timeout(1000);
  it('is slow', /** @this {Mocha.Context} */ function() {
    this.timeout(2000);
  });
})
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
