### PR TITLE
feat: coerce query object with schema

### DIFF
--- a/packages/rest/src/__tests__/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/coercion/coercion.acceptance.ts
@@ -27,6 +27,21 @@ describe('Coercion', () => {
     if (spy) spy.restore();
   });
 
+  const filterSchema = {
+    type: 'object',
+    title: 'filter',
+    properties: {
+      where: {
+        type: 'object',
+        properties: {
+          id: {type: 'number'},
+          name: {type: 'string'},
+          active: {type: 'boolean'},
+        },
+      },
+    },
+  };
+
   class MyController {
     @get('/create-number-from-path/{num}')
     createNumberFromPath(@param.path.number('num') num: number) {
@@ -49,7 +64,14 @@ describe('Coercion', () => {
     }
 
     @get('/object-from-query')
-    getObjectFromQuery(@param.query.object('filter') filter: object) {
+    getObjectFromQuery(
+      @param.query.object('filter', filterSchema) filter: object,
+    ) {
+      return filter;
+    }
+
+    @get('/random-object-from-query')
+    getRandomObjectFromQuery(@param.query.object('filter') filter: object) {
       return filter;
     }
   }
@@ -84,6 +106,8 @@ describe('Coercion', () => {
   });
 
   it('coerces parameter in query from nested keys to object', async () => {
+    // Notice that numeric and boolean values are coerced to their own types
+    // because the schema is provided.
     spy = sinon.spy(MyController.prototype, 'getObjectFromQuery');
     await client
       .get('/object-from-query')
@@ -94,9 +118,28 @@ describe('Coercion', () => {
       })
       .expect(200);
     sinon.assert.calledWithExactly(spy, {
-      // Notice that numeric and boolean values are converted to strings.
-      // This is because all values are encoded as strings on URL queries
-      // and we did not specify any schema in @param.query.object() decorator.
+      where: {
+        id: 1,
+        name: 'Pen',
+        active: true,
+      },
+    });
+  });
+
+  it('coerces parameter in query from nested keys to object - no schema', async () => {
+    // Notice that numeric and boolean values are converted to strings.
+    // This is because all values are encoded as strings on URL queries
+    // and we did not specify any schema in @param.query.object() decorator.
+    spy = sinon.spy(MyController.prototype, 'getRandomObjectFromQuery');
+    await client
+      .get('/random-object-from-query')
+      .query({
+        'filter[where][id]': 1,
+        'filter[where][name]': 'Pen',
+        'filter[where][active]': true,
+      })
+      .expect(200);
+    sinon.assert.calledWithExactly(spy, {
       where: {
         id: '1',
         name: 'Pen',

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -83,7 +83,7 @@ async function buildOperationArguments(
     }
     const spec = paramSpec as ParameterObject;
     const rawValue = getParamFromRequest(spec, request, pathParams);
-    const coercedValue = coerceParameter(rawValue, spec);
+    const coercedValue = await coerceParameter(rawValue, spec);
     paramArgs.push(coercedValue);
   }
 

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -109,6 +109,17 @@ export type AjvKeyword = KeywordDefinition & {name: string};
 export type AjvFormat = FormatDefinition & {name: string};
 
 /**
+ * Options for any value validation using AJV
+ */
+export interface ValueValidationOptions extends RequestBodyValidationOptions {
+  /**
+   * Where the data comes from. It can be 'body', 'path', 'header',
+   * 'query', 'cookie', etc...
+   */
+  source?: string;
+}
+
+/**
  * Options for request body validation using AJV
  */
 export interface RequestBodyValidationOptions extends ajv.Options {


### PR DESCRIPTION
Connect to #4992 

Filter with non-string properties like `?filter[fields][name]=false` are not coerced, so `false` turns to be `'false'`. This PR applies coercion for parameter query.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
