### PR TITLE
feat(context): improve binding resolution error reporting with more contextual info

### DIFF
--- a/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/class-level-bindings.acceptance.ts
@@ -51,7 +51,15 @@ describe('Context bindings - Injecting dependencies of classes', () => {
         throw new Error('ctx.get() should have failed');
       },
       function onError(err) {
-        expect(err).to.match(/resolve.*InfoController.*argument 1/);
+        expect(err.message).to.match(
+          /The argument 'InfoController\.constructor\[0\]' is not decorated for dependency injection/,
+        );
+        expect(err.message).to.match(
+          /but no value was supplied by the caller\. Did you forget to apply @inject\(\) to the argument\?/,
+        );
+        expect(err.message).to.match(
+          /\(context: [\w\-]+, resolutionPath: controllers\.info\)/,
+        );
       },
     );
   });
@@ -72,7 +80,15 @@ describe('Context bindings - Injecting dependencies of classes', () => {
         throw new Error('ctx.get() should have failed');
       },
       function onError(err) {
-        expect(err).to.match(/resolve.*InfoController.*argument 1/);
+        expect(err.message).to.match(
+          /The argument 'InfoController\.constructor\[0\]' is not decorated for dependency injection/,
+        );
+        expect(err.message).to.match(
+          /but no value was supplied by the caller\. Did you forget to apply @inject\(\) to the argument\?/,
+        );
+        expect(err.message).to.match(
+          /\(context: [\w\-]+, resolutionPath: controllers\.info\)/,
+        );
       },
     );
   });

--- a/packages/context/src/__tests__/acceptance/method-level-bindings.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/method-level-bindings.acceptance.ts
@@ -80,7 +80,14 @@ describe('Context bindings - Injecting dependencies of method', () => {
     const instance = await ctx.get(INFO_CONTROLLER);
     expect(() => {
       invokeMethod(instance, 'greet', ctx);
-    }).to.throw(/The arguments\[0\] is not decorated for dependency injection/);
+    }).to.throw(
+      /The argument 'InfoController\.prototype\.greet\[0\]' is not decorated for dependency injection/,
+    );
+    expect(() => {
+      invokeMethod(instance, 'greet', ctx);
+    }).to.throw(
+      /but no value was supplied by the caller\. Did you forget to apply @inject\(\) to the argument\?/,
+    );
   });
 
   function createContext() {

--- a/packages/context/src/__tests__/unit/resolver.unit.ts
+++ b/packages/context/src/__tests__/unit/resolver.unit.ts
@@ -51,14 +51,14 @@ describe('constructor injection', () => {
   });
 
   it('can report error for missing binding key', () => {
-    class TestClass {
-      constructor(@inject('', {x: 'bar'}) public fooBar: string) {}
-    }
-
     expect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      instantiateClass(TestClass, ctx);
-    }).to.throw(/Cannot resolve injected arguments/);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      class TestClass {
+        constructor(@inject('', {x: 'bar'}) public fooBar: string) {}
+      }
+    }).to.throw(
+      /A non-empty binding selector or resolve function is required for @inject/,
+    );
   });
 
   it('allows optional constructor injection', () => {
@@ -378,15 +378,15 @@ describe('property injection', () => {
   });
 
   it('can report error for missing binding key', () => {
-    class TestClass {
-      @inject('', {x: 'bar'})
-      public fooBar: string;
-    }
-
     expect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      instantiateClass(TestClass, ctx);
-    }).to.throw(/Cannot resolve injected property/);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      class TestClass {
+        @inject('', {x: 'bar'})
+        public fooBar: string;
+      }
+    }).to.throw(
+      /A non-empty binding selector or resolve function is required for @inject/,
+    );
   });
 
   it('resolves injected properties with custom resolve function', () => {

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -133,6 +133,11 @@ export function inject(
   if (injectionMetadata.bindingComparator && !resolve) {
     throw new Error('Binding comparator is only allowed with a binding filter');
   }
+  if (!bindingSelector && typeof resolve !== 'function') {
+    throw new Error(
+      'A non-empty binding selector or resolve function is required for @inject',
+    );
+  }
   return function markParameterOrPropertyAsInjected(
     target: Object,
     member: string | undefined,

--- a/packages/context/src/resolution-session.ts
+++ b/packages/context/src/resolution-session.ts
@@ -394,3 +394,51 @@ export interface ResolutionContext<T = unknown> {
    */
   readonly options: ResolutionOptions;
 }
+
+/**
+ * Error for context binding resolutions and dependency injections
+ */
+export class ResolutionError extends Error {
+  constructor(
+    message: string,
+    readonly resolutionCtx: Partial<ResolutionContext>,
+  ) {
+    super(ResolutionError.buildMessage(message, resolutionCtx));
+    this.name = ResolutionError.name;
+  }
+
+  private static buildDetails(resolutionCtx: Partial<ResolutionContext>) {
+    return {
+      context: resolutionCtx.context?.name ?? '',
+      binding: resolutionCtx.binding?.key ?? '',
+      resolutionPath: resolutionCtx.options?.session?.getResolutionPath() ?? '',
+    };
+  }
+
+  /**
+   * Build the error message for the resolution to include more contextual data
+   * @param reason - Cause of the error
+   * @param resolutionCtx - Resolution context
+   */
+  private static buildMessage(
+    reason: string,
+    resolutionCtx: Partial<ResolutionContext>,
+  ) {
+    const info = this.describeResolutionContext(resolutionCtx);
+    const message = `${reason} (${info})`;
+    return message;
+  }
+
+  private static describeResolutionContext(
+    resolutionCtx: Partial<ResolutionContext>,
+  ) {
+    const details = ResolutionError.buildDetails(resolutionCtx);
+    const items: string[] = [];
+    for (const [name, val] of Object.entries(details)) {
+      if (val !== '') {
+        items.push(`${name}: ${val}`);
+      }
+    }
+    return items.join(', ');
+  }
+}

--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -148,7 +148,7 @@ export class DecoratorFactory<
     if (member == null && descriptorOrIndex == null) {
       return `class ${name}`;
     }
-    if (member == null) member = 'constructor';
+    if (member == null || member === '') member = 'constructor';
 
     const memberAccessor =
       typeof member === 'symbol' ? '[' + member.toString() + ']' : '.' + member;


### PR DESCRIPTION
Current issue: when a binding key is not bound, a long stack trace is printed and it's not easy to find out where the failure happens. This PR introduces `ResolutionError` to capture more contextual information.

TBD:
I was planning to extend the `message` with such information, but it breaks a lot of existing test assertions, for example:

```
AssertionError: expected [Promise] to be rejected with a message matching 'bar: error', but got 'bar: error (@TestClass.prototype.bar => cb8e48c2-8d0e-4d28-bd93-0738840afdd9#bar)'
```
Should we bite the bullet to fix old assertions?


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
