### PR TITLE
fix: globalize strings for repository generator

### DIFF
--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -38,7 +38,7 @@ const CLI_BASE_KEY_VALUE_REPOSITORIES = [
 const CLI_BASE_SEPARATOR = [
   {
     type: 'separator',
-    line: '----- Custom Repositories -----',
+    line: g.f('----- Custom Repositories -----'),
   },
 ];
 

--- a/packages/cli/intl/en/messages.json
+++ b/packages/cli/intl/en/messages.json
@@ -42,6 +42,7 @@
   "44d2743e9d8e6106410b7fea1fcb69a0": "An example extension project for LoopBack 4.",
   "4670d311aa36fb13d626ec4ab55d4f19": "Next steps:",
   "48b75482f8e08e012b70a495df71d514": "Mark the project private (excluded from npm publish)",
+  "4a33ae949b2b741e075c445df3cca1d7": "----- Custom Repositories -----",
   "4b1516463cdea3b248eeb97ac4948198": "Allow additional (free-form) properties?",
   "4d8a9b728bee844a0a6647379ab86826": "Let's add a property to {0}",
   "5225c88650d6a337fb4c215cca812f96": "An access control example migrated from the LoopBack 3 repository loopback-example-access-control.",


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
fixes #5656 

Only `custom repository` was not being translated.

<img width="550" alt="截圖 2020-07-08 下午1 36 59" src="https://user-images.githubusercontent.com/50331796/86951873-1b56a980-c120-11ea-97ac-2c4edf758755.png">

![image](https://user-images.githubusercontent.com/50331796/86951717-e77b8400-c11f-11ea-9aa1-2164f59ef2a2.png)


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
