### PR TITLE
fix: normalize project ref update path

### DIFF
--- a/bin/update-ts-project-refs.js
+++ b/bin/update-ts-project-refs.js
@@ -64,7 +64,9 @@ async function updateReferences(options) {
     const tsconfigMeta = loadTsConfig(pkgLocation, dryRun);
     const tsconfigFile = tsconfigMeta.file;
     rootRefs.push({
-      path: path.join(path.relative(project.rootPath, pkgLocation), TSCONFIG),
+      path: path
+        .join(path.relative(project.rootPath, pkgLocation), TSCONFIG)
+        .replace(/\\/g, '/'),
     });
     const tsconfig = tsconfigMeta.tsconfig;
     const originalTsconfigJson = JSON.stringify(tsconfig, null, 2);
@@ -75,7 +77,7 @@ async function updateReferences(options) {
       // Skip non-typescript packages
       if (loadTsConfig(depPkg.location, dryRun) == null) continue;
       const relativePath = path.relative(pkgLocation, depPkg.pkg.location);
-      refs.push({path: path.join(relativePath, TSCONFIG)});
+      refs.push({path: path.join(relativePath, TSCONFIG).replace(/\\/g, '/')});
     }
     tsconfig.compilerOptions = {
       // outDir has to be set in tsconfig instead of CLI for tsc -b


### PR DESCRIPTION
Normalize 'update-ts-project-refs.ts' paths to be POSIX-compliant (use forward slash '/')  irregardless of host platform.

This resolves an issue with Windows-based development environments that would cause all `tsconfig.json` project reference paths to be updated to use Windows path syntax.


**@loopback/tsdocs `tsconfig.json`:**
```diff
{
  "$schema": "http://json.schemastore.org/tsconfig",
  "extends": "@loopback/build/config/tsconfig.common.json",
  "compilerOptions": {
    "outDir": "dist",
    "rootDir": "src",
    "composite": true
  },
  "include": [
    "src"
  ],
  "references": [
    {
-      "path": "..\\testlab\\tsconfig.json"
+      "path": "../testlab/tsconfig.json"
    }
  ]
}
```

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
