### PR TITLE
fix: enable custom AJV validation errors

### DIFF
--- a/docs/site/Model.md
+++ b/docs/site/Model.md
@@ -918,10 +918,12 @@ If the `jsonSchema` field is missing, you will get an error saying
 
 > You must provide the "jsonSchema" field when define a nested array property'
 
-### Validation Rules
+### Custom Validation Rules and Error Messages
 
-You can also specify the validation rules in the field `jsonSchema`. For
-example:
+You can also specify the validation rules in the `jsonSchema` field of the
+property option and configure them with custom error messages.
+
+The validation rules and custom error messages are configured this way.
 
 ```ts
 @model()
@@ -930,15 +932,29 @@ class Product extends Entity {
     name: 'name',
     description: "The product's common name.",
     type: 'string',
-    // Specify the JSON validation rules here
+    // JSON validation rules
     jsonSchema: {
-      maxLength: 30,
       minLength: 10,
-      errorMessage:
-        'name must be at least 10 characters and maximum 30 characters',
+      maxLength: 30,
+      errorMessage: 'Name should be between 10 and 30 characters.',
     },
   })
   public name: string;
+}
+```
+
+In case you want to send an error message specific to the validation rule that
+did not pass, you can configure `errorMessage` this way.
+
+```ts
+jsonSchema: {
+  minLength: 10,
+  maxLength: 30,
+  errorMessage: {
+    // Corresponding error messages
+    minLength: 'Name should be at least 10 characters.',
+    maxLength: 'Name should not exceed 30 characters.',
+  }
 }
 ```
 

--- a/docs/site/Parsing-requests.md
+++ b/docs/site/Parsing-requests.md
@@ -208,28 +208,9 @@ A full list of validation keywords could be found in the
 
 ##### Custom Error Messages
 
-You can also specify custom error messages for the JSON schema validation rules
-in the model property decorator. The messages are added in field called
-`errorMessage` inside `jsonSchema` like:
-
-```ts
-@model()
-class Product extends Entity {
-  @property({
-    name: 'name',
-    description: "The product's common name.",
-    type: 'string',
-    // Specify the JSON validation rules here
-    jsonSchema: {
-      maxLength: 30,
-      minLength: 10,
-      errorMessage:
-        'name must be at least 10 characters and maximum 30 characters',
-    },
-  })
-  public name: string;
-}
-```
+You can also specify custom error messages for JSON schema validation rules, as
+explained in
+[Custom Validation Rules and Error Messages](Model.md#custom-validation-rules-and-error-messages).
 
 A full list of options & usage scenarios could be found in the
 [documentation of AJV errors](https://github.com/epoberezkin/ajv-errors).

--- a/examples/validation-app/README.md
+++ b/examples/validation-app/README.md
@@ -19,22 +19,26 @@ instance with the in-memory storage.
    @property({
     type: 'string',
     required: true,
-    // --- add jsonSchema -----
+    // Add jsonSchema
     jsonSchema: {
       maxLength: 10,
-      minLength: 1,
+      minLength: 5,
+      errorMessage: 'City name should be between 5 and 10 characters',
     },
-    // ------------------------
    })
    city: string;
    ```
 
 2. [ValidatePhoneNumInterceptor](src/interceptors/validate-phone-num.interceptor.ts):
-   interceptor that checks whether the area code of the phone number matches
-   with the city name
+   an interceptor for custom validation - it checks whether the area code of the
+   phone number matches with the city name.
 
 3. [CoffeeShopController](src/controllers/coffee-shop.controller.ts): controller
    where the `ValidatePhoneNumInterceptor` is applied.
+
+4. [MySequence](src/sequence.ts): a custom sequence for creating custom error
+   messages. This is not a requirement, just a demonstration of how to customize
+   error messages during runtime.
 
 ## Use
 
@@ -62,7 +66,7 @@ is happening. An example of valid request body for `CoffeeShop` is:
 ```
 
 However, the following examples of request body are not valid, and you'll be
-getting an error with status code 422.
+getting an error with status code 422 and their corresponding error messages.
 
 ### Example 1: CoffeeShop.city length exceeds limit of 10
 

--- a/examples/validation-app/src/models/coffee-shop.model.ts
+++ b/examples/validation-app/src/models/coffee-shop.model.ts
@@ -17,37 +17,50 @@ export class CoffeeShop extends Entity {
   @property({
     type: 'string',
     required: true,
-    // --- add jsonSchema -----
+    // Add jsonSchema
     jsonSchema: {
       maxLength: 10,
-      minLength: 1,
+      minLength: 5,
+      errorMessage: 'City name should be between 5 and 10 characters',
     },
-    // ------------------------
   })
   city: string;
 
   @property({
     type: 'string',
     required: true,
-    // --- add jsonSchema -----
+    // Add jsonSchema
     jsonSchema: {
       pattern: '\\d{3}-\\d{3}-\\d{4}',
+      errorMessage: 'Invalid phone number',
     },
-    // ------------------------
   })
   phoneNum: string;
 
   @property({
     type: 'number',
     required: true,
-    // --- add jsonSchema -----
+    // Add jsonSchema
     jsonSchema: {
       maximum: 100,
-      minimum: 1,
+      minimum: 10,
+      errorMessage: {
+        maximum: 'Capacity cannot exceed 100',
+        minimum: 'Capacity cannot be less than 1',
+      },
     },
-    // ------------------------
   })
   capacity: number;
+
+  @property({
+    type: 'number',
+    // Add jsonSchema
+    jsonSchema: {
+      range: [1, 5],
+      errorMessage: 'Rating should be between 1 and 5',
+    },
+  })
+  rating: string;
 
   constructor(data?: Partial<CoffeeShop>) {
     super(data);

--- a/examples/validation-app/src/sequence.ts
+++ b/examples/validation-app/src/sequence.ts
@@ -73,8 +73,9 @@ export class MySequence implements SequenceHandler {
   handleError(context: RequestContext, err: HttpErrors.HttpError) {
     // 2. customize error for particular endpoint
     if (context.request.url === '/coffee-shops') {
-      // if this is a validation error
-      if (err.statusCode === 422) {
+      // if this is a validation error from the PATCH method, customize it
+      // for other validation errors, the default AJV error object will be sent
+      if (err.statusCode === 422 && context.request.method === 'PATCH') {
         const customizedMessage = 'My customized validation error message';
 
         let customizedProps = {};

--- a/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/validation/validation.acceptance.ts
@@ -17,10 +17,10 @@ import {
   jsonToSchemaObject,
   post,
   requestBody,
-  RequestBodyValidationOptions,
   RestApplication,
   RestBindings,
   SchemaObject,
+  ValidationOptions,
 } from '../../..';
 import {aBodySpec} from '../../helpers';
 
@@ -788,7 +788,7 @@ describe('Validation at REST level', () => {
 
   async function givenAnAppAndAClient(
     controller: ControllerClass,
-    validationOptions?: RequestBodyValidationOptions,
+    validationOptions?: ValidationOptions,
   ) {
     app = new RestApplication({rest: givenHttpServerConfig()});
     if (validationOptions)

--- a/packages/rest/src/__tests__/fixtures/models/book.model.ts
+++ b/packages/rest/src/__tests__/fixtures/models/book.model.ts
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Book extends Entity {
+  constructor(data?: Partial<Book>) {
+    super(data);
+  }
+
+  @property({
+    type: 'number',
+    id: true,
+    generated: true,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+    jsonSchema: {
+      maxLength: 10,
+      minLength: 3,
+      errorMessage: 'Name should be between 3 and 10 characters.',
+    },
+  })
+  title: string;
+}
+
+export interface BookRelations {
+  // describe navigational properties here
+}
+
+export type BookWithRelations = Book & BookRelations;

--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -11,12 +11,13 @@ import {
 } from '@loopback/openapi-v3';
 import debugModule from 'debug';
 import {
-  RequestBodyValidationOptions,
   RestHttpErrors,
   validateValueAgainstSchema,
+  ValidationOptions,
   ValueValidationOptions,
 } from '../';
 import {parseJson} from '../parse-json';
+import {DEFAULT_AJV_VALIDATION_OPTIONS} from '../validation/ajv-factory.provider';
 import {
   DateCoercionOptions,
   getOAIPrimitiveType,
@@ -167,7 +168,7 @@ function coerceBoolean(data: string | object, spec: ParameterObject) {
 async function coerceObject(
   input: string | object,
   spec: ParameterObject,
-  options?: RequestBodyValidationOptions,
+  options: ValidationOptions = DEFAULT_AJV_VALIDATION_OPTIONS,
 ) {
   const data = parseJsonIfNeeded(input, spec);
 

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -19,8 +19,9 @@ import {
   OperationArgs,
   PathParameterValues,
   Request,
-  RequestBodyValidationOptions,
+  ValidationOptions,
 } from './types';
+import {DEFAULT_AJV_VALIDATION_OPTIONS} from './validation/ajv-factory.provider';
 import {validateRequestBody} from './validation/request-body.validator';
 const debug = debugFactory('loopback:rest:parser');
 
@@ -35,7 +36,7 @@ export async function parseOperationArgs(
   request: Request,
   route: ResolvedRoute,
   requestBodyParser: RequestBodyParser = new RequestBodyParser(),
-  options: RequestBodyValidationOptions = {},
+  options: ValidationOptions = DEFAULT_AJV_VALIDATION_OPTIONS,
 ): Promise<OperationArgs> {
   debug('Parsing operation arguments for route %s', route.describe());
   const operationSpec = route.spec;
@@ -60,7 +61,7 @@ async function buildOperationArguments(
   pathParams: PathParameterValues,
   body: RequestBody,
   globalSchemas: SchemasObject,
-  options: RequestBodyValidationOptions = {},
+  options: ValidationOptions = DEFAULT_AJV_VALIDATION_OPTIONS,
 ): Promise<OperationArgs> {
   let requestBodyIndex = -1;
   if (operationSpec.requestBody) {

--- a/packages/rest/src/providers/parse-params.provider.ts
+++ b/packages/rest/src/providers/parse-params.provider.ts
@@ -8,12 +8,8 @@ import {RequestBodyParser} from '../body-parsers';
 import {RestBindings} from '../keys';
 import {parseOperationArgs} from '../parser';
 import {ResolvedRoute} from '../router';
-import {
-  AjvFactory,
-  ParseParams,
-  Request,
-  RequestBodyValidationOptions,
-} from '../types';
+import {AjvFactory, ParseParams, Request, ValidationOptions} from '../types';
+import {DEFAULT_AJV_VALIDATION_OPTIONS} from '../validation/ajv-factory.provider';
 /**
  * Provides the function for parsing args in requests at runtime.
  *
@@ -27,7 +23,7 @@ export class ParseParamsProvider implements Provider<ParseParams> {
       RestBindings.REQUEST_BODY_PARSER_OPTIONS.deepProperty('validation'),
       {optional: true},
     )
-    private validationOptions: RequestBodyValidationOptions = {},
+    private validationOptions: ValidationOptions = DEFAULT_AJV_VALIDATION_OPTIONS,
     @inject(RestBindings.AJV_FACTORY, {optional: true})
     private ajvFactory?: AjvFactory,
   ) {}

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -111,7 +111,7 @@ export type AjvFormat = FormatDefinition & {name: string};
 /**
  * Options for any value validation using AJV
  */
-export interface ValueValidationOptions extends RequestBodyValidationOptions {
+export interface ValueValidationOptions extends ValidationOptions {
   /**
    * Where the data comes from. It can be 'body', 'path', 'header',
    * 'query', 'cookie', etc...
@@ -122,7 +122,7 @@ export interface ValueValidationOptions extends RequestBodyValidationOptions {
 /**
  * Options for request body validation using AJV
  */
-export interface RequestBodyValidationOptions extends ajv.Options {
+export interface ValidationOptions extends ajv.Options {
   /**
    * Custom cache for compiled schemas by AJV. This setting makes it possible
    * to skip the default cache.
@@ -184,7 +184,7 @@ export interface RequestBodyParserOptions extends Options {
    * This setting is global for all request body parsers and it cannot be
    * overridden inside parser specific properties such as `json` or `text`.
    */
-  validation?: RequestBodyValidationOptions;
+  validation?: ValidationOptions;
   /**
    * Common options for all parsers
    */
@@ -225,3 +225,7 @@ export interface Session {
 export interface RequestWithSession extends Request {
   session: Session;
 }
+
+// For backwards compatibility
+// TODO(SEMVER-MAJOR)
+export type RequestBodyValidationOptions = ValidationOptions;

--- a/packages/rest/src/validation/ajv-factory.provider.ts
+++ b/packages/rest/src/validation/ajv-factory.provider.ts
@@ -13,16 +13,18 @@ import {
 import AjvCtor from 'ajv';
 import debugModule from 'debug';
 import {RestBindings, RestTags} from '../keys';
-import {
-  AjvFactory,
-  AjvFormat,
-  AjvKeyword,
-  RequestBodyValidationOptions,
-} from '../types';
+import {AjvFactory, AjvFormat, AjvKeyword, ValidationOptions} from '../types';
+
 const debug = debugModule('loopback:rest:ajv');
 
 const ajvKeywords = require('ajv-keywords');
 const ajvErrors = require('ajv-errors');
+
+export const DEFAULT_AJV_VALIDATION_OPTIONS: ValidationOptions = {
+  $data: true,
+  ajvKeywords: true,
+  ajvErrors: true,
+};
 
 /**
  * A provider class that instantiate an AJV instance
@@ -34,7 +36,7 @@ export class AjvFactoryProvider implements Provider<AjvFactory> {
       RestBindings.REQUEST_BODY_PARSER_OPTIONS.deepProperty('validation'),
       {optional: true},
     )
-    private options: RequestBodyValidationOptions = {},
+    private options: ValidationOptions = DEFAULT_AJV_VALIDATION_OPTIONS,
   ) {}
 
   @inject(filterByTag(RestTags.AJV_KEYWORD))
@@ -45,7 +47,7 @@ export class AjvFactoryProvider implements Provider<AjvFactory> {
 
   value(): AjvFactory {
     return options => {
-      let validationOptions: RequestBodyValidationOptions = {
+      let validationOptions: ValidationOptions = {
         ...this.options,
         ...options,
       };

--- a/packages/rest/src/validation/request-body.validator.ts
+++ b/packages/rest/src/validation/request-body.validator.ts
@@ -16,11 +16,14 @@ import _ from 'lodash';
 import util from 'util';
 import {HttpErrors, RequestBody, RestHttpErrors} from '..';
 import {
-  RequestBodyValidationOptions,
   SchemaValidatorCache,
+  ValidationOptions,
   ValueValidationOptions,
 } from '../types';
-import {AjvFactoryProvider} from './ajv-factory.provider';
+import {
+  AjvFactoryProvider,
+  DEFAULT_AJV_VALIDATION_OPTIONS,
+} from './ajv-factory.provider';
 
 const toJsonSchema = require('@openapi-contrib/openapi-schema-to-json-schema');
 const debug = debugModule('loopback:rest:validation');
@@ -39,7 +42,7 @@ export async function validateRequestBody(
   body: RequestBody,
   requestBodySpec?: RequestBodyObject,
   globalSchemas: SchemasObject = {},
-  options: RequestBodyValidationOptions = {},
+  options: ValidationOptions = DEFAULT_AJV_VALIDATION_OPTIONS,
 ) {
   const required = requestBodySpec?.required;
 
@@ -102,12 +105,12 @@ const DEFAULT_COMPILED_SCHEMA_CACHE: SchemaValidatorCache = new WeakMap();
  * Build a cache key for AJV options
  * @param options - Request body validation options
  */
-function getKeyForOptions(options: RequestBodyValidationOptions) {
+function getKeyForOptions(
+  options: ValidationOptions = DEFAULT_AJV_VALIDATION_OPTIONS,
+) {
   const ajvOptions: Record<string, unknown> = {};
   // Sort keys for options
-  const keys = Object.keys(
-    options,
-  ).sort() as (keyof RequestBodyValidationOptions)[];
+  const keys = Object.keys(options).sort() as (keyof ValidationOptions)[];
   for (const k of keys) {
     if (k === 'compiledSchemaCache') continue;
     ajvOptions[k] = options[k];


### PR DESCRIPTION
The current documentation is missing a crucial piece of information on how to enable custom validation and error messages, added the details.