### PR TITLE
Fix: bootmixin should use super.component() to get binding key

### DIFF
--- a/packages/boot/src/__tests__/unit/boot.custom-binding.component.unit.ts
+++ b/packages/boot/src/__tests__/unit/boot.custom-binding.component.unit.ts
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {
+  Application,
+  bind,
+  BindingKey,
+  BindingScope,
+  Component,
+  ContextTags,
+} from '@loopback/core';
+import {expect} from '@loopback/testlab';
+import {BootBindings, BootMixin} from '../../';
+import {BaseArtifactBooter} from '../../booters';
+import {InstanceWithBooters} from '../../types';
+
+describe('boot.component unit tests', () => {
+  it('binds a component with the custom binding key', async () => {
+    const app = getApp();
+    app.component(CustomBoundComponent);
+    await app.boot();
+    const bootstrapper = await app.get(CustomBinding);
+    expect(bootstrapper).to.be.an.instanceOf(CustomBoundComponent);
+  });
+
+  it('binds mounts booters from an instance', async () => {
+    const app = getApp();
+    const component = new ClassicComponent(__dirname, {});
+    app.bind('components.ClassicComponent').to(component);
+
+    // covers the resolveComponentInstance functionality
+    app.mountComponentBooters(ClassicComponent);
+    await app.boot();
+    const bootstrapper: ClassicComponent = await app.get(
+      'components.ClassicComponent',
+    );
+    expect(bootstrapper).to.be.an.instanceOf(ClassicComponent);
+  });
+
+  function getApp() {
+    const app = new BootableApp();
+    app.bind(BootBindings.PROJECT_ROOT).to(__dirname);
+    return app;
+  }
+  class BootableApp extends BootMixin(Application) {}
+
+  const CustomBinding = BindingKey.create<CustomBoundComponent>(
+    'io.loopback.custom.binding.CustomBoundComponent',
+  );
+  @bind({
+    tags: {[ContextTags.KEY]: CustomBinding},
+    scope: BindingScope.SINGLETON,
+  })
+  class CustomBoundComponent implements Component {
+    configured = false;
+    async configure() {
+      this.configured = true;
+    }
+  }
+
+  class ClassicComponent extends BaseArtifactBooter
+    implements InstanceWithBooters {
+    configured = false;
+    async configure() {
+      this.configured = true;
+    }
+    booters = [];
+  }
+});

--- a/packages/boot/src/types.ts
+++ b/packages/boot/src/types.ts
@@ -159,3 +159,10 @@ export function booter(artifactNamespace: string, ...specs: BindingSpec[]) {
     ...specs,
   );
 }
+
+/**
+ * Interface to describe an object that may have an array of `booters`.
+ */
+export interface InstanceWithBooters {
+  booters?: Constructor<Booter>[];
+}


### PR DESCRIPTION
There is a small misbehavior in `boot.mixin.ts`, where upon invoking `this.component(ComponentClass)`, `mountComponentBooters` will assume `"components.${class.name}"` to be the binding key, even if another key was specified.

This presents itself in Applications where components marked with `@bind()` using a custom name, and attempting to use them:
```ts
export const COMPONENT_KEY = BindingKey.create<MyComponent>('org.my.namespace.MyComponent');
@bind({
  tags: {[ContextTags.KEY]: COMPONENT_KEY},
  scope: BindingScope.SINGLETON,
})
export class MyComponent implements Component, LifeCycleObserver {
}
```
```ts
import { MyComponent } from '@myScope/my-library';
export class MyApplication extends BootMixin(ServiceMixin(RestApplication)) {
  constructor() {
    this.component(MyComponent);
    // Error: The key 'components.MyComponent' is not bound to any value in context
  }
}
```

This PR addresses this, by implementing a similar fix to what was done in `repository.mixin.ts`.

See also #5477 

## Checklist
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [n/a] API Documentation in code was updated
- [n/a] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [n/a] Affected artifact templates in `packages/cli` were updated
- [n/a] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
