### PR TITLE
fix(repository): fix DynamicModelCtor type to correctly preserve Props

### DIFF
--- a/packages/repository/src/__tests__/unit/model/define-model-class.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/define-model-class.unit.ts
@@ -31,6 +31,24 @@ describe('defineModelClass', () => {
     expect(instance.title).to.equal('a title');
   });
 
+  it('creates a correctly typed constructor', () => {
+    const definition = new ModelDefinition('Product').addProperty('name', {
+      type: 'string',
+    });
+    const Product = defineModelClass<typeof Model, {name: string}>(
+      Model,
+      definition,
+    );
+
+    // When the `data` argument is not provided, then TypeScript may pick
+    // Model's constructor signature instead of Product constructor signature.
+    // When that happens, `p` has type `Model` without Product properties.
+    // This test verifies that such situation does not happen.
+    const p = new Product();
+    p.name = 'Pen';
+    // The test passed when the line above is accepted by the compiler.
+  });
+
   it('creates an Entity class', () => {
     const definition = new ModelDefinition('Product')
       .addProperty('id', {type: 'number', id: true})

--- a/packages/repository/src/define-model-class.ts
+++ b/packages/repository/src/define-model-class.ts
@@ -79,10 +79,10 @@ export function defineModelClass<
 export type DynamicModelCtor<
   BaseCtor extends typeof Model,
   Props extends object
-> = BaseCtor & {
+> = {
   /** Model constructor accepting partial model data. */
   new (data?: DataObject<PrototypeOf<BaseCtor> & Props>): PrototypeOf<
     BaseCtor
   > &
     Props;
-};
+} & BaseCtor;


### PR DESCRIPTION
Before this change, the following code would create an instance with the type of the base model class, ignoring custom model properties:

```ts
const Product = defineModelClass<typeof Model, {name: string}>(
  Model,
  definition,
);
const p = new Product();
// p has type Model now
```

This patch fixes the problem by changing the order in which constructor functions are defined in `DynamicModelCtor`, so that the compiler always picks the constructor returning `Base & Props`.

I discovered this problem while reviewing #5591.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
