### PR TITLE
docs: Incorrect link to using components from creating components

### DIFF
--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -6,8 +6,8 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/Creating-components.html
 ---
 
-As explained in [Using Components](Using-components.md), a typical LoopBack
-component is an npm package exporting a Component class.
+As explained in [Using Components](Components.md), a typical LoopBack component
+is an npm package exporting a Component class.
 
 ```ts
 import {MyController} from './controllers/my.controller';


### PR DESCRIPTION
`Using-components.md` doesn't exist.
I changed the link to `components.md` instead, which is where I assume the link was supposed to take me.


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈
(I'm unable to sign the license agreement currently. I will keep retrying, otherwise feel free for someone else to just make this change)

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
