### PR TITLE
feat(core): add services to component artifacts

### DIFF
--- a/docs/site/Components.md
+++ b/docs/site/Components.md
@@ -27,6 +27,7 @@ properties:
   context.
 - `servers` - A map of name/class pairs for [servers](Server.md).
 - `lifeCycleObservers` - An array of [life cycle observers](Life-cycle.md).
+- `services` - An array of [service](Services.md) classes or providers.
 - `bindings` - An array of [bindings](Binding.md) to be added to the application
   context. A good example of using bindings to extend the functionality of a
   LoopBack 4 app is

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -171,6 +171,35 @@ describe('Application', () => {
       expect(binding.tagNames).to.containEql('foo');
     });
 
+    it('binds services from a component', () => {
+      class MyService {}
+
+      class MyComponentWithServices implements Component {
+        services = [MyService];
+      }
+
+      app.component(MyComponentWithServices);
+
+      expect(
+        app.getBinding('services.MyService').valueConstructor,
+      ).to.be.exactly(MyService);
+    });
+
+    it('binds services with @bind from a component', () => {
+      @bind({scope: BindingScope.TRANSIENT, tags: ['foo']})
+      class MyService {}
+
+      class MyComponentWithServices implements Component {
+        services = [MyService];
+      }
+
+      app.component(MyComponentWithServices);
+
+      const binding = app.getBinding('services.MyService');
+      expect(binding.scope).to.eql(BindingScope.TRANSIENT);
+      expect(binding.tagNames).to.containEql('foo');
+    });
+
     it('honors tags when binding providers from a component', () => {
       @bind({tags: ['foo']})
       class MyProvider implements Provider<string> {

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -451,7 +451,7 @@ export class Application extends Context implements LifeCycleObserver {
    * ```
    */
   public service<S>(
-    cls: Constructor<S | Provider<S>>,
+    cls: ServiceOrProviderClass<S>,
     nameOrOptions?: string | ServiceOptions,
   ): Binding<S> {
     const options = toOptions(nameOrOptions);
@@ -601,6 +601,9 @@ export interface ApplicationConfig {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ControllerClass<T = any> = Constructor<T>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ServiceOrProviderClass<T = any> = Constructor<T | Provider<T>>;
 
 /**
  * Type description for `package.json`

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -10,7 +10,11 @@ import {
   createBindingFromClass,
   Provider,
 } from '@loopback/context';
-import {Application, ControllerClass} from './application';
+import {
+  Application,
+  ControllerClass,
+  ServiceOrProviderClass,
+} from './application';
 import {LifeCycleObserver} from './lifecycle';
 import {Server} from './server';
 
@@ -70,6 +74,11 @@ export interface Component {
   };
 
   lifeCycleObservers?: Constructor<LifeCycleObserver>[];
+
+  /**
+   * An array of service or provider classes
+   */
+  services?: ServiceOrProviderClass[];
 
   /**
    * An array of bindings to be aded to the application context.
@@ -135,6 +144,12 @@ export function mountComponent(app: Application, component: Component) {
   if (component.lifeCycleObservers) {
     for (const observer of component.lifeCycleObservers) {
       app.lifeCycleObserver(observer);
+    }
+  }
+
+  if (component.services) {
+    for (const service of component.services) {
+      app.service(service);
     }
   }
 }


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Add services to component artifacts and automatically bind services to application when mounting the component.

Currently, to add a service from a component to an application the following needs to be done

```ts
export class MyComponent implements Component {
    constructor(@inject(CoreBindings.APPLICATION_INSTANCE) app: Application) {
        app.service(MyService);
     }
}
```

After this change adding services would be possible without a workaround and similar to adding controllers, repositories, models, life cycle observers, etc.

```ts
export class MyComponent implements Component {
    services = [MyService];
}
```

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
