### PR TITLE
fix(context): inspectTargetType needs to check parameters if index is a number

### DIFF
--- a/packages/context/src/__tests__/unit/inject.unit.ts
+++ b/packages/context/src/__tests__/unit/inject.unit.ts
@@ -9,6 +9,7 @@ import {
   describeInjectedArguments,
   describeInjectedProperties,
   inject,
+  inspectTargetType,
 } from '../..';
 
 describe('function argument injection', () => {
@@ -270,4 +271,77 @@ describe('property injection', () => {
     expect(meta.foo.metadata).to.be.not.exactly(options);
     expect(meta.foo.metadata).to.eql({x: 1, decorator: '@inject'});
   });
+});
+
+describe('inspectTargetType', () => {
+  it('handles static method injection', () => {
+    const type = inspectTargetType({
+      target: HelloProviderWithMI,
+      member: 'value',
+      methodDescriptorOrParameterIndex: 0,
+      bindingSelector: 'hello',
+      metadata: {},
+    });
+    expect(type).to.eql(Number);
+  });
+
+  it('handles prototype method injection', () => {
+    const type = inspectTargetType({
+      target: HelloProviderWithMI.prototype,
+      member: 'count',
+      methodDescriptorOrParameterIndex: 0,
+      bindingSelector: 'hello',
+      metadata: {},
+    });
+    expect(type).to.eql(Number);
+  });
+
+  it('handles constructor injection', () => {
+    const type = inspectTargetType({
+      target: HelloProviderWithCI,
+      member: '',
+      methodDescriptorOrParameterIndex: 0,
+      bindingSelector: 'hello',
+      metadata: {},
+    });
+    expect(type).to.eql(Number);
+  });
+
+  it('handles property injection', () => {
+    const type = inspectTargetType({
+      target: HelloProviderWithPI.prototype,
+      member: 'count',
+      bindingSelector: 'hello',
+      metadata: {},
+    });
+    expect(type).to.eql(Number);
+  });
+
+  class HelloProviderWithMI {
+    static value(
+      @inject('count')
+      count: number,
+    ) {
+      return 'hello';
+    }
+
+    count(
+      @inject('count')
+      count: number,
+    ) {
+      return count;
+    }
+  }
+
+  class HelloProviderWithCI {
+    constructor(
+      @inject('count')
+      count: number,
+    ) {}
+  }
+
+  class HelloProviderWithPI {
+    @inject('count')
+    count: number;
+  }
 });

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -613,22 +613,19 @@ export function describeInjectedArguments(
  * @param injection - Injection information
  */
 export function inspectTargetType(injection: Readonly<Injection>) {
-  let type = MetadataInspector.getDesignTypeForProperty(
-    injection.target,
-    injection.member!,
-  );
-  if (type) {
-    return type;
-  }
-  const designType = MetadataInspector.getDesignTypeForMethod(
-    injection.target,
-    injection.member!,
-  );
-  type =
-    designType.parameterTypes[
+  if (typeof injection.methodDescriptorOrParameterIndex === 'number') {
+    const designType = MetadataInspector.getDesignTypeForMethod(
+      injection.target,
+      injection.member!,
+    );
+    return designType.parameterTypes[
       injection.methodDescriptorOrParameterIndex as number
     ];
-  return type;
+  }
+  return MetadataInspector.getDesignTypeForProperty(
+    injection.target,
+    injection.member!,
+  );
 }
 
 /**


### PR DESCRIPTION
`inspectTargetType` fails to handle the following case correctly:

```ts
class HelloProviderWithMI {
    static value(
      @inject('count')
      count: number,
    ) {
      return 'hello';
    }

    count(
      @inject('count')
      count: number,
    ) {
      return count;
    }
  }
```
The PR makes sure the parameter design type is checked if the injection is for a parameter.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
