### PR TITLE
honor excluded "include" property

### DIFF
--- a/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
@@ -17,6 +17,7 @@ describe('getFilterJsonSchemaFor', () => {
   let ajv: Ajv.Ajv;
   let customerFilterSchema: JsonSchema;
   let customerFilterExcludingWhereSchema: JsonSchema;
+  let customerFilterExcludingIncludeSchema: JsonSchema;
   let orderFilterSchema: JsonSchema;
 
   beforeEach(() => {
@@ -24,6 +25,9 @@ describe('getFilterJsonSchemaFor', () => {
     customerFilterSchema = getFilterJsonSchemaFor(Customer);
     customerFilterExcludingWhereSchema = getFilterJsonSchemaFor(Customer, {
       exclude: ['where'],
+    });
+    customerFilterExcludingIncludeSchema = getFilterJsonSchemaFor(Customer, {
+      exclude: ['include'],
     });
     orderFilterSchema = getFilterJsonSchemaFor(Order);
   });
@@ -64,6 +68,21 @@ describe('getFilterJsonSchemaFor', () => {
         dataPath: '',
         schemaPath: '#/additionalProperties',
         params: {additionalProperty: 'where'},
+        message: 'should NOT have additional properties',
+      },
+    ]);
+  });
+
+  it('disallows "include"', () => {
+    const filter = {include: 'orders'};
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    ajv.validate(customerFilterExcludingIncludeSchema, filter);
+    expect(ajv.errors ?? []).to.containDeep([
+      {
+        keyword: 'additionalProperties',
+        dataPath: '',
+        schemaPath: '#/additionalProperties',
+        params: {additionalProperty: 'include'},
         message: 'should NOT have additional properties',
       },
     ]);
@@ -216,6 +235,24 @@ describe('getFilterJsonSchemaFor - excluding where', () => {
       exclude: 'where',
     });
     expect(customerFilterSchema.properties).to.not.have.property('where');
+  });
+});
+
+describe('getFilterJsonSchemaFor - excluding include', () => {
+  let customerFilterSchema: JsonSchema;
+
+  it('excludes "include" using string[]', () => {
+    customerFilterSchema = getFilterJsonSchemaFor(Customer, {
+      exclude: ['include'],
+    });
+    expect(customerFilterSchema.properties).to.not.have.property('include');
+  });
+
+  it('excludes "include" using string', () => {
+    customerFilterSchema = getFilterJsonSchemaFor(Customer, {
+      exclude: 'include',
+    });
+    expect(customerFilterSchema.properties).to.not.have.property('include');
   });
 });
 

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -115,7 +115,7 @@ export function getFilterJsonSchemaFor(
   const modelRelations = getModelRelations(modelCtor);
   const hasRelations = Object.keys(modelRelations).length > 0;
 
-  if (hasRelations) {
+  if (hasRelations && !excluded.includes('include')) {
     schema.properties!.include = {
       ...(options.setTitle !== false && {
         title: `${modelCtor.modelName}.IncludeFilter`,


### PR DESCRIPTION
Allow user to define `Filter` object without "include" property.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
