### PR TITLE
docs: rename "Usage Scenarios" to "How-to guides"

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -177,7 +177,7 @@ children:
         url: core-tutorial-part11.html
         output: 'web, pdf'
 
-- title: 'Usage Scenarios'
+- title: 'How-to guides'
   output: 'web, pdf'
   children:
 


### PR DESCRIPTION
To further align our sidebar with the four-quadrant documentation system (see #5549 and #5718), I am proposing to rename "Usage Scenarios" to "How-to guides". 

This pull request is extracted from https://github.com/strongloop/loopback-next/pull/5768.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
