### PR TITLE
fix(context): destroy debug instances to avoid memory leak

### DIFF
--- a/packages/context/src/__tests__/unit/context.unit.ts
+++ b/packages/context/src/__tests__/unit/context.unit.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {expect} from '@loopback/testlab';
-import {Debugger} from 'debug';
+import debugFactory, {Debugger} from 'debug';
 import {format} from 'util';
 import {
   Binding,
@@ -35,6 +35,10 @@ class TestContext extends Context {
 
   get parent() {
     return this._parent;
+  }
+
+  get debugInstance() {
+    return this._debug;
   }
 
   get bindingMap() {
@@ -842,6 +846,15 @@ describe('Context', () => {
       childCtx.close();
       expect(childCtx.parent).to.equal(ctx);
       expect(childCtx.contains('foo'));
+    });
+
+    it('destroys the debug instance', () => {
+      const childCtx = new TestContext(ctx);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const instances: Debugger[] = (debugFactory as any).instances;
+      expect(instances.includes(childCtx.debugInstance));
+      childCtx.close();
+      expect(!instances.includes(childCtx.debugInstance));
     });
   });
 

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -417,6 +417,9 @@ export class Context extends EventEmitter {
     this.debug('Closing context...');
     this.subscriptionManager.close();
     this.tagIndexer.close();
+    // Destroy instance level `debug` to avoid memory leak
+    // https://github.com/strongloop/loopback-next/issues/5943
+    this._debug.destroy();
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/5943

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
