### PR TITLE
test(express): add a test to illstruate how to use express router

### DIFF
--- a/docs/site/Express-middleware.md
+++ b/docs/site/Express-middleware.md
@@ -333,6 +333,27 @@ export class MorganInterceptor extends ExpressMiddlewareInterceptorProvider<
 }
 ```
 
+## Use Express Router to enable
+
+Express allows HTTP verbs to be used to set up routes, such as
+`app.post('/hello', ...)`. See http://expressjs.com/en/4x/api.html#app.METHOD.
+
+To allow a similar usage in LoopBack, we can create an Express router and
+register it to LoopBack as follows:
+
+```ts
+import {ExpressRequestHandler, Router} from '@loopback/express';
+
+const handler: ExpressRequestHandler = async (req, res, next) => {
+  res.send(req.path);
+};
+
+const router = Router();
+router.post('/greet', handler);
+router.get('/hello', handler);
+const binding = server.expressMiddleware('middleware.express.greeting', router);
+```
+
 ## What's behind the scenes
 
 `Middleware` and `Interceptor` are key concepts that allow Express middleware

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -16,7 +16,7 @@ import {Request, RequestHandler, Response} from 'express';
 import onFinished from 'on-finished';
 import {MiddlewareBindings} from './keys';
 
-export {Request, Response} from 'express';
+export {Request, Response, Router, RouterOptions} from 'express';
 
 /**
  * An object holding HTTP request, response and other data


### PR DESCRIPTION
To simulate expressApp.get(...), post(...), we can create an Express router.
add handlers, and register the router as an Express middleware to LoopBack.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
