### PR TITLE
feat(docs): add troubleshooting guide

### DIFF
--- a/docs/site/Troubleshooting-guide.md
+++ b/docs/site/Troubleshooting-guide.md
@@ -1,0 +1,17 @@
+---
+title: 'Troubleshooting Guide'
+lang: en
+layout: page
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Troubleshooting
+tags:
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Troubleshooting-guide.html
+summary: Transactional API usage in LoopBack 4
+---
+
+The following documentation pages can help you troubleshoot problems you
+encountered.
+
+- [Running and debuggin apps](Running-and-debugging-apps.md)
+- [Setting debug strings](Setting-debug-strings.md)

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -233,19 +233,6 @@ children:
       url: Database-migrations.html
       output: 'web, pdf'
 
-  - title: 'Running and debugging apps'
-    url: Running-and-debugging-apps.html
-    output: 'web, pdf'
-    children:
-
-    - title: 'Setting debug strings'
-      url: Setting-debug-strings.html
-      output: 'web, pdf'
-
-    - title: 'Using strong-error-handler'
-      url: Using-strong-error-handler.html
-      output: 'web, pdf'
-
   - title: 'Call Other Services'
     url: Calling-other-APIs-and-web-services.html
     output: 'web, pdf'
@@ -503,6 +490,11 @@ children:
   - title: 'Error handling'
     url: Error-handling.html
     output: 'web, pdf'
+    children:
+
+    - title: 'Using strong-error-handler'
+      url: Using-strong-error-handler.html
+      output: 'web, pdf'
 
   - title: 'Context'
     url: Context.html
@@ -805,6 +797,19 @@ children:
 
   - title: 'Considerations for GDPR readiness'
     url: Deploy-for-GDPR-readiness.html
+    output: 'web, pdf'
+
+- title: 'Troubleshooting Guide'
+  url: Troubleshooting-guide.html
+  output: 'web, pdf'
+  children:
+
+  - title: 'Running and debugging apps'
+    url: Running-and-debugging-apps.html
+    output: 'web, pdf'
+
+  - title: 'Setting debug strings'
+    url: Setting-debug-strings.html
     output: 'web, pdf'
 
 - title: 'Extending LoopBack 4'


### PR DESCRIPTION
With the new acceptance criteria in https://github.com/strongloop/loopback-next/issues/5701, I'm taking a slightly different approach and making this PR as the first one.
- add the troubleshooting guide in the sidebar
- add "running and debugging app" and "setting debug strings" under it. 

<img width="263" alt="Screen Shot 2020-06-15 at 9 56 24 PM" src="https://user-images.githubusercontent.com/25489897/84723367-692e2680-af53-11ea-8d23-bd86f38dcf85.png">

Related to https://github.com/strongloop/loopback-next/pull/5705. 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
