### PR TITLE
fix(boot): generate unique binding keys for component application booters

### DIFF
--- a/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
+++ b/packages/boot/src/__tests__/acceptance/component-application.booter.acceptance.ts
@@ -67,6 +67,17 @@ describe('component application booter acceptance tests', () => {
     expect(current).to.be.exactly(lockedBinding);
   });
 
+  it('creates binding key based on application name', () => {
+    const binding = createComponentApplicationBooterBinding(app);
+    expect(binding.key).to.eql(`booters.${app.name}`);
+  });
+
+  it('creates unique bindings for different applications', () => {
+    const binding1 = createComponentApplicationBooterBinding(new BooterApp());
+    const binding2 = createComponentApplicationBooterBinding(new BooterApp());
+    expect(binding1.key).to.not.eql(binding2.key);
+  });
+
   class MainApp extends BootMixin(Application) {
     constructor() {
       super();

--- a/packages/boot/src/booters/component-application.booter.ts
+++ b/packages/boot/src/booters/component-application.booter.ts
@@ -119,5 +119,6 @@ export function createComponentApplicationBooterBinding(
 ) {
   return createBindingFromClass(
     createBooterForComponentApplication(componentApp, filter),
+    {key: `booters.${componentApp.name}`},
   );
 }


### PR DESCRIPTION
Before this PR, the following calls will override each other as they have the same binding key:

```
createComponentApplicationBooterBinding(subApp1);
createComponentApplicationBooterBinding(subApp2);
```

The fix uses application name to build the binding key to avoid conflicts.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
