### PR TITLE
fix(mock-oauth2-provider): reset publish status

### DIFF
--- a/fixtures/mock-oauth2-provider/package.json
+++ b/fixtures/mock-oauth2-provider/package.json
@@ -5,7 +5,6 @@
   "engines": {
     "node": ">=10.16"
   },
-  "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
See the error mentioned in https://github.com/strongloop/loopback-next/issues/5573#issuecomment-649046288

npm still has 0.1.0 for `@loopback/mock-oauth2-provider`

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
