### PR TITLE
docs: remove references to openapi-v3

### DIFF
--- a/docs/site/Command-line-interface.md
+++ b/docs/site/Command-line-interface.md
@@ -59,7 +59,6 @@ cli.
   - @loopback/core: ^1.10.4
   - @loopback/metadata: ^1.3.4
   - @loopback/openapi-spec-builder: ^1.2.15
-  - @loopback/openapi-v3: ^1.9.9
   - @loopback/repository-json-schema: ^1.10.2
   - @loopback/repository: ^1.15.1
   - @loopback/rest: ^1.20.1

--- a/docs/site/Extending-OpenAPI-specification.md
+++ b/docs/site/Extending-OpenAPI-specification.md
@@ -22,7 +22,7 @@ _Read about the extension point/extension pattern in
 
 ## Adding a New OAS Enhancer
 
-Interface `OASEnhancer` is created in `@loopback/openapi-v3` to describe the
+Interface `OASEnhancer` provided by `@loopback/rest` is describing the
 specification enhancers. A typical OAS enhancer class should have a string type
 `name` field and a function `modifySpec()` to modify the current specification.
 
@@ -36,7 +36,7 @@ import {
   asSpecEnhancer,
   OASEnhancer,
   OpenApiSpec,
-} from '@loopback/openapi-v3';
+} from '@loopback/rest';
 
 /**
  * A spec enhancer to add OpenAPI info spec
@@ -98,8 +98,8 @@ class MyApplication extends RestApplication {
 
 ## OAS Enhancer Service as Extension Point
 
-The OAS enhancer extension point is created in package `@loopback/openapi-v3`.
-It organizes the registered OAS enhancers, and provides APIs to either apply one
+The OAS enhancer extension point is provided by package `@loopback/rest`. It
+organizes the registered OAS enhancers, and provides APIs to either apply one
 enhancer by name, or apply all enhancers automatically.
 
 ### Registering an Enhancer Service
@@ -109,7 +109,7 @@ You can bind the OAS enhancer extension point to your app via key
 
 ```ts
 import {RestApplication} from '@loopback/rest';
-import {OASEnhancerService, OASEnhancerBindings} from '@loopback/openapi-v3';
+import {OASEnhancerService, OASEnhancerBindings} from '@loopback/rest';
 
 class MyApplication extends RestApplication {
   constructor() {

--- a/docs/site/Update-generator.md
+++ b/docs/site/Update-generator.md
@@ -49,7 +49,6 @@ The following dependencies are incompatible with @loopback/cli@1.24.0:
 - @loopback/boot: ^1.2.7 (cli ^1.5.10)
 - @loopback/build: ^1.5.4 (cli ^2.0.15)
 - @loopback/core: ^1.7.0 (cli ^1.10.6)
-- @loopback/openapi-v3: ^1.3.11 (cli ^1.10.0)
 - @loopback/repository: ^1.5.5 (cli ^1.15.3)
 - @loopback/rest: ^1.11.2 (cli ^1.22.0)
 - @loopback/testlab: ^1.2.9 (cli ^1.9.3)
@@ -57,7 +56,6 @@ The following dependencies are incompatible with @loopback/cli@1.24.0:
 ? How do you want to proceed? Upgrade project dependencies
 - Dependency @loopback/boot: ^1.2.7 => ^1.5.10
 - Dependency @loopback/core: ^1.7.0 => ^1.10.6
-- Dependency @loopback/openapi-v3: ^1.3.11 => ^1.10.0
 - Dependency @loopback/repository: ^1.5.5 => ^1.15.3
 - Dependency @loopback/rest: ^1.11.2 => ^1.22.0
 - Dependency @loopback/service-proxy: ^1.1.10 => ^1.3.10

--- a/docs/site/decorators/Decorators_openapi.md
+++ b/docs/site/decorators/Decorators_openapi.md
@@ -378,8 +378,7 @@ class MyController {
 upload. For example,
 
 ```ts
-import {post, requestBody} from '@loopback/openapi-v3';
-import {Request} from '@loopback/rest';
+import {post, Request, requestBody} from '@loopback/rest';
 class MyController {
   @post('/pictures')
   upload(
@@ -404,7 +403,7 @@ example,
 
 ```ts
 import {model, property} from '@loopback/repository';
-import {requestBody, post, get} from '@loopback/openapi-v3';
+import {requestBody, post, get} from '@loopback/rest';
 
 @model()
 class MyModel {
@@ -566,11 +565,11 @@ use verbose JSON.
 
 ## Shortcuts for the OpenAPI Spec (OAS) Objects
 
-All of the above are direct exports of `@loopback/openapi-v3`, but they are also
+All of the above are direct exports of `@loopback/rest`, but they are also
 available under the `oas` namespace:
 
 ```ts
-import {oas} from '@loopback/openapi-v3';
+import {oas} from '@loopback/rest';
 
 @oas.api({})
 class MyController {
@@ -800,8 +799,7 @@ class MyController {
 file download. For example:
 
 ```ts
-import {oas, get, param} from '@loopback/openapi-v3';
-import {RestBindings, Response} from '@loopback/rest';
+import {get, oas, param, RestBindings, Response} from '@loopback/rest';
 
 class MyController {
   @get('/files/{filename}')


### PR DESCRIPTION
Rework references to `@loopback/openapi-v3` to refer to `@loopback/rest` instead.

See #5692

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
