### PR TITLE
fix(docs): fix broken links

### DIFF
--- a/docs/site/Dynamic-models-repositories-controllers.md
+++ b/docs/site/Dynamic-models-repositories-controllers.md
@@ -5,7 +5,7 @@ keywords:
   LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Model, Repository,
   Controller, Tutorial
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Dynamic-models-repositories-controllers-tutorial.html
+permalink: /doc/en/lb4/Dynamic-models-repositories-controllers.html
 ---
 
 ## How to dynamically add models, repositories, and controllers during runtime

--- a/docs/site/migration/auth/authentication.md
+++ b/docs/site/migration/auth/authentication.md
@@ -57,7 +57,7 @@ We highly recommend you read and understand the document of LoopBack 4
 authentication system before the migration:
 
 - [Introducing component `@loopback/authentication`](https://loopback.io/doc/en/lb4/Loopback-component-authentication.html)
-- [Tutorial of how to secure your LoopBack 4 APIs with jwt strategy](https://loopback.io/doc/en/lb4/Authentication-Tutorial.html)
+- [Tutorial of how to secure your LoopBack 4 APIs with jwt strategy](https://loopback.io/doc/en/lb4/Authentication-tutorial.html)
 
 As a summary for the above documents: LoopBack 4 has a more flexible
 authentication module that can potentially support any authentication
@@ -258,7 +258,7 @@ which will decide the `principal`'s access later.
 To simplify the implementation for readers, we provide a brief introduction of
 the extracted services and bindings instead of unfolding all the implementation
 details. You can find a very detailed steps of creating it in
-[this tutorial](https://loopback.io/doc/en/lb4/Authentication-Tutorial.html).
+[this tutorial](https://loopback.io/doc/en/lb4/Authentication-tutorial.html).
 
 The component consists of the following files:
 

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -363,6 +363,10 @@ children:
     url: Loopback-component-authorization.html
     output: 'web, pdf'
 
+  - title: 'Authentication'
+    url: Loopback-component-authentication.html
+    output: 'web, pdf'
+
   - title: 'Boot and Mount a LoopBack 3 Application'
     url: Boot-and-Mount-a-LoopBack-3-application.html
     output: 'web, pdf'

--- a/docs/site/tutorials/authentication/Authentication-Tutorial.md
+++ b/docs/site/tutorials/authentication/Authentication-Tutorial.md
@@ -5,7 +5,7 @@ keywords:
   LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Authentication,
   Tutorial
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Authentication-Tutorial.html
+permalink: /doc/en/lb4/Authentication-tutorial.html
 summary: A LoopBack 4 application that uses JWT authentication
 ---
 

--- a/extensions/authentication-passport/README.md
+++ b/extensions/authentication-passport/README.md
@@ -182,7 +182,7 @@ This part is same as registering a non-passport based strategy. Please make sure
 you follow the documentation
 [adding-an-authentication-action-to-a-custom-sequence](https://loopback.io/doc/en/lb4/Loopback-component-authentication.html#adding-an-authentication-action-to-a-custom-sequence)
 to rewrite your sequence. You can also find a sample implementation in
-[this example tutorial](https://loopback.io/doc/en/lb4/Authentication-Tutorial.html#creating-a-custom-sequence-and-adding-the-authentication-action).
+[this example tutorial](https://loopback.io/doc/en/lb4/Authentication-tutorial.html#creating-a-custom-sequence-and-adding-the-authentication-action).
 
 ### With Provider
 
@@ -391,4 +391,4 @@ This part is same as registering a non-passport based strategy. Please make sure
 you follow the documentation
 [adding-an-authentication-action-to-a-custom-sequence](https://loopback.io/doc/en/lb4/Loopback-component-authentication.html#adding-an-authentication-action-to-a-custom-sequence)
 to rewrite your sequence. You can also find a sample implementation in
-[this example tutorial](https://loopback.io/doc/en/lb4/Authentication-Tutorial.html#creating-a-custom-sequence-and-adding-the-authentication-action).
+[this example tutorial](https://loopback.io/doc/en/lb4/Authentication-tutorial.html#creating-a-custom-sequence-and-adding-the-authentication-action).

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -48,7 +48,7 @@ For detailed documentation, see
 [AuthenticationComponent](https://loopback.io/doc/en/lb4/Loopback-component-authentication.html).
 
 For a tutorial on how to add **JWT** authentication to an application, see
-[How to secure your LoopBack 4 application with JWT authentication](https://loopback.io/doc/en/lb4/Authentication-Tutorial.html).
+[How to secure your LoopBack 4 application with JWT authentication](https://loopback.io/doc/en/lb4/Authentication-tutorial.html).
 
 For some background on our design decisions, please read
 [Multiple Authentication strategies](./docs/authentication-system.md).


### PR DESCRIPTION
Fix broken links
Also, the authentication extension under the "Using Components" section does not exist, so I added there too. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
