### PR TITLE
feat(rest): expose types from strong-error-handler

### DIFF
--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -21,6 +21,12 @@
  */
 
 export * from '@loopback/openapi-v3';
+export {
+  ErrorHandlerOptions,
+  ErrorWriterOptions,
+  StrongErrorHandler,
+  writeErrorToResponse,
+} from 'strong-error-handler';
 export * from './body-parsers';
 export * from './http-handler';
 export * from './keys';


### PR DESCRIPTION
Some of the public APIs use strong-error-handler types. This PR makes it
easy to override/customize RejectProvider.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
