### PR TITLE
fix(boot): make sure sandbox directories are removed after tests

### DIFF
--- a/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
@@ -5,19 +5,16 @@
 
 import {CoreBindings} from '@loopback/core';
 import {expect, givenHttpServerConfig, TestSandbox} from '@loopback/testlab';
+import fs from 'fs';
 import {resolve} from 'path';
 import {BooterApp} from '../fixtures/application';
 
 describe('application metadata booter acceptance tests', () => {
   let app: BooterApp;
-  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'), {
-    // We intentionally use this flag so that `dist/application.js` can keep
-    // its relative path to satisfy import statements
-    subdir: false,
-  });
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
-  beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
+  after('delete sandbox', () => sandbox.delete());
 
   it('binds content of package.json to application metadata', async () => {
     await app.boot();
@@ -33,14 +30,18 @@ describe('application metadata booter acceptance tests', () => {
     // Add the following files
     // - package.json
     // - dist/application.js
+
+    const appJsFile = resolve(__dirname, '../fixtures/application.js');
+    let appJs = fs.readFileSync(appJsFile, 'utf-8');
+    // Adjust the relative path for `import`
+    appJs = appJs.replace('../..', '../../..');
+    await sandbox.writeTextFile('dist/application.js', appJs);
+
     await sandbox.copyFile(resolve(__dirname, '../fixtures/package.json'));
-    await sandbox.copyFile(
-      resolve(__dirname, '../fixtures/application.js'),
-      'dist/application.js',
-    );
 
     const MyApp = require(resolve(sandbox.path, 'dist/application.js'))
       .BooterApp;
+
     app = new MyApp({
       rest: givenHttpServerConfig(),
     });

--- a/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
@@ -5,6 +5,7 @@
 
 import {Application, Component} from '@loopback/core';
 import {expect, givenHttpServerConfig, TestSandbox} from '@loopback/testlab';
+import fs from 'fs';
 import {resolve} from 'path';
 import {BootMixin, createComponentApplicationBooterBinding} from '../..';
 import {bindingKeysExcludedFromSubApp} from '../../booters';
@@ -13,14 +14,12 @@ import {BooterApp} from '../fixtures/application';
 
 describe('component application booter acceptance tests', () => {
   let app: BooterApp;
-  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'), {
-    // We intentionally use this flag so that `dist/application.js` can keep
-    // its relative path to satisfy import statements
-    subdir: false,
-  });
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
+
+  after('delete sandbox', () => sandbox.delete());
 
   it('binds artifacts booted from the component application', async () => {
     class BooterAppComponent implements Component {
@@ -87,8 +86,13 @@ describe('component application booter acceptance tests', () => {
   }
 
   async function getApp() {
+    const appJsFile = resolve(__dirname, '../fixtures/application.js');
+    let appJs = fs.readFileSync(appJsFile, 'utf-8');
+    // Adjust the relative path for `import`
+    appJs = appJs.replace('../..', '../../..');
+    await sandbox.writeTextFile('application.js', appJs);
+
     await sandbox.copyFile(resolve(__dirname, '../fixtures/package.json'));
-    await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/multiple.artifact.js'),
       'controllers/multiple.controller.js',

--- a/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
@@ -20,6 +20,8 @@ describe('controller booter acceptance tests', () => {
 
   afterEach(stopApp);
 
+  after('delete sandbox', () => sandbox.delete());
+
   it('binds controllers using ControllerDefaults and REST endpoints work', async () => {
     await app.boot();
     await app.start();
@@ -46,10 +48,6 @@ describe('controller booter acceptance tests', () => {
   }
 
   async function stopApp() {
-    try {
-      await app.stop();
-    } catch (err) {
-      console.log(`Stopping the app threw an error: ${err}`);
-    }
+    await app?.stop();
   }
 });

--- a/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
@@ -21,6 +21,8 @@ describe('CRUD rest builder acceptance tests', () => {
 
   afterEach(stopApp);
 
+  after('delete sandbox', () => sandbox.delete());
+
   it('binds the controller and repository to the application', async () => {
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/product.model.js'),
@@ -165,7 +167,6 @@ module.exports = {
   }
 
   async function stopApp() {
-    if (app.state !== 'started') return;
-    await app.stop();
+    if (app?.state === 'started') await app?.stop();
   }
 });

--- a/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
@@ -33,6 +33,8 @@ describe('model API booter acceptance tests', () => {
 
   afterEach(stopApp);
 
+  after('delete sandbox', () => sandbox.delete());
+
   it('uses the correct model API builder', async () => {
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/product.model.js'),
@@ -167,10 +169,6 @@ module.exports = {
   }
 
   async function stopApp() {
-    try {
-      await app.stop();
-    } catch (err) {
-      // console.error('Cannot stop the app, ignoring the error.', err);
-    }
+    if (app?.state === 'started') await app?.stop();
   }
 });

--- a/packages/boot/src/__tests__/fixtures/application.ts
+++ b/packages/boot/src/__tests__/fixtures/application.ts
@@ -9,10 +9,6 @@ import {RestApplication} from '@loopback/rest';
 import {ServiceMixin} from '@loopback/service-proxy';
 import {BootMixin} from '../..';
 
-// Force package.json to be copied to `dist` by `tsc`
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import * as pkg from './package.json';
-
 export class BooterApp extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
 ) {

--- a/packages/boot/src/__tests__/integration/controller.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/controller.booter.integration.ts
@@ -19,6 +19,8 @@ describe('controller booter integration tests', () => {
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
+  after('delete sandbox', () => sandbox.delete());
+
   it('boots controllers when app.boot() is called', async () => {
     const expectedBindings = [
       `${CONTROLLERS_PREFIX}.ArtifactOne`,

--- a/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/datasource.booter.integration.ts
@@ -18,6 +18,8 @@ describe('datasource booter integration tests', () => {
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
+  after('delete sandbox', () => sandbox.delete());
+
   it('boots datasources when app.boot() is called', async () => {
     const expectedBindings = [`${DATASOURCES_PREFIX}.db`];
 

--- a/packages/boot/src/__tests__/integration/interceptor.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/interceptor.booter.integration.ts
@@ -20,6 +20,8 @@ describe('interceptor script booter integration tests', () => {
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(buildAppWithInterceptors);
 
+  after('delete sandbox', () => sandbox.delete());
+
   it('boots global interceptors when app.boot() is called', async () => {
     const expectedBinding = {
       key: `${GLOBAL_INTERCEPTOR_NAMESPACE}.myGlobalInterceptor`,

--- a/packages/boot/src/__tests__/integration/lifecycle-observer.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/lifecycle-observer.booter.integration.ts
@@ -24,6 +24,8 @@ describe('lifecycle script booter integration tests', () => {
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
+  after('delete sandbox', () => sandbox.delete());
+
   it('boots life cycle observers when app.boot() is called', async () => {
     const expectedBinding = {
       key: `${OBSERVER_PREFIX}.MyLifeCycleObserver`,


### PR DESCRIPTION
Extracted from #5011. It cleans up the tests to avoid conflicting sandbox paths for parallel testing.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
