### PR TITLE
feat: remove openapi-v3 from apiconnect dependencies

### DIFF
--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -40,13 +40,12 @@
   },
   "dependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
+    "@loopback/rest": "^5.2.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
     "@loopback/eslint-config": "^8.0.3",
-    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27"
   }

--- a/extensions/apiconnect/src/apiconnect.spec-enhancer.ts
+++ b/extensions/apiconnect/src/apiconnect.spec-enhancer.ts
@@ -10,7 +10,7 @@ import {
   CoreBindings,
   inject,
 } from '@loopback/core';
-import {asSpecEnhancer, OASEnhancer, OpenAPIObject} from '@loopback/openapi-v3';
+import {asSpecEnhancer, OASEnhancer, OpenAPIObject} from '@loopback/rest';
 
 /**
  * Configuration for IBM API Connect extensions to the OpenAPI spec

--- a/extensions/apiconnect/tsconfig.json
+++ b/extensions/apiconnect/tsconfig.json
@@ -14,9 +14,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/rest/tsconfig.json"
     },
     {


### PR DESCRIPTION
Use `@loopback/rest` to access openapi-related types and helpers.

This pull request is a part of #5692.

~~BREAKING CHANGE: `@loopback/core` and `@loopback/rest` were moved to peer dependencies, to ensure the extension uses application's version of these modules. If this change breaks your application (which is unlikely), then simply add both `@loopback/core` and `@loopback/rest` to your project dependencies.~~

~~_I am observing timeouts when running the tests locally (even on master), I think they are not related to my changes and will rely on CI builds to confirm._~~

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
