### PR TITLE
fix(docs): fix variable name in boot script docs

### DIFF
--- a/docs/site/migration/boot-scripts.md
+++ b/docs/site/migration/boot-scripts.md
@@ -263,7 +263,7 @@ export class CreateSampleObserver implements LifeCycleObserver {
 
     const sample = {title: 'a todo sample', desc: 'Something to do.'};
     // Create the sample by calling TodoRepo.create()
-    const result = await TodoRepo.create(sample);
+    const result = await todoRepo.create(sample);
     console.log('Sample created as ', result);
   }
 


### PR DESCRIPTION
In async start function on line 260, TodoRepo variable is used but during variable injection in constructor, the variable name used is todoRepo so changed the start function variable name to todoRepo from TodoRepo