### PR TITLE
docs: close hidden content properly

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -773,7 +773,7 @@ corresponding database column name (`testId`) can be different if needed.
           </tr>
         </tbody>
       </table>
-    </div>
+</div>
 
 ### Array Property Decorator
 


### PR DESCRIPTION
Before (content after the </div> are also hidden):
<img width="898" alt="Screen Shot 2020-05-26 at 9 37 51 AM" src="https://user-images.githubusercontent.com/12554153/82907449-a1ce7780-9f34-11ea-8725-b72d80c83632.png">

After (content after the </div> display well):
<img width="742" alt="Screen Shot 2020-05-26 at 9 39 03 AM" src="https://user-images.githubusercontent.com/12554153/82907561-c3c7fa00-9f34-11ea-8c49-e5cd96324eb0.png">


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
