### PR TITLE
fix: ensure delete only applies to optional properties

### DIFF
--- a/examples/rest-crud/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/rest-crud/src/__tests__/acceptance/todo.acceptance.ts
@@ -41,7 +41,7 @@ describe('TodoApplication', () => {
   });
 
   it('rejects requests to create a todo with no title', async () => {
-    const todo = givenTodo();
+    const todo: Partial<Todo> = givenTodo();
     delete todo.title;
     await client.post('/todos').send(todo).expect(422);
   });

--- a/examples/todo-list/src/__tests__/acceptance/todo-list-image.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-image.acceptance.ts
@@ -44,7 +44,7 @@ describe('TodoListApplication', () => {
   });
 
   it('creates image for a todoList', async () => {
-    const todoListImage = givenTodoListImage();
+    const todoListImage: Partial<TodoListImage> = givenTodoListImage();
     delete todoListImage.todoListId;
     const response = await client
       .post(`/todo-lists/${persistedTodoList.id}/image`)
@@ -94,7 +94,7 @@ describe('TodoListApplication', () => {
     id: typeof TodoList.prototype.id,
     todoListImage?: Partial<TodoListImage>,
   ) {
-    const data = givenTodoListImage(todoListImage);
+    const data: Partial<TodoListImage> = givenTodoListImage(todoListImage);
     delete data.todoListId;
     return todoListRepo.image(id).create(data);
   }

--- a/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list-todo.acceptance.ts
@@ -235,7 +235,7 @@ describe('TodoListApplication', () => {
     id: typeof Todo.prototype.id,
     todo?: Partial<Todo>,
   ) {
-    const data = givenTodo(todo);
+    const data: Partial<Todo> = givenTodo(todo);
     delete data.todoListId;
     return todoListRepo.todos(id).create(data);
   }

--- a/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
@@ -47,7 +47,7 @@ describe('TodoListApplication', () => {
   });
 
   it('rejects requests to create a todo with no title', async () => {
-    const todo = givenTodo();
+    const todo: Partial<Todo> = givenTodo();
     delete todo.title;
     await client.post('/todos').send(todo).expect(422);
   });

--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -74,7 +74,7 @@ describe('TodoApplication', () => {
   });
 
   it('rejects requests to create a todo with no title', async () => {
-    const todo = givenTodo();
+    const todo: Partial<Todo> = givenTodo();
     delete todo.title;
     await client.post('/todos').send(todo).expect(422);
   });

--- a/packages/repository/src/__tests__/unit/model/model.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/model.unit.ts
@@ -85,7 +85,7 @@ describe('model', () => {
   class Customer extends Entity {
     static definition = customerDef;
     id: string;
-    email: string;
+    email?: string;
     firstName: string;
     lastName: string;
     createdAt?: Date;

--- a/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/routing/routing.acceptance.ts
@@ -486,7 +486,7 @@ describe('Routing', () => {
     const app = givenAnApplication();
     const server = await givenAServer(app);
     const spec = anOpenApiSpec().build();
-    delete spec.paths;
+    spec.paths = {};
     server.api(spec);
   });
 


### PR DESCRIPTION
TypeScript 4.x reports errors for `delete x.y` if `y` is not optional

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
