### PR TITLE
fix: array decorator

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -851,6 +851,27 @@ class TestModel {
 }
 ```
 
+To define a nested array property, you must provide the `jsonSchema` field to
+describe the sub-array property. For example:
+
+```ts
+@model()
+class TestModel {
+  // alternatively use @property.array('array')
+  @property.array(Array, {
+    jsonSchema: {
+      type: 'array',
+      items: {type: 'string'},
+    },
+  })
+  nestedArr: Array<Array<string>>;
+}
+```
+
+If the `jsonSchema` field is missing, you will get an error saying
+
+> You must provide the "jsonSchema" field when define a nested array property'
+
 ### Validation Rules
 
 You can also specify the validation rules in the field `jsonSchema`. For

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -71,12 +71,6 @@ describe('build-schema', () => {
   });
 
   describe('metaToJsonSchema', () => {
-    it('errors out if "itemType" is an array', () => {
-      expect(() => metaToJsonProperty({type: Array, itemType: []})).to.throw(
-        /itemType as an array is not supported/,
-      );
-    });
-
     it('converts Boolean', () => {
       expect(metaToJsonProperty({type: Boolean})).to.eql({
         type: 'boolean',

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -10,6 +10,7 @@ import {
   ModelMetadataHelper,
   Null,
   PropertyDefinition,
+  PropertyType,
   RelationMetadata,
   resolveType,
 } from '@loopback/repository';
@@ -242,7 +243,7 @@ export function stringTypeToWrapper(type: string | Function): Function {
  * Determines whether a given string or constructor is array type or not
  * @param type - Type as string or wrapper
  */
-export function isArrayType(type: string | Function) {
+export function isArrayType(type: string | Function | PropertyType) {
   return type === Array || type === 'array';
 }
 
@@ -256,8 +257,11 @@ export function metaToJsonProperty(meta: PropertyDefinition): JsonSchema {
   let propertyType = meta.type as string | Function;
 
   if (isArrayType(propertyType) && meta.itemType) {
-    if (Array.isArray(meta.itemType)) {
-      throw new Error('itemType as an array is not supported');
+    if (isArrayType(meta.itemType) && !meta.jsonSchema) {
+      throw new Error(
+        'You must provide the "jsonSchema" field when define ' +
+          'a nested array property',
+      );
     }
     result = {type: 'array', items: propDef};
     propertyType = meta.itemType as string | Function;


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/4754

To define a nested array property with `@property.array()`, you must provide a json schema to describe the sub array item:

```ts
@model()
class TestModel {
  // alternatively use @property.array('array')
  @property.array(Array, {
    jsonSchema: {
      type: 'array',
      items: {type: 'string'},
    },
  })
  nestedArr: Array<Array<string>>;
}
```

A few issues this PR addresses:

- We didn't allow nested array property before due to 
https://github.com/strongloop/loopback-next/blob/ef155eeddf11895bac8ddc491cb87c1e5b7398d0/packages/repository-json-schema/src/build-schema.ts#L260
   which is not correct. I tested with todo app, when decorate the nested array property well, creating & retrieving an instance works properly.

- It's not possible to infer the sub type of nested array property, that's why the json schema field is needed(Thank you @deepakrkris for your suggestion in https://github.com/strongloop/loopback-next/issues/4754#issuecomment-592117906). I added a new check for that field to avoid triggering the subsequent error '"items" property must be present if "type" is an array' instead.
 
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
