### PR TITLE
docs: move "Reserved binding keys" to "Reference guides"

### DIFF
--- a/docs/site/reference/reserved-binding-keys.md
+++ b/docs/site/reference/reserved-binding-keys.md
@@ -7,8 +7,6 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Reserved-binding-keys.html
 ---
 
-## Overview
-
 When using [dependency injection](Dependency-injection.md) there are a few
 things to keep in mind with regards to binding keys.
 

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -511,10 +511,6 @@ children:
     output: 'web, pdf'
     children:
 
-      - title: 'Reserved binding keys'
-        url: Reserved-binding-keys.html
-        output: 'web, pdf'
-
   - title: 'Components'
     url: Components.html
     output: 'web, pdf'
@@ -554,6 +550,10 @@ children:
 
   - title: 'API docs'
     url: apidocs.index.html
+    output: 'web, pdf'
+
+  - title: 'Reserved binding keys'
+    url: Reserved-binding-keys.html
     output: 'web, pdf'
 
   - title: 'Error codes'


### PR DESCRIPTION
Also remove "Overview" heading from the page. I feel the heading is redundant when there are no other headings. Before this change, the page was rendered with a single-item Table of Contents at the top, which looked weird to me. After this change, the pages is rendered as a single block with the page title as the only heading.

This is a follow-up to #5718, see also #5549.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
