### PR TITLE
fix(docs): set `toc_level` to customize toc layout for changelogs

### DIFF
--- a/docs/bin/copy-changelogs.js
+++ b/docs/bin/copy-changelogs.js
@@ -96,6 +96,7 @@ lang: en
 title: 'CHANGELOG - ${name}'
 keywords: LoopBack 4.0, LoopBack 4, CHANGELOG
 sidebar: lb4_sidebar
+toc_level: 0
 permalink: /doc/en/lb4/changelog.${shortName}.html
 ---
 

--- a/docs/bin/copy-changelogs.js
+++ b/docs/bin/copy-changelogs.js
@@ -97,6 +97,7 @@ title: 'CHANGELOG - ${name}'
 keywords: LoopBack 4.0, LoopBack 4, CHANGELOG
 sidebar: lb4_sidebar
 toc_level: 0
+editurl: https://github.com/strongloop/loopback-next/blob/master/${location}/CHANGELOG.md
 permalink: /doc/en/lb4/changelog.${shortName}.html
 ---
 


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/5474

Depends on https://github.com/strongloop/loopback.io/pull/985

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
