### PR TITLE
feat(context): add strongly typed `on` and `once` methods

### DIFF
--- a/packages/context/src/__tests__/unit/binding.unit.ts
+++ b/packages/context/src/__tests__/unit/binding.unit.ts
@@ -663,7 +663,7 @@ describe('Binding', () => {
 
   function listenOnBinding() {
     const events: BindingEvent[] = [];
-    binding.on('changed', (event: BindingEvent) => {
+    binding.on('changed', event => {
       events.push(event);
     });
     return events;

--- a/packages/context/src/__tests__/unit/context-view.unit.ts
+++ b/packages/context/src/__tests__/unit/context-view.unit.ts
@@ -208,7 +208,7 @@ describe('ContextView', () => {
 
     function setupListeners() {
       events = [];
-      ['open', 'close', 'refresh', 'resolve', 'bind', 'unbind'].forEach(t =>
+      ['close', 'refresh', 'resolve', 'bind', 'unbind'].forEach(t =>
         taggedAsFoo.on(t, () => events.push(t)),
       );
     }

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -201,7 +201,7 @@ export type BindingEvent = {
   /**
    * Event type
    */
-  type: string;
+  type: 'changed' | string;
   /**
    * Source binding that emits the event
    */
@@ -209,7 +209,7 @@ export type BindingEvent = {
   /**
    * Operation that triggers the event
    */
-  operation: string;
+  operation: 'tag' | 'scope' | 'value' | string;
 };
 
 /**
@@ -870,6 +870,42 @@ export class Binding<T = BoundValue> extends EventEmitter {
     return new Binding(BindingKey.buildKeyForConfig<T>(key)).tag({
       [ContextTags.CONFIGURATION_FOR]: key.toString(),
     });
+  }
+
+  /**
+   * The "changed" event is emitted by methods such as `tag`, `inScope`, `to`,
+   * and `toClass`.
+   *
+   * @param eventName The name of the event - always `changed`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  on(eventName: 'changed', listener: BindingEventListener): this;
+
+  // The generic variant inherited from EventEmitter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  /**
+   * The "changed" event is emitted by methods such as `tag`, `inScope`, `to`,
+   * and `toClass`.
+   *
+   * @param eventName The name of the event - always `changed`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  once(eventName: 'changed', listener: BindingEventListener): this;
+
+  // The generic variant inherited from EventEmitter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.once(event, listener);
   }
 }
 

--- a/packages/context/src/context-view.ts
+++ b/packages/context/src/context-view.ts
@@ -241,6 +241,126 @@ export class ContextView<T = unknown> extends EventEmitter
       'The ContextView has more than one value. Use values() to access them.',
     );
   }
+
+  /**
+   * The "bind" event is emitted when a new binding is added to the view.
+   *
+   * @param eventName The name of the event - always `bind`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  on(
+    eventName: 'bind',
+    listener: <T>(event: ContextViewEvent<T>) => void,
+  ): this;
+
+  /**
+   * The "unbind" event is emitted a new binding is removed from the view.
+   *
+   * @param eventName The name of the event - always `unbind`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  on(
+    eventName: 'unbind',
+    listener: <T>(event: ContextViewEvent<T> & {cachedValue?: T}) => void,
+  ): this;
+
+  /**
+   * The "refresh" event is emitted when the view is refreshed as bindings are
+   * added/removed.
+   *
+   * @param eventName The name of the event - always `refresh`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  on(eventName: 'refresh', listener: () => void): this;
+
+  /**
+   * The "resolve" event is emitted when the cached values are resolved and
+   * updated.
+   *
+   * @param eventName The name of the event - always `refresh`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  on(eventName: 'refresh', listener: <T>(result: T[]) => void): this;
+
+  /**
+   * The "close" event is emitted when the view is closed (stopped observing
+   * context events)
+   *
+   * @param eventName The name of the event - always `close`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  on(eventName: 'close', listener: () => void): this;
+
+  // The generic variant inherited from EventEmitter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  /**
+   * The "bind" event is emitted when a new binding is added to the view.
+   *
+   * @param eventName The name of the event - always `bind`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  once(
+    eventName: 'bind',
+    listener: <T>(event: ContextViewEvent<T>) => void,
+  ): this;
+
+  /**
+   * The "unbind" event is emitted a new binding is removed from the view.
+   *
+   * @param eventName The name of the event - always `unbind`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  once(
+    eventName: 'unbind',
+    listener: <T>(event: ContextViewEvent<T> & {cachedValue?: T}) => void,
+  ): this;
+
+  /**
+   * The "refresh" event is emitted when the view is refreshed as bindings are
+   * added/removed.
+   *
+   * @param eventName The name of the event - always `refresh`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  once(eventName: 'refresh', listener: () => void): this;
+
+  /**
+   * The "resolve" event is emitted when the cached values are resolved and
+   * updated.
+   *
+   * @param eventName The name of the event - always `refresh`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  once(eventName: 'refresh', listener: <T>(result: T[]) => void): this;
+
+  /**
+   * The "close" event is emitted when the view is closed (stopped observing
+   * context events)
+   *
+   * @param eventName The name of the event - always `close`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  once(eventName: 'close', listener: () => void): this;
+
+  // The generic variant inherited from EventEmitter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.once(event, listener);
+  }
 }
 
 /**

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -18,7 +18,7 @@ import {
 } from './binding-filter';
 import {BindingAddress, BindingKey} from './binding-key';
 import {BindingComparator} from './binding-sorter';
-import {ContextEvent} from './context-event';
+import {ContextEvent, ContextEventListener} from './context-event';
 import {ContextEventObserver, ContextObserver} from './context-observer';
 import {ContextSubscriptionManager, Subscription} from './context-subscription';
 import {ContextTagIndexer} from './context-tag-indexer';
@@ -877,6 +877,42 @@ export class Context extends EventEmitter {
       json.parent = this._parent._inspect(options, visitedClasses);
     }
     return json;
+  }
+
+  /**
+   * The "bind" event is emitted when a new binding is added to the context.
+   * The "unbind" event is emitted when an existing binding is removed.
+   *
+   * @param eventName The name of the event - always `bind` or `unbind`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  on(eventName: 'bind' | 'unbind', listener: ContextEventListener): this;
+
+  // The generic variant inherited from EventEmitter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  /**
+   * The "bind" event is emitted when a new binding is added to the context.
+   * The "unbind" event is emitted when an existing binding is removed.
+   *
+   * @param eventName The name of the event - always `bind` or `unbind`.
+   * @param listener The listener function to call when the event is emitted.
+   */
+  once(eventName: 'bind' | 'unbind', listener: ContextEventListener): this;
+
+  // The generic variant inherited from EventEmitter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.once(event, listener);
   }
 }
 


### PR DESCRIPTION
Declare `on` and `once` overload methods to describe event parameters in a strongly typed way:

```ts
context.on('bind' | 'unbind', ContextEventListener)
context.once('bind' | 'unbind', ContextEventListener)
binding.on('changed', BindingEventListener)
binding.once('changed', BindingEventListener)
view.on('refresh', listener);
view.once('refresh', listener);
// and so on
```

The change preserves the generic variant provided by `EventEmitter` too and thus is fully backwards compatible.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
