### PR TITLE
fix(cli): group union/intersection types for array

### DIFF
--- a/packages/cli/generators/openapi/schema-helper.js
+++ b/packages/cli/generators/openapi/schema-helper.js
@@ -121,10 +121,14 @@ function mapArrayType(schema, options) {
     const typeSpec = getTypeSpec(schema, options);
     const itemTypeSpec = mapSchemaType(schema.items, opts);
     const defaultVal = getDefault(schema, options);
-    typeSpec.name = itemTypeSpec.signature + '[]';
-    typeSpec.declaration = itemTypeSpec.signature + '[]';
-    typeSpec.signature =
-      (typeSpec.className || itemTypeSpec.signature + '[]') + defaultVal;
+    let arrayType = `${itemTypeSpec.signature}[]`;
+    if (itemTypeSpec.signature.match(/[\|\&]/)) {
+      // The type is a union or intersection
+      arrayType = `(${itemTypeSpec.signature})[]`;
+    }
+    typeSpec.name = arrayType;
+    typeSpec.declaration = arrayType;
+    typeSpec.signature = (typeSpec.className || arrayType) + defaultVal;
     typeSpec.itemType = itemTypeSpec;
     collectImports(typeSpec, itemTypeSpec);
     return typeSpec;

--- a/packages/cli/test/unit/openapi/schema-helper.unit.js
+++ b/packages/cli/test/unit/openapi/schema-helper.unit.js
@@ -89,6 +89,19 @@ describe('primitive types with enum', () => {
   it('maps string', () => {
     expectMapping({type: 'string', enum: ['A', 'B', 'C']}, "'A' | 'B' | 'C'");
   });
+
+  it('maps string array', () => {
+    expectMapping(
+      {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['A', 'B', 'C'],
+        },
+      },
+      "('A' | 'B' | 'C')[]",
+    );
+  });
 });
 
 describe('array types', () => {
@@ -169,6 +182,18 @@ describe('composite types', () => {
     );
   });
 
+  it('maps array oneOf', () => {
+    expectMapping(
+      {
+        type: 'array',
+        items: {
+          oneOf: [{type: 'string'}, {type: 'number'}],
+        },
+      },
+      '(string | number)[]',
+    );
+  });
+
   it('maps anyOf', () => {
     expectMapping(
       {anyOf: [{type: 'string'}, {type: 'number'}]},
@@ -180,6 +205,18 @@ describe('composite types', () => {
     expectMapping(
       {allOf: [{type: 'string'}, {type: 'number'}]},
       'string & number',
+    );
+  });
+
+  it('maps array allOf', () => {
+    expectMapping(
+      {
+        type: 'array',
+        items: {
+          allOf: [{type: 'string'}, {type: 'number'}],
+        },
+      },
+      '(string & number)[]',
     );
   });
 });


### PR DESCRIPTION
Mapping array types as follows:

- `(string | number)[]` (instead of `string | number[]`)
- `({x: string} & {y: boolean})[]` (instead of `{x: string} & {y: boolean}[]` )

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
