### PR TITLE
refactor: remove `@loopback/openapi-v3` from dependencies

### DIFF
--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -43,7 +43,6 @@
     "@loopback/authorization": "^0.6.2",
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/access-control-migration/src/components/jwt-authentication/services/security.spec.ts
+++ b/examples/access-control-migration/src/components/jwt-authentication/services/security.spec.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {SecuritySchemeObject, ReferenceObject} from '@loopback/openapi-v3';
+import {SecuritySchemeObject, ReferenceObject} from '@loopback/rest';
 
 export const OPERATION_SECURITY_SPEC = [{jwt: []}];
 export type SecuritySchemeObjects = {

--- a/examples/access-control-migration/tsconfig.json
+++ b/examples/access-control-migration/tsconfig.json
@@ -27,9 +27,6 @@
       "path": "../../packages/http-caching-proxy/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/express-composition/package.json
+++ b/examples/express-composition/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/express-composition/tsconfig.json
+++ b/examples/express-composition/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",
     "multer": "^1.4.2",

--- a/examples/file-transfer/tsconfig.json
+++ b/examples/file-transfer/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/rest-explorer/tsconfig.json"
     },
     {

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",
     "tslib": "^2.0.0"

--- a/examples/greeter-extension/tsconfig.json
+++ b/examples/greeter-extension/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/testlab/tsconfig.json"
     }
   ]

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -59,7 +59,6 @@
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
     "@loopback/example-greeter-extension": "^2.1.5",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/rest": "^5.2.0",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",

--- a/examples/greeting-app/tsconfig.json
+++ b/examples/greeting-app/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/rest/tsconfig.json"
     },
     {

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -54,7 +54,6 @@
   },
   "dependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/rest": "^5.2.0",
     "chalk": "^4.1.0",
     "debug": "^4.1.1",

--- a/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
+++ b/examples/log-extension/src/__tests__/acceptance/log.extension.acceptance.ts
@@ -4,10 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {inject} from '@loopback/core';
-import {get, param} from '@loopback/openapi-v3';
 import {
+  get,
   FindRoute,
   InvokeMethod,
+  param,
   ParseParams,
   Reject,
   RequestContext,

--- a/examples/log-extension/tsconfig.json
+++ b/examples/log-extension/tsconfig.json
@@ -15,9 +15,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/rest/tsconfig.json"
     },
     {

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/multi-tenancy/tsconfig.json
+++ b/examples/multi-tenancy/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/passport-login/package.json
+++ b/examples/passport-login/package.json
@@ -42,7 +42,6 @@
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
     "@loopback/mock-oauth2-provider": "^0.1.3",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-crud": "^0.8.9",

--- a/examples/passport-login/tsconfig.json
+++ b/examples/passport-login/tsconfig.json
@@ -31,9 +31,6 @@
       "path": "../../packages/http-caching-proxy/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-crud": "^0.8.9",

--- a/examples/rest-crud/tsconfig.json
+++ b/examples/rest-crud/tsconfig.json
@@ -21,9 +21,6 @@
       "path": "../../packages/http-caching-proxy/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/soap-calculator/tsconfig.json
+++ b/examples/soap-calculator/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -43,7 +43,6 @@
     "@loopback/authentication-jwt": "^0.4.3",
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/todo-jwt/tsconfig.json
+++ b/examples/todo-jwt/tsconfig.json
@@ -27,9 +27,6 @@
       "path": "../../packages/http-caching-proxy/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/todo-list/tsconfig.json
+++ b/examples/todo-list/tsconfig.json
@@ -21,9 +21,6 @@
       "path": "../../packages/http-caching-proxy/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/todo/tsconfig.json
+++ b/examples/todo/tsconfig.json
@@ -21,9 +21,6 @@
       "path": "../../packages/http-caching-proxy/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@loopback/boot": "^2.3.5",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/repository": "^2.9.0",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",

--- a/examples/validation-app/tsconfig.json
+++ b/examples/validation-app/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@loopback/authentication": "^4.2.9",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-explorer": "^2.2.6",
     "@loopback/security": "^0.2.14",

--- a/extensions/authentication-jwt/src/services/security.spec.enhancer.ts
+++ b/extensions/authentication-jwt/src/services/security.spec.enhancer.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/openapi-v3
+// Node module: @loopback/authentication-jwt"
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
@@ -11,7 +11,7 @@ import {
   OpenApiSpec,
   ReferenceObject,
   SecuritySchemeObject,
-} from '@loopback/openapi-v3';
+} from '@loopback/rest';
 import debugModule from 'debug';
 import {inspect} from 'util';
 const debug = debugModule('loopback:jwt-extension:spec-enhancer');

--- a/extensions/authentication-jwt/tsconfig.json
+++ b/extensions/authentication-jwt/tsconfig.json
@@ -21,9 +21,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@loopback/authentication": "^4.2.9",
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/rest": "^5.2.0",
     "@loopback/security": "^0.2.14",
     "passport": "^0.4.1",

--- a/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
+++ b/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-adapter.acceptance.ts
@@ -13,11 +13,12 @@ import {
   UserProfileFactory,
   USER_PROFILE_NOT_FOUND,
 } from '@loopback/authentication';
-import {inject, addExtension, CoreTags, Provider} from '@loopback/core';
+import {addExtension, CoreTags, inject, Provider} from '@loopback/core';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
-import {api, get} from '@loopback/openapi-v3';
 import {
+  api,
   FindRoute,
+  get,
   InvokeMethod,
   ParseParams,
   Reject,

--- a/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-oauth2-adapter.acceptance.ts
+++ b/extensions/authentication-passport/src/__tests__/acceptance/authentication-with-passport-strategy-oauth2-adapter.acceptance.ts
@@ -10,8 +10,7 @@ import {
   MyUser,
   userRepository,
 } from '@loopback/mock-oauth2-provider';
-import {get} from '@loopback/openapi-v3';
-import {Response, RestApplication, RestBindings} from '@loopback/rest';
+import {get, Response, RestApplication, RestBindings} from '@loopback/rest';
 import {SecurityBindings, securityId, UserProfile} from '@loopback/security';
 import {
   Client,

--- a/extensions/authentication-passport/tsconfig.json
+++ b/extensions/authentication-passport/tsconfig.json
@@ -23,9 +23,6 @@
       "path": "../../packages/openapi-spec-builder/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/rest/tsconfig.json"
     },
     {

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -25,7 +25,6 @@
     "@loopback/build": "^5.4.3",
     "@loopback/eslint-config": "^8.0.1",
     "@loopback/repository": "^2.7.0",
-    "@loopback/rest": "^5.1.1",
     "@loopback/testlab": "^3.1.7",
     "@types/json-schema": "^7.0.5",
     "@types/node": "^10.17.27",
@@ -34,7 +33,7 @@
   "dependencies": {
     "@loopback/boot": "^2.3.3",
     "@loopback/core": "^2.8.0",
-    "@loopback/openapi-v3": "^3.4.3",
+    "@loopback/rest": "^5.1.1",
     "tslib": "^2.0.0",
     "typeorm": "^0.2.25"
   },

--- a/extensions/typeorm/src/typeorm.utils.ts
+++ b/extensions/typeorm/src/typeorm.utils.ts
@@ -3,11 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {
-  JsonSchemaOptions,
-  ReferenceObject,
-  SchemaObject,
-} from '@loopback/openapi-v3';
+import {JsonSchemaOptions, ReferenceObject, SchemaObject} from '@loopback/rest';
 import debugFactory from 'debug';
 import {getMetadataArgsStorage} from 'typeorm';
 import {ColumnType} from 'typeorm/driver/types/ColumnTypes';

--- a/extensions/typeorm/tsconfig.json
+++ b/extensions/typeorm/tsconfig.json
@@ -17,9 +17,6 @@
       "path": "../../packages/core/tsconfig.json"
     },
     {
-      "path": "../../packages/openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../../packages/repository/tsconfig.json"
     },
     {

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/rest": "^5.2.0",
     "@loopback/security": "^0.2.14",
     "@types/express": "^4.17.7",

--- a/packages/authentication/src/__tests__/acceptance/basic-auth-extension.acceptance.ts
+++ b/packages/authentication/src/__tests__/acceptance/basic-auth-extension.acceptance.ts
@@ -3,10 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {inject, Application} from '@loopback/core';
+import {Application, inject} from '@loopback/core';
 import {anOpenApiSpec} from '@loopback/openapi-spec-builder';
-import {api, get} from '@loopback/openapi-v3';
-import {Request, RestServer} from '@loopback/rest';
+import {api, get, Request, RestServer} from '@loopback/rest';
 import {SecurityBindings, securityId, UserProfile} from '@loopback/security';
 import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {

--- a/packages/authentication/src/__tests__/acceptance/jwt-auth-extension.acceptance.ts
+++ b/packages/authentication/src/__tests__/acceptance/jwt-auth-extension.acceptance.ts
@@ -4,8 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {inject, Application} from '@loopback/core';
-import {get, post} from '@loopback/openapi-v3';
-import {Request, RestServer} from '@loopback/rest';
+import {get, post, Request, RestServer} from '@loopback/rest';
 import {SecurityBindings, securityId, UserProfile} from '@loopback/security';
 import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {

--- a/packages/authentication/src/__tests__/fixtures/strategies/basic-strategy.ts
+++ b/packages/authentication/src/__tests__/fixtures/strategies/basic-strategy.ts
@@ -6,11 +6,12 @@
 import {bind, inject} from '@loopback/core';
 import {
   asSpecEnhancer,
+  HttpErrors,
   mergeSecuritySchemeToSpec,
   OASEnhancer,
   OpenApiSpec,
-} from '@loopback/openapi-v3';
-import {HttpErrors, Request} from '@loopback/rest';
+  Request,
+} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
 import {asAuthStrategy, AuthenticationStrategy} from '../../../types';
 import {BasicAuthenticationStrategyBindings} from '../keys';

--- a/packages/authentication/src/__tests__/fixtures/strategies/jwt-strategy.ts
+++ b/packages/authentication/src/__tests__/fixtures/strategies/jwt-strategy.ts
@@ -6,11 +6,12 @@
 import {bind, inject} from '@loopback/core';
 import {
   asSpecEnhancer,
+  HttpErrors,
   mergeSecuritySchemeToSpec,
   OASEnhancer,
   OpenApiSpec,
-} from '@loopback/openapi-v3';
-import {HttpErrors, Request} from '@loopback/rest';
+  Request,
+} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
 import {asAuthStrategy, AuthenticationStrategy} from '../../../types';
 import {JWTAuthenticationStrategyBindings} from '../keys';

--- a/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
+++ b/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
@@ -9,8 +9,8 @@ import {
   OASEnhancer,
   OASEnhancerBindings,
   OpenApiSpec,
-} from '@loopback/openapi-v3';
-import {Request} from '@loopback/rest';
+  Request,
+} from '@loopback/rest';
 import {securityId, UserProfile} from '@loopback/security';
 import {expect} from '@loopback/testlab';
 import {

--- a/packages/authentication/tsconfig.json
+++ b/packages/authentication/tsconfig.json
@@ -17,9 +17,6 @@
       "path": "../openapi-spec-builder/tsconfig.json"
     },
     {
-      "path": "../openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../rest/tsconfig.json"
     },
     {

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@loopback/build": "^6.1.0",
     "@loopback/eslint-config": "^8.0.3",
-    "@loopback/openapi-v3": "^3.4.5",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-crud": "^0.8.9",
     "@loopback/testlab": "^3.2.0",

--- a/packages/boot/tsconfig.json
+++ b/packages/boot/tsconfig.json
@@ -18,9 +18,6 @@
       "path": "../model-api-builder/tsconfig.json"
     },
     {
-      "path": "../openapi-v3/tsconfig.json"
-    },
-    {
       "path": "../repository/tsconfig.json"
     },
     {

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -97,7 +97,7 @@ or properties.
 import {repository} from '@loopback/repository';
 import {NoteRepository} from '../repositories';
 import {Note} from '../models';
-import {post, requestBody, get, param} from '@loopback/openapi-v3';
+import {post, requestBody, get, param} from '@loopback/rest';
 
 export class NoteController {
   constructor(


### PR DESCRIPTION
Import OpenAPI-related helpers from `@loopback/rest` instead.

See #5692 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
