### PR TITLE
Hide `@loopback/metadata` from framework-level documentation

### DIFF
--- a/docs/site/Creating-decorators.md
+++ b/docs/site/Creating-decorators.md
@@ -7,5 +7,5 @@ source: loopback-next
 file: packages/metadata/README.md
 sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-decorators.html
-summary: A tutorial to use `@loopback/metadata` module to create new decorators
+summary: A tutorial to use `@loopback/core` module to create new decorators
 ---

--- a/docs/site/tutorials/core/10-advanced-recipes.md
+++ b/docs/site/tutorials/core/10-advanced-recipes.md
@@ -15,7 +15,7 @@ You can create your own
 [decorator](https://loopback.io/doc/en/lb4/Decorators.html):
 
 1. Create a new decorator from scratch by using `DecoratorFactory` from
-   `@loopback/metadata`. See an example in
+   `@loopback/core`. See an example in
    [custom-inject-decorator.ts](https://github.com/strongloop/loopback-next/blob/master/examples/context/src/custom-inject-decorator.ts)
 
 2. Create a sugar decorator for an existing decorator.

--- a/docs/site/tutorials/core/2-architecture.md
+++ b/docs/site/tutorials/core/2-architecture.md
@@ -54,13 +54,16 @@ LoopBack 4 core is an open source TypeScript platform for Node.js, specializing
 in building large scale applications with great flexibility, composability, and
 extensibility.
 
-The following key modules are used by the LoopBack framework to offer API and
-Microservice capabilities. They can be used independently as a base platform to
-build large scale applications in TypeScript and Node.js.
+The module [@loopback/core](https://www.npmjs.com/package/@loopback/core) is
+used by the LoopBack framework to offer API and Microservice capabilities.
+
+It builds on top of the following lower-level modules:
 
 - [@loopback/metadata](https://www.npmjs.com/package/@loopback/metadata)
 - [@loopback/context](https://www.npmjs.com/package/@loopback/context)
-- [@loopback/core](https://www.npmjs.com/package/@loopback/core)
+
+Any of these three modules can be used independently as a base platform to build
+large scale applications in TypeScript and Node.js.
 
 ## Design goals
 

--- a/examples/log-extension/README.md
+++ b/examples/log-extension/README.md
@@ -169,7 +169,7 @@ extension to add extra processing accordingly.
 
 For this extension, the decorator marks which controller methods should be
 logged (and optionally at which level they should be logged). We leverage
-`@loopback/metadata` module to implement the decorator and inspection function.
+`@loopback/core` module to implement the decorator and inspection function.
 
 ```ts
 import {LOG_LEVEL, EXAMPLE_LOG_BINDINGS} from '../keys';
@@ -177,7 +177,7 @@ import {
   Constructor,
   MethodDecoratorFactory,
   MetadataInspector,
-} from '@loopback/context';
+} from '@loopback/core';
 import {LevelMetadata} from '../types';
 
 /**

--- a/examples/log-extension/src/keys.ts
+++ b/examples/log-extension/src/keys.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingKey} from '@loopback/core';
-import {TimerFn, LogFn, LogWriterFn} from './types';
+import {LogFn, LogWriterFn, TimerFn} from './types';
 
 /**
  * Binding keys used by this component.
@@ -19,7 +19,7 @@ export namespace EXAMPLE_LOG_BINDINGS {
 }
 
 /**
- * The key used to store log-related via @loopback/metadata and reflection.
+ * The key used to store log-related metadata via decorators and reflection.
  */
 export const EXAMPLE_LOG_METADATA_KEY = 'example.log.metadata';
 

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@loopback/authentication": "^4.2.6",
     "@loopback/core": "^2.7.1",
-    "@loopback/metadata": "^2.1.6",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/rest": "^5.1.0",
     "@loopback/security": "^0.2.11",

--- a/extensions/authentication-passport/tsconfig.json
+++ b/extensions/authentication-passport/tsconfig.json
@@ -20,9 +20,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/metadata/tsconfig.json"
-    },
-    {
       "path": "../../packages/openapi-spec-builder/tsconfig.json"
     },
     {

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@loopback/core": "^2.7.1",
-    "@loopback/metadata": "^2.1.6",
     "@loopback/openapi-v3": "^3.4.2",
     "@loopback/rest": "^5.1.0",
     "@loopback/security": "^0.2.11",

--- a/packages/authentication/tsconfig.json
+++ b/packages/authentication/tsconfig.json
@@ -14,9 +14,6 @@
       "path": "../core/tsconfig.json"
     },
     {
-      "path": "../metadata/tsconfig.json"
-    },
-    {
       "path": "../openapi-spec-builder/tsconfig.json"
     },
     {


### PR DESCRIPTION
- Remove unused dependency `@loopback/metadata` from `extensions/authentication-passport` and ` packages/authentication`
- Remove references to `@loopback/metadata`, rework code and docs to import from `@loopback/core` instead.

This is a follow-up for #5659, see also #5550.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
