### PR TITLE
fix(docs): improve keywords in frontmatter

### DIFF
--- a/docs/bin/copy-changelogs.js
+++ b/docs/bin/copy-changelogs.js
@@ -69,7 +69,7 @@ async function copyChangelogs() {
     `---
 lang: en
 title: 'CHANGELOG Docs'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/changelog.index.html
 ---
@@ -94,7 +94,7 @@ permalink: /doc/en/lb4/changelog.index.html
       const md = `---
 lang: en
 title: 'CHANGELOG - ${name}'
-keywords: LoopBack 4.0, LoopBack 4, CHANGELOG
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Node.js, TypeScript, OpenAPI, CHANGELOG
 sidebar: lb4_sidebar
 toc_level: 0
 editurl: https://github.com/strongloop/loopback-next/blob/master/${location}/CHANGELOG.md

--- a/docs/site/Access-databases.md
+++ b/docs/site/Access-databases.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Access Databases'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Database
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Access-databases.html
 ---

--- a/docs/site/Application-generator.md
+++ b/docs/site/Application-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Application generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, CLI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Application-generator.html
 ---

--- a/docs/site/Application.md
+++ b/docs/site/Application.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Application'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Application.html
 ---

--- a/docs/site/Appsody-LoopBack.md
+++ b/docs/site/Appsody-LoopBack.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Developing and Deploying LoopBack Applications with Appsody'
-keywords: LoopBack 4.0, LoopBack 4, Appsody
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Appsody, Cloud
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Appsody-LoopBack.html
 ---

--- a/docs/site/Authentication-passport.md
+++ b/docs/site/Authentication-passport.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'Passport Authentication Strategy Adapter'
-keywords: LoopBack 4.0, LoopBack 4, Authentication, Passport
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Authentication,
+  Passport
 layout: readme
 source: loopback-next
 file: extensions/authentication-passport/README.md

--- a/docs/site/Behind-the-scene.md
+++ b/docs/site/Behind-the-scene.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Components'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Behind-the-scene.html
 ---

--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'belongsTo Relation'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Model Relation
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/BelongsTo-relation.html
 ---

--- a/docs/site/Best-practices.md
+++ b/docs/site/Best-practices.md
@@ -1,7 +1,7 @@
 ---
 lang: en
-title: 'Best practices with Loopback 4'
-keywords: LoopBack 4.0, LoopBack 4
+title: 'Best practices with LoopBack 4'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Best-practices.html
 redirect_from:

--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Binding'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Binding.html
 ---

--- a/docs/site/Boot-and-Mount-a-LoopBack-3-application.md
+++ b/docs/site/Boot-and-Mount-a-LoopBack-3-application.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Boot and Mount a LoopBack 3 Application'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3
+keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Node.js, TypeScript, OpenAPI
 layout: readme
 source: loopback-next
 file: packages/booter-lb3app/README.md

--- a/docs/site/Booting-an-Application.md
+++ b/docs/site/Booting-an-Application.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Booting an Application'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Booting
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Booting-an-Application.html
 ---

--- a/docs/site/Calling-other-APIs-and-Web-Services.md
+++ b/docs/site/Calling-other-APIs-and-Web-Services.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Calling other APIs and web services'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, REST, SOAP
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Calling-other-APIs-and-web-services.html
 ---

--- a/docs/site/Command-line-interface.md
+++ b/docs/site/Command-line-interface.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Command-line interface'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, CLI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Command-line-interface.html
 ---

--- a/docs/site/Components.md
+++ b/docs/site/Components.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Components'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Components.html
 ---

--- a/docs/site/Concepts.md
+++ b/docs/site/Concepts.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Key concepts'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Concepts.html
 ---

--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Context'
-keywords: LoopBack 4.0, LoopBack 4
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts, Context
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Context.html
 ---

--- a/docs/site/Controller-generator.md
+++ b/docs/site/Controller-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Controller generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, CLI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Controller-generator.html
 ---

--- a/docs/site/Controllers.md
+++ b/docs/site/Controllers.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Controllers'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Controllers.html
 ---

--- a/docs/site/Copyright-generator.md
+++ b/docs/site/Copyright-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Generate copyright/license header for JavaScript/TypeScript files'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, CLI, Utility
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Copyright-generator.html
 ---

--- a/docs/site/Crafting-LoopBack-4.md
+++ b/docs/site/Crafting-LoopBack-4.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Crafting LoopBack 4'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Architecture
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Crafting-LoopBack-4.html
 ---

--- a/docs/site/Create-other-forms-of-apis.md
+++ b/docs/site/Create-other-forms-of-apis.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'Create Other Forms of APIs'
-keywords: LoopBack 4.0, LoopBack 4
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, REST, SOAP, Web
+  services
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Create-other-forms-of-apis.html
 ---

--- a/docs/site/Creating-CRUD-REST-apis.md
+++ b/docs/site/Creating-CRUD-REST-apis.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Creating CRUD REST APIs from a model'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-crud-rest-apis.html
 summary:

--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Creating components'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Components
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-components.html
 ---

--- a/docs/site/Creating-decorators.md
+++ b/docs/site/Creating-decorators.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Creating decorators'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Decorators
 layout: readme
 source: loopback-next
 file: packages/metadata/README.md

--- a/docs/site/Creating-servers.md
+++ b/docs/site/Creating-servers.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Creating servers'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-servers.html
 ---

--- a/docs/site/DataSource-generator.md
+++ b/docs/site/DataSource-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'DataSource generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/DataSource-generator.html
 ---

--- a/docs/site/DataSources.md
+++ b/docs/site/DataSources.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'DataSources'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/DataSources.html
 ---

--- a/docs/site/Database-migrations.md
+++ b/docs/site/Database-migrations.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Database Migrations'
-keywords: LoopBack 4.0
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Database
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Database-migrations.html
 ---

--- a/docs/site/Defining-the-API-using-code-first-approach.md
+++ b/docs/site/Defining-the-API-using-code-first-approach.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Defining the API using code-first approach'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Defining-the-API-using-code-first-approach.html
 ---

--- a/docs/site/Defining-the-API-using-design-first-approach.shelved.md
+++ b/docs/site/Defining-the-API-using-design-first-approach.shelved.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Defining the API using design-first approach'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Defining-the-API-using-design-first-approach.html
 ---

--- a/docs/site/Defining-your-testing-strategy.md
+++ b/docs/site/Defining-your-testing-strategy.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Defining your testing strategy'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Defining-your-testing-strategy.html
 ---

--- a/docs/site/Dependency-injection.md
+++ b/docs/site/Dependency-injection.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Dependency injection'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Dependency-injection.html
 ---

--- a/docs/site/Download-examples.md
+++ b/docs/site/Download-examples.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Download examples'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Download-examples.html
 ---

--- a/docs/site/Dynamic-models-repositories-controllers.md
+++ b/docs/site/Dynamic-models-repositories-controllers.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'Dynamically adding models, repositories, and controllers during runtime'
-keywords: LoopBack 4.0, LoopBack 4, model, repository, controller, tutorial
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, model, repository,
+  controller, tutorial
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Dynamic-models-repositories-controllers-tutorial.html
 ---

--- a/docs/site/Express-middleware.md
+++ b/docs/site/Express-middleware.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Using Express middleware'
-keywords: LoopBack 4.0, LoopBack 4, Express, Middleware
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Express, Middleware
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Express-middleware.html
 ---

--- a/docs/site/Extending-LoopBack-4.md
+++ b/docs/site/Extending-LoopBack-4.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extending LoopBack 4'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extending-LoopBack-4.html
 ---

--- a/docs/site/Extending-Model-API-builder.md
+++ b/docs/site/Extending-Model-API-builder.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extending Model API builder'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extending-Model-API-builder.html
 ---

--- a/docs/site/Extending-OpenAPI-specification.md
+++ b/docs/site/Extending-OpenAPI-specification.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extending OpenAPI Specification'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extending-OpenAPI-specification.html
 ---

--- a/docs/site/Extending-request-body-parsing.md
+++ b/docs/site/Extending-request-body-parsing.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extending request body parsing'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extending-request-body-parsing.html
 ---

--- a/docs/site/Extension-generator.md
+++ b/docs/site/Extension-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extension generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extension-generator.html
 ---

--- a/docs/site/Extension-life-cycle.md
+++ b/docs/site/Extension-life-cycle.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extension life cycle'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extension-life-cycle.html
 ---

--- a/docs/site/Extension-point-and-extensions.md
+++ b/docs/site/Extension-point-and-extensions.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extension point and extensions'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Extension-point-and-extensions.html
 ---

--- a/docs/site/FAQ.md
+++ b/docs/site/FAQ.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Frequently-asked questions'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/FAQ.html
 summary: LoopBack 4 is a completely new framework, also known as LoopBack-Next.

--- a/docs/site/Fields-filter.md
+++ b/docs/site/Fields-filter.md
@@ -1,7 +1,7 @@
 ---
 title: 'Fields filter'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, fields
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, fields
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Fields-filter.html
 ---

--- a/docs/site/Getting-started.md
+++ b/docs/site/Getting-started.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Getting started'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Getting-started.html
 summary: Write and run a LoopBack 4 "Hello World" project in TypeScript.

--- a/docs/site/Glossary.md
+++ b/docs/site/Glossary.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Glossary'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 toc_level: 1
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Glossary.html

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'hasMany Relation'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/HasMany-relation.html
 ---

--- a/docs/site/HasOne-relation.md
+++ b/docs/site/HasOne-relation.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'hasOne Relation'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/HasOne-relation.html
 ---

--- a/docs/site/Health.md
+++ b/docs/site/Health.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Health checks'
-keywords: LoopBack 4.0, LoopBack 4, Cloud Native
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Cloud Native
 layout: readme
 source: loopback-next
 file: extensions/health/README.md

--- a/docs/site/How-tos.md
+++ b/docs/site/How-tos.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'HOWTOs'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/How-tos.html
 ---

--- a/docs/site/Implementing-features.shelved.md
+++ b/docs/site/Implementing-features.shelved.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Implementing features'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Implementing-features.html
 ---

--- a/docs/site/Include-filter.md
+++ b/docs/site/Include-filter.md
@@ -1,7 +1,7 @@
 ---
 title: 'Include filter'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, include
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, include
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Include-filter.html
 ---

--- a/docs/site/Inside-Loopback-Application.md
+++ b/docs/site/Inside-Loopback-Application.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Inside a LoopBack Application'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Inside-LoopBack-Application.html
 ---

--- a/docs/site/Interceptor-generator.md
+++ b/docs/site/Interceptor-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Interceptor generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Interceptor-generator.html
 ---

--- a/docs/site/Interceptors.md
+++ b/docs/site/Interceptors.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Interceptors'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Interceptors.html
 ---

--- a/docs/site/Introduction-to-LoopBack-Next-development.md
+++ b/docs/site/Introduction-to-LoopBack-Next-development.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Introduction to LoopBack 4 development'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Intro-to-LB4-development.html
 ---

--- a/docs/site/LB3-vs-LB4-request-response-cycle.md
+++ b/docs/site/LB3-vs-LB4-request-response-cycle.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'Differences in LoopBack 3 and LoopBack 4 request/response cycle'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3.0, LoopBack 3
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3.0, LoopBack
+  3
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/LB3-vs-LB4-request-response-cycle.html
 ---

--- a/docs/site/Language-related-concepts.md
+++ b/docs/site/Language-related-concepts.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Language-related concepts'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Language-related-concepts.html
 ---

--- a/docs/site/Life-cycle-observer-generator.md
+++ b/docs/site/Life-cycle-observer-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Life cycle observer generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Life-cycle-observer-generator.html
 ---

--- a/docs/site/Life-cycle.md
+++ b/docs/site/Life-cycle.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Life cycle events and observers'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Life-cycle.html
 ---

--- a/docs/site/Limit-filter.md
+++ b/docs/site/Limit-filter.md
@@ -1,7 +1,7 @@
 ---
 title: 'Limit filter'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, limit
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, limit
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Limit-filter.html
 summary:

--- a/docs/site/Loopback-component-authentication.md
+++ b/docs/site/Loopback-component-authentication.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Authentication'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Loopback-component-authentication.html
 ---

--- a/docs/site/Loopback-component-authorization.md
+++ b/docs/site/Loopback-component-authorization.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Authorization'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Loopback-component-authorization.html
 ---

--- a/docs/site/Metrics.md
+++ b/docs/site/Metrics.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'Metrics collection for Prometheus'
-keywords: LoopBack 4.0, LoopBack 4, Cloud Native, Metrics, Prometheus
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Cloud Native, Metrics,
+  Prometheus
 layout: readme
 source: loopback-next
 file: extensions/metrics/README.md

--- a/docs/site/Middleware.md
+++ b/docs/site/Middleware.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Middleware'
-keywords: LoopBack 4.0, LoopBack 4, Express, Middleware
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Express, Middleware
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Middleware.html
 ---

--- a/docs/site/Migrating-from-LoopBack-3-redirect.md
+++ b/docs/site/Migrating-from-LoopBack-3-redirect.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating from LoopBack 3'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Migrating-from-LoopBack-3.html
 ---

--- a/docs/site/Mixin.md
+++ b/docs/site/Mixin.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Mixin'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Mixin.html
 ---

--- a/docs/site/Model-generator.md
+++ b/docs/site/Model-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Model generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Model-generator.html
 ---

--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Model'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Model.html
 ---

--- a/docs/site/OpenAPI-generator.md
+++ b/docs/site/OpenAPI-generator.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'OpenAPI generator'
-keywords: LoopBack 4.0, LoopBack 4, OpenAPI, Swagger
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, OpenAPI, Swagger
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/OpenAPI-generator.html
 ---

--- a/docs/site/Order-filter.md
+++ b/docs/site/Order-filter.md
@@ -1,7 +1,7 @@
 ---
 title: 'Order filter'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, order
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, order
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Order-filter.html
 summary:

--- a/docs/site/Parsing-requests.md
+++ b/docs/site/Parsing-requests.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Parsing requests'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Parsing-requests.html
 ---

--- a/docs/site/Preparing-the-API-for-consumption.shelved.md
+++ b/docs/site/Preparing-the-API-for-consumption.shelved.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Preparing the API for consumption'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Preparing-the-API-for-consumption.html
 ---

--- a/docs/site/Querying-data.md
+++ b/docs/site/Querying-data.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Querying data'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Querying-data.html
 ---

--- a/docs/site/Reference.md
+++ b/docs/site/Reference.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Reference'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Reference.html
 ---

--- a/docs/site/Relation-generator.md
+++ b/docs/site/Relation-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Relation generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Relation-generator.html
 ---

--- a/docs/site/Relations.md
+++ b/docs/site/Relations.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Relations'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Relations.html
 ---

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Repositories'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Repositories.html
 ---

--- a/docs/site/Repository-generator.md
+++ b/docs/site/Repository-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Repository generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Repository-generator.html
 ---

--- a/docs/site/Request-response-cycle.md
+++ b/docs/site/Request-response-cycle.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Request/response cycle'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Request-response-cycle.html
 ---

--- a/docs/site/Reserved-binding-keys.md
+++ b/docs/site/Reserved-binding-keys.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Reserved binding keys'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 toc_level: 1
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Reserved-binding-keys.html

--- a/docs/site/Rest-Crud-generator.md
+++ b/docs/site/Rest-Crud-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'REST CRUD model endpoints generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Rest-Crud-generator.html
 ---

--- a/docs/site/Routes.md
+++ b/docs/site/Routes.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Routes'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Routes.html
 ---

--- a/docs/site/Routing-requests.md
+++ b/docs/site/Routing-requests.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Routing requests'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Routing-requests.html
 ---

--- a/docs/site/Running-cron-jobs.md
+++ b/docs/site/Running-cron-jobs.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Running cron jobs'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 layout: readme
 source: loopback-next
 file: extensions/cron/README.md

--- a/docs/site/Running-debugging-apps.md
+++ b/docs/site/Running-debugging-apps.md
@@ -1,7 +1,7 @@
 ---
 title: 'Running and debugging apps'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, Debug
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Debug
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Running-and-debugging-apps.html
 summary:

--- a/docs/site/Security.md
+++ b/docs/site/Security.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Security'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Security.html
 ---

--- a/docs/site/Self-hosted-REST-API-Explorer.md
+++ b/docs/site/Self-hosted-REST-API-Explorer.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Self-hosted REST API Explorer'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 layout: readme
 source: loopback-next
 file: packages/rest-explorer/README.md

--- a/docs/site/Sequence.md
+++ b/docs/site/Sequence.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Sequence'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Sequence.html
 ---

--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Server'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Server.html
 ---

--- a/docs/site/Service-generator.md
+++ b/docs/site/Service-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Service generator'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Service-generator.html
 ---

--- a/docs/site/Services.md
+++ b/docs/site/Services.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Services'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Services.html
 ---

--- a/docs/site/Setting-debug-strings.md
+++ b/docs/site/Setting-debug-strings.md
@@ -1,7 +1,8 @@
 ---
 title: 'Setting debug strings'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, base-connector.js
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, base-connector.js
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Setting-debug-strings.html
 summary:

--- a/docs/site/Skip-filter.md
+++ b/docs/site/Skip-filter.md
@@ -1,7 +1,7 @@
 ---
 title: 'Skip filter'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, skip
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, skip
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Skip-filter.html
 ---

--- a/docs/site/Testing-Your-Extensions.md
+++ b/docs/site/Testing-Your-Extensions.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Testing your extension'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Testing-your-extension.html
 ---

--- a/docs/site/Testing-the-API.shelved.md
+++ b/docs/site/Testing-the-API.shelved.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Testing the API'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Testing-the-API.html
 ---

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'Testing your application'
-keywords: LoopBack 4.0, LoopBack 4
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Node.js, TypeScript,
+  OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Testing-your-application.html
 ---

--- a/docs/site/Transactions.md
+++ b/docs/site/Transactions.md
@@ -2,7 +2,9 @@
 title: 'Using database transactions'
 lang: en
 layout: page
-keywords: LoopBack 4.0, LoopBack 4, Transactions, Transaction
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Transactions,
+  Transaction
 tags:
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Using-database-transactions.html

--- a/docs/site/Understanding-the-differences.md
+++ b/docs/site/Understanding-the-differences.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Understanding the differences between LoopBack 3 and LoopBack 4'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Understanding-the-differences.html
 ---

--- a/docs/site/Update-generator.md
+++ b/docs/site/Update-generator.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Update project dependencies'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Update-generator.html
 ---

--- a/docs/site/Using-components.md
+++ b/docs/site/Using-components.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Using components'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Using-components.html
 ---

--- a/docs/site/Validation-ORM-layer.md
+++ b/docs/site/Validation-ORM-layer.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Validation in ORM Layer'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Validation-ORM-layer.html
 ---

--- a/docs/site/Validation-REST-layer.md
+++ b/docs/site/Validation-REST-layer.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Validation in REST Layer'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Validation-REST-layer.html
 ---

--- a/docs/site/Validation-controller-layer.md
+++ b/docs/site/Validation-controller-layer.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Validation in the Controller, Repository and Service Layer'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Validation-controller-repo-service-layer.html
 ---

--- a/docs/site/Validation.md
+++ b/docs/site/Validation.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Validation'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Validation.html
 ---

--- a/docs/site/Where-filter.md
+++ b/docs/site/Where-filter.md
@@ -1,7 +1,7 @@
 ---
 title: 'Where filter'
 lang: en
-keywords: LoopBack 4.0, LoopBack 4, where
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, where
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Where-filter.html
 summary:

--- a/docs/site/Working-with-data.md
+++ b/docs/site/Working-with-data.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Working with data'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Working-with-data.html
 ---

--- a/docs/site/exposing-graphql-apis.md
+++ b/docs/site/exposing-graphql-apis.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Exposing GraphQL APIs'
-keywords: LoopBack 4.0, LoopBack 4, GraphQL
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, GraphQL
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/exposing-graphql-apis.html
 ---

--- a/docs/site/express-with-lb4-rest-tutorial.md
+++ b/docs/site/express-with-lb4-rest-tutorial.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Creating an Express Application with LoopBack REST API'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/express-with-lb4-rest-tutorial.html
 summary: A simple Express application with LoopBack 4 REST API

--- a/docs/site/migration/LB3-vs-LB4-booting.md
+++ b/docs/site/migration/LB3-vs-LB4-booting.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'Differences in LoopBack 3 and LoopBack 4 booting process'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3.0, LoopBack 3
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3.0, LoopBack
+  3
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/LB3-vs-LB4-booting.html
 ---

--- a/docs/site/migration/auth/authentication.md
+++ b/docs/site/migration/auth/authentication.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating built-in authentication'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-authentication.html
 ---

--- a/docs/site/migration/auth/example.md
+++ b/docs/site/migration/auth/example.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating access control example'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-access-control-example.html
 ---

--- a/docs/site/migration/auth/oauth2.md
+++ b/docs/site/migration/auth/oauth2.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating OAuth2 provider'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-oauth2.html
 ---

--- a/docs/site/migration/auth/overview.md
+++ b/docs/site/migration/auth/overview.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating authentication and authorization'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-overview.html
 ---

--- a/docs/site/migration/auth/passport.md
+++ b/docs/site/migration/auth/passport.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating Passport-based authentication'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-auth-passport.html
 ---

--- a/docs/site/migration/boot-scripts.md
+++ b/docs/site/migration/boot-scripts.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating boot scripts'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-boot-scripts.html
 ---

--- a/docs/site/migration/cli.md
+++ b/docs/site/migration/cli.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating CLI usage patterns'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-cli.html
 ---

--- a/docs/site/migration/clients.md
+++ b/docs/site/migration/clients.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating clients'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-clients.html
 ---

--- a/docs/site/migration/datasources.md
+++ b/docs/site/migration/datasources.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating datasources'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-datasources.html
 ---

--- a/docs/site/migration/express-middleware.md
+++ b/docs/site/migration/express-middleware.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating Express middleware'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-express-middleware.html
 ---

--- a/docs/site/migration/models/core.md
+++ b/docs/site/migration/models/core.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating model definitions and built-in APIs'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-core.html
 ---

--- a/docs/site/migration/models/methods.md
+++ b/docs/site/migration/models/methods.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating custom model methods'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-methods.html
 ---

--- a/docs/site/migration/models/mixins.md
+++ b/docs/site/migration/models/mixins.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating model mixins'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-mixins.html
 ---

--- a/docs/site/migration/models/operation-hooks.md
+++ b/docs/site/migration/models/operation-hooks.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating CRUD operation hooks'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-operation-hooks.html
 ---

--- a/docs/site/migration/models/overview.md
+++ b/docs/site/migration/models/overview.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating models'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-overview.html
 ---

--- a/docs/site/migration/models/relations.md
+++ b/docs/site/migration/models/relations.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating model relations'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-relations.html
 ---

--- a/docs/site/migration/models/remoting-hooks.md
+++ b/docs/site/migration/models/remoting-hooks.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migrating remoting hooks'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-models-remoting-hooks.html
 ---

--- a/docs/site/migration/mounting-lb3app.md
+++ b/docs/site/migration/mounting-lb3app.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Mounting a LoopBack 3 application'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-mounting-lb3app.html
 ---

--- a/docs/site/migration/not-planned.md
+++ b/docs/site/migration/not-planned.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'LoopBack 3 features not planned in LoopBack 4'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-not-planned.html
 ---

--- a/docs/site/migration/overview.md
+++ b/docs/site/migration/overview.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'Migration guide'
-keywords: LoopBack 4.0, LoopBack 4, LoopBack 3, Migration
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, LoopBack 3, Migration
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/migration-overview.html
 ---

--- a/docs/site/soap-calculator-tutorial.md
+++ b/docs/site/soap-calculator-tutorial.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'SOAP calculator Web Service integration tutorial'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 layout: readme
 source: loopback-next
 file: examples/soap-calculator/README.md

--- a/docs/site/todo-list-tutorial.md
+++ b/docs/site/todo-list-tutorial.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'TodoList tutorial'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 layout: readme
 source: loopback-next
 file: examples/todo-list/README.md

--- a/docs/site/todo-tutorial.md
+++ b/docs/site/todo-tutorial.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Todo tutorial'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 layout: readme
 source: loopback-next
 file: examples/todo/README.md

--- a/docs/site/tutorials/authentication/Authentication-Tutorial.md
+++ b/docs/site/tutorials/authentication/Authentication-Tutorial.md
@@ -1,7 +1,9 @@
 ---
 lang: en
 title: 'How to secure your LoopBack 4 application with JWT authentication'
-keywords: LoopBack 4.0, LoopBack 4, Authentication, Tutorial
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Authentication,
+  Tutorial
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Authentication-Tutorial.html
 summary: A LoopBack 4 application that uses JWT authentication

--- a/docs/site/tutorials/connectors/Mongodb-tutorial.md
+++ b/docs/site/tutorials/connectors/Mongodb-tutorial.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'MongoDB connector tutorial'
-keywords: LoopBack 4.0, LoopBack 4, connector, MongoDB
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, connector, MongoDB
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Connecting-to-MongoDB.html
 ---

--- a/docs/site/tutorials/connectors/Postgresql-tutorial.md
+++ b/docs/site/tutorials/connectors/Postgresql-tutorial.md
@@ -1,7 +1,8 @@
 ---
 lang: en
 title: 'PostgreSQL connector tutorial'
-keywords: LoopBack 4.0, LoopBack 4, connector, postgreSQL
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, connector, postgreSQL
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Connecting-to-PostgreSQL.html
 ---

--- a/docs/site/tutorials/core/1-introduction.md
+++ b/docs/site/tutorials/core/1-introduction.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Introduction of the application scenario'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part1.html
 ---

--- a/docs/site/tutorials/core/10-advanced-recipes.md
+++ b/docs/site/tutorials/core/10-advanced-recipes.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Advanced Recipes'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part10.html
 ---

--- a/docs/site/tutorials/core/11-summary.md
+++ b/docs/site/tutorials/core/11-summary.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Summary'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part11.html
 ---

--- a/docs/site/tutorials/core/2-architecture.md
+++ b/docs/site/tutorials/core/2-architecture.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Architectural challenges'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part2.html
 ---

--- a/docs/site/tutorials/core/3-context-in-action.md
+++ b/docs/site/tutorials/core/3-context-in-action.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Context in action'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part3.html
 ---

--- a/docs/site/tutorials/core/4-dependency-injection.md
+++ b/docs/site/tutorials/core/4-dependency-injection.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Dependency injection'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part4.html
 ---

--- a/docs/site/tutorials/core/5-extension-point-extension.md
+++ b/docs/site/tutorials/core/5-extension-point-extension.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Extension point and extensions'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part5.html
 ---

--- a/docs/site/tutorials/core/6-interception.md
+++ b/docs/site/tutorials/core/6-interception.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Interception'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part6.html
 ---

--- a/docs/site/tutorials/core/7-observation.md
+++ b/docs/site/tutorials/core/7-observation.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Observation of life cycle events'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part7.html
 ---

--- a/docs/site/tutorials/core/8-configuration.md
+++ b/docs/site/tutorials/core/8-configuration.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Configuration'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part8.html
 ---

--- a/docs/site/tutorials/core/9-boot-by-convention.md
+++ b/docs/site/tutorials/core/9-boot-by-convention.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Discover and load artifacts by convention'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial-part9.html
 ---

--- a/docs/site/tutorials/core/index.md
+++ b/docs/site/tutorials/core/index.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Build large scale Node.js projects with LoopBack 4'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/core-tutorial.html
 ---

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-controller.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add a Controller'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial-add-controller.html
 ---

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-datasource.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-datasource.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add a Datasource'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial-add-datasource.html
 ---

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-service.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-add-service.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add a Service'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial-add-service.html
 ---

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-run-and-test.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-run-and-test.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Run and Test it'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial-run-and-test.html
 ---

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-scaffolding.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-scaffolding.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'App scaffolding'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial-scaffolding.html
 ---

--- a/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-web-service-overview.md
+++ b/docs/site/tutorials/soap-calculator/soap-calculator-tutorial-web-service-overview.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Soap Web Service Overview'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/soap-calculator-tutorial-web-service-overview.html
 ---

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: "Add TodoList and TodoList's Todo Controller"
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-controller.html
 summary:

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-has-one-relation.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-has-one-relation.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add TodoListImage Relation'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-has-one-relation.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoListImage Relation

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-model.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add TodoList Model'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-model.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Model

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-relations.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-relations.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add Model Relations'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-relations.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Repository

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add TodoList Repository'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-repository.html
 summary: LoopBack 4 TodoList Application Tutorial - Add TodoList Repository

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-sqldb.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-sqldb.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Running on relational databases'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-list-tutorial-sqldb.html
 summary:

--- a/docs/site/tutorials/todo/todo-tutorial-controller.md
+++ b/docs/site/tutorials/todo/todo-tutorial-controller.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add a Controller'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-controller.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Controller

--- a/docs/site/tutorials/todo/todo-tutorial-datasource.md
+++ b/docs/site/tutorials/todo/todo-tutorial-datasource.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add a Datasource'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-datasource.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Datasource

--- a/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
+++ b/docs/site/tutorials/todo/todo-tutorial-geocoding-service.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Integrate with a geo-coding service'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-geocoding-service.html
 summary:

--- a/docs/site/tutorials/todo/todo-tutorial-model.md
+++ b/docs/site/tutorials/todo/todo-tutorial-model.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add the Todo Model'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-model.html
 summary: LoopBack 4 Todo Application Tutorial - Add the Todo Model

--- a/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
+++ b/docs/site/tutorials/todo/todo-tutorial-putting-it-together.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Putting it all together'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-putting-it-together.html
 summary: LoopBack 4 Todo Application Tutorial - Putting it all together

--- a/docs/site/tutorials/todo/todo-tutorial-repository.md
+++ b/docs/site/tutorials/todo/todo-tutorial-repository.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Add a Repository'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-repository.html
 summary: LoopBack 4 Todo Application Tutorial - Add a Repository

--- a/docs/site/tutorials/todo/todo-tutorial-scaffolding.md
+++ b/docs/site/tutorials/todo/todo-tutorial-scaffolding.md
@@ -1,7 +1,7 @@
 ---
 lang: en
 title: 'Create your app scaffolding'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/todo-tutorial-scaffolding.html
 summary: LoopBack 4 Todo Application Tutorial - Create app scaffolding

--- a/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
+++ b/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
@@ -120,7 +120,7 @@ describe('tsdocs', function (this: Mocha.Suite) {
     expect(index).to.containEql(`---
 lang: en
 title: 'API docs: index'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 editurl: https://github.com/strongloop/loopback-next
 permalink: /doc/en/lb4/apidocs.index.html

--- a/packages/tsdocs/src/update-api-md-docs.ts
+++ b/packages/tsdocs/src/update-api-md-docs.ts
@@ -129,7 +129,7 @@ async function addJekyllMetadata(
     doc = `---
 lang: en
 title: 'API docs: ${name}'
-keywords: LoopBack 4.0, LoopBack 4
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
 editurl: ${pkgUrl}
 permalink: /doc/en/lb4/apidocs.${name}.html


### PR DESCRIPTION
Taking suggestion from @raymondfeng, improve the keywords in the frontmatter of the docs pages.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
