### PR TITLE
test: enable parallel execution of Mocha tests

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -6,8 +6,12 @@
 const {mergeMochaConfigs} = require('./packages/build');
 const defaultConfig = require('./packages/build/config/.mocharc.json');
 
+const MONOREPO_CONFIG = {
+};
+
 module.exports = mergeMochaConfigs(
   defaultConfig,
+  MONOREPO_CONFIG,
   // Apply Mocha config from packages that require custom Mocha setup
   require('./packages/cli/.mocharc.js'),
 );

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -7,6 +7,7 @@ const {mergeMochaConfigs} = require('./packages/build');
 const defaultConfig = require('./packages/build/config/.mocharc.json');
 
 const MONOREPO_CONFIG = {
+  parallel: true,
 };
 
 module.exports = mergeMochaConfigs(

--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -142,7 +142,7 @@ npm test
 
 It does all you need:
 
-- Compile TypeScript
+- Compile TypeScript (full rebuild)
 - Run all tests
 - Check code formatting using [Prettier](https://prettier.io/)
 - Lint the code using [ESLint](https://typescript-eslint.io/)
@@ -159,6 +159,40 @@ Or use a simpler form on Mac and Linux.
 
 ```sh
 CI=1 npm test
+```
+
+Running the full test suite after each small change is not very effective. You
+can use the following commands to run a subset of checks:
+
+- `npm run build` for a fast incremental build
+- `npm run mocha` to (re)run the test suite
+
+We are running tests in parallel, use the Mocha option `-j` (`--jobs`) to
+control the number of worker processes or disable parallel execution entirely by
+using a single job only:
+
+```
+$ npm run mocha -- -j 1
+```
+
+When working in a single package, it's possible to limit the compilation to this
+package & its dependencies and then run only package tests.
+
+For example, run the following Unix command in `loopback-next` root directory to
+build and test changes made in `@loopback/rest` only:
+
+```
+$ (cd packages/rest && npm t)
+```
+
+On Windows, you have to change the working directory once and then you can
+repeatedly run `npm t` inside the package.
+
+```bat
+rem Run this only once
+cd packages/rest
+rem Run this to build & test your changes
+npm t
 ```
 
 ## Coding rules

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "build:site": "./bin/build-docs-site.sh",
     "docs:prepare": "./docs/bin/build-preview-site.sh",
     "docs:start": "cd docs/_preview && bundle exec jekyll serve --no-w --i",
-    "mocha": "node packages/build/bin/run-mocha --lang en_US.UTF-8 --timeout 5000 \"packages/*/dist/__tests__/**/*.js\" \"extensions/*/dist/__tests__/**/*.js\" \"examples/*/dist/__tests__/**/*.js\" \"packages/cli/test/**/*.js\" \"packages/build/test/*/*.js\"",
+    "mocha": "node packages/build/bin/run-mocha --lang en_US.UTF-8 \"packages/*/dist/__tests__/**/*.js\" \"extensions/*/dist/__tests__/**/*.js\" \"examples/*/dist/__tests__/**/*.js\" \"packages/cli/test/**/*.js\" \"packages/build/test/*/*.js\"",
     "posttest": "npm run lint"
   },
   "config": {

--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -49,7 +49,10 @@ describe('cli', () => {
     expect(entries).to.not.containEql('Available commands:');
   });
 
-  it('saves command metadata to .yo-rc.json', () => {
+  it('saves command metadata to .yo-rc.json', function () {
+    // This test can be slow under parallel mode
+    // eslint-disable-next-line @typescript-eslint/no-invalid-this
+    this.timeout(15000);
     const entries = [];
     main({meta: true}, getLog(entries));
     const logs = entries.join('');


### PR DESCRIPTION
- move Mocha flags from CLI args to config file 
- enable parallel execution of Mocha tests  by adding `parallel: true` to monorepo's root mocha config
- update DEVELOPING.md to mention parallel execution and to show how to run tests in series

This pull request supersedes #5011. I am intentionally keeping this change small and enabling parallel test execution only when the tests are executed for the entire monorepo. We can discuss further improvements after this pull request is landed. (E.g. which packages should run tests in parallel when running `npm t` from their package directory. At the moment, users can opt into parallel execution via `npm t -- -p`).

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
