### PR TITLE
fix(docs): fix typo in guide command

### DIFF
--- a/docs/site/exposing-graphql-apis.md
+++ b/docs/site/exposing-graphql-apis.md
@@ -45,7 +45,7 @@ todo-application as the parameter, start up the server by running the following
 command:
 
 ```sh
-npx openapi-to-graphql --port=3001 http://localhost:3000/openapi.json
+npx openapi-to-graphql-cli --port=3001 http://localhost:3000/openapi.json
 ```
 
 _Haven't heard about `npx` yet? It's a cool helper provided by `npm` and


### PR DESCRIPTION
## Checklist

- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated

---

I hit an error while running through the sample commands. I believe that `openapi-to-graphql` should be `openapi-to-graphql-cli`.


```bash
$ npx openapi-to-graphql --port=3001 http://localhost:3000/openapi.json

command not found: openapi-to-graphql
```