### PR TITLE
docs: move "Error handling" to "Error codes" in "Reference guides"

### DIFF
--- a/docs/site/reference/error-codes.md
+++ b/docs/site/reference/error-codes.md
@@ -1,12 +1,11 @@
 ---
 lang: en
-title: Error Handling
+title: Error Codes
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Error Handling
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Error-handling.html
+permalink: /doc/en/lb4/Error-codes.html
+redirect_from: /doc/en/lb4/Error-handling.html
 ---
-
-## Known Error Codes
 
 In order to allow clients to reliably detect individual error causes, LoopBack
 sets the error `code` property to a machine-readable string.

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -498,10 +498,6 @@ children:
     url: Mixin.html
     output: 'web, pdf'
 
-  - title: 'Error handling'
-    url: Error-handling.html
-    output: 'web, pdf'
-
   - title: 'Context'
     url: Context.html
     output: 'web, pdf'
@@ -558,6 +554,10 @@ children:
 
   - title: 'API docs'
     url: apidocs.index.html
+    output: 'web, pdf'
+
+  - title: 'Error codes'
+    url: Error-codes.html
     output: 'web, pdf'
 
   - title: 'CLI References'


### PR DESCRIPTION
This is a follow-up to #5718, see also #5549.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
