### PR TITLE
feat(docs): add community extensions page

### DIFF
--- a/docs/site/Community-extensions.md
+++ b/docs/site/Community-extensions.md
@@ -1,0 +1,92 @@
+---
+lang: en
+title: 'Community extensions'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Extensions
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Community-extensions.html
+---
+
+In addition to the extensions that LoopBack provides and maintains, there are a
+number of extensions created by the open source community.
+
+To create a LoopBack extension, see
+[Extending LoopBack 4 documentation page](https://loopback.io/doc/en/lb4/Extending-LoopBack-4.html)
+for details. It is recommended to use the
+[extension generator](https://loopback.io/doc/en/lb4/Extension-generator.html)
+to scaffold a new extension.
+
+The following table lists some of the community extensions. See
+[npmjs.org](https://www.npmjs.com/search?q=loopback4%20extension) for a complete
+list.
+
+{% include warning.html content="The extensions listed here are not supported by the LoopBack team; they are maintained by the LoopBack community and are listed here for convenience."%}
+
+## General
+
+<table>
+  <thead>
+    <tr>
+      <th width="160">Extension</th>
+      <th width="280">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback4-soft-delete">loopback4-soft-delete</a></td>
+      <td>Used for soft-deletes in a multi-tenant application</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback4-helmet">loopback4-helmet</a></td>
+      <td>Integrate <a href="https://helmetjs.github.io/">helmetjs</a> in LoopBack applications</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback4-ratelimiter">loopback4-ratelimiter</a></td>
+      <td>Provide rate limiting in LoopBack applications</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback4-notifications">loopback4-notifications</a></td>
+      <td>Add different notification mechanisms vis-à-vis, Push, SMS, Email, to any LoopBack 4 based REST API application or microservice</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback4-s3">loopback4-s3</a></td>
+      <td>Integrate AWS S3 in LoopBack applications</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback-component-history">loopback-component-history</a></td>
+      <td>Soft create, edit, delete models, saving history of changes</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback-component-filter">loopback-component-filter</a></td>
+      <td>Filter models in repository layer, using an async function</td>
+    </tr>
+  </tbody>
+</table>
+
+## Authentication and authorization related extensions
+
+<table>
+  <thead>
+    <tr>
+      <th width="160">Extension</th>
+      <th width="280">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback4-authentication">loopback4-authentication</a></td>
+      <td>Provide support for five passport based strategies</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback4-authorization">loopback4-authorization</a></td>
+      <td>Implement authorization using simple string based permissions</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback-component-crud">loopback-component-crud</a></td>
+      <td>Generic CRUD controller mixin, supports authentication, nested authorization(cascade)</td>
+    </tr>
+    <tr>
+      <td><a href="https://www.npmjs.com/package/loopback-component-authorization">loopback-component-authorization</a></td>
+      <td>Implement HRBAC authorization</td>
+    </tr>
+  </tbody>
+<table>

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -858,6 +858,10 @@ children:
     url: Testing-your-extension.html
     output: 'web, pdf'
 
+- title: 'Community extensions'
+  url: Community-extensions.html
+  output: 'web, pdf'
+
 - title: 'Contribute to LoopBack 4'
   url: code-contrib-lb4.html
   output: 'web, pdf'


### PR DESCRIPTION
Fixes #5702

Add a community extensions page with some of the extensions we know about. The intention of this page is to have community adding their own extensions there. 

Preview of the change: 
![Screen Shot 2020-06-09 at 11 05 24 PM](https://user-images.githubusercontent.com/25489897/84222494-b880dc80-aaa5-11ea-8b2f-3925065d4113.png)


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
