### PR TITLE
chore: use `@loopback/core` for packages consistently

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -33,7 +33,7 @@
     "!*/__tests__"
   ],
   "dependencies": {
-    "@loopback/context": "^3.8.2",
+    "@loopback/core": "^2.7.1",
     "@loopback/example-todo": "^3.5.0",
     "@loopback/openapi-spec-builder": "^2.1.6",
     "@loopback/rest": "^5.1.0",

--- a/benchmark/src/context-binding/context-binding.ts
+++ b/benchmark/src/context-binding/context-binding.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, Provider, ValueFactory} from '@loopback/context';
+import {Context, inject, Provider, ValueFactory} from '@loopback/core';
 import Benchmark from 'benchmark';
 
 /**

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -14,7 +14,7 @@
       "path": "../examples/todo/tsconfig.json"
     },
     {
-      "path": "../packages/context/tsconfig.json"
+      "path": "../packages/core/tsconfig.json"
     },
     {
       "path": "../packages/openapi-spec-builder/tsconfig.json"

--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -238,7 +238,7 @@ The following code snippet shows how it would look like:
 content="/src/repositories/order.repository.ts" %}
 
 ```ts
-import {Getter, inject} from '@loopback/context';
+import {Getter, inject} from '@loopback/core';
 import {
   BelongsToAccessor,
   DefaultCrudRepository,

--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -32,6 +32,7 @@ There are a few ways to create a binding:
 - Use `Binding` constructor:
 
   ```ts
+  import {Context, Binding} from '@loopback/core';
   const context = new Context();
   const binding = new Binding('my-key');
   ctx.add(binding);
@@ -40,6 +41,7 @@ There are a few ways to create a binding:
 - Use `Binding.bind()`
 
   ```ts
+  import {Context, Binding} from '@loopback/core';
   const context = new Context();
   const binding = Binding.bind('my-key');
   ctx.add(binding);
@@ -48,9 +50,23 @@ There are a few ways to create a binding:
 - Use `context.bind()`
 
   ```ts
+  import {Context, Binding} from '@loopback/core';
   const context = new Context();
   context.bind('my-key');
   ```
+
+  {% include note.html content="The `@loopback/core` package re-exports all
+  public APIs of `@loopback/context`. For consistency, we recommend the usage of
+  `@loopback/core` for imports in LoopBack modules and applications unless they
+  depend on `@loopback/context` explicitly. The two statements below are
+  equivalent:
+
+  ```ts
+  import {inject} from '@loopback/context';
+  import {inject} from '@loopback/core';
+  ```
+
+  " %}
 
 ## How to set up a binding?
 
@@ -87,7 +103,7 @@ The factory function can receive extra information about the context, binding,
 and resolution options.
 
 ```ts
-import {ValueFactory} from '@loopback/context';
+import {ValueFactory} from '@loopback/core';
 
 // The factory function now have access extra metadata about the resolution
 const factory: ValueFactory<string> = resolutionCtx => {
@@ -113,7 +129,7 @@ An advanced form of value factory is a class that has a static `value` method
 that allows parameter injection.
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 class GreetingProvider {
   static value(@inject('user') user: string) {
@@ -458,7 +474,7 @@ match/find bindings by tag. The search criteria can be one of the followings:
      filterByTag,
      includesTagValue, // Match tag value as an array that includes the item
      TagValueMatcher,
-   } from '@loopback/context';
+   } from '@loopback/core';
    // Match a binding with a named service
    ctx.find(filterByTag({name: ANY_TAG_VALUE, service: 'service'}));
 
@@ -504,7 +520,7 @@ When the class is bound, these attributes are honored to create a binding. You
 can use `@bind` decorator to configure how to bind a class.
 
 ```ts
-import {bind, BindingScope} from '@loopback/context';
+import {bind, BindingScope} from '@loopback/core';
 
 // @bind() accepts scope and tags
 @bind({
@@ -538,7 +554,7 @@ export class YourController {}
 Then a binding can be created by inspecting the class,
 
 ```ts
-import {createBindingFromClass} from '@loopback/context';
+import {createBindingFromClass} from '@loopback/core';
 
 const ctx = new Context();
 const binding = createBindingFromClass(MyService);

--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -37,12 +37,25 @@ can be chained using the `parent` to form a hierarchy. For example, the code
 below creates a chain of three contexts: `reqCtx -> serverCtx -> rootCtx`.
 
 ```ts
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 
 const rootCtx = new Context('root-ctx'); // No parent
 const serverCtx = new Context(rootCtx, 'server-ctx'); // rootCtx as the parent
 const reqCtx = new Context(serverCtx); // No explicit name, a UUID will be generated
 ```
+
+{% include note.html content="The `@loopback/core` package re-exports all public
+APIs of `@loopback/context`. For consistency, we recommend the usage of
+`@loopback/core` for imports in LoopBack modules and applications unless they
+depend on `@loopback/context` explicitly. The two statements below are
+equivalent:
+
+```ts
+import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
+```
+
+" %}
 
 LoopBack's context system allows an unlimited amount of Context instances, each
 of which may have a parent Context.
@@ -180,8 +193,7 @@ However, when using classes, LoopBack provides a better way to get at stuff in
 the context via the `@inject` decorator:
 
 ```ts
-import {inject} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {inject, Application} from '@loopback/core';
 
 const app = new Application();
 app.bind('defaultName').to('John');
@@ -489,7 +501,7 @@ be used to watch a list of bindings matching certain criteria depicted by a
 matched bindings.
 
 ```ts
-import {Context, ContextView} from '@loopback/context';
+import {Context, ContextView} from '@loopback/core';
 
 // Set up a context chain
 const appCtx = new Context('app');

--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -51,7 +51,7 @@ based on the given name:
 ```ts
 // Uncomment these imports to begin using these cool features!
 
-// import {inject} from '@loopback/context';
+// import {inject} from '@loopback/core';
 
 export class FooController {
   constructor() {}

--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -90,7 +90,7 @@ function called by [Context](Context.md) when another entity requests a value to
 be injected.
 
 ```ts
-import {Provider} from '@loopback/context';
+import {Provider} from '@loopback/core';
 
 export class MyValueProvider implements Provider<string> {
   value() {
@@ -168,7 +168,7 @@ the list of keys reserved for the framework use.
 Provider's `value()` method can be asynchronous too:
 
 ```ts
-import {Provider} from '@loopback/context';
+import {Provider} from '@loopback/core';
 const request = require('request-promise-native');
 const weatherUrl =
   'http://samples.openweathermap.org/data/2.5/weather?appid=b1b15e88fa797225412429c1c50c122a1';
@@ -192,7 +192,7 @@ dependencies annotated with `@inject` keyword, so that LoopBack runtime can
 resolve them automatically.
 
 ```ts
-import {Provider} from '@loopback/context';
+import {Provider} from '@loopback/core';
 import {Request, RestBindings} from '@loopback/rest';
 import {v4 as uuid} from 'uuid';
 

--- a/docs/site/Dependency-injection.md
+++ b/docs/site/Dependency-injection.md
@@ -22,6 +22,8 @@ the caller specify which strategy to use.
 The implementation of the `authenticate` action is shown below.
 
 ```ts
+import {inject, Provider} from '@loopback/core';
+
 export class AuthenticateActionProvider implements Provider<AuthenticateFn> {
   constructor(
     // The provider is instantiated for Sequence constructor,
@@ -72,6 +74,19 @@ export class AuthenticateActionProvider implements Provider<AuthenticateFn> {
   }
 }
 ```
+
+{% include note.html content="The `@loopback/core` package re-exports all public
+APIs of `@loopback/context`. For consistency, we recommend the usage of
+`@loopback/core` for imports in LoopBack modules and applications unless they
+depend on `@loopback/context` explicitly. The two statements below are
+equivalent:
+
+```ts
+import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
+```
+
+" %}
 
 Dependency Injection makes the code easier to extend and customize, because the
 dependencies can be easily rewired by the application developer. It makes the
@@ -296,7 +311,7 @@ problem.
 Consider the following example:
 
 ```ts
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 
 interface Developer {
   // Each developer belongs to a team
@@ -363,7 +378,7 @@ Let's take a look at the following example:
 The corresponding code is:
 
 ```ts
-import {inject, Context, BindingScope} from '@loopback/context';
+import {inject, Context, BindingScope} from '@loopback/core';
 import {RestBindings} from '@loopback/rest';
 
 interface Logger() {

--- a/docs/site/Express-middleware.md
+++ b/docs/site/Express-middleware.md
@@ -220,7 +220,7 @@ Alternatively, we can create a subclass of
 `ExpressMiddlewareInterceptorProvider`.
 
 ```ts
-import {config} from '@loopback/context';
+import {config} from '@loopback/core';
 import {
   ExpressMiddlewareInterceptorProvider,
   createMiddlewareInterceptorBinding,

--- a/docs/site/Extending-LoopBack-4.md
+++ b/docs/site/Extending-LoopBack-4.md
@@ -46,7 +46,7 @@ that the service provider can be injected into the consumer class. The code
 snippet below shows the usage of `@inject` for dependency injection.
 
 ```ts
-import {inject, Context} from '@loopback/context';
+import {inject, Context} from '@loopback/core';
 
 /**
  * A UserController implementation that depends on UserRepository and PasswordHasher

--- a/docs/site/Extension-point-and-extensions.md
+++ b/docs/site/Extension-point-and-extensions.md
@@ -68,7 +68,7 @@ decorators and functions are provided to ensure consistency and convention.
 1. Inject a getter function for extensions
 
    ```ts
-   import {Getter} from '@loopback/context';
+   import {Getter} from '@loopback/core';
    import {extensionPoint, extensions} from '@loopback/core';
 
    @extensionPoint('greeters')
@@ -81,7 +81,7 @@ decorators and functions are provided to ensure consistency and convention.
 2. Inject a context view for extensions
 
    ```ts
-   import {ContextView} from '@loopback/context';
+   import {ContextView} from '@loopback/core';
    import {extensionPoint, extensions} from '@loopback/core';
 
    @extensionPoint('greeters')

--- a/docs/site/FAQ.md
+++ b/docs/site/FAQ.md
@@ -135,7 +135,7 @@ headers). This can be accomplished by injecting the `Response` object into the
 controller:
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {get, Response, RestBindings} from '@loopback/rest';
 
 export class PingController {

--- a/docs/site/File-upload-download.md
+++ b/docs/site/File-upload-download.md
@@ -25,7 +25,7 @@ A few steps are involved to create an endpoint for file upload.
    [`FileUploadController`](https://github.com/strongloop/loopback-next/blob/master/examples/file-transfer/src/controllers/file-upload.controller.ts)
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   post,
   Request,
@@ -110,7 +110,7 @@ To download files from the backend, please follow the following steps.
    [`FileDownloadController`](https://github.com/strongloop/loopback-next/blob/master/examples/file-transfer/src/controllers/file-download.controller.ts)
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   get,
   HttpErrors,

--- a/docs/site/Interceptor-generator.md
+++ b/docs/site/Interceptor-generator.md
@@ -63,7 +63,7 @@ import {
   bind,
   Interceptor,
   Provider,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as a global `Interceptor` during
@@ -115,7 +115,7 @@ import {
   bind,
   Interceptor,
   Provider,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as a global `Interceptor` during

--- a/docs/site/Interceptors.md
+++ b/docs/site/Interceptors.md
@@ -34,7 +34,7 @@ Controller methods decorated with `@intercept` are invoked with applied
 interceptors for corresponding routes upon API requests.
 
 ```ts
-import {intercept} from '@loopback/context';
+import {intercept} from '@loopback/core';
 
 @intercept(log) // `log` is an interceptor function
 export class OrderController {
@@ -74,7 +74,7 @@ services and would like to allow repository or service methods to be
 intercepted.
 
 ```ts
-import {createProxyWithInterceptors} from '@loopback/context';
+import {createProxyWithInterceptors} from '@loopback/core';
 
 const proxy = createProxyWithInterceptors(controllerInstance, ctx);
 const msg = await proxy.greet('John');
@@ -148,7 +148,7 @@ To explicitly invoke a method with interceptors, use `invokeMethod` from
 `RestServer` for controller methods.
 
 ```ts
-import {Context, invokeMethod} from '@loopback/context';
+import {Context, invokeMethod} from '@loopback/core';
 
 const ctx: Context = new Context();
 
@@ -336,7 +336,7 @@ Global interceptors are discovered from the `InvocationContext`. They are
 registered as bindings with `globalInterceptor` tag. For example,
 
 ```ts
-import {asGlobalInterceptor} from '@loopback/context';
+import {asGlobalInterceptor} from '@loopback/core';
 
 app
   .bind('globalInterceptors.MetricsInterceptor')
@@ -747,7 +747,7 @@ Sometimes we want to apply more than one interceptors together as a whole. It
 can be done by `composeInterceptors`:
 
 ```ts
-import {composeInterceptors} from '@loopback/context';
+import {composeInterceptors} from '@loopback/core';
 
 const interceptor = composeInterceptors(
   interceptorFn1,
@@ -768,7 +768,7 @@ is the base class that can be extended to create your own flavor of interceptors
 and chains. For example,
 
 ```ts
-import {GenericInvocationChain, GenericInterceptor} from '@loopback/context';
+import {GenericInvocationChain, GenericInterceptor} from '@loopback/core';
 import {RequestContext} from '@loopback/rest';
 
 export interface RequestInterceptor
@@ -795,7 +795,7 @@ await chain.invokeInterceptors();
 It's also possible to pass in a final handler:
 
 ```ts
-import {Next} from '@loopback/context';
+import {Next} from '@loopback/core';
 const finalHandler: Next = async () => {
   // return ...;
 };

--- a/docs/site/LB3-vs-LB4-request-response-cycle.md
+++ b/docs/site/LB3-vs-LB4-request-response-cycle.md
@@ -331,7 +331,7 @@ available to them via [dependency injection](./Dependency-injection.md).
 Example of accesssing the request and response object in a Controller:
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {Request, Response, RestBindings, get} from '@loopback/rest';
 
 export class ExampleController {

--- a/docs/site/Life-cycle.md
+++ b/docs/site/Life-cycle.md
@@ -150,7 +150,7 @@ To react on life cycle events, a life cycle observer implements the
 `LifeCycleObserver` interface.
 
 ```ts
-import {ValueOrPromise} from '@loopback/context';
+import {ValueOrPromise} from '@loopback/core';
 
 /**
  * Observers to handle life cycle start/stop events
@@ -236,7 +236,7 @@ The observer class can also be decorated with `@bind` to provide binding
 metadata.
 
 ```ts
-import {bind, createBindingFromClass} from '@loopback/context';
+import {bind, createBindingFromClass} from '@loopback/core';
 import {CoreTags, asLifeCycleObserver} from '@loopback/core';
 
 @bind(
@@ -257,7 +257,7 @@ app.add(createBindingFromClass(MyObserver));
 Or even simpler with `@lifeCycleObserver`:
 
 ```ts
-import {createBindingFromClass} from '@loopback/context';
+import {createBindingFromClass} from '@loopback/core';
 import {lifeCycleObserver} from '@loopback/core';
 
 @lifeCycleObserver('g1')

--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -146,7 +146,7 @@ Here is an example of the decorator using a custom authentication strategy named
 authentication strategy in later sections)
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {AuthenticationBindings, authenticate} from '@loopback/authentication';
 import {SecurityBindings, securityId, UserProfile} from '@loopback/security';
 import {get} from '@loopback/rest';
@@ -715,7 +715,7 @@ with a value of `false` for the `/scareme` endpoint. We use the **default**
 option value for the `/whoami` endpoint.
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {AuthenticationBindings, authenticate} from '@loopback/authentication';
 import {UserProfile, securityId} from '@loopback/security';
 import {get} from '@loopback/rest';

--- a/docs/site/Middleware.md
+++ b/docs/site/Middleware.md
@@ -71,7 +71,7 @@ work with the `MiddlewareContext` - a wrapper object for `request` and
 
 ```ts
 import {MiddlewareContext} from '@loopback/express';
-import {Next, ValueOrPromise, InvocationResult} from '@loopback/context';
+import {Next, ValueOrPromise, InvocationResult} from '@loopback/core';
 
 (context: MiddlewareContext, next: Next) => ValueOrPromise<InvocationResult>;
 ```

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -166,7 +166,7 @@ TypeScript version:
 import {DefaultCrudRepository, juggler} from '@loopback/repository';
 import {Account, AccountRelations} from '../models';
 import {DbDataSource} from '../datasources';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 export class AccountRepository extends DefaultCrudRepository<
   Account,
@@ -354,7 +354,7 @@ implementation based on `loopback-datasource-juggler`.
 import {DefaultKeyValueRepository} from '@loopback/repository';
 import {ShoppingCart} from '../models/shopping-cart.model';
 import {RedisDataSource} from '../datasources/redis.datasource';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 export class ShoppingCartRepository extends DefaultKeyValueRepository<
   ShoppingCart

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -204,7 +204,7 @@ function upon injection.
 
 ```ts
 import {Send, Response} from '@loopback/rest';
-import {Provider, BoundValue, inject} from '@loopback/context';
+import {Provider, BoundValue, inject} from '@loopback/core';
 import {writeResultToResponse, RestBindings, Request} from '@loopback/rest';
 
 // Note: This is an example class; we do not provide this for you.
@@ -264,7 +264,7 @@ import {
 } from '@loopback/repository';
 import {CustomSendProvider} from './providers/custom-send.provider';
 import {Formatter} from './utils';
-import {BindingScope} from '@loopback/context';
+import {BindingScope} from '@loopback/core';
 
 export class YourApp extends RepositoryMixin(RestApplication) {
   constructor() {

--- a/docs/site/Testing-Your-Extensions.md
+++ b/docs/site/Testing-Your-Extensions.md
@@ -183,7 +183,7 @@ using a test double for any constructor arguments.
 {% include code-caption.html content="src/providers/random-number.provider.ts" %}
 
 ```ts
-import {Provider} from '@loopback/context';
+import {Provider} from '@loopback/core';
 
 export class RandomNumberProvider implements Provider<number> {
   value() {
@@ -233,7 +233,7 @@ class. Following is an example for an integration test for a Mixin:
 {% include code-caption.html content="src/mixins/time.mixin.ts" %}
 
 ```ts
-import {Constructor} from '@loopback/context';
+import {Constructor} from '@loopback/core';
 export function TimeMixin<T extends MixinTarget<object>>(superClass: T) {
   return class extends superClass {
     constructor(...args: any[]) {

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -144,7 +144,7 @@ belongs to Category, include it in the repository call, for example:
 {% include code-caption.html content="src/__tests__/helpers/database.helpers.ts" %}
 
 ```ts
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {ProductRepository, CategoryRepository} from '../../repositories';
 import {testdb} from '../fixtures/datasources/testdb.datasource';
 

--- a/docs/site/decorators/Decorators_authenticate.md
+++ b/docs/site/decorators/Decorators_authenticate.md
@@ -20,7 +20,7 @@ Here's an example using 'BasicStrategy': to authenticate user in function
 {% include code-caption.html content="src/controllers/who-am-i.controller.ts" %}
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {securityId, SecurityBindings, UserProfile} from '@loopback/security';
 import {authenticate} from '@loopback/authentication';
 import {get} from '@loopback/rest';

--- a/docs/site/decorators/Decorators_inject.md
+++ b/docs/site/decorators/Decorators_inject.md
@@ -55,7 +55,7 @@ WidgetController:
 {% include code-caption.html content="src/controllers/widget.controller.ts" %}
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 export class WidgetController {
   // injection for property
@@ -75,6 +75,8 @@ array of values can be injected. If the target type is not `Array`, an error
 will be thrown.
 
 ```ts
+import {inject} from '@loopback/core';
+
 class MyControllerWithValues {
   constructor(
     @inject(binding => binding.tagNames.includes('foo'))
@@ -87,6 +89,8 @@ To sort matched bindings found by the binding filter function, `@inject` honors
 `bindingComparator` in `metadata`:
 
 ```ts
+import {inject} from '@loopback/core';
+
 class MyControllerWithValues {
   constructor(
     @inject(binding => binding.tagNames.includes('foo'), {
@@ -100,6 +104,19 @@ class MyControllerWithValues {
 }
 ```
 
+{% include note.html content="The `@loopback/core` package re-exports all public
+APIs of `@loopback/context`. For consistency, we recommend the usage of
+`@loopback/core` for imports in LoopBack modules and applications unless they
+depend on `@loopback/context` explicitly. The two statements below are
+equivalent:
+
+```ts
+import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
+```
+
+" %}
+
 A few variants of `@inject` are provided to declare special forms of
 dependencies.
 
@@ -111,7 +128,7 @@ value of the key.
 Syntax: `@inject.getter(bindingSelector: BindingSelector)`.
 
 ```ts
-import {inject, Getter} from '@loopback/context';
+import {inject, Getter} from '@loopback/core';
 import {UserProfile} from '@loopback/authentication';
 import {get} from '@loopback/rest';
 
@@ -276,7 +293,7 @@ console.log(store.locations); // ['San Francisco', 'San Jose']
 a filter function.
 
 ```ts
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {DataSource} from '@loopback/repository';
 
 export class DataSourceTracker {

--- a/docs/site/extending/rest-api.md
+++ b/docs/site/extending/rest-api.md
@@ -53,7 +53,7 @@ Example showing a component exporting a `/ping` endpoint at a configurable base
 path:
 
 ```ts
-import {config} from '@loopback/context';
+import {config} from '@loopback/core';
 import {Component} from '@loopback/core';
 import {RestApplication} from '@loopback/rest';
 import {MyComponentBindings} from './my-component.keys.ts';
@@ -99,7 +99,7 @@ The example below shows a component that always contributed a `ping` endpoint
 and sometimes contributes a `stats` endpoint, depending on the configuration.
 
 ```ts
-import {bind, config, ContextTags} from '@loopback/context';
+import {bind, config, ContextTags} from '@loopback/core';
 import {MyComponentBindings} from './my-component.keys.ts';
 import {PingController, StatsController} from './controllers';
 

--- a/docs/site/migration/components/project-layout.md
+++ b/docs/site/migration/components/project-layout.md
@@ -57,7 +57,7 @@ The component class is usually implemented inside
 
 ```ts
 import {Application, Component, CoreBindings} from '@loopback/core';
-import {bind, config, ContextTags, inject} from '@loopback/context';
+import {bind, config, ContextTags, inject} from '@loopback/core';
 import {MetricsBindings} from './keys';
 import {DEFAULT_METRICS_OPTIONS, MetricsOptions} from './types';
 

--- a/docs/site/migration/models/mixins.md
+++ b/docs/site/migration/models/mixins.md
@@ -160,7 +160,7 @@ This mixin class factory function `AddCategoryPropertyMixin` in
 {% include code-caption.html content="src/mixins/category-property-mixin.ts" %}
 
 ```ts
-import {Constructor} from '@loopback/context';
+import {Constructor} from '@loopback/core';
 import {property, Model} from '@loopback/repository';
 
 /**
@@ -432,7 +432,7 @@ method to any repository.
 {% include code-caption.html content="src/mixins/find-by-title-repository-mixin.ts" %}
 
 ```ts
-import {Constructor} from '@loopback/context';
+import {Constructor} from '@loopback/core';
 import {Model, CrudRepository, Where} from '@loopback/repository';
 import {FindByTitle} from './find-by-title-interface';
 
@@ -523,7 +523,7 @@ method to any controller.
 {% include code-caption.html content="src/mixins/src/mixins/find-by-title-controller-mixin.ts" %}
 
 ```ts
-import {Constructor} from '@loopback/context';
+import {Constructor} from '@loopback/core';
 import {Model} from '@loopback/repository';
 import {FindByTitle} from './find-by-title-interface';
 import {param, get, getModelSchemaRef} from '@loopback/rest';

--- a/docs/site/tutorials/core/3-context-in-action.md
+++ b/docs/site/tutorials/core/3-context-in-action.md
@@ -34,7 +34,7 @@ To register artifacts, we first create an instance of `Context` and use `bind`
 to add artifacts to the registry as bindings.
 
 ```ts
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {GreetingController} from './controllers';
 import {CACHING_SERVICE, GREETING_SERVICE} from './keys';
 import {CachingService} from './caching-service';

--- a/docs/site/tutorials/core/4-dependency-injection.md
+++ b/docs/site/tutorials/core/4-dependency-injection.md
@@ -33,7 +33,7 @@ locating the dependent artifacts. For example:
 2. Use `ServiceLocator` pattern
 
    ```ts
-   import {Context} from '@loopback/context';
+   import {Context} from '@loopback/core';
    import {EnglishGreeter, ChineseGreeter} from './greeters';
    export class GreetingService {
      private chineseGreeter: ChineseGreeter;
@@ -58,7 +58,7 @@ locating the dependent artifacts. For example:
    This technique is being used commonly within the LoopBack framework.
 
    ```ts
-   import {inject} from '@loopback/context';
+   import {inject} from '@loopback/core';
    import {LifeCycleObserver} from '@loopback/core';
    import {CachingService} from '../caching-service';
    import {CACHING_SERVICE} from '../keys';

--- a/docs/site/tutorials/core/5-extension-point-extension.md
+++ b/docs/site/tutorials/core/5-extension-point-extension.md
@@ -49,8 +49,7 @@ context. In our case, we mark `GreetingService` as the extension point that has
 access to a list of greeters which are defined as extensions.
 
 ```ts
-import {Getter} from '@loopback/context';
-import {extensionFilter, CoreTags} from '@loopback/core';
+import {extensionFilter, CoreTags, Getter} from '@loopback/core';
 /**
  * An extension point for greeters that can greet in different languages
  */
@@ -164,7 +163,7 @@ knowing much about one another.
 
 ```ts
 import {Greeter, asGreeter} from '../types';
-import {bind, inject} from '@loopback/context';
+import {bind, inject} from '@loopback/core';
 /**
  * Options for the Chinese greeter
  */
@@ -229,8 +228,7 @@ app
 The process can be automated with a component:
 
 ```ts
-import {createBindingFromClass} from '@loopback/context';
-import {Component} from '@loopback/core';
+import {createBindingFromClass, Component} from '@loopback/core';
 import {GreetingService} from './greeting-service';
 import {GREETING_SERVICE} from './keys';
 /**

--- a/docs/site/tutorials/core/9-boot-by-convention.md
+++ b/docs/site/tutorials/core/9-boot-by-convention.md
@@ -13,7 +13,7 @@ be achieved by calling `Context` APIs or helper methods on the application
 object:
 
 ```ts
-import {createBindingFromClass, BindingScope} from '@loopback/context';
+import {createBindingFromClass, BindingScope} from '@loopback/core';
 import {CACHING_SERVICE} from './keys';
 import {CachingService} from './caching-service';
 import {GreetingController} from './controllers';

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
@@ -42,7 +42,7 @@ this point.
 ```ts
 // Uncomment these imports to begin using these cool features!
 
-// import {inject} from '@loopback/context';
+// import {inject} from '@loopback/core';
 
 export class CalculatorController {
   constructor() {}

--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -42,7 +42,6 @@
     "@loopback/authentication": "^4.2.6",
     "@loopback/authorization": "^0.5.11",
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/access-control-migration/src/components/jwt-authentication/services/jwt.auth.strategy.ts
+++ b/examples/access-control-migration/src/components/jwt-authentication/services/jwt.auth.strategy.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {AuthenticationStrategy, TokenService} from '@loopback/authentication';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {HttpErrors, Request} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
 import {TokenServiceBindings} from '../keys';

--- a/examples/access-control-migration/src/components/jwt-authentication/services/jwt.service.ts
+++ b/examples/access-control-migration/src/components/jwt-authentication/services/jwt.service.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {TokenService} from '@loopback/authentication';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {HttpErrors} from '@loopback/rest';
 import {securityId, UserProfile} from '@loopback/security';
 import {promisify} from 'util';

--- a/examples/access-control-migration/src/controllers/user.controller.ts
+++ b/examples/access-control-migration/src/controllers/user.controller.ts
@@ -6,7 +6,7 @@
 // Uncomment these imports to begin using these cool features!
 
 import {TokenService, UserService} from '@loopback/authentication';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {post, requestBody} from '@loopback/rest';
 import {
   Credentials,

--- a/examples/access-control-migration/src/keys.ts
+++ b/examples/access-control-migration/src/keys.ts
@@ -3,6 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 
 export const RESOURCE_ID = BindingKey.create<string>('resourceId');

--- a/examples/access-control-migration/src/sequence.ts
+++ b/examples/access-control-migration/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/access-control-migration/tsconfig.json
+++ b/examples/access-control-migration/tsconfig.json
@@ -21,9 +21,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/express-composition/src/controllers/ping.controller.ts
+++ b/examples/express-composition/src/controllers/ping.controller.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Request, RestBindings, get, ResponseObject} from '@loopback/rest';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 /**
  * OpenAPI response for ping()

--- a/examples/express-composition/src/sequence.ts
+++ b/examples/express-composition/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/express-composition/tsconfig.json
+++ b/examples/express-composition/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/rest": "^5.1.0",

--- a/examples/file-transfer/src/controllers/file-download.controller.ts
+++ b/examples/file-transfer/src/controllers/file-download.controller.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   get,
   HttpErrors,

--- a/examples/file-transfer/src/controllers/file-upload.controller.ts
+++ b/examples/file-transfer/src/controllers/file-upload.controller.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   post,
   Request,

--- a/examples/file-transfer/src/sequence.ts
+++ b/examples/file-transfer/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/file-transfer/src/services/file-upload.service.ts
+++ b/examples/file-transfer/src/services/file-upload.service.ts
@@ -9,7 +9,7 @@ import {
   config,
   ContextTags,
   Provider,
-} from '@loopback/context';
+} from '@loopback/core';
 import multer from 'multer';
 import {FILE_UPLOAD_SERVICE} from '../keys';
 import {FileUploadHandler} from '../types';

--- a/examples/file-transfer/tsconfig.json
+++ b/examples/file-transfer/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -55,7 +55,6 @@
     "typescript": "~3.9.3"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "chalk": "^4.0.0",

--- a/examples/greeter-extension/src/component.ts
+++ b/examples/greeter-extension/src/component.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, createBindingFromClass} from '@loopback/context';
-import {Component} from '@loopback/core';
+import {Binding, createBindingFromClass, Component} from '@loopback/core';
 import {ChineseGreeter} from './greeters/greeter-cn';
 import {EnglishGreeter} from './greeters/greeter-en';
 import {GreetingService} from './greeting-service';

--- a/examples/greeter-extension/src/greeters/greeter-cn.ts
+++ b/examples/greeter-extension/src/greeters/greeter-cn.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, config} from '@loopback/context';
+import {bind, config} from '@loopback/core';
 import {asGreeter, Greeter} from '../types';
 
 /**

--- a/examples/greeter-extension/src/greeters/greeter-en.ts
+++ b/examples/greeter-extension/src/greeters/greeter-en.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind} from '@loopback/context';
+import {bind} from '@loopback/core';
 import {asGreeter, Greeter} from '../types';
 
 /**

--- a/examples/greeter-extension/src/greeting-service.ts
+++ b/examples/greeter-extension/src/greeting-service.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, Getter} from '@loopback/context';
-import {extensionPoint, extensions} from '@loopback/core';
+import {config, Getter, extensionPoint, extensions} from '@loopback/core';
 import chalk from 'chalk';
 import {Greeter, GREETER_EXTENSION_POINT_NAME} from './types';
 

--- a/examples/greeter-extension/src/keys.ts
+++ b/examples/greeter-extension/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {GreetingService} from './greeting-service';
 
 /**

--- a/examples/greeter-extension/src/types.ts
+++ b/examples/greeter-extension/src/types.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingTemplate} from '@loopback/context';
-import {extensionFor} from '@loopback/core';
+import {BindingTemplate, extensionFor} from '@loopback/core';
 
 /**
  * Typically an extension point defines an interface as the contract for

--- a/examples/greeter-extension/tsconfig.json
+++ b/examples/greeter-extension/tsconfig.json
@@ -12,9 +12,6 @@
   ],
   "references": [
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -57,7 +57,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/example-greeter-extension": "^2.1.2",
     "@loopback/openapi-v3": "^3.4.2",

--- a/examples/greeting-app/src/controllers/greeting.controller.ts
+++ b/examples/greeting-app/src/controllers/greeting.controller.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   GreetingService,
   GREETING_SERVICE,

--- a/examples/greeting-app/src/interceptors/caching.interceptor.ts
+++ b/examples/greeting-app/src/interceptors/caching.interceptor.ts
@@ -12,7 +12,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 import {RestBindings} from '@loopback/rest';
 import debugFactory from 'debug';
 import {CachingService} from '../caching-service';

--- a/examples/greeting-app/src/keys.ts
+++ b/examples/greeting-app/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {CachingService} from './caching-service';
 
 /**

--- a/examples/greeting-app/src/observers/cache.observer.ts
+++ b/examples/greeting-app/src/observers/cache.observer.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
-import {lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
+import {inject, lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
 import {CachingService} from '../caching-service';
 import {CACHING_SERVICE} from '../keys';
 

--- a/examples/greeting-app/tsconfig.json
+++ b/examples/greeting-app/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.2",
     "@loopback/booter-lb3app": "^2.2.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/repository": "^2.6.0",
     "@loopback/rest": "^5.1.0",

--- a/examples/lb3-application/src/sequence.ts
+++ b/examples/lb3-application/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/lb3-application/tsconfig.json
+++ b/examples/lb3-application/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/booter-lb3app/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -53,7 +53,6 @@
     "typescript": "~3.9.3"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/rest": "^5.1.0",

--- a/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
+++ b/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {get, param} from '@loopback/openapi-v3';
 import {
   FindRoute,

--- a/examples/log-extension/src/decorators/log.decorator.ts
+++ b/examples/log-extension/src/decorators/log.decorator.ts
@@ -8,7 +8,7 @@ import {
   Constructor,
   MethodDecoratorFactory,
   MetadataInspector,
-} from '@loopback/context';
+} from '@loopback/core';
 import {LevelMetadata} from '../types';
 
 /**

--- a/examples/log-extension/src/keys.ts
+++ b/examples/log-extension/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {TimerFn, LogFn, LogWriterFn} from './types';
 
 /**

--- a/examples/log-extension/src/providers/log-action.provider.ts
+++ b/examples/log-extension/src/providers/log-action.provider.ts
@@ -3,8 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor, Getter, inject, Provider} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {
+  Constructor,
+  Getter,
+  inject,
+  Provider,
+  CoreBindings,
+} from '@loopback/core';
 import {OperationArgs, Request} from '@loopback/rest';
 import chalk from 'chalk';
 import {getLogMetadata} from '../decorators';

--- a/examples/log-extension/src/providers/timer.provider.ts
+++ b/examples/log-extension/src/providers/timer.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Provider} from '@loopback/context';
+import {Provider} from '@loopback/core';
 import {TimerFn, HighResTime} from '../types';
 
 export class TimerProvider implements Provider<TimerFn> {

--- a/examples/log-extension/tsconfig.json
+++ b/examples/log-extension/tsconfig.json
@@ -12,9 +12,6 @@
   ],
   "references": [
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -52,7 +52,6 @@
   ],
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/multi-tenancy/src/controllers/ping.controller.ts
+++ b/examples/multi-tenancy/src/controllers/ping.controller.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Request, RestBindings, get, ResponseObject} from '@loopback/rest';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 /**
  * OpenAPI response for ping()

--- a/examples/multi-tenancy/src/multi-tenancy/actions/multi-tenancy-action.provider.ts
+++ b/examples/multi-tenancy/src/multi-tenancy/actions/multi-tenancy-action.provider.ts
@@ -3,8 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, ContextTags, Getter, Provider} from '@loopback/context';
-import {extensionPoint, extensions} from '@loopback/core';
+import {
+  config,
+  ContextTags,
+  Getter,
+  Provider,
+  extensionPoint,
+  extensions,
+} from '@loopback/core';
 import {RequestContext} from '@loopback/rest';
 import debugFactory from 'debug';
 import {MultiTenancyBindings, MULTI_TENANCY_STRATEGIES} from '../keys';

--- a/examples/multi-tenancy/src/sequence.ts
+++ b/examples/multi-tenancy/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/multi-tenancy/tsconfig.json
+++ b/examples/multi-tenancy/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -40,7 +40,6 @@
     "@loopback/authentication": "^4.2.6",
     "@loopback/authentication-passport": "^2.1.6",
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/express": "^1.2.2",
     "@loopback/openapi-v3": "^3.4.2",

--- a/examples/passport-login/src/authentication-strategies/basic.ts
+++ b/examples/passport-login/src/authentication-strategies/basic.ts
@@ -8,7 +8,7 @@ import {StrategyAdapter} from '@loopback/authentication-passport';
 import {Request, RedirectRoute} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
 import {User} from '../models';
-import {bind} from '@loopback/context';
+import {bind} from '@loopback/core';
 import {BasicStrategy as Strategy} from 'passport-http';
 import {repository} from '@loopback/repository';
 import {UserRepository} from '../repositories';

--- a/examples/passport-login/src/authentication-strategies/facebook.ts
+++ b/examples/passport-login/src/authentication-strategies/facebook.ts
@@ -6,8 +6,7 @@
 import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
 import {StrategyAdapter} from '@loopback/authentication-passport';
 import {Strategy} from 'passport-facebook';
-import {bind, inject} from '@loopback/context';
-import {extensionFor} from '@loopback/core';
+import {bind, inject, extensionFor} from '@loopback/core';
 import {UserProfile} from '@loopback/security';
 import {User} from '../models';
 import {Request, RedirectRoute} from '@loopback/rest';

--- a/examples/passport-login/src/authentication-strategies/google.ts
+++ b/examples/passport-login/src/authentication-strategies/google.ts
@@ -6,8 +6,7 @@
 import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
 import {StrategyAdapter} from '@loopback/authentication-passport';
 import {Strategy} from 'passport-google-oauth2';
-import {bind, inject} from '@loopback/context';
-import {extensionFor} from '@loopback/core';
+import {bind, inject, extensionFor} from '@loopback/core';
 import {UserProfile} from '@loopback/security';
 import {User} from '../models';
 import {Request, RedirectRoute} from '@loopback/rest';

--- a/examples/passport-login/src/authentication-strategies/local.ts
+++ b/examples/passport-login/src/authentication-strategies/local.ts
@@ -8,7 +8,7 @@ import {StrategyAdapter} from '@loopback/authentication-passport';
 import {Request, RedirectRoute} from '@loopback/rest';
 import {UserProfile, securityId} from '@loopback/security';
 import {User} from '../models';
-import {bind} from '@loopback/context';
+import {bind} from '@loopback/core';
 import {Strategy, IVerifyOptions} from 'passport-local';
 import {repository} from '@loopback/repository';
 import {UserRepository} from '../repositories';

--- a/examples/passport-login/src/authentication-strategies/session.ts
+++ b/examples/passport-login/src/authentication-strategies/session.ts
@@ -7,7 +7,7 @@ import {AuthenticationStrategy, asAuthStrategy} from '@loopback/authentication';
 import {RedirectRoute, RequestWithSession, HttpErrors} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
 import {User} from '../models';
-import {bind} from '@loopback/context';
+import {bind} from '@loopback/core';
 import {repository} from '@loopback/repository';
 import {UserRepository} from '../repositories';
 import {mapProfile} from './types';

--- a/examples/passport-login/src/controllers/ping.controller.ts
+++ b/examples/passport-login/src/controllers/ping.controller.ts
@@ -10,7 +10,7 @@ import {
   RequestBodyObject,
   SchemaObject,
 } from '@loopback/rest';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {authenticate} from '@loopback/authentication';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 

--- a/examples/passport-login/src/controllers/user.controller.ts
+++ b/examples/passport-login/src/controllers/user.controller.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   post,
   del,

--- a/examples/passport-login/src/sequence.ts
+++ b/examples/passport-login/src/sequence.ts
@@ -9,7 +9,7 @@ import {
   AUTHENTICATION_STRATEGY_NOT_FOUND,
   USER_PROFILE_NOT_FOUND,
 } from '@loopback/authentication';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/passport-login/tsconfig.json
+++ b/examples/passport-login/tsconfig.json
@@ -25,9 +25,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/rest-crud/src/sequence.ts
+++ b/examples/rest-crud/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/rest-crud/tsconfig.json
+++ b/examples/rest-crud/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -41,7 +41,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "express": "^4.17.1",
     "tslib": "^2.0.0"

--- a/examples/rpc-server/src/rpc.server.ts
+++ b/examples/rpc-server/src/rpc.server.ts
@@ -3,8 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
-import {Application, CoreBindings, Server} from '@loopback/core';
+import {
+  Context,
+  inject,
+  Application,
+  CoreBindings,
+  Server,
+} from '@loopback/core';
 import {once} from 'events';
 import express from 'express';
 import http from 'http';

--- a/examples/rpc-server/tsconfig.json
+++ b/examples/rpc-server/tsconfig.json
@@ -12,9 +12,6 @@
   ],
   "references": [
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/soap-calculator/src/sequence.ts
+++ b/examples/soap-calculator/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/soap-calculator/tsconfig.json
+++ b/examples/soap-calculator/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -42,7 +42,6 @@
     "@loopback/authentication": "^4.2.6",
     "@loopback/authentication-jwt": "^0.4.0",
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/todo-jwt/src/sequence.ts
+++ b/examples/todo-jwt/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/todo-jwt/tsconfig.json
+++ b/examples/todo-jwt/tsconfig.json
@@ -21,9 +21,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/todo-list/src/sequence.ts
+++ b/examples/todo-list/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/todo-list/tsconfig.json
+++ b/examples/todo-list/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/todo/src/sequence.ts
+++ b/examples/todo/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/examples/todo/tsconfig.json
+++ b/examples/todo/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@loopback/boot": "^2.3.2",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",

--- a/examples/validation-app/src/interceptors/validate-phone-num.interceptor.ts
+++ b/examples/validation-app/src/interceptors/validate-phone-num.interceptor.ts
@@ -10,7 +10,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 import {CoffeeShop} from '../models';
 
 /**

--- a/examples/validation-app/src/sequence.ts
+++ b/examples/validation-app/src/sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   HttpErrors,

--- a/examples/validation-app/tsconfig.json
+++ b/examples/validation-app/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/boot/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -39,7 +39,6 @@
     "directory": "extensions/apiconnect"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/openapi-v3": "^3.4.2",
     "tslib": "^2.0.0"

--- a/extensions/apiconnect/tsconfig.json
+++ b/extensions/apiconnect/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@loopback/authentication": "^4.2.6",
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/metadata": "^2.1.6",
     "@loopback/openapi-v3": "^3.4.2",

--- a/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
+++ b/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
@@ -13,8 +13,7 @@ import {
   UserProfileFactory,
   USER_PROFILE_NOT_FOUND,
 } from '@loopback/authentication';
-import {inject} from '@loopback/context';
-import {addExtension, CoreTags, Provider} from '@loopback/core';
+import {inject, addExtension, CoreTags, Provider} from '@loopback/core';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {api, get} from '@loopback/openapi-v3';
 import {

--- a/extensions/authentication-passport/src/__tests__/acceptance/fixtures/simple-rest-app.ts
+++ b/extensions/authentication-passport/src/__tests__/acceptance/fixtures/simple-rest-app.ts
@@ -8,7 +8,7 @@ import {
   AuthenticationBindings,
   AuthenticationComponent,
 } from '@loopback/authentication';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/extensions/authentication-passport/tsconfig.json
+++ b/extensions/authentication-passport/tsconfig.json
@@ -17,9 +17,6 @@
       "path": "../../packages/authentication/tsconfig.json"
     },
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -21,7 +21,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/rest": "^5.1.0",
     "ts-graphviz": "^0.13.1",

--- a/extensions/context-explorer/src/__tests__/integration/context-graph.integration.ts
+++ b/extensions/context-explorer/src/__tests__/integration/context-graph.integration.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {ContextGraph} from '../..';
 

--- a/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
+++ b/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {ContextGraph} from '../..';
 import {renderGraph} from '../../visualizer';

--- a/extensions/context-explorer/src/context-explorer.component.ts
+++ b/extensions/context-explorer/src/context-explorer.component.ts
@@ -3,9 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import {bind, config, ContextTags, inject} from '@loopback/context';
-import {Component, CoreBindings} from '@loopback/core';
+import {
+  bind,
+  Component,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  config,
+  ContextTags,
+  CoreBindings,
+  inject,
+} from '@loopback/core';
 import {RestApplication} from '@loopback/rest';
 import path from 'path';
 import {contextExplorerControllerFactory} from './context-explorer.controller';

--- a/extensions/context-explorer/src/context-explorer.controller.ts
+++ b/extensions/context-explorer/src/context-explorer.controller.ts
@@ -4,13 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-  config,
-  Constructor,
-  Context,
-  inject,
-  JSONObject,
-} from '@loopback/context';
+import {config, Constructor, Context, inject, JSONObject} from '@loopback/core';
 import {
   api,
   get,

--- a/extensions/context-explorer/src/context-graph.ts
+++ b/extensions/context-explorer/src/context-graph.ts
@@ -3,12 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  BindingScope,
-  ContextTags,
-  JSONArray,
-  JSONObject,
-} from '@loopback/context';
+import {BindingScope, ContextTags, JSONArray, JSONObject} from '@loopback/core';
 import {attribute, Digraph, ICluster, toDot, INode, IEdge} from 'ts-graphviz';
 
 /**

--- a/extensions/context-explorer/src/keys.ts
+++ b/extensions/context-explorer/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {ContextExplorerComponent} from './context-explorer.component';
 
 /**

--- a/extensions/context-explorer/tsconfig.json
+++ b/extensions/context-explorer/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -21,7 +21,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/rest": "^5.1.0",
     "fluent-logger": "^3.4.1",

--- a/extensions/logging/src/__tests__/acceptance/winston.acceptance.ts
+++ b/extensions/logging/src/__tests__/acceptance/winston.acceptance.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
-import {extensionFor} from '@loopback/core';
+import {Context, extensionFor} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {
   format,

--- a/extensions/logging/src/decorators/logging.decorator.ts
+++ b/extensions/logging/src/decorators/logging.decorator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {intercept} from '@loopback/context';
+import {intercept} from '@loopback/core';
 import {LoggingBindings} from '../keys';
 
 /**

--- a/extensions/logging/src/interceptors/logging.interceptor.ts
+++ b/extensions/logging/src/interceptors/logging.interceptor.ts
@@ -14,7 +14,7 @@ import {
   InvocationContext,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 import {RequestContext, RestBindings} from '@loopback/rest';
 import morgan from 'morgan';
 import {format} from 'util';

--- a/extensions/logging/tsconfig.json
+++ b/extensions/logging/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -21,7 +21,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/rest": "^5.1.0",
     "prom-client": "^12.0.0",

--- a/extensions/metrics/src/interceptors/metrics.interceptor.ts
+++ b/extensions/metrics/src/interceptors/metrics.interceptor.ts
@@ -11,7 +11,7 @@ import {
   InvocationContext,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 import {Counter, Gauge, Histogram, register, Summary} from 'prom-client';
 
 /**

--- a/extensions/metrics/src/keys.ts
+++ b/extensions/metrics/src/keys.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {BindingKey, CoreBindings} from '@loopback/core';
 import {MetricsComponent} from './metrics.component';
 
 /**

--- a/extensions/metrics/src/metrics.component.ts
+++ b/extensions/metrics/src/metrics.component.ts
@@ -4,14 +4,16 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  Application,
   bind,
+  Component,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   config,
   ContextTags,
+  CoreBindings,
   createBindingFromClass,
   inject,
-} from '@loopback/context';
-import {Application, Component, CoreBindings} from '@loopback/core';
+} from '@loopback/core';
 import {metricsControllerFactory} from './controllers';
 import {MetricsInterceptor} from './interceptors';
 import {MetricsBindings} from './keys';

--- a/extensions/metrics/tsconfig.json
+++ b/extensions/metrics/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../../packages/context/tsconfig.json"
-    },
-    {
       "path": "../../packages/core/tsconfig.json"
     },
     {

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -24,7 +24,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/metadata": "^2.1.6",
     "@loopback/openapi-v3": "^3.4.2",

--- a/packages/authentication/src/__tests__/acceptance/basic-auth-extension.acceptance.ts
+++ b/packages/authentication/src/__tests__/acceptance/basic-auth-extension.acceptance.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {inject, Application} from '@loopback/core';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {api, get} from '@loopback/openapi-v3';
 import {Request, RestServer} from '@loopback/rest';

--- a/packages/authentication/src/__tests__/acceptance/jwt-auth-extension.acceptance.ts
+++ b/packages/authentication/src/__tests__/acceptance/jwt-auth-extension.acceptance.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {inject, Application} from '@loopback/core';
 import {get, post} from '@loopback/openapi-v3';
 import {Request, RestServer} from '@loopback/rest';
 import {SecurityBindings, securityId, UserProfile} from '@loopback/security';

--- a/packages/authentication/src/__tests__/fixtures/keys.ts
+++ b/packages/authentication/src/__tests__/fixtures/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {BasicAuthenticationUserService} from './services/basic-auth-user-service';
 import {JWTService} from './services/jwt-service';
 import {UserRepository} from './users/user.repository';

--- a/packages/authentication/src/__tests__/fixtures/sequences/authentication.sequence.ts
+++ b/packages/authentication/src/__tests__/fixtures/sequences/authentication.sequence.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/packages/authentication/src/__tests__/fixtures/services/basic-auth-user-service.ts
+++ b/packages/authentication/src/__tests__/fixtures/services/basic-auth-user-service.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {HttpErrors} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
 import {AuthenticationBindings} from '../../../';

--- a/packages/authentication/src/__tests__/fixtures/services/jwt-service.ts
+++ b/packages/authentication/src/__tests__/fixtures/services/jwt-service.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {HttpErrors} from '@loopback/rest';
 import {securityId, UserProfile} from '@loopback/security';
 import {promisify} from 'util';

--- a/packages/authentication/src/__tests__/fixtures/strategies/basic-strategy.ts
+++ b/packages/authentication/src/__tests__/fixtures/strategies/basic-strategy.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, inject} from '@loopback/context';
+import {bind, inject} from '@loopback/core';
 import {
   asSpecEnhancer,
   mergeSecuritySchemeToSpec,

--- a/packages/authentication/src/__tests__/fixtures/strategies/jwt-strategy.ts
+++ b/packages/authentication/src/__tests__/fixtures/strategies/jwt-strategy.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, inject} from '@loopback/context';
+import {bind, inject} from '@loopback/core';
 import {
   asSpecEnhancer,
   mergeSecuritySchemeToSpec,

--- a/packages/authentication/src/__tests__/unit/providers/auth-metadata.provider.unit.ts
+++ b/packages/authentication/src/__tests__/unit/providers/auth-metadata.provider.unit.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, Provider} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {Context, Provider, CoreBindings} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {authenticate, AuthenticationMetadata} from '../../..';
 import {AuthenticationBindings} from '../../../keys';

--- a/packages/authentication/src/__tests__/unit/providers/authentication.provider.unit.ts
+++ b/packages/authentication/src/__tests__/unit/providers/authentication.provider.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, instantiateClass} from '@loopback/context';
+import {Context, instantiateClass} from '@loopback/core';
 import {Request} from '@loopback/rest';
 import {securityId, UserProfile} from '@loopback/security';
 import {expect} from '@loopback/testlab';

--- a/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
+++ b/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Context, createBindingFromClass} from '@loopback/context';
+import {bind, Context, createBindingFromClass} from '@loopback/core';
 import {
   asSpecEnhancer,
   OASEnhancer,

--- a/packages/authentication/src/decorators/authenticate.decorator.ts
+++ b/packages/authentication/src/decorators/authenticate.decorator.ts
@@ -9,7 +9,7 @@ import {
   DecoratorFactory,
   MetadataInspector,
   MethodDecoratorFactory,
-} from '@loopback/context';
+} from '@loopback/core';
 import {
   AUTHENTICATION_METADATA_CLASS_KEY,
   AUTHENTICATION_METADATA_KEY,

--- a/packages/authentication/src/keys.ts
+++ b/packages/authentication/src/keys.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
-import {MetadataAccessor} from '@loopback/metadata';
+import {BindingKey, MetadataAccessor} from '@loopback/core';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {AuthenticationComponent} from './authentication.component';
 import {

--- a/packages/authentication/src/providers/auth-action.provider.ts
+++ b/packages/authentication/src/providers/auth-action.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter, inject, Provider, Setter} from '@loopback/context';
+import {Getter, inject, Provider, Setter} from '@loopback/core';
 import {Request, RedirectRoute} from '@loopback/rest';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {AuthenticationBindings} from '../keys';

--- a/packages/authentication/src/providers/auth-metadata.provider.ts
+++ b/packages/authentication/src/providers/auth-metadata.provider.ts
@@ -3,8 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, Constructor, inject, Provider} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {
+  config,
+  Constructor,
+  inject,
+  Provider,
+  CoreBindings,
+} from '@loopback/core';
 import {getAuthenticateMetadata} from '../decorators';
 import {AuthenticationBindings} from '../keys';
 import {AuthenticationMetadata, AuthenticationOptions} from '../types';

--- a/packages/authentication/src/providers/auth-strategy.provider.ts
+++ b/packages/authentication/src/providers/auth-strategy.provider.ts
@@ -3,8 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingScope, Getter, inject} from '@loopback/context';
-import {extensionPoint, extensions, Provider} from '@loopback/core';
+import {
+  BindingScope,
+  Getter,
+  inject,
+  extensionPoint,
+  extensions,
+  Provider,
+} from '@loopback/core';
 import {AuthenticationBindings} from '../keys';
 import {
   AuthenticationMetadata,

--- a/packages/authentication/tsconfig.json
+++ b/packages/authentication/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -24,7 +24,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/security": "^0.2.11",
     "debug": "^4.1.1",

--- a/packages/authorization/src/__tests__/acceptance/authorization-casbin.acceptance.ts
+++ b/packages/authorization/src/__tests__/acceptance/authorization-casbin.acceptance.ts
@@ -3,8 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, invokeMethod, Provider} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {
+  Context,
+  inject,
+  invokeMethod,
+  Provider,
+  Application,
+} from '@loopback/core';
 import {SecurityBindings, securityId, UserProfile} from '@loopback/security';
 import {expect} from '@loopback/testlab';
 import * as casbin from 'casbin';

--- a/packages/authorization/src/__tests__/acceptance/authorization.acceptance.ts
+++ b/packages/authorization/src/__tests__/acceptance/authorization.acceptance.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, invokeMethod, Provider} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {Context, invokeMethod, Provider, Application} from '@loopback/core';
 import {SecurityBindings, securityId} from '@loopback/security';
 import {expect} from '@loopback/testlab';
 import {

--- a/packages/authorization/src/__tests__/acceptance/authorization.options.acceptance.ts
+++ b/packages/authorization/src/__tests__/acceptance/authorization.options.acceptance.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, invokeMethod, Provider} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {Context, invokeMethod, Provider, Application} from '@loopback/core';
 import {SecurityBindings, securityId} from '@loopback/security';
 import {expect} from '@loopback/testlab';
 import {AuthorizationComponent} from '../../authorization-component';

--- a/packages/authorization/src/authorize-interceptor.ts
+++ b/packages/authorization/src/authorize-interceptor.ts
@@ -15,7 +15,7 @@ import {
   Next,
   NonVoid,
   Provider,
-} from '@loopback/context';
+} from '@loopback/core';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import debugFactory from 'debug';
 import {getAuthorizationMetadata} from './decorators/authorize';

--- a/packages/authorization/src/decorators/authorize.ts
+++ b/packages/authorization/src/decorators/authorize.ts
@@ -11,7 +11,7 @@ import {
   MetadataInspector,
   MetadataMap,
   MethodDecoratorFactory,
-} from '@loopback/context';
+} from '@loopback/core';
 import {
   AUTHENTICATED,
   AuthorizationMetadata,

--- a/packages/authorization/src/types.ts
+++ b/packages/authorization/src/types.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingAddress, InvocationContext} from '@loopback/context';
+import {BindingAddress, InvocationContext} from '@loopback/core';
 import {Principal, Role} from '@loopback/security';
 
 /**

--- a/packages/authorization/tsconfig.json
+++ b/packages/authorization/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -24,7 +24,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/model-api-builder": "^2.1.6",
     "@loopback/repository": "^2.6.0",

--- a/packages/boot/src/__tests__/fixtures/interceptor.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/interceptor.artifact.ts
@@ -10,7 +10,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as a global `Interceptor` during

--- a/packages/boot/src/__tests__/fixtures/non-global-interceptor.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/non-global-interceptor.artifact.ts
@@ -10,7 +10,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as a global `Interceptor` during

--- a/packages/boot/src/boot.component.ts
+++ b/packages/boot/src/boot.component.ts
@@ -3,8 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingScope, inject} from '@loopback/context';
-import {Application, Component, CoreBindings} from '@loopback/core';
+import {
+  BindingScope,
+  inject,
+  Application,
+  Component,
+  CoreBindings,
+} from '@loopback/core';
 import {
   ApplicationMetadataBooter,
   ControllerBooter,

--- a/packages/boot/src/booters/application-metadata.booter.ts
+++ b/packages/boot/src/booters/application-metadata.booter.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
-import {Application, CoreBindings} from '@loopback/core';
+import {inject, Application, CoreBindings} from '@loopback/core';
 import debugModule from 'debug';
 import {BootBindings} from '../keys';
 import {Booter} from '../types';

--- a/packages/boot/src/booters/base-artifact.booter.ts
+++ b/packages/boot/src/booters/base-artifact.booter.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor} from '@loopback/context';
+import {Constructor} from '@loopback/core';
 import debugFactory from 'debug';
 import path from 'path';
 import {ArtifactOptions, Booter} from '../types';

--- a/packages/boot/src/booters/booter-utils.ts
+++ b/packages/boot/src/booters/booter-utils.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Constructor} from '@loopback/context';
+import {Constructor} from '@loopback/core';
 import debugFactory from 'debug';
 import path from 'path';
 import {promisify} from 'util';

--- a/packages/boot/src/booters/controller.booter.ts
+++ b/packages/boot/src/booters/controller.booter.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, inject} from '@loopback/context';
-import {Application, CoreBindings} from '@loopback/core';
+import {config, inject, Application, CoreBindings} from '@loopback/core';
 import {BootBindings} from '../keys';
 import {ArtifactOptions, booter} from '../types';
 import {BaseArtifactBooter} from './base-artifact.booter';

--- a/packages/boot/src/booters/datasource.booter.ts
+++ b/packages/boot/src/booters/datasource.booter.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, inject} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {config, inject, CoreBindings} from '@loopback/core';
 import {
   ApplicationWithRepositories,
   Class,

--- a/packages/boot/src/booters/interceptor.booter.ts
+++ b/packages/boot/src/booters/interceptor.booter.ts
@@ -4,13 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  Application,
   config,
   Constructor,
+  CoreBindings,
   inject,
   Interceptor,
   Provider,
-} from '@loopback/context';
-import {Application, CoreBindings} from '@loopback/core';
+} from '@loopback/core';
 import debugFactory from 'debug';
 import {BootBindings} from '../keys';
 import {ArtifactOptions, booter} from '../types';

--- a/packages/boot/src/booters/lifecyle-observer.booter.ts
+++ b/packages/boot/src/booters/lifecyle-observer.booter.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, Constructor, inject} from '@loopback/context';
+import {config, Constructor, inject} from '@loopback/core';
 import {
   Application,
   CoreBindings,

--- a/packages/boot/src/booters/model.booter.ts
+++ b/packages/boot/src/booters/model.booter.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, Constructor, inject} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {config, Constructor, inject, CoreBindings} from '@loopback/core';
 import {
   ApplicationWithRepositories,
   ModelMetadataHelper,

--- a/packages/boot/src/booters/repository.booter.ts
+++ b/packages/boot/src/booters/repository.booter.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {config, inject} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {config, inject, CoreBindings} from '@loopback/core';
 import {ApplicationWithRepositories} from '@loopback/repository';
 import {BootBindings} from '../keys';
 import {ArtifactOptions, booter} from '../types';

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -7,10 +7,10 @@ import {
   BINDING_METADATA_KEY,
   config,
   Constructor,
+  CoreBindings,
   inject,
   MetadataInspector,
-} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+} from '@loopback/core';
 import {ApplicationWithServices} from '@loopback/service-proxy';
 import debugFactory from 'debug';
 import {BootBindings} from '../keys';

--- a/packages/boot/src/bootstrapper.ts
+++ b/packages/boot/src/bootstrapper.ts
@@ -3,8 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, resolveList} from '@loopback/context';
-import {Application, CoreBindings} from '@loopback/core';
+import {
+  Context,
+  inject,
+  resolveList,
+  Application,
+  CoreBindings,
+} from '@loopback/core';
 import debugModule from 'debug';
 import {resolve} from 'path';
 import {BootBindings, BootTags} from './keys';

--- a/packages/boot/src/keys.ts
+++ b/packages/boot/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {Bootstrapper} from './bootstrapper';
 import {BootOptions} from './types';
 

--- a/packages/boot/src/mixins/boot.mixin.ts
+++ b/packages/boot/src/mixins/boot.mixin.ts
@@ -11,7 +11,7 @@ import {
   Constructor,
   Context,
   createBindingFromClass,
-} from '@loopback/context';
+} from '@loopback/core';
 import {
   Application,
   Component,
@@ -26,7 +26,7 @@ import {Bootable, Booter, BootOptions, InstanceWithBooters} from '../types';
 
 // FIXME(rfeng): Workaround for https://github.com/microsoft/rushstack/pull/1867
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as loopbackContext from '@loopback/context';
+import * as loopbackContext from '@loopback/core';
 import * as loopbackCore from '@loopback/core';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/packages/boot/src/types.ts
+++ b/packages/boot/src/types.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Binding, BindingSpec, Constructor} from '@loopback/context';
+import {bind, Binding, BindingSpec, Constructor} from '@loopback/core';
 import {BootTags} from './keys';
 
 /**

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -12,9 +12,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
+++ b/packages/cli/generators/app/templates/src/controllers/ping.controller.ts.ejs
@@ -1,5 +1,5 @@
 import {Request, RestBindings, get, ResponseObject} from '@loopback/rest';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 /**
  * OpenAPI response for ping()

--- a/packages/cli/generators/app/templates/src/sequence.ts.ejs
+++ b/packages/cli/generators/app/templates/src/sequence.ts.ejs
@@ -1,4 +1,4 @@
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   FindRoute,
   InvokeMethod,

--- a/packages/cli/generators/controller/templates/src/controllers/controller-template.ts.ejs
+++ b/packages/cli/generators/controller/templates/src/controllers/controller-template.ts.ejs
@@ -1,6 +1,6 @@
 // Uncomment these imports to begin using these cool features!
 
-// import {inject} from '@loopback/context';
+// import {inject} from '@loopback/core';
 
 
 export class <%= className %>Controller {

--- a/packages/cli/generators/interceptor/templates/interceptor-template.ts.ejs
+++ b/packages/cli/generators/interceptor/templates/interceptor-template.ts.ejs
@@ -10,7 +10,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as an `Interceptor` during

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -73,9 +73,8 @@
   ],
   "dependencies": {
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
-    "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",
-<% if (project.projectType === 'application') { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
+<% if (project.projectType === 'application') { -%>
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
 <% if (project.repositories) { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
@@ -90,8 +89,6 @@
 <% } else { -%>
     "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",
 <% } -%>
-<% } else { /* NOT AN APPLICATION */-%>
-    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
 <% } -%>
     "tslib": "<%= project.dependencies['tslib'] -%>"
   },

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -73,9 +73,8 @@
   ],
   "dependencies": {
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
-    "@loopback/context": "<%= project.dependencies['@loopback/context'] -%>",
-<% if (project.projectType === 'application') { -%>
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
+<% if (project.projectType === 'application') { -%>
     "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
 <% if (project.apiconnect) { -%>
@@ -83,8 +82,6 @@
 <% } -%>
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
     "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",
-<% } else { -%>
-    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
 <% } -%>
     "tslib": "<%= project.dependencies['tslib'] -%>"
   },

--- a/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
@@ -102,7 +102,7 @@ if (require.main === module) {
 
 exports[`app-generator specific files generates all the proper files 3`] = `
 import {Request, RestBindings, get, ResponseObject} from '@loopback/rest';
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 
 /**
  * OpenAPI response for ping()

--- a/packages/cli/snapshots/integration/generators/controller.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/controller.integration.snapshots.js
@@ -366,7 +366,7 @@ export class ProductReviewController {
 exports[`lb4 controller basic controller scaffolds correct file with args 1`] = `
 // Uncomment these imports to begin using these cool features!
 
-// import {inject} from '@loopback/context';
+// import {inject} from '@loopback/core';
 
 
 export class ProductReviewController {
@@ -379,7 +379,7 @@ export class ProductReviewController {
 exports[`lb4 controller basic controller scaffolds correct file with input 1`] = `
 // Uncomment these imports to begin using these cool features!
 
-// import {inject} from '@loopback/context';
+// import {inject} from '@loopback/core';
 
 
 export class ProductReviewController {

--- a/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
@@ -16,7 +16,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as an \`Interceptor\` during
@@ -77,7 +77,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as an \`Interceptor\` during
@@ -138,7 +138,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as an \`Interceptor\` during
@@ -199,7 +199,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as an \`Interceptor\` during
@@ -262,7 +262,7 @@ import {
   InvocationResult,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 
 /**
  * This class will be bound to the application as an \`Interceptor\` during

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -279,10 +279,6 @@ module.exports = function (projGenerator, props, projectType) {
           );
           assert.fileContent(
             'package.json',
-            `"@loopback/context": "${deps['@loopback/context']}"`,
-          );
-          assert.fileContent(
-            'package.json',
             `"@loopback/rest": "${deps['@loopback/rest']}"`,
           );
           assert.fileContent(
@@ -300,10 +296,6 @@ module.exports = function (projGenerator, props, projectType) {
           assert.fileContent(
             'package.json',
             `"@loopback/core": "${deps['@loopback/core']}"`,
-          );
-          assert.fileContent(
-            'package.json',
-            `"@loopback/context": "${deps['@loopback/context']}"`,
           );
           assert.noFileContent('package.json', '"@loopback/rest"');
           assert.noFileContent('package.json', '"@loopback/openapi-v3"');
@@ -339,10 +331,6 @@ module.exports = function (projGenerator, props, projectType) {
         assert.fileContent(
           'package.json',
           `"@loopback/core": "${deps['@loopback/core']}"`,
-        );
-        assert.fileContent(
-          'package.json',
-          `"@loopback/context": "${deps['@loopback/context']}"`,
         );
         assert.fileContent('package.json', `"rimraf": "${deps['rimraf']}"`);
         assert.noFileContent([

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -37,7 +37,6 @@
     "!*/__tests__"
   ],
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/http-server": "^2.1.6",
     "@types/body-parser": "^1.19.0",

--- a/packages/express/src/__tests__/acceptance/middleware-interceptor.acceptance.ts
+++ b/packages/express/src/__tests__/acceptance/middleware-interceptor.acceptance.ts
@@ -10,9 +10,9 @@ import {
   ContextView,
   createBindingFromClass,
   Interceptor,
+  InterceptorOrKey,
   Provider,
-} from '@loopback/context';
-import {InterceptorOrKey} from '@loopback/core';
+} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {
   createInterceptor,

--- a/packages/express/src/__tests__/acceptance/test-helpers.ts
+++ b/packages/express/src/__tests__/acceptance/test-helpers.ts
@@ -8,7 +8,7 @@ import {
   createProxyWithInterceptors,
   intercept,
   InterceptorOrKey,
-} from '@loopback/context';
+} from '@loopback/core';
 import {Client, givenHttpServerConfig, supertest} from '@loopback/testlab';
 import bodyParser from 'body-parser';
 import {ExpressApplication} from '../../express.application';

--- a/packages/express/src/keys.ts
+++ b/packages/express/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {MiddlewareContext} from './types';
 
 export namespace MiddlewareBindings {

--- a/packages/express/src/middleware-registry.ts
+++ b/packages/express/src/middleware-registry.ts
@@ -20,7 +20,7 @@ import {
 
 // FIXME(rfeng): Workaround for https://github.com/microsoft/rushstack/pull/1867
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as loopbackContext from '@loopback/context';
+import * as loopbackContext from '@loopback/core';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 /**

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -12,13 +12,14 @@ import {
   Constructor,
   Context,
   createBindingFromClass,
+  extensionFilter,
+  extensionFor,
   InvocationResult,
   isProviderClass,
   Provider,
   transformValueOrPromise,
   ValueOrPromise,
-} from '@loopback/context';
-import {extensionFilter, extensionFor} from '@loopback/core';
+} from '@loopback/core';
 import debugFactory from 'debug';
 import {DEFAULT_MIDDLEWARE_GROUP, MIDDLEWARE_NAMESPACE} from './keys';
 import {

--- a/packages/express/src/mixins/middleware.mixin.ts
+++ b/packages/express/src/mixins/middleware.mixin.ts
@@ -27,7 +27,7 @@ import {
 
 // FIXME(rfeng): Workaround for https://github.com/microsoft/rushstack/pull/1867
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as loopbackContext from '@loopback/context';
+import * as loopbackContext from '@loopback/core';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 function extendsFrom(

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -26,8 +26,7 @@
     "JSON Schema"
   ],
   "dependencies": {
-    "@loopback/context": "^3.8.2",
-    "@loopback/metadata": "^2.1.6",
+    "@loopback/core": "^2.7.1",
     "@loopback/repository": "^2.6.0",
     "@types/json-schema": "^7.0.4",
     "debug": "^4.1.1",

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector} from '@loopback/context';
+import {MetadataInspector} from '@loopback/core';
 import {
   belongsTo,
   Entity,

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector} from '@loopback/context';
+import {MetadataInspector} from '@loopback/core';
 import {
   isBuiltinType,
   ModelDefinition,

--- a/packages/repository-json-schema/src/keys.ts
+++ b/packages/repository-json-schema/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataAccessor} from '@loopback/metadata';
+import {MetadataAccessor} from '@loopback/core';
 import {JsonSchema} from './index';
 
 /**

--- a/packages/repository-json-schema/tsconfig.json
+++ b/packages/repository-json-schema/tsconfig.json
@@ -11,10 +11,7 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
-      "path": "../metadata/tsconfig.json"
+      "path": "../core/tsconfig.json"
     },
     {
       "path": "../repository/tsconfig.json"

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.15"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
+    "@loopback/core": "^2.7.1",
     "@loopback/testlab": "^3.1.6",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/address.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/address.repository.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {
   BelongsToAccessor,
   juggler,

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/customer.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/customer.repository.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {
   BelongsToAccessor,
   HasManyRepositoryFactory,

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/order.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/order.repository.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {
   BelongsToAccessor,
   juggler,

--- a/packages/repository-tests/src/crud/relations/fixtures/repositories/shipment.repository.ts
+++ b/packages/repository-tests/src/crud/relations/fixtures/repositories/shipment.repository.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {
   HasManyRepositoryFactory,
   juggler,

--- a/packages/repository-tests/tsconfig.json
+++ b/packages/repository-tests/tsconfig.json
@@ -11,7 +11,7 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
+      "path": "../core/tsconfig.json"
     },
     {
       "path": "../repository/tsconfig.json"

--- a/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-class.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 
 import {
   repository,

--- a/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
+++ b/packages/repository/examples/juggler-bridge/note-with-repo-instance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 
 import {
   juggler,

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -32,7 +32,6 @@
     "bson": "4.0.4"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",

--- a/packages/repository/src/__tests__/unit/decorator/metadata.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/metadata.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector} from '@loopback/context';
+import {MetadataInspector} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {
   model,

--- a/packages/repository/src/__tests__/unit/decorator/model-and-relation.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/model-and-relation.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector} from '@loopback/context';
+import {MetadataInspector} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {RelationMetadata} from '../../..';
 import {

--- a/packages/repository/src/__tests__/unit/decorator/relation.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/relation.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector} from '@loopback/context';
+import {MetadataInspector} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {
   belongsTo,

--- a/packages/repository/src/__tests__/unit/decorator/repository-with-di.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/repository-with-di.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject} from '@loopback/context';
+import {Context, inject} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {
   DefaultCrudRepository,

--- a/packages/repository/src/__tests__/unit/decorator/repository-with-value-provider.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/repository-with-value-provider.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, Provider, ValueOrPromise} from '@loopback/context';
+import {Context, inject, Provider, ValueOrPromise} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {
   DefaultCrudRepository,

--- a/packages/repository/src/__tests__/unit/decorator/repository.decorator.unit.ts
+++ b/packages/repository/src/__tests__/unit/decorator/repository.decorator.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, Getter} from '@loopback/context';
+import {Context, Getter} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {
   DefaultCrudRepository,

--- a/packages/repository/src/__tests__/unit/mixins/model.mixin.unit.ts
+++ b/packages/repository/src/__tests__/unit/mixins/model.mixin.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector, MetadataMap} from '@loopback/context';
+import {MetadataInspector, MetadataMap} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {MODEL_PROPERTIES_KEY} from '../../../';
 import {Note} from '../../fixtures/models/note.model';

--- a/packages/repository/src/__tests__/unit/repositories/has-many-repository-factory.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/has-many-repository-factory.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {createStubInstance, expect} from '@loopback/testlab';
 import {
   createHasManyRepositoryFactory,

--- a/packages/repository/src/__tests__/unit/repositories/has-one-repository-factory.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/has-one-repository-factory.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {createStubInstance, expect} from '@loopback/testlab';
 import {
   createHasOneRepositoryFactory,

--- a/packages/repository/src/__tests__/unit/repositories/relation.repository.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relation.repository.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {
   createStubInstance,
   expect,

--- a/packages/repository/src/decorators/metadata.ts
+++ b/packages/repository/src/decorators/metadata.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {InspectionOptions, MetadataInspector} from '@loopback/context';
+import {InspectionOptions, MetadataInspector} from '@loopback/core';
 import {ModelDefinition, RelationDefinitionMap} from '../model';
 import {RELATIONS_KEY} from '../relations';
 import {

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -9,7 +9,7 @@ import {
   MetadataInspector,
   MetadataMap,
   PropertyDecoratorFactory,
-} from '@loopback/context';
+} from '@loopback/core';
 import {
   ModelDefinition,
   ModelDefinitionSyntax,

--- a/packages/repository/src/decorators/repository.decorator.ts
+++ b/packages/repository/src/decorators/repository.decorator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, Injection} from '@loopback/context';
+import {Context, inject, Injection} from '@loopback/core';
 import assert from 'assert';
 import {Class} from '../common-types';
 import {DataSource} from '../datasource';

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -8,7 +8,7 @@ import {
   BindingFromClassOptions,
   BindingScope,
   createBindingFromClass,
-} from '@loopback/context';
+} from '@loopback/core';
 import {
   Application,
   Component,
@@ -27,7 +27,7 @@ const debug = debugFactory('loopback:repository:mixin');
 
 // FIXME(rfeng): Workaround for https://github.com/microsoft/rushstack/pull/1867
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as loopbackContext from '@loopback/context';
+import * as loopbackContext from '@loopback/core';
 import * as loopbackCore from '@loopback/core';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.decorator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector} from '@loopback/context';
+import {MetadataInspector} from '@loopback/core';
 import {property} from '../../decorators/model.decorator';
 import {Entity, EntityResolver, PropertyDefinition} from '../../model';
 import {relation} from '../relation.decorator';

--- a/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.repository.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {DataObject, Options} from '../../common-types';
 import {EntityNotFoundError} from '../../errors';
 import {Entity} from '../../model';

--- a/packages/repository/src/relations/has-many/has-many.repository.ts
+++ b/packages/repository/src/relations/has-many/has-many.repository.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {Count, DataObject, Options} from '../../common-types';
 import {Entity} from '../../model';
 import {Filter, Where} from '../../query';

--- a/packages/repository/src/relations/has-one/has-one.repository.ts
+++ b/packages/repository/src/relations/has-one/has-one.repository.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import {Count, DataObject, Options} from '../../common-types';
 import {EntityNotFoundError} from '../../errors';
 import {Entity} from '../../model';

--- a/packages/repository/src/relations/relation.decorator.ts
+++ b/packages/repository/src/relations/relation.decorator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {PropertyDecoratorFactory} from '@loopback/context';
+import {PropertyDecoratorFactory} from '@loopback/core';
 import {buildModelDefinition} from '../decorators';
 import {Model, RelationDefinitionMap} from '../model';
 import {RelationType} from './relation.types';

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -155,7 +155,7 @@ export type RelationMetadata =
   | RelationDefinitionBase;
 
 // Re-export Getter so that users don't have to import from @loopback/context
-export {Getter} from '@loopback/context';
+export {Getter} from '@loopback/core';
 
 /**
  * @returns An array of resolved values, the items must be ordered in the same

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Getter} from '@loopback/context';
+import {Getter} from '@loopback/core';
 import assert from 'assert';
 import legacy from 'loopback-datasource-juggler';
 import {

--- a/packages/repository/tsconfig.json
+++ b/packages/repository/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -21,7 +21,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/rest": "^5.1.0",
     "ejs": "^3.1.3",

--- a/packages/rest-explorer/src/rest-explorer.component.ts
+++ b/packages/rest-explorer/src/rest-explorer.component.ts
@@ -3,9 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import {bind, config, ContextTags, inject} from '@loopback/context';
-import {Component, CoreBindings} from '@loopback/core';
+import {
+  bind,
+  Component,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  config,
+  ContextTags,
+  CoreBindings,
+  inject,
+} from '@loopback/core';
 import {createControllerFactoryForClass, RestApplication} from '@loopback/rest';
 import {ExplorerController} from './rest-explorer.controller';
 import {RestExplorerBindings} from './rest-explorer.keys';

--- a/packages/rest-explorer/src/rest-explorer.controller.ts
+++ b/packages/rest-explorer/src/rest-explorer.controller.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import {config, inject} from '@loopback/context';
+import {config, inject} from '@loopback/core';
 import {
   OpenApiSpecForm,
   RequestContext,

--- a/packages/rest-explorer/src/rest-explorer.keys.ts
+++ b/packages/rest-explorer/src/rest-explorer.keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingAddress, BindingKey} from '@loopback/context';
+import {BindingAddress, BindingKey} from '@loopback/core';
 import {RestExplorerComponent} from './rest-explorer.component';
 import {RestExplorerConfig} from './rest-explorer.types';
 

--- a/packages/rest-explorer/tsconfig.json
+++ b/packages/rest-explorer/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -24,7 +24,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "@loopback/express": "^1.2.2",
     "@loopback/http-server": "^2.1.6",

--- a/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.acceptance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {intercept} from '@loopback/context';
+import {intercept} from '@loopback/core';
 import {get, param} from '@loopback/openapi-v3';
 import {
   Client,

--- a/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.ts
+++ b/packages/rest/src/__tests__/acceptance/caching-interceptor/caching-interceptor.ts
@@ -9,7 +9,7 @@ import {
   InvocationContext,
   Provider,
   ValueOrPromise,
-} from '@loopback/context';
+} from '@loopback/core';
 import {Request, RestBindings, RouteSource} from '../../..';
 
 /**

--- a/packages/rest/src/__tests__/acceptance/caching-interceptor/global-caching-interceptor.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/caching-interceptor/global-caching-interceptor.acceptance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {asGlobalInterceptor} from '@loopback/context';
+import {asGlobalInterceptor} from '@loopback/core';
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
 import {get, param} from '@loopback/openapi-v3';
 import {

--- a/packages/rest/src/__tests__/acceptance/file-upload/file-upload.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/file-upload/file-upload.acceptance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {
   Client,
   createRestAppClient,

--- a/packages/rest/src/__tests__/acceptance/middleware/test-helpers.ts
+++ b/packages/rest/src/__tests__/acceptance/middleware/test-helpers.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Binding, intercept, InterceptorOrKey} from '@loopback/context';
+import {Binding, intercept, InterceptorOrKey} from '@loopback/core';
 import {post, requestBody} from '@loopback/openapi-v3';
 import {
   Client,

--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -3,8 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingScope, Constructor, Context, inject} from '@loopback/context';
-import {Application, CoreBindings} from '@loopback/core';
+import {
+  BindingScope,
+  Constructor,
+  Context,
+  inject,
+  Application,
+  CoreBindings,
+} from '@loopback/core';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
 import {
   api,

--- a/packages/rest/src/__tests__/acceptance/sequence/sequence.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/sequence/sequence.acceptance.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {inject, Application} from '@loopback/core';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
 import {api} from '@loopback/openapi-v3';
 import {Client, createClientForHandler} from '@loopback/testlab';

--- a/packages/rest/src/__tests__/integration/http-handler.integration.ts
+++ b/packages/rest/src/__tests__/integration/http-handler.integration.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {anOpenApiSpec, anOperationSpec} from '@loopback/openapi-spec-builder';
 import {
   ControllerSpec,

--- a/packages/rest/src/__tests__/unit/rest.component.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.component.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BoundValue, Context, inject, Provider} from '@loopback/context';
+import {BoundValue, Context, inject, Provider} from '@loopback/core';
 import {
   Application,
   Component,

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.unit.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
-import {Application} from '@loopback/core';
+import {Context, Application} from '@loopback/core';
 import {anOperationSpec} from '@loopback/openapi-spec-builder';
 import {expect} from '@loopback/testlab';
 import {

--- a/packages/rest/src/body-parsers/body-parser.json.ts
+++ b/packages/rest/src/body-parsers/body-parser.json.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {json} from 'body-parser';
 import {is} from 'type-is';
 import {RestBindings} from '../keys';

--- a/packages/rest/src/body-parsers/body-parser.raw.ts
+++ b/packages/rest/src/body-parsers/body-parser.raw.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {raw} from 'body-parser';
 import {is} from 'type-is';
 import {RestBindings} from '../keys';

--- a/packages/rest/src/body-parsers/body-parser.text.ts
+++ b/packages/rest/src/body-parsers/body-parser.text.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {text} from 'body-parser';
 import {is} from 'type-is';
 import {RestBindings} from '../keys';

--- a/packages/rest/src/body-parsers/body-parser.ts
+++ b/packages/rest/src/body-parsers/body-parser.ts
@@ -10,7 +10,7 @@ import {
   filterByTag,
   inject,
   instantiateClass,
-} from '@loopback/context';
+} from '@loopback/core';
 import {isReferenceObject, OperationObject} from '@loopback/openapi-v3';
 import debugModule from 'debug';
 import {is} from 'type-is';

--- a/packages/rest/src/body-parsers/body-parser.urlencoded.ts
+++ b/packages/rest/src/body-parsers/body-parser.urlencoded.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {urlencoded} from 'body-parser';
 import {is} from 'type-is';
 import {RestBindings} from '../keys';

--- a/packages/rest/src/http-handler.ts
+++ b/packages/rest/src/http-handler.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {
   ComponentsObject,
   ControllerSpec,

--- a/packages/rest/src/keys.ts
+++ b/packages/rest/src/keys.ts
@@ -3,8 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey, Context} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+import {BindingKey, Context, CoreBindings} from '@loopback/core';
 import {InvokeMiddleware} from '@loopback/express';
 import {HttpProtocol} from '@loopback/http-server';
 import {OpenApiSpec, OperationObject} from '@loopback/openapi-v3';

--- a/packages/rest/src/providers/find-route.provider.ts
+++ b/packages/rest/src/providers/find-route.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, Provider} from '@loopback/context';
+import {Context, inject, Provider} from '@loopback/core';
 import {FindRoute, Request} from '../types';
 import {HttpHandler} from '../http-handler';
 import {RestBindings} from '../keys';

--- a/packages/rest/src/providers/invoke-method.provider.ts
+++ b/packages/rest/src/providers/invoke-method.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, inject, Provider} from '@loopback/context';
+import {Context, inject, Provider} from '@loopback/core';
 import {InvokeMethod, OperationArgs, OperationRetval} from '../types';
 import {RestBindings} from '../keys';
 import {RouteEntry} from '../router';

--- a/packages/rest/src/providers/log-error.provider.ts
+++ b/packages/rest/src/providers/log-error.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Provider} from '@loopback/context';
+import {Provider} from '@loopback/core';
 import {LogError, Request} from '../types';
 
 export class LogErrorProvider implements Provider<LogError> {

--- a/packages/rest/src/providers/parse-params.provider.ts
+++ b/packages/rest/src/providers/parse-params.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject, Provider} from '@loopback/context';
+import {inject, Provider} from '@loopback/core';
 import {RequestBodyParser} from '../body-parsers';
 import {RestBindings} from '../keys';
 import {parseOperationArgs} from '../parser';

--- a/packages/rest/src/providers/reject.provider.ts
+++ b/packages/rest/src/providers/reject.provider.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {LogError, Reject, HandlerContext} from '../types';
-import {inject, Provider} from '@loopback/context';
+import {inject, Provider} from '@loopback/core';
 import {HttpError} from 'http-errors';
 import {RestBindings} from '../keys';
 import {writeErrorToResponse, ErrorWriterOptions} from 'strong-error-handler';

--- a/packages/rest/src/providers/send.provider.ts
+++ b/packages/rest/src/providers/send.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Provider, BoundValue} from '@loopback/context';
+import {Provider, BoundValue} from '@loopback/core';
 import {writeResultToResponse} from '../writer';
 /**
  * Provides the function that populates the response object with

--- a/packages/rest/src/request-context.ts
+++ b/packages/rest/src/request-context.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {
   HandlerContext,
   MiddlewareContext,

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -4,13 +4,15 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  Application,
+  ApplicationConfig,
   Binding,
   BindingAddress,
   Constructor,
   Context,
   Provider,
-} from '@loopback/context';
-import {Application, ApplicationConfig, Server} from '@loopback/core';
+  Server,
+} from '@loopback/core';
 import {
   ExpressMiddlewareFactory,
   ExpressRequestHandler,

--- a/packages/rest/src/rest.component.ts
+++ b/packages/rest/src/rest.component.ts
@@ -8,7 +8,7 @@ import {
   Constructor,
   createBindingFromClass,
   inject,
-} from '@loopback/context';
+} from '@loopback/core';
 import {
   Application,
   Component,

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -4,18 +4,20 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  Application,
   Binding,
   BindingAddress,
   BindingScope,
   Constructor,
   ContextObserver,
+  CoreBindings,
   createBindingFromClass,
   filterByKey,
   filterByTag,
   inject,
+  Server,
   Subscription,
-} from '@loopback/context';
-import {Application, CoreBindings, Server} from '@loopback/core';
+} from '@loopback/core';
 import {BaseMiddlewareRegistry, ExpressRequestHandler} from '@loopback/express';
 import {HttpServer, HttpServerOptions} from '@loopback/http-server';
 import {

--- a/packages/rest/src/router/base-route.ts
+++ b/packages/rest/src/router/base-route.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, InvocationSource} from '@loopback/context';
+import {Context, InvocationSource} from '@loopback/core';
 import {OperationObject} from '@loopback/openapi-v3';
 import {OperationArgs, OperationRetval} from '../types';
 import {RouteEntry} from './route-entry';

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -7,11 +7,11 @@ import {
   BindingScope,
   Constructor,
   Context,
+  CoreBindings,
   instantiateClass,
   invokeMethod,
   ValueOrPromise,
-} from '@loopback/context';
-import {CoreBindings} from '@loopback/core';
+} from '@loopback/core';
 import {ControllerSpec, OperationObject} from '@loopback/openapi-v3';
 import assert from 'assert';
 import debugFactory from 'debug';

--- a/packages/rest/src/router/external-express-routes.ts
+++ b/packages/rest/src/router/external-express-routes.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {
   executeExpressRequestHandler,
   ExpressRequestHandler,

--- a/packages/rest/src/router/handler-route.ts
+++ b/packages/rest/src/router/handler-route.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, invokeMethodWithInterceptors} from '@loopback/context';
+import {Context, invokeMethodWithInterceptors} from '@loopback/core';
 import {OperationObject} from '@loopback/openapi-v3';
 import {RestBindings} from '../keys';
 import {OperationArgs, OperationRetval} from '../types';

--- a/packages/rest/src/router/regexp-router.ts
+++ b/packages/rest/src/router/regexp-router.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {inspect} from 'util';
 import {RestBindings} from '../keys';
 import {PathParameterValues} from '../types';

--- a/packages/rest/src/router/route-entry.ts
+++ b/packages/rest/src/router/route-entry.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {OperationObject, SchemasObject} from '@loopback/openapi-v3';
 import {OperationArgs, OperationRetval, PathParameterValues} from '../types';
 

--- a/packages/rest/src/router/trie-router.ts
+++ b/packages/rest/src/router/trie-router.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
 import {inspect} from 'util';
 import {RestBindings} from '../keys';
 import {RestRouterOptions} from './rest-router';

--- a/packages/rest/src/sequence.ts
+++ b/packages/rest/src/sequence.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 const debug = require('debug')('loopback:rest:sequence');
-import {inject, ValueOrPromise} from '@loopback/context';
+import {inject, ValueOrPromise} from '@loopback/core';
 import {InvokeMiddleware} from '@loopback/express';
 import {RestBindings} from './keys';
 import {RequestContext} from './request-context';

--- a/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
+++ b/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
@@ -4,13 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  ApplicationMetadata,
   bind,
   BindingScope,
+  CoreBindings,
   inject,
   JSONObject,
   JSONValue,
-} from '@loopback/context';
-import {ApplicationMetadata, CoreBindings} from '@loopback/core';
+} from '@loopback/core';
 import {
   asSpecEnhancer,
   ContactObject,

--- a/packages/rest/tsconfig.json
+++ b/packages/rest/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -24,7 +24,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "debug": "^4.1.1",
     "tslib": "^2.0.0"

--- a/packages/security/src/keys.ts
+++ b/packages/security/src/keys.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingKey} from '@loopback/context';
+import {BindingKey} from '@loopback/core';
 import {Subject, UserProfile} from './types';
 
 /**

--- a/packages/security/tsconfig.json
+++ b/packages/security/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -30,7 +30,6 @@
     "@types/node": "^10.17.24"
   },
   "dependencies": {
-    "@loopback/context": "^3.8.2",
     "@loopback/core": "^2.7.1",
     "loopback-datasource-juggler": "^4.21.2",
     "tslib": "^2.0.0"

--- a/packages/service-proxy/src/__tests__/unit/decorators/service-proxy.decorator.unit.ts
+++ b/packages/service-proxy/src/__tests__/unit/decorators/service-proxy.decorator.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Context} from '@loopback/context';
+import {Context} from '@loopback/core';
 import {serviceProxy} from '../../../';
 
 import {juggler} from '../../../';

--- a/packages/service-proxy/src/decorators/service.decorator.ts
+++ b/packages/service-proxy/src/decorators/service.decorator.ts
@@ -9,7 +9,7 @@ import {
   Context,
   Injection,
   InjectionMetadata,
-} from '@loopback/context';
+} from '@loopback/core';
 import {getService, juggler} from '..';
 
 /**

--- a/packages/service-proxy/src/mixins/service.mixin.ts
+++ b/packages/service-proxy/src/mixins/service.mixin.ts
@@ -9,7 +9,7 @@ import {
   BindingFromClassOptions,
   Provider,
   Constructor,
-} from '@loopback/context';
+} from '@loopback/core';
 import {
   Application,
   MixinTarget,
@@ -19,7 +19,7 @@ import {
 
 // FIXME(rfeng): Workaround for https://github.com/microsoft/rushstack/pull/1867
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as loopbackContext from '@loopback/context';
+import * as loopbackContext from '@loopback/core';
 import * as loopbackCore from '@loopback/core';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 

--- a/packages/service-proxy/tsconfig.json
+++ b/packages/service-proxy/tsconfig.json
@@ -11,9 +11,6 @@
   ],
   "references": [
     {
-      "path": "../context/tsconfig.json"
-    },
-    {
       "path": "../core/tsconfig.json"
     },
     {


### PR DESCRIPTION
Use `@loopback/core` as the aggregated dependency for packages.

MD docs updated too.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
