### PR TITLE
docs: usage of openapi spec enhancer

### DIFF
--- a/docs/site/Extending-OpenAPI-specification.md
+++ b/docs/site/Extending-OpenAPI-specification.md
@@ -151,3 +151,10 @@ To apply an enhancer by name, call `applyEnhancerByName`:
 ```ts
 await app.getSpecService.applyEnhancerByName('info');
 ```
+
+## Usage in REST Server
+
+The REST server in `@loopback/rest` has a built-in OAS enhancer service. By
+default it applies all the enhancers bound to its application. You can read
+section [Enhance OpenAPI Specification](Server.md#Enhance-openAPI-specification)
+to learn more about how to add your own enhancers.

--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -338,6 +338,51 @@ export class HelloWorldApp extends Application {
 You can also add multiple servers in the constructor of your application class
 as shown [here](Application.md#servers).
 
+### Enhance OpenAPI Specification
+
+The REST server exposes a function `getApiSpec()` to retrieve its OpenAPI
+specifications:
+
+```ts
+// in code, retrieve the OpenAPI spec by `getApiSpec()`
+const spec = await app.restServer.getApiSpec();
+```
+
+An application's OpenAPI specification is mainly generated from
+[controllers](https://loopback.io/doc/en/lb4/Controllers.html) and their
+members. Besides the controller, other artifacts should also be able to
+contribute specifications. Therefore we introduced
+[OpenAPI specification enhancer](Extending-OpenAPI-specification.md) to
+customize it.
+
+You can read the page
+[Extending OpenAPI specification](Extending-OpenAPI-specification.md) to get
+familiar with its concepts and usages.
+
+The REST server has a built-in enhancer service to scan all the enhancers bound
+to the application and apply them by default. To add your own enhancer, just
+bind it to your application and the server will automatically pick it up:
+
+```ts
+import {RestApplication} from '@loopback/rest';
+
+export class SomeApp extends RestApplication {
+constructor(options: ApplicationConfig = {}) {
+  super(options);
+  this.add(createBindingFromClass(SomeSpecEnhancer));
+}
+```
+
+If you contribute the enhancer from a [component](Components.md), create the
+binding in this way:
+
+```ts
+import {createBindingFromClass} from '@loopback/core';
+export class SomeComponent implements Component {
+  bindings = [createBindingFromClass(SomeSpecEnhancer)];
+}
+```
+
 ## Next Steps
 
 - Learn about [Server-level Context](Context.md#server-level-context)


### PR DESCRIPTION
When working on https://github.com/strongloop/loopback-next/pull/5493, I think it's better to add a section for retrieving the openapi spec in code from the app. Therefore created this PR. It also explains the usage of adding spec enhancer.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
