### PR TITLE
docs: add "alumni" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,27 +98,37 @@ See [SECURITY.md](SECURITY.md) for more details.
 
 ### Project Architects
 
-|                  Raymond Feng                   |            Miroslav Bajtos            |           Ritchie Martori           |
-| :---------------------------------------------: | :-----------------------------------: | :---------------------------------: |
-| [![raymondfeng]](http://github.com/raymondfeng) | [![bajtos]](http://github.com/bajtos) | [![ritch]](http://github.com/ritch) |
+|                  Raymond Feng                   |            Miroslav Bajtoš            |     |
+| :---------------------------------------------: | :-----------------------------------: | :-: |
+| [![raymondfeng]](http://github.com/raymondfeng) | [![bajtos]](http://github.com/bajtos) |     |
 
 ### Project Maintainers
 
-|                                                  |                                                            |                                                  |
-| :----------------------------------------------: | :--------------------------------------------------------: | :----------------------------------------------: |
-|                    Diana Lau                     |                         Janny Hou                          |                    Hage Yaapa                    |
-|      [![dhmlau]](http://github.com/dhmlau)       |         [![jannyhou]](http://github.com/jannyHou)          | [![hacksparrow]](https://github.com/hacksparrow) |
-|                 Nora Abdelgadir                  |                       Mario Estrada                        |                   Hugo Da Roit                   |
-| [![nabdelgadir]](https://github.com/nabdelgadir) | [![marioestradarosa]](https://github.com/marioestradarosa) |        [![yaty]](https://github.com/yaty)        |
-|                 Dominique Emond                  |                         Agnes Lin                          |                 Deepak Rajamohan                 |
-|     [![emonddr]](https://github.com/emonddr)     |         [![agnes512]](https://github.com/agnes512)         | [![deepakrkris]](https://github.com/deepakrkris) |
-|                  Denny Bartelt                   |                    Douglas McConnachie                     |                  Rifa Achrinza                   |
-|     [![derdeka]](https://github.com/derdeka)     |         [![dougal83]](https://github.com/dougal83)         |    [![achrinza]](https://github.com/achrinza)    |
-|                 Francisco Buceta                 |                       Matthew Schnee                       |                                                  |
-|    [![frbuceta]](https://github.com/frbuceta)    |          [![mschnee]](https://github.com/mschnee)          |                                                  |
+|                                            |                                                            |                                                  |
+| :----------------------------------------: | :--------------------------------------------------------: | :----------------------------------------------: |
+|                 Diana Lau                  |                         Janny Hou                          |                    Hage Yaapa                    |
+|   [![dhmlau]](http://github.com/dhmlau)    |         [![jannyhou]](http://github.com/jannyHou)          | [![hacksparrow]](https://github.com/hacksparrow) |
+|                 Agnes Lin                  |                       Mario Estrada                        |                   Hugo Da Roit                   |
+| [![agnes512]](https://github.com/agnes512) | [![marioestradarosa]](https://github.com/marioestradarosa) |        [![yaty]](https://github.com/yaty)        |
+|              Dominique Emond               |                       Denny Bartelt                        |               Douglas McConnachie                |
+|  [![emonddr]](https://github.com/emonddr)  |          [![derdeka]](https://github.com/derdeka)          |    [![dougal83]](https://github.com/dougal83)    |
+|               Rifa Achrinza                |                      Francisco Buceta                      |                  Matthew Schnee                  |
+| [![achrinza]](https://github.com/achrinza) |         [![frbuceta]](https://github.com/frbuceta)         |     [![mschnee]](https://github.com/mschnee)     |  |
 
 See
 [all contributors](https://github.com/strongloop/loopback-next/graphs/contributors).
+
+### Alumni
+
+- [@ritch](http://github.com/ritch)
+- [@superkhau](https://github.com/superkhau)
+- [@rashmihunt](https://github.com/rashmihunt)
+- [@kjdelisle](https://github.com/kjdelisle)
+- [@virkt25](https://github.com/virkt25)
+- [@shimks](https://github.com/shimks)
+- [@b-admike](https://github.com/b-admike)
+- [@nabdelgadir](https://github.com/nabdelgadir)
+- [@deepakrkris](https://github.com/deepakrkris)
 
 ## License
 


### PR DESCRIPTION
I hope I listed everybody who used to be a maintainer at some point in the past 🤞 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
