### PR TITLE
fix: set NODE_OPTIONS in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
     - nodejs_version: "10"
+  NODE_OPTIONS: "--max-old-space-size=2048"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
When running Appveyor, there is error:
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 00F6D5CE node::MakeCallback+3982
 2: 0139AD32 v8::internal::Heap::MaxHeapGrowingFactor+8194
 3: 01391F21 v8::internal::ScavengeJob::operator=+14993
 4: 0139966E v8::internal::Heap::MaxHeapGrowingFactor+2366
npm ERR! code ELIFECYCLE
npm ERR! errno 134
```

@raymondfeng suggested to configure the heap.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
