### PR TITLE
fix(repository-json-schema): added type 'object' to model json schema

### DIFF
--- a/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/controller-spec.integration.ts
@@ -76,17 +76,20 @@ describe('controller spec', () => {
         schemas: {
           Bar: {
             title: 'Bar',
+            type: 'object',
             properties: {name: {type: 'string'}},
             additionalProperties: false,
           },
           Baz: {
             title: 'Baz',
+            type: 'object',
             properties: {name: {type: 'string'}},
             additionalProperties: false,
           },
           Foo: {
             // guarantee `definition` is deleted
             title: 'Foo',
+            type: 'object',
             properties: {
               bar: {$ref: '#/components/schemas/Bar'},
               baz: {$ref: '#/components/schemas/Baz'},
@@ -562,6 +565,7 @@ describe('controller spec', () => {
       },
       additionalProperties: false,
       title: 'MyModel',
+      type: 'object',
     };
 
     it('generates schema for response content', () => {
@@ -804,6 +808,7 @@ describe('controller spec', () => {
       expect(globalSchemas).to.deepEqual({
         MyModel: {
           title: 'MyModel',
+          type: 'object',
           properties: {
             name: {
               type: 'string',

--- a/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
+++ b/packages/openapi-v3/src/__tests__/integration/operation-spec.integration.ts
@@ -64,6 +64,7 @@ describe('operation arguments', () => {
         schemas: {
           User: {
             title: 'User',
+            type: 'object',
             properties: {name: {type: 'string'}, password: {type: 'number'}},
             additionalProperties: false,
           },

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -47,6 +47,7 @@ describe('build-schema', () => {
         const jsonSchema = modelToJsonSchema(TestModel);
         expect(jsonSchema).to.eql({
           title: 'TestModel',
+          type: 'object',
           properties: {nul: {type: 'null'}},
           additionalProperties: false,
         });
@@ -466,6 +467,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomType: {
               title: 'CustomType',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -500,6 +502,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomType: {
               title: 'CustomType',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -538,6 +541,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomTypePartial: {
               title: 'CustomTypePartial',
+              type: 'object',
               description:
                 "(tsType: Partial<CustomType>, schemaOptions: { partial: 'deep' })",
               properties: {
@@ -600,6 +604,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomType: {
               title: 'CustomType',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -637,6 +642,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             CustomTypePartial: {
               title: 'CustomTypePartial',
+              type: 'object',
               description:
                 "(tsType: Partial<CustomType>, schemaOptions: { partial: 'deep' })",
               properties: {
@@ -715,6 +721,7 @@ describe('build-schema', () => {
           expect(jsonSchema.definitions).to.deepEqual({
             Address: {
               title: 'Address',
+              type: 'object',
               properties: {
                 city: {
                   type: 'string',
@@ -808,6 +815,7 @@ describe('build-schema', () => {
           expect(schemaDefs).to.deepEqual({
             CustomTypeFoo: {
               title: 'CustomTypeFoo',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'string',
@@ -817,6 +825,7 @@ describe('build-schema', () => {
             },
             CustomTypeBar: {
               title: 'CustomTypeBar',
+              type: 'object',
               properties: {
                 prop: {
                   type: 'array',
@@ -848,6 +857,7 @@ describe('build-schema', () => {
 
       const expectedSchema = {
         title: 'Category',
+        type: 'object',
         properties: {
           products: {
             type: 'array',
@@ -858,6 +868,7 @@ describe('build-schema', () => {
         definitions: {
           Product: {
             title: 'Product',
+            type: 'object',
             properties: {
               category: {
                 $ref: '#/definitions/Category',
@@ -998,6 +1009,7 @@ describe('build-schema', () => {
 
       const expectedSchemaForCategory = {
         title: 'Category',
+        type: 'object',
         properties: {
           products: {
             type: 'array',
@@ -1008,6 +1020,7 @@ describe('build-schema', () => {
         definitions: {
           Product: {
             title: 'Product',
+            type: 'object',
             properties: {
               category: {
                 $ref: '#/definitions/Category',
@@ -1047,6 +1060,7 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
+            type: 'object',
             description:
               `(tsType: ProductWithRelations, ` +
               `schemaOptions: { includeRelations: true })`,
@@ -1067,6 +1081,7 @@ describe('build-schema', () => {
         },
         additionalProperties: false,
         title: 'CategoryWithRelations',
+        type: 'object',
         description:
           `(tsType: CategoryWithRelations, ` +
           `schemaOptions: { includeRelations: true })`,
@@ -1094,6 +1109,7 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
+            type: 'object',
             description:
               `(tsType: ProductWithRelations, ` +
               `schemaOptions: { includeRelations: true })`,
@@ -1115,6 +1131,7 @@ describe('build-schema', () => {
         },
         additionalProperties: false,
         title: 'CategoryWithoutPropWithRelations',
+        type: 'object',
         description:
           `(tsType: CategoryWithoutPropWithRelations, ` +
           `schemaOptions: { includeRelations: true })`,
@@ -1201,6 +1218,7 @@ describe('build-schema', () => {
         definitions: {
           ProductWithRelations: {
             title: 'ProductWithRelations',
+            type: 'object',
             properties: {
               id: {type: 'number'},
               categoryId: {type: 'number'},
@@ -1219,6 +1237,7 @@ describe('build-schema', () => {
         },
         additionalProperties: false,
         title: 'CategoryWithRelations',
+        type: 'object',
       };
       MetadataInspector.defineMetadata(
         JSON_SCHEMA_KEY,
@@ -1234,6 +1253,7 @@ describe('build-schema', () => {
         },
         additionalProperties: false,
         title: 'Category',
+        type: 'object',
       });
     });
 
@@ -1284,6 +1304,7 @@ describe('build-schema', () => {
         const excludeIdSchema = getJsonSchema(Product, {exclude: ['id']});
         expect(excludeIdSchema).to.deepEqual({
           title: 'ProductExcluding_id_',
+          type: 'object',
           properties: {
             name: {type: 'string'},
             description: {type: 'string'},
@@ -1309,6 +1330,7 @@ describe('build-schema', () => {
         });
         expect(excludeIdAndNameSchema).to.deepEqual({
           title: 'ProductExcluding_id-name_',
+          type: 'object',
           properties: {
             description: {type: 'string'},
           },

--- a/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/schema-ref.integration.ts
@@ -22,6 +22,7 @@ describe('getJsonSchemaRef', () => {
       definitions: {
         MyModel: {
           title: 'MyModel',
+          type: 'object',
           properties: {
             name: {
               type: 'string',

--- a/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/build-schema.unit.ts
@@ -324,6 +324,7 @@ describe('build-schema', () => {
       expect(schema.definitions).to.containEql({
         ChildWithRelations: {
           title: 'ChildWithRelations',
+          type: 'object',
           description:
             '(tsType: ChildWithRelations, schemaOptions: { includeRelations: true })',
           properties: {name: {type: 'string'}},
@@ -379,6 +380,7 @@ describe('build-schema', () => {
       expect(schema.definitions).to.containEql({
         Child: {
           title: 'Child',
+          type: 'object',
           properties: {name: {type: 'string'}},
           additionalProperties: false,
         },
@@ -410,6 +412,7 @@ describe('build-schema', () => {
       const userSchema = modelToJsonSchema(User, {});
       expect(userSchema).to.eql({
         title: 'User',
+        type: 'object',
         properties: {id: {type: 'string'}, name: {type: 'string'}},
         required: ['name'],
         additionalProperties: false,
@@ -417,6 +420,7 @@ describe('build-schema', () => {
       const newUserSchema = modelToJsonSchema(NewUser, {});
       expect(newUserSchema).to.eql({
         title: 'NewUser',
+        type: 'object',
         properties: {
           id: {type: 'string'},
           name: {type: 'string'},
@@ -472,6 +476,7 @@ describe('build-schema', () => {
       const userSchema = modelToJsonSchema(User, {});
       expect(userSchema).to.eql({
         title: 'User',
+        type: 'object',
         properties: {
           id: {type: 'string'},
           name: {type: 'string'},
@@ -482,6 +487,7 @@ describe('build-schema', () => {
         definitions: {
           Address: {
             title: 'Address',
+            type: 'object',
             properties: {
               street: {type: 'string'},
               city: {type: 'string'},
@@ -491,6 +497,7 @@ describe('build-schema', () => {
           },
           Email: {
             title: 'Email',
+            type: 'object',
             properties: {
               label: {type: 'string'},
               id: {type: 'string'},

--- a/packages/repository-json-schema/src/build-schema.ts
+++ b/packages/repository-json-schema/src/build-schema.ts
@@ -452,6 +452,8 @@ export function modelToJsonSchema<T extends object>(
   const result: JsonSchema = {title};
   options.visited[title] = result;
 
+  result.type = 'object';
+
   const descriptionSuffix = getDescriptionSuffix(ctor.name, options);
 
   if (meta.description) {

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -283,6 +283,7 @@ describe('RestServer.getApiSpec()', () => {
     expect(spec.components?.schemas).to.deepEqual({
       MyModel: {
         title: 'MyModel',
+        type: 'object',
         properties: {
           bar: {
             type: 'string',


### PR DESCRIPTION
#3804

Added type 'object' to generated model schema to allow `ajv` validation to work correctly.

Fixes #3804 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
