### PR TITLE
test: improve fix for eslint no-invalid-this

### DIFF
--- a/packages/cli/test/integration/cli/cli.integration.js
+++ b/packages/cli/test/integration/cli/cli.integration.js
@@ -49,9 +49,8 @@ describe('cli', () => {
     expect(entries).to.not.containEql('Available commands:');
   });
 
-  it('saves command metadata to .yo-rc.json', function () {
+  it('saves command metadata to .yo-rc.json', /** @this {Mocha.Context} */ function () {
     // This test can be slow under parallel mode
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this
     this.timeout(15000);
     const entries = [];
     main({meta: true}, getLog(entries));


### PR DESCRIPTION
Instead of supressing the linter check, use a jsdoc-style comment to provide type information about `this` value.

See https://github.com/strongloop/loopback-next/pull/5831

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
