### PR TITLE
fix: ensure unique sandbox directories for boot tests

### DIFF
--- a/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/application-metadata.booter.acceptance.ts
@@ -10,12 +10,7 @@ import {BooterApp} from '../fixtures/application';
 
 describe('application metadata booter acceptance tests', () => {
   let app: BooterApp;
-  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'), {
-    // We intentionally use this flag so that `dist/application.js` can keep
-    // its relative path to satisfy import statements
-    subdir: false,
-  });
-
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
 
@@ -33,14 +28,19 @@ describe('application metadata booter acceptance tests', () => {
     // Add the following files
     // - package.json
     // - dist/application.js
-    await sandbox.copyFile(resolve(__dirname, '../fixtures/package.json'));
+
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/application.js'),
       'dist/application.js',
+      // Adjust the relative path for `import`
+      content => content.replace('../..', '../../..'),
     );
+
+    await sandbox.copyFile(resolve(__dirname, '../fixtures/package.json'));
 
     const MyApp = require(resolve(sandbox.path, 'dist/application.js'))
       .BooterApp;
+
     app = new MyApp({
       rest: givenHttpServerConfig(),
     });

--- a/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
@@ -13,11 +13,7 @@ import {BooterApp} from '../fixtures/application';
 
 describe('component application booter acceptance tests', () => {
   let app: BooterApp;
-  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'), {
-    // We intentionally use this flag so that `dist/application.js` can keep
-    // its relative path to satisfy import statements
-    subdir: false,
-  });
+  const sandbox = new TestSandbox(resolve(__dirname, '../../.sandbox'));
 
   beforeEach('reset sandbox', () => sandbox.reset());
   beforeEach(getApp);
@@ -87,8 +83,14 @@ describe('component application booter acceptance tests', () => {
   }
 
   async function getApp() {
+    await sandbox.copyFile(
+      resolve(__dirname, '../fixtures/application.js'),
+      'application.js',
+      // Adjust the relative path for `import`
+      content => content.replace('../..', '../../..'),
+    );
+
     await sandbox.copyFile(resolve(__dirname, '../fixtures/package.json'));
-    await sandbox.copyFile(resolve(__dirname, '../fixtures/application.js'));
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/multiple.artifact.js'),
       'controllers/multiple.controller.js',

--- a/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/controller.booter.acceptance.ts
@@ -46,10 +46,6 @@ describe('controller booter acceptance tests', () => {
   }
 
   async function stopApp() {
-    try {
-      await app.stop();
-    } catch (err) {
-      console.log(`Stopping the app threw an error: ${err}`);
-    }
+    await app?.stop();
   }
 });

--- a/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/crud-rest.api-builder.acceptance.ts
@@ -165,7 +165,6 @@ module.exports = {
   }
 
   async function stopApp() {
-    if (app.state !== 'started') return;
-    await app.stop();
+    if (app?.state === 'started') await app?.stop();
   }
 });

--- a/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/model-api.booter.acceptance.ts
@@ -167,10 +167,6 @@ module.exports = {
   }
 
   async function stopApp() {
-    try {
-      await app.stop();
-    } catch (err) {
-      // console.error('Cannot stop the app, ignoring the error.', err);
-    }
+    if (app?.state === 'started') await app?.stop();
   }
 });

--- a/packages/testlab/src/__tests__/integration/test-sandbox.integration.ts
+++ b/packages/testlab/src/__tests__/integration/test-sandbox.integration.ts
@@ -36,6 +36,27 @@ describe('TestSandbox integration tests', () => {
     await expectFilesToBeIdentical(COPY_FILE_PATH, resolve(path, COPY_FILE));
   });
 
+  it('copies a file to the sandbox with transform', async () => {
+    await sandbox.copyFile(COPY_FILE_PATH, undefined, content =>
+      content.toUpperCase(),
+    );
+    const dest = resolve(path, COPY_FILE);
+    expect(await pathExists(dest)).to.be.True();
+    const content = await readFile(dest, 'utf-8');
+    expect(content).to.equal('HELLO WORLD!');
+  });
+
+  it('copies a file to the sandbox with dest and transform', async () => {
+    const rename = 'copy.me.js';
+    await sandbox.copyFile(COPY_FILE_PATH, rename, content =>
+      content.toUpperCase(),
+    );
+    const dest = resolve(path, rename);
+    expect(await pathExists(dest)).to.be.True();
+    const content = await readFile(dest, 'utf-8');
+    expect(content).to.equal('HELLO WORLD!');
+  });
+
   it('copies and renames the file to the sandbox', async () => {
     const rename = 'copy.me.js';
     await sandbox.copyFile(COPY_FILE_PATH, rename);


### PR DESCRIPTION
Extracted from https://github.com/strongloop/loopback-next/pull/5744 for ease of review.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
