### PR TITLE
Simplify build of tsdocs' monorepo fixture

### DIFF
--- a/packages/tsdocs/fixtures/monorepo/package.json
+++ b/packages/tsdocs/fixtures/monorepo/package.json
@@ -2,6 +2,7 @@
   "name": "@loopack-tsdocs-fixtures/monorepo",
   "version": "1.0.0",
   "description": "A dummy package file that must stay (mostly) empty. Put any dependencies or scripts into tsdocs' package.json file instead.",
+  "private": true,
   "author": "IBM Corp.",
   "license": "MIT"
 }

--- a/packages/tsdocs/fixtures/monorepo/package.json
+++ b/packages/tsdocs/fixtures/monorepo/package.json
@@ -1,15 +1,7 @@
 {
-  "name": "root",
+  "name": "@loopack-tsdocs-fixtures/monorepo",
   "version": "1.0.0",
-  "description": "Root",
-  "scripts": {
-    "clean-fixtures": "node run-lerna run clean",
-    "bootstrap": "node run-lerna bootstrap",
-    "build": "npm -s run bootstrap && npm -s run clean-fixtures && node run-lerna run build"
-  },
-  "author": "",
-  "license": "MIT",
-  "devDependencies": {
-    "@loopback/build": "file:../../../build"
-  }
+  "description": "A dummy package file that must stay (mostly) empty. Put any dependencies or scripts into tsdocs' package.json file instead.",
+  "author": "IBM Corp.",
+  "license": "MIT"
 }

--- a/packages/tsdocs/fixtures/monorepo/run-lerna.js
+++ b/packages/tsdocs/fixtures/monorepo/run-lerna.js
@@ -5,15 +5,8 @@
 // License text available at https://opensource.org/licenses/MIT
 
 /**
- * An internal script to run lerna command
+ * An internal script to run `lerna` installed in loopback-next monorepo root.
+ * loopback-next dependencies are not added to PATH when running `npm` in the
+ * `fixtures` monorepo, we must locate lerna CLI manually.
  */
-const path = require('path');
-const lerna = path.resolve(__dirname, '../../../../node_modules/.bin/lerna');
-
-const runShell = require('@loopback/build').runShell;
-const child = runShell(lerna, process.argv.splice(2), {
-  cwd: __dirname,
-});
-child.on('exit', code => {
-  process.exit(code);
-});
+require('../../../../node_modules/lerna/cli.js');

--- a/packages/tsdocs/fixtures/monorepo/run-lerna.js
+++ b/packages/tsdocs/fixtures/monorepo/run-lerna.js
@@ -5,6 +5,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 /**
+ * Change to the root directory of our monorepo, to prevent lerna from running
+ * against loopback-next monorepo.
+ */
+process.chdir(__dirname);
+
+/**
  * An internal script to run `lerna` installed in loopback-next monorepo root.
  * loopback-next dependencies are not added to PATH when running `npm` in the
  * `fixtures` monorepo, we must locate lerna CLI manually.

--- a/packages/tsdocs/fixtures/monorepo/run-lerna.js
+++ b/packages/tsdocs/fixtures/monorepo/run-lerna.js
@@ -5,12 +5,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 /**
- * Change to the root directory of our monorepo, to prevent lerna from running
- * against loopback-next monorepo.
- */
-process.chdir(__dirname);
-
-/**
  * An internal script to run `lerna` installed in loopback-next monorepo root.
  * loopback-next dependencies are not added to PATH when running `npm` in the
  * `fixtures` monorepo, we must locate lerna CLI manually.

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -15,7 +15,7 @@
     "document-apidocs": "api-documenter markdown -i ../../docs/apidocs/models -o ../../docs/site/apidocs",
     "update-apidocs": "node bin/update-apidocs",
     "build": "lb-tsc",
-    "build:fixtures": "npm run build --prefix fixtures/monorepo",
+    "build:fixtures": "node fixtures/monorepo/run-lerna bootstrap && node fixtures/monorepo/run-lerna run clean && node fixtures/monorepo/run-lerna run build",
     "clean": "lb-clean loopback-tsdocs*.tgz dist *.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",

--- a/packages/tsdocs/package.json
+++ b/packages/tsdocs/package.json
@@ -15,7 +15,7 @@
     "document-apidocs": "api-documenter markdown -i ../../docs/apidocs/models -o ../../docs/site/apidocs",
     "update-apidocs": "node bin/update-apidocs",
     "build": "lb-tsc",
-    "build:fixtures": "node fixtures/monorepo/run-lerna bootstrap && node fixtures/monorepo/run-lerna run clean && node fixtures/monorepo/run-lerna run build",
+    "build:fixtures": "cd fixtures/monorepo && node run-lerna bootstrap && node run-lerna run clean && node run-lerna run build",
     "clean": "lb-clean loopback-tsdocs*.tgz dist *.tsbuildinfo package",
     "pretest": "npm run build",
     "test": "lb-mocha \"dist/__tests__/**/*.js\"",


### PR DESCRIPTION
I find the setup of `fixtures/monorepo` as weird. Monorepo's package.json list a dependency on `@loopback/build` via `file:` version spec, but we are never running `npm install` there. I think `fixtures/monorepo` scripts are somehow managing to access `@loopback/build` that's linked in `packages/tsdocs/node_modules`, which works when the scripts are invoked via `npm run` executed from `packages/tsdocs`, but (most likely) not when executed directly from `fixtures/monorepo`.

In this pull request, I am proposing two changes:

1. Simplify `run-lerna` script to simply load lerna's `cli.js`, there is no need to spawn another process. I hope this may fix the problems encountered by RenovateBot (see #5796 and #5797).

2. Reorganize `fixtures/monorepo`-related artifacts and move custom npm scripts to `packages/tsdocs`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
