### PR TITLE
feat(cli): add a prompt for `lb4 update` to open changelog

### DIFF
--- a/packages/cli/generators/update/index.js
+++ b/packages/cli/generators/update/index.js
@@ -7,6 +7,8 @@
 
 const BaseGenerator = require('../../lib/base-generator');
 const g = require('../../lib/globalize');
+const link = require('terminal-link');
+const chalk = require('chalk');
 
 module.exports = class UpdateGenerator extends BaseGenerator {
   // Note: arguments and options should be defined in the constructor.
@@ -29,12 +31,25 @@ module.exports = class UpdateGenerator extends BaseGenerator {
     return super.setOptions();
   }
 
-  checkLoopBackProject() {
+  async checkLoopBackProject() {
     if (this.shouldExit()) return;
-    return super.checkLoopBackProject();
+    this.updated = await super.checkLoopBackProject();
+  }
+
+  async _openChangeLog() {
+    if (this.shouldExit()) return;
+    if (this.updated !== true) return;
+    this.log(chalk.red(g.f('The upgrade may break the current project.')));
+    this.log(
+      link(
+        g.f('Please check out change logs for breaking changes.'),
+        'https://loopback.io/doc/en/lb4/changelog.index.html',
+      ),
+    );
   }
 
   async end() {
+    await this._openChangeLog();
     await super.end();
   }
 };

--- a/packages/cli/lib/base-generator.js
+++ b/packages/cli/lib/base-generator.js
@@ -407,9 +407,9 @@ module.exports = class BaseGenerator extends Generator {
    * "@loopback/core" package in the dependencies section of the
    * package.json.
    */
-  async checkLoopBackProject() {
+  checkLoopBackProject() {
     debug('Checking for loopback project');
-    await checkLoopBackProject(this);
+    return checkLoopBackProject(this);
   }
 
   _runNpmScript(projectDir, args) {

--- a/packages/cli/lib/version-helper.js
+++ b/packages/cli/lib/version-helper.js
@@ -179,8 +179,8 @@ async function checkLoopBackProject(generator) {
   if (generator.shouldExit()) return false;
 
   const incompatibleDeps = await checkDependencies(generator);
-  if (incompatibleDeps == null) return;
-  if (Object.keys(incompatibleDeps) === 0) return;
+  if (incompatibleDeps == null) return false;
+  if (Object.keys(incompatibleDeps) === 0) return false;
 
   const choices = [
     {
@@ -209,11 +209,11 @@ async function checkLoopBackProject(generator) {
   ];
   const answers = await generator.prompt(prompts);
   if (answers && answers.decision === 'continue') {
-    return;
+    return false;
   }
   if (answers && answers.decision === 'upgrade') {
     updateDependencies(generator);
-    return;
+    return true;
   }
   generator.exit(new Error('Incompatible dependencies'));
 }

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -7696,6 +7696,15 @@
 				"has-flag": "^4.0.0"
 			}
 		},
+		"supports-hyperlinks": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			}
+		},
 		"swagger-client": {
 			"version": "3.10.3",
 			"resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.10.3.tgz",
@@ -7823,6 +7832,30 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
 			"integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
+		},
+		"terminal-link": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"supports-hyperlinks": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+					"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+					"requires": {
+						"type-fest": "^0.11.0"
+					}
+				},
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+				}
+			}
 		},
 		"text-table": {
 			"version": "0.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,6 +71,7 @@
     "swagger-parser": "^9.0.1",
     "swagger2openapi": "^6.0.3",
     "tabtab": "^3.0.2",
+    "terminal-link": "^2.1.1",
     "tildify": "^2.0.0",
     "ts-morph": "^7.1.0",
     "typescript": "~3.9.2",


### PR DESCRIPTION
If `lb4 update` changes dependencies of an application, the user will be prompted to check out 
https://loopback.io/doc/en/lb4/changelog.index.html. It will remind our users to pay attention to breaking changes.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
