### PR TITLE
feat(cli): remove openapi-v3 from project template dependencies

### DIFF
--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -75,7 +75,6 @@
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
 <% if (project.projectType === 'application') { -%>
-    "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
 <% if (project.repositories) { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
 <% } -%>

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -75,7 +75,6 @@
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
 <% if (project.projectType === 'application') { -%>
-    "@loopback/openapi-v3": "<%= project.dependencies['@loopback/openapi-v3'] -%>",
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
 <% if (project.apiconnect) { -%>
     "@loopback/apiconnect": "<%= project.dependencies['@loopback/apiconnect'] -%>",

--- a/packages/cli/test/integration/lib/project-generator.js
+++ b/packages/cli/test/integration/lib/project-generator.js
@@ -281,10 +281,6 @@ module.exports = function (projGenerator, props, projectType) {
             'package.json',
             `"@loopback/rest": "${deps['@loopback/rest']}"`,
           );
-          assert.fileContent(
-            'package.json',
-            `"@loopback/openapi-v3": "${deps['@loopback/openapi-v3']}"`,
-          );
           assert.jsonFileContent('package.json', {
             scripts: {
               prestart: 'npm run build',


### PR DESCRIPTION
See #5692. This pull request changes the project template only, I'll be updating documentation files later (but still as part of #5692).

It is safe to remove `@loopback/openapi-v3` from the template, because we are not importing from that package in any other CLI templates. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
