### PR TITLE
set default HTTP status code for authorization error to 403

### DIFF
--- a/examples/access-control-migration/src/__tests__/acceptance/project.acceptance.ts
+++ b/examples/access-control-migration/src/__tests__/acceptance/project.acceptance.ts
@@ -111,7 +111,8 @@ describe('AccessControlApplication - permissions', () => {
     });
 
     it(`view returns ${permissions.view} for role ${role}`, async () => {
-      const expectedStatus = permissions.view ? 200 : 401;
+      const errorCode = role === 'anonymous' ? 401 : 403;
+      const expectedStatus = permissions.view ? 200 : errorCode;
 
       if (role === 'anonymous') {
         await client.get('/view-all-projects').expect(expectedStatus);
@@ -125,7 +126,8 @@ describe('AccessControlApplication - permissions', () => {
     });
 
     it(`show-balance returns ${permissions.balance} for role ${role}`, async () => {
-      const expectedStatus = permissions.balance ? 200 : 401;
+      const errorCode = role === 'anonymous' ? 401 : 403;
+      const expectedStatus = permissions.balance ? 200 : errorCode;
 
       if (role === 'anonymous') {
         await client.get('/projects/1/show-balance').expect(expectedStatus);
@@ -139,7 +141,8 @@ describe('AccessControlApplication - permissions', () => {
     });
 
     it(`donate returns ${permissions.donate} for role ${role}`, async () => {
-      const expectedStatus = permissions.donate ? 204 : 401;
+      const errorCode = role === 'anonymous' ? 401 : 403;
+      const expectedStatus = permissions.donate ? 204 : errorCode;
 
       if (role === 'anonymous') {
         await client.patch('/projects/1/donate').expect(expectedStatus);
@@ -153,7 +156,8 @@ describe('AccessControlApplication - permissions', () => {
     });
 
     it(`withdraw returns ${permissions.withdraw} for role ${role}`, async () => {
-      const expectedStatus = permissions.withdraw ? 204 : 401;
+      const errorCode = role === 'anonymous' ? 401 : 403;
+      const expectedStatus = permissions.withdraw ? 204 : errorCode;
 
       if (role === 'anonymous') {
         await client.patch('/projects/1/withdraw').expect(expectedStatus);

--- a/packages/authorization/src/__tests__/acceptance/authorization.acceptance.ts
+++ b/packages/authorization/src/__tests__/acceptance/authorization.acceptance.ts
@@ -44,7 +44,10 @@ describe('Authorization', () => {
     const result = invokeMethod(controller, 'cancelOrder', reqCtx, [
       'order-01',
     ]);
-    await expect(result).to.be.rejectedWith('Access denied');
+    await expect(result).to.be.rejectedWith({
+      statusCode: 403,
+      message: 'Access denied',
+    });
     expect(events).to.eql(['OrderController.prototype.cancelOrder']);
   });
 

--- a/packages/authorization/src/__tests__/acceptance/authorization.options.acceptance.ts
+++ b/packages/authorization/src/__tests__/acceptance/authorization.options.acceptance.ts
@@ -118,6 +118,19 @@ describe('Authorization', () => {
     await testPlaceOrder(matrix5);
   });
 
+  it('honors options.defaultStatusCodeForDeny', async () => {
+    givenRequestContext();
+    const row = matrix1[0];
+    setupAuthorization({defaultStatusCodeForDeny: 401}, ...row[1]);
+    const result = invokeMethod(controller, 'cancelOrder', reqCtx, [
+      'order-01',
+    ]);
+    await expect(result).to.be.rejectedWith({
+      statusCode: 401,
+      message: 'Access denied',
+    });
+  });
+
   async function testCancelOrder(matrix: DecisionMatrix) {
     let index = 0;
     for (const row of matrix) {

--- a/packages/authorization/src/authorize-interceptor.ts
+++ b/packages/authorization/src/authorize-interceptor.ts
@@ -42,6 +42,7 @@ export class AuthorizationInterceptor implements Provider<Interceptor> {
     this.options = {
       defaultDecision: AuthorizationDecision.DENY,
       precedence: AuthorizationDecision.DENY,
+      defaultStatusCodeForDeny: 403,
       ...options,
     };
     debug('Authorization options', this.options);
@@ -107,7 +108,7 @@ export class AuthorizationInterceptor implements Provider<Interceptor> {
       ) {
         debug('Access denied');
         const error = new AuthorizationError('Access denied');
-        error.statusCode = 401;
+        error.statusCode = this.options.defaultStatusCodeForDeny;
         throw error;
       }
       if (
@@ -122,7 +123,7 @@ export class AuthorizationInterceptor implements Provider<Interceptor> {
     // Handle the final decision
     if (finalDecision === AuthorizationDecision.DENY) {
       const error = new AuthorizationError('Access denied');
-      error.statusCode = 401;
+      error.statusCode = this.options.defaultStatusCodeForDeny;
       throw error;
     }
     return next();

--- a/packages/authorization/src/types.ts
+++ b/packages/authorization/src/types.ts
@@ -187,4 +187,9 @@ export interface AuthorizationOptions {
    * not associated with authorization metadata.
    */
   defaultMetadata?: AuthorizationMetadata;
+  /**
+   * Default HTTP status code when the final decision is `AuthorizationDecision.DENY`.
+   * If not set, default to 403
+   */
+  defaultStatusCodeForDeny?: number;
 }


### PR DESCRIPTION
Fixes #5411 according to the [suggested solution](https://github.com/strongloop/loopback-next/issues/5411#issuecomment-628065626)

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
