### PR TITLE
fix(docs): copy navbar-template to fast preview site

### DIFF
--- a/docs/bin/build-preview-site.sh
+++ b/docs/bin/build-preview-site.sh
@@ -47,7 +47,7 @@ cp -r $SOURCE_DIR/_includes $JEKYLL_DIR/
 cp -r $SOURCE_DIR/_layouts $JEKYLL_DIR/
 
 echo "Copying static assets"
-cp -r $SOURCE_DIR/{css,images,dist,js,fonts} $JEKYLL_DIR/
+cp -r $SOURCE_DIR/{css,images,dist,js,fonts,navbar-template.html} $JEKYLL_DIR/
 rm -rf $JEKYLL_DIR/doc
 mkdir -p $JEKYLL_DIR/doc
 cp -r $SOURCE_DIR/doc/index.md $JEKYLL_DIR/doc


### PR DESCRIPTION
I noticed that recent changes in our website broke the fast preview (`npm run docs:preview`) - the top navigation bar was no longer displayed in the preview.

This change is fixing the problem by adding `navbar-template.html` to the list of static assets copied from `loopback.io` to the preview site.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
