### PR TITLE
fix(security): support type number in securityId

### DIFF
--- a/examples/passport-login/src/controllers/user.controller.ts
+++ b/examples/passport-login/src/controllers/user.controller.ts
@@ -138,7 +138,7 @@ export class UserLoginController {
     @inject(SecurityBindings.USER) profile: UserProfile,
   ) {
     const user = await this.userRepository.findById(
-      parseInt(profile[securityId]),
+      parseInt(<string>profile[securityId]),
       {
         include: [
           {

--- a/extensions/authentication-jwt/src/__tests__/fixtures/controllers/user.controller.ts
+++ b/extensions/authentication-jwt/src/__tests__/fixtures/controllers/user.controller.ts
@@ -93,6 +93,6 @@ export class UserController {
     },
   })
   async whoAmI(): Promise<string> {
-    return this.user[securityId];
+    return <string>this.user[securityId];
   }
 }

--- a/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
+++ b/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
@@ -283,7 +283,7 @@ describe('Basic Authentication', () => {
 
       @authenticate(AUTH_STRATEGY_NAME)
       async whoAmI(): Promise<string> {
-        return this.user[securityId];
+        return <string>this.user[securityId];
       }
     }
     app.controller(MyController);

--- a/packages/authentication/src/__tests__/acceptance/basic-auth-extension.acceptance.ts
+++ b/packages/authentication/src/__tests__/acceptance/basic-auth-extension.acceptance.ts
@@ -240,7 +240,7 @@ describe('Basic Authentication', () => {
       ): Promise<string> {
         if (!userProfile) return 'userProfile is undefined';
         if (!userProfile[securityId]) return 'userProfile id is undefined';
-        return userProfile[securityId];
+        return <string>userProfile[securityId];
       }
     }
     app.controller(MyController);

--- a/packages/security/src/types.ts
+++ b/packages/security/src/types.ts
@@ -15,7 +15,7 @@ export interface Principal {
   /**
    * Name/id
    */
-  [securityId]: string;
+  [securityId]: number | string;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [attribute: string]: any;


### PR DESCRIPTION
I have a model with the id of type number and I have to change it to string and then change it back to number. Hence this PR

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
