### PR TITLE
cli: add a test suite for snapshot-matcher + improve debug logs

### DIFF
--- a/packages/cli/snapshots/integration/snapshot-matcher/suite-first-run.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/snapshot-matcher/suite-first-run.integration.snapshots.js
@@ -1,0 +1,17 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`snapshot-matcher first case matches snapshot 1`] = `
+first case
+`;
+
+
+exports[`snapshot-matcher first case shared test matches snapshot 1`] = `
+common result
+`;

--- a/packages/cli/snapshots/integration/snapshot-matcher/suite-second-run.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/snapshot-matcher/suite-second-run.integration.snapshots.js
@@ -1,0 +1,17 @@
+// IMPORTANT
+// This snapshot file is auto-generated, but designed for humans.
+// It should be checked into source control and tracked carefully.
+// Re-generate by setting UPDATE_SNAPSHOTS=1 and running tests.
+// Make sure to inspect the changes in the snapshots below.
+// Do not ignore changes!
+
+'use strict';
+
+exports[`snapshot-matcher second case matches snapshot 1`] = `
+second case
+`;
+
+
+exports[`snapshot-matcher second case shared test matches snapshot 1`] = `
+common result
+`;

--- a/packages/cli/test/integration/snapshot-matcher/common.suite.js
+++ b/packages/cli/test/integration/snapshot-matcher/common.suite.js
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+// A shared test suite executed by "suite-first-run.integration.js"
+// and "suite-second-run.integration.js"
+const {expectToMatchSnapshot} = require('../../snapshots');
+
+/**
+ * Execute this method from inside a `describe()` block in your test file.
+ */
+exports.commonTestSuite = function () {
+  describe('shared test', () => {
+    it('matches snapshot', function () {
+      expectToMatchSnapshot('common result');
+    });
+  });
+};

--- a/packages/cli/test/integration/snapshot-matcher/suite-first-run.integration.js
+++ b/packages/cli/test/integration/snapshot-matcher/suite-first-run.integration.js
@@ -1,0 +1,17 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const {expectToMatchSnapshot} = require('../../snapshots');
+const {commonTestSuite} = require('./common.suite');
+
+describe('snapshot-matcher first case', () => {
+  commonTestSuite();
+
+  it('matches snapshot', () => {
+    expectToMatchSnapshot('first case');
+  });
+});

--- a/packages/cli/test/integration/snapshot-matcher/suite-second-run.integration.js
+++ b/packages/cli/test/integration/snapshot-matcher/suite-second-run.integration.js
@@ -1,0 +1,17 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: @loopback/cli
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+const {expectToMatchSnapshot} = require('../../snapshots');
+const {commonTestSuite} = require('./common.suite');
+
+describe('snapshot-matcher second case', () => {
+  commonTestSuite();
+
+  it('matches snapshot', () => {
+    expectToMatchSnapshot('second case');
+  });
+});


### PR DESCRIPTION
- add debug logs to snapshot-matcher to make it easier to troubleshoot snapshot-matcher related problems,
especially when running the tests in parallel.
- add a test suite with a shared test suite to verify snapshot-matcher's support for this advanced test organization. This scenario is tricky to get right when running tests in parallel.

Extracted from #5724

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
