### PR TITLE
fix: set node version to >=10.16 to support events.once

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ for more details.
 
 Make sure you have the following installed:
 
-- [Node.js](https://nodejs.org/en/download/) >= 10
+- [Node.js](https://nodejs.org/en/download/) >= 10.16
 
 Install LoopBack 4 CLI to help create new projects as follows:
 

--- a/acceptance/extension-logging-fluentd/package.json
+++ b/acceptance/extension-logging-fluentd/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-cloudant/package.json
+++ b/acceptance/repository-cloudant/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mongodb/package.json
+++ b/acceptance/repository-mongodb/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-mysql/package.json
+++ b/acceptance/repository-mysql/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/acceptance/repository-postgresql/package.json
+++ b/acceptance/repository-postgresql/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -11,7 +11,7 @@
     "benchmark"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "files": [
     "*.md",

--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -12,7 +12,7 @@
     "express"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -10,7 +10,7 @@
     "multi-tenancy"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/rpc-server/package.json
+++ b/examples/rpc-server/package.json
@@ -9,7 +9,7 @@
     "loopback"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/fixtures/mock-oauth2-provider/package.json
+++ b/fixtures/mock-oauth2-provider/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "An internal application to mock the OAuth2 authorization flow login with a social app like facebook, google etc",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "private": true,
   "main": "dist/index.js",

--- a/fixtures/tsdocs-monorepo/package.json
+++ b/fixtures/tsdocs-monorepo/package.json
@@ -2,7 +2,7 @@
   "name": "@loopback/tsdocs-monorepo",
   "version": "0.0.1",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "private": true,
   "description": "A monorepo for tsdocs testing",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "version": "0.1.0",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "license": "MIT",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/boot/src/__tests__/fixtures/package.json
+++ b/packages/boot/src/__tests__/fixtures/package.json
@@ -7,7 +7,7 @@
     "loopback"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
   },

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -8,7 +8,7 @@
   },
   "version": "5.4.3",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "main": "index.js",
   "author": "IBM Corp.",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -9,7 +9,7 @@
   "main": "dist/index.js",
   "main": "types/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "files": [
     "bin",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.1",
   "description": "ESLint configuration for LoopBack projects",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "main": "eslintrc.js",
   "author": "IBM Corp.",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -9,7 +9,7 @@
     "loopback"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "dependencies": {
     "@loopback/core": "^2.8.0",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",

--- a/packages/testlab/package.json
+++ b/packages/testlab/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build": "lb-tsc",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "scripts": {
     "build:tsdocs": "npm run build && npm run -s extract-apidocs && npm run -s document-apidocs && npm run -s update-apidocs",

--- a/sandbox/example/package.json
+++ b/sandbox/example/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"This is an example for sandbox\""
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16"
   },
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",


### PR DESCRIPTION
In PR https://github.com/strongloop/loopback-next/pull/5429 was added `require('events').once` which is only available in Node  >=10.16.

Fixes https://github.com/strongloop/loopback-next/issues/5789

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
     (**for node >=10.16**)
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
