### PR TITLE
fix: nested scope filter

### DIFF
--- a/docs/site/Include-filter.md
+++ b/docs/site/Include-filter.md
@@ -64,6 +64,38 @@ You can also use
 [stringified JSON format](Querying-data.md#using-stringified-json-in-rest-queries) in
 a REST query.
 
+#### Scope Filter
+
+Please note if the scope filter contains non-string data, they won't be coerced
+if you use the plain query. Only the stringified JSON format works as expected.
+
+For example, the following REST query which includes related `users` without
+their names:
+
+`/modelName?filter[include][0][relation]=users&filter[include][0][scope][fields][name]=false`
+
+won't hide the `name` field for `users`, because `false` is a boolean value. It
+won't be coerced and will present as a string when passed to the controller
+function.
+
+A solution is to use the stringified JSON query instead to include data with
+scope specified:
+
+```ts
+// Define the inclusion filter and get its encoded format
+const inclusionFilter = {
+  include: {
+    relation: 'users',
+    scope: {
+      fields: {name: false},
+    },
+  },
+};
+const encodedFilter = encodeURIComponent(JSON.stringify(filter));
+```
+
+and call `/modelName?filter=<encodedFilter>`
+
 ### Examples
 
 - Return all customers with their orders:

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -21,6 +21,15 @@ export interface FilterSchemaOptions {
   exclude?: string[] | string;
 }
 
+export const AnyScopeFilterSchema: JsonSchema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {},
+    additionalProperties: true,
+  },
+};
+
 /**
  * Build a JSON schema describing the format of the "scope" object
  * used to query model instances.
@@ -38,12 +47,17 @@ export function getScopeFilterJsonSchemaFor(
   class EmptyModel extends Model {}
 
   const schema: JsonSchema = {
-    ...getFilterJsonSchemaFor(EmptyModel, {setTitle: false}),
+    ...getFilterJsonSchemaFor(EmptyModel, {
+      setTitle: false,
+    }),
     ...(options.setTitle !== false && {
       title: `${modelCtor.modelName}.ScopeFilter`,
     }),
   };
 
+  // To include nested models, we need to hard-code the inclusion
+  // filter schema for EmptyModel to allow any object query.
+  schema.properties!.include = {...AnyScopeFilterSchema};
   return schema;
 }
 


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/5872

Nested inclusion filter like 

```ts
{
  include: [{
    relation: 'todos',
    scope: {
      // after enabling coercion against spec schema in PR 
      // https://github.com/strongloop/loopback-next/pull/5808
      // it breaks cuz scope schema doesn't have property include.
      include: [{
        relation: 'someOtherRelation',
      }]
    }
  }]
}
```

Fails. Because the `scope` schema is generated from `EmptyModel`, which doesn't have a relation:

https://github.com/strongloop/loopback-next/blob/683e162de982acde34b45101383a5d69cf1c0df1/packages/repository-json-schema/src/filter-json-schema.ts#L38

and thus does not have `include` generated in its `properties`:

https://github.com/strongloop/loopback-next/blob/683e162de982acde34b45101383a5d69cf1c0df1/packages/repository-json-schema/src/filter-json-schema.ts#L118-L120

This PR adds an any inclusion schema for the empty model's scope filter schema.


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
