### PR TITLE
fix: broken link in sidebar

### DIFF
--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -125,7 +125,7 @@ children:
     output: 'web, pdf'
 
   - title: 'How to secure your LoopBack 4 application with JWT authentication'
-    url: Authentication-Tutorial.html
+    url: Authentication-tutorial.html
     output: 'web, pdf'
 
   - title: 'Build large scale Node.js projects with LoopBack 4'


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

The link https://loopback.io/doc/en/lb4/Authentication-Tutorial.html doesn't exist, it should be https://loopback.io/doc/en/lb4/Authentication-tutorial.html. There are 2 occurrences in the sidebar, we probably fixed one of them last time. 


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
