### PR TITLE
fix(express): ensure options are honored for `invokeMiddleware` resolved from the provider

### DIFF
--- a/packages/express/src/__tests__/acceptance/invoke-middleware.acceptance.ts
+++ b/packages/express/src/__tests__/acceptance/invoke-middleware.acceptance.ts
@@ -3,8 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {ExpressServer, invokeExpressMiddleware} from '../../';
-import {invokeMiddleware, toMiddleware} from '../../middleware';
+import {createBindingFromClass} from '@loopback/core';
+import {
+  ExpressServer,
+  invokeExpressMiddleware,
+  invokeMiddleware,
+  InvokeMiddlewareProvider,
+  toMiddleware,
+} from '../../';
+import {InvokeMiddleware} from '../../types';
 import spyMiddlewareFactory from '../fixtures/spy.middleware';
 import {spy, TestHelper} from './test-helpers';
 
@@ -42,6 +49,34 @@ describe('Express middleware registry', () => {
         chain: 'log',
         next: () => {
           return invokeMiddleware(ctx, {chain: 'mock', next});
+        },
+      });
+    });
+    await helper.client
+      .post('/hello')
+      .send('"World"')
+      .set('content-type', 'application/json')
+      .expect(200, 'Hello, Spy')
+      .expect('x-spy-log', 'POST /hello')
+      .expect('x-spy-mock', 'POST /hello');
+  });
+
+  it('invokes middleware using the provider', async () => {
+    const logMiddleware = toMiddleware(spyMiddlewareFactory({action: 'log'}));
+    const mockMiddleware = toMiddleware(spyMiddlewareFactory({action: 'mock'}));
+
+    server.middleware(logMiddleware, {chain: 'log'});
+    server.middleware(mockMiddleware, {chain: 'mock'});
+
+    const binding = createBindingFromClass(InvokeMiddlewareProvider);
+    server.add(binding);
+    const invoke = await server.get<InvokeMiddleware>(binding.key);
+
+    server.middleware(async (ctx, next) => {
+      return invoke(ctx, {
+        chain: 'log',
+        next: () => {
+          return invoke(ctx, {chain: 'mock', next});
         },
       });
     });

--- a/packages/express/src/providers/invoke-middleware.provider.ts
+++ b/packages/express/src/providers/invoke-middleware.provider.ts
@@ -60,6 +60,7 @@ export class InvokeMiddlewareProvider implements Provider<InvokeMiddleware> {
         this.binding?.tagMap[CoreTags.EXTENSION_POINT] ??
         this.defaultOptions.chain;
       return this.action(middlewareCtx, {
+        ...options,
         chain,
         orderedGroups: orderedGroups ?? this.defaultOptions.orderedGroups,
       });


### PR DESCRIPTION
Before this change, if we have an injected `invokeMidddleware` from the `InvokeMiddlewareProvider`, the `next` option is not honored.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
