### PR TITLE
chore: remove extra }) in docs

### DIFF
--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -109,7 +109,6 @@ Let's also update it in the `TodoController`:
     },
   },
 })
-})
 async findTodos(/*...*/) {/*...*/}
 
 @get('/todos/{id}', {


### PR DESCRIPTION
There's a tiny error that I noticed as I went through these incredibly written docs :)

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
