### PR TITLE
feat(core): enable application config with configure/getConfig/@config

### DIFF
--- a/docs/site/Context.md
+++ b/docs/site/Context.md
@@ -684,13 +684,21 @@ We also allow `@config.*` to be resolved from another binding than the current
 one:
 
 ```ts
+import {config, CoreBindings} from '@loopback/core';
+
 export class MyRestServer {
   constructor(
     // Inject the `rest.host` from the application config
-    @config({fromBinding: 'application', propertyPath: 'rest.host'})
+    @config({
+      fromBinding: CoreBinding.APPLICATION_INSTANCE,
+      propertyPath: 'rest.host',
+    })
     host: string,
     // Inject the `rest.port` from the application config
-    @config({fromBinding: 'application', propertyPath: 'rest.port'})
+    @config({
+      fromBinding: CoreBinding.APPLICATION_INSTANCE,
+      propertyPath: 'rest.port',
+    })
     port: number,
   ) {
     // ...

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -25,6 +25,29 @@ describe('Application', () => {
 
   afterEach('clean up application', () => app.stop());
 
+  describe('app bindings', () => {
+    it('binds the application itself', () => {
+      app = new Application();
+      expect(app.getSync(CoreBindings.APPLICATION_INSTANCE)).to.equal(app);
+    });
+
+    it('binds the application config', () => {
+      const myAppConfig = {name: 'my-app', port: 3000};
+      app = new Application(myAppConfig);
+      expect(app.getSync(CoreBindings.APPLICATION_CONFIG)).to.equal(
+        myAppConfig,
+      );
+    });
+
+    it('configures the application', () => {
+      const myAppConfig = {name: 'my-app', port: 3000};
+      app = new Application(myAppConfig);
+      expect(app.getConfigSync(CoreBindings.APPLICATION_INSTANCE)).to.equal(
+        myAppConfig,
+      );
+    });
+  });
+
   describe('controller binding', () => {
     beforeEach(givenApp);
 

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -129,6 +129,11 @@ export class Application extends Context implements LifeCycleObserver {
     // Make options available to other modules as well.
     this.bind(CoreBindings.APPLICATION_CONFIG).to(this.options);
 
+    // Also configure the application instance to allow `@config`
+    this.configure(CoreBindings.APPLICATION_INSTANCE).toAlias(
+      CoreBindings.APPLICATION_CONFIG,
+    );
+
     this._shutdownOptions = {signals: ['SIGTERM'], ...this.options.shutdown};
   }
 


### PR DESCRIPTION
@frbuceta pointed an error in https://loopback.io/doc/en/lb4/Context.html#configuration-by-convention.

This PR allows `CoreBindings.APPLICATION_INSTANCE` to have corresponding `config`. It also keeps backward compatibility for `CoreBindings.APPLICATION_CONFIG`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
