### PR TITLE
feat(cli): allow custom copyright/license lines

### DIFF
--- a/docs/site/Copyright-generator.md
+++ b/docs/site/Copyright-generator.md
@@ -58,6 +58,18 @@ The command prompts you for:
 2. The license name. The default value is read from `license` in the
    `package.json`.
 
+   If the license name is `CUSTOM`, you'll be prompted to provide a custom
+   template. For example:
+
+   ```
+   =============================================================================
+   Licensed Materials - Property of <%= owner %>
+   (C) Copyright <%= owner %> <%= years %>
+   US Government Users Restricted Rights - Use, duplication or disclosure
+   restricted by GSA ADP Schedule Contract with <%= owner %>.
+   =============================================================================
+   ```
+
 The default owner is `IBM Corp.` and license is `MIT` with the following
 `package.json`.
 

--- a/packages/cli/generators/copyright/license.js
+++ b/packages/cli/generators/copyright/license.js
@@ -8,6 +8,14 @@ const {FSE} = require('./fs');
 const {getYears} = require('./git');
 const {wrapText} = require('../../lib/utils');
 const spdxLicenses = require('spdx-license-list/full');
+
+spdxLicenses.CUSTOM = {
+  name: 'Custom License',
+  url: '',
+  osiApproved: false,
+  licenseText: '',
+};
+
 const spdxLicenseList = {};
 for (const id in spdxLicenses) {
   spdxLicenseList[id.toLowerCase()] = {id, ...spdxLicenses[id]};

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -83,6 +83,41 @@ describe('lb4 copyright', /** @this {Mocha.Suite} */ function () {
     );
   });
 
+  it('updates custom copyright/license headers with options', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
+          excludePackageJSON: true,
+          additionalFiles: SANDBOX_FILES,
+        }),
+      )
+      .withOptions({
+        owner: 'ACME Inc.',
+        license: 'CUSTOM',
+        gitOnly: false,
+      })
+      .withPrompts({
+        customLicenseLines: `
+=============================================================================
+Licensed Materials - Property of <%= owner %>
+(C) Copyright <%= owner %> <%= years %>
+US Government Users Restricted Rights - Use, duplication or disclosure
+restricted by GSA ADP Schedule Contract with <%= owner %>.
+=============================================================================`,
+      });
+
+    assertHeader(
+      ['src/application.ts', 'lib/no-header.js'],
+      `=============================================================================`,
+      `Licensed Materials - Property of ACME Inc.`,
+      `(C) Copyright ACME Inc. ${year}`,
+      `US Government Users Restricted Rights - Use, duplication or disclosure`,
+      `restricted by GSA ADP Schedule Contract with ACME Inc..`,
+      `=============================================================================`,
+    );
+  });
+
   it('updates copyright/license headers with options.exclude', async () => {
     await testUtils
       .executeGenerator(generator)


### PR DESCRIPTION
Add `custom` license to generate custom copyright/license headers, such as:
```
=============================================================================
Licensed Materials - Property of <%= owner %>
(C) Copyright <%= owner %> <%= years %>
US Government Users Restricted Rights - Use, duplication or disclosure
restricted by GSA ADP Schedule Contract with <%= owner %>.
=============================================================================
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
