### PR TITLE
Hide `@loopback/express` from framework-level documentation

### DIFF
--- a/docs/site/Express-middleware.md
+++ b/docs/site/Express-middleware.md
@@ -171,7 +171,7 @@ If the Express middleware only exposes the handler function without a factory or
 a single instance is desired, use `toInterceptor`.
 
 ```ts
-import {toInterceptor} from '@loopback/express';
+import {toInterceptor} from '@loopback/rest';
 import morgan from 'morgan';
 
 const morganInterceptor = toInterceptor(morgan('combined'));
@@ -183,7 +183,7 @@ When the Express middleware module exports a factory function that takes an
 optional argument for configuration, use `createInterceptor`.
 
 ```ts
-import {createInterceptor} from '@loopback/express';
+import {createInterceptor} from '@loopback/rest';
 import helmet, {IHelmetConfiguration} from 'helmet';
 const helmetConfig: IHelmetConfiguration = {};
 const helmetInterceptor = createInterceptor(helmet, helmetConfig);
@@ -208,7 +208,7 @@ for the middleware. We can use `defineInterceptorProvider` to simplify
 definition of such provider classes.
 
 ```ts
-import {defineInterceptorProvider} from '@loopback/express';
+import {defineInterceptorProvider} from '@loopback/rest';
 import helmet, {IHelmetConfiguration} from 'helmet';
 
 const helmetProviderClass = defineInterceptorProvider<IHelmetConfiguration>(
@@ -225,7 +225,7 @@ import {config} from '@loopback/core';
 import {
   ExpressMiddlewareInterceptorProvider,
   createMiddlewareInterceptorBinding,
-} from '@loopback/express';
+} from '@loopback/rest';
 import helmet, {IHelmetConfiguration} from 'helmet';
 
 class HelmetInterceptorProvider extends ExpressMiddlewareInterceptorProvider<
@@ -317,7 +317,7 @@ Let's update `src/interceptors/helmet.interceptor.ts:
 ```ts
 import {config, globalInterceptor} from '@loopback/core';
 import helmet, {IHelmetConfiguration} from 'helmet';
-import {ExpressMiddlewareInterceptorProvider} from '@loopback/express';
+import {ExpressMiddlewareInterceptorProvider} from '@loopback/rest';
 
 @globalInterceptor('middleware', {tags: {name: 'Helmet'}})
 export class MorganInterceptor extends ExpressMiddlewareInterceptorProvider<
@@ -343,7 +343,7 @@ To allow a similar usage in LoopBack, we can create an Express router and
 register it to LoopBack as follows:
 
 ```ts
-import {ExpressRequestHandler, Router} from '@loopback/express';
+import {ExpressRequestHandler, Router} from '@loopback/rest';
 
 const handler: ExpressRequestHandler = async (req, res, next) => {
   res.send(req.path);

--- a/docs/site/Middleware.md
+++ b/docs/site/Middleware.md
@@ -71,7 +71,7 @@ work with the `MiddlewareContext` - a wrapper object for `request` and
 `response`. The signature is of `Middleware` is:
 
 ```ts
-import {MiddlewareContext} from '@loopback/express';
+import {MiddlewareContext} from '@loopback/rest';
 import {Next, ValueOrPromise, InvocationResult} from '@loopback/core';
 
 (context: MiddlewareContext, next: Next) => ValueOrPromise<InvocationResult>;

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -41,7 +41,6 @@
     "@loopback/authentication-passport": "^2.1.6",
     "@loopback/boot": "^2.3.2",
     "@loopback/core": "^2.7.1",
-    "@loopback/express": "^1.2.2",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/repository": "^2.6.0",
     "@loopback/rest": "^5.1.0",

--- a/examples/passport-login/tsconfig.json
+++ b/examples/passport-login/tsconfig.json
@@ -28,9 +28,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/express/tsconfig.json"
-    },
-    {
       "path": "../../packages/http-caching-proxy/tsconfig.json"
     },
     {


### PR DESCRIPTION
- Update code snippets to import from `@loopback/rest` instead of `@loopback/express`.
- Remove `@loopback/express` from dependencies of `examples/passport-login`, it was not used at all.

This is a follow-up for #5659, see also #5550

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
