### PR TITLE
Refactor extensions to move framework modules to peerDependencies

### DIFF
--- a/docs/site/Creating-components.md
+++ b/docs/site/Creating-components.md
@@ -36,6 +36,59 @@ export class MyComponent implements Component {
 }
 ```
 
+## Working with dependencies
+
+Extensions should preferably use LoopBack modules installed by the target
+application, to allow application developers to choose the version of framework
+modules they want to use. For example, they may want to hold to an older version
+until a regression is fixed in the latest version, or even use their own fork to
+have a bug fix available before it's officially published.
+
+We recommend to use `peerDependencies` to specify what packages is your
+extension expecting in the target application and `devDependencies` to make
+these packages available for extension tests.
+
+For example:
+
+```json
+{
+  "name": "my-lb4-extension",
+  "version": "1.0.0",
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1",
+    "@loopback/rest": "^5.2.0"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
+    "@loopback/eslint-config": "^8.0.3",
+    "@loopback/rest": "^5.2.0",
+    "@loopback/testlab": "^3.2.0"
+  }
+}
+```
+
+It is also possible for a single extension version to support multiple versions
+of a framework dependency:
+
+```json
+{
+  "peerDependencies": {
+    "@loopback/core": "^1.9.0 || ^2.0.0"
+  }
+}
+```
+
+{% include important.html content=' Shrinking the supported version range of a
+peer dependency is a breaking change that should trigger a semver-major release.
+
+For example, changing the range from `"^1.5.3"` to `"^1.5.3 || ^2.0.0"` is
+backwards compatible, while changing the range from `"^1.5.3"` to `"^2.0.0"` is
+a breaking change. ' %}
+
 ## Injecting the target application instance
 
 You can inject anything from the context and access them from a component. In

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -38,14 +38,18 @@
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "extensions/apiconnect"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
+    "@loopback/rest": "^5.2.0"
+  },
+  "dependencies": {
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27"
   }

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -20,22 +20,28 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/authentication": "^4.2.9",
     "@loopback/core": "^2.9.1",
     "@loopback/rest": "^5.2.0",
+    "@loopback/service-proxy": "^2.3.4"
+  },
+  "dependencies": {
     "@loopback/rest-explorer": "^2.2.6",
     "@loopback/security": "^0.2.14",
-    "@loopback/service-proxy": "^2.3.4",
     "@types/bcryptjs": "2.4.2",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
+    "@loopback/authentication": "^4.2.9",
     "@loopback/boot": "^2.3.5",
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/repository": "^2.9.0",
+    "@loopback/rest": "^5.2.0",
+    "@loopback/service-proxy": "^2.3.4",
     "@loopback/testlab": "^2.0.2",
     "@types/lodash": "^4.14.157",
     "@types/node": "^10.17.27",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -39,20 +39,25 @@
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "extensions/authentication-passport"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/authentication": "^4.2.9",
     "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
+    "@loopback/rest": "^5.2.0"
+  },
+  "dependencies": {
     "@loopback/security": "^0.2.14",
     "passport": "^0.4.1",
     "tslib": "^2.0.0",
     "util-promisifyall": "^1.0.6"
   },
   "devDependencies": {
+    "@loopback/authentication": "^4.2.9",
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/mock-oauth2-provider": "^0.1.3",
     "@loopback/openapi-spec-builder": "^2.1.9",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/lodash": "^4.14.157",

--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -20,15 +20,19 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
+    "@loopback/rest": "^5.2.0"
+  },
+  "dependencies": {
     "ts-graphviz": "^0.13.1",
     "viz.js": "^2.1.2"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27"
   },

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -20,8 +20,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@types/cron": "^1.7.2",
     "@types/debug": "^4.1.5",
     "cron": "^1.8.2",
@@ -30,6 +32,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27"

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -21,15 +21,19 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1",
+    "@loopback/rest": "^5.2.0"
+  },
   "dependencies": {
     "@cloudnative/health": "^2.1.2",
-    "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27"
   },

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -20,9 +20,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
+    "@loopback/rest": "^5.2.0"
+  },
+  "dependencies": {
     "fluent-logger": "^3.4.1",
     "morgan": "^1.10.0",
     "tslib": "^2.0.0",
@@ -31,7 +33,9 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/morgan": "^1.9.1",
     "@types/node": "^10.17.27"

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -20,15 +20,19 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
+    "@loopback/rest": "^5.2.0"
+  },
+  "dependencies": {
     "prom-client": "^12.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/express": "^4.17.7",
     "@types/node": "^10.17.27",

--- a/extensions/pooling/package.json
+++ b/extensions/pooling/package.json
@@ -31,14 +31,17 @@
     "src",
     "!*/__tests__"
   ],
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@types/generic-pool": "^3.1.9",
     "generic-pool": "^3.7.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27",
     "typescript": "~3.9.7"

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -21,19 +21,24 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/boot": "^2.3.3",
+    "@loopback/core": "^2.8.0",
+    "@loopback/rest": "^5.1.1"
+  },
   "devDependencies": {
+    "@loopback/boot": "^2.3.3",
     "@loopback/build": "^5.4.3",
+    "@loopback/core": "^2.8.0",
     "@loopback/eslint-config": "^8.0.1",
     "@loopback/repository": "^2.7.0",
+    "@loopback/rest": "^5.1.1",
     "@loopback/testlab": "^3.1.7",
     "@types/json-schema": "^7.0.5",
     "@types/node": "^10.17.27",
     "sqlite3": "^5.0.0"
   },
   "dependencies": {
-    "@loopback/boot": "^2.3.3",
-    "@loopback/core": "^2.8.0",
-    "@loopback/rest": "^5.1.1",
     "tslib": "^2.0.0",
     "typeorm": "^0.2.25"
   },

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -23,9 +23,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
+    "@loopback/rest": "^5.2.0"
+  },
+  "dependencies": {
     "@loopback/security": "^0.2.14",
     "@types/express": "^4.17.7",
     "@types/lodash": "^4.14.157",
@@ -34,8 +36,10 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/openapi-spec-builder": "^2.1.9",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27",
     "jsonwebtoken": "^8.5.1"

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -23,14 +23,17 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@loopback/security": "^0.2.14",
     "debug": "^4.1.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/testlab": "^3.2.0",
     "@types/debug": "^4.1.5",
     "@types/node": "10.17.27",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -23,8 +23,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@loopback/model-api-builder": "^2.1.9",
     "@loopback/repository": "^2.9.0",
     "@loopback/service-proxy": "^2.3.4",
@@ -36,6 +38,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/rest": "^5.2.0",
     "@loopback/rest-crud": "^0.8.9",

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -20,6 +20,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/boot": "^2.3.5",
+    "@loopback/core": "^2.9.1",
+    "@loopback/rest": "^5.2.0"
+  },
   "dependencies": {
     "@types/express": "^4.17.7",
     "debug": "^4.1.1",
@@ -27,11 +32,6 @@
     "loopback-swagger": "^5.9.0",
     "swagger2openapi": "^6.2.1",
     "tslib": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@loopback/boot": "^2.3.5",
-    "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0"
   },
   "devDependencies": {
     "@loopback/boot": "^2.3.5",

--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -71,10 +71,15 @@
     "src",
     "!*/__tests__"
   ],
+<% if (project.projectType === 'extension') { -%>
+  "peerDependencies": {
+    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>"
+  },
+<% } -%>
   "dependencies": {
+<% if (project.projectType === 'application') { -%>
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
-<% if (project.projectType === 'application') { -%>
 <% if (project.repositories) { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
 <% } -%>
@@ -94,6 +99,9 @@
   "devDependencies": {
     "@loopback/build": "<%= project.dependencies['@loopback/build'] -%>",
     "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
+<% if (project.projectType === 'extension') { -%>
+    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
+<% } -%>
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
     "@types/node": "<%= project.dependencies['@types/node'] -%>",
 <% if (project.eslint) { -%>

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -71,10 +71,15 @@
     "src",
     "!*/__tests__"
   ],
+<% if (project.projectType === 'extension') { -%>
+  "peerDependencies": {
+    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>"
+  },
+<% } -%>
   "dependencies": {
+<% if (project.projectType === 'application') { -%>
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
-<% if (project.projectType === 'application') { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
 <% if (project.apiconnect) { -%>
     "@loopback/apiconnect": "<%= project.dependencies['@loopback/apiconnect'] -%>",
@@ -87,6 +92,9 @@
   "devDependencies": {
     "rimraf": "<%= project.dependencies['rimraf'] -%>",
     "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
+<% if (project.projectType === 'extension') { -%>
+    "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
+<% } -%>
     "@loopback/testlab": "<%= project.dependencies['@loopback/testlab'] -%>",
 <% if (project.mocha) { -%>
     "@types/mocha": "<%= project.dependencies['@types/mocha'] -%>",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -36,8 +36,10 @@
     "src",
     "!*/__tests__"
   ],
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@loopback/http-server": "^2.1.9",
     "@types/body-parser": "^1.19.0",
     "@types/express": "^4.17.7",
@@ -52,6 +54,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/testlab": "^3.2.0",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.27",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -7,8 +7,10 @@
   "engines": {
     "node": ">=10.16"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@loopback/repository-json-schema": "^2.4.6",
     "debug": "^4.1.1",
     "http-status": "^1.4.2",
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/openapi-spec-builder": "^2.1.9",
     "@loopback/repository": "^2.9.0",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -25,16 +25,20 @@
     "TypeScript",
     "JSON Schema"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/repository": "^2.9.0",
+    "@loopback/repository": "^2.9.0"
+  },
+  "dependencies": {
     "@types/json-schema": "^7.0.5",
     "debug": "^4.1.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
+    "@loopback/repository": "^2.9.0",
     "@loopback/testlab": "^3.2.0",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.27",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -20,8 +20,13 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1",
+    "@loopback/repository": "^2.9.0"
+  },
   "devDependencies": {
     "@loopback/build": "^1.7.1",
+    "@loopback/core": "^2.9.1",
     "@loopback/repository": "^2.9.0",
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.14.157",
@@ -29,14 +34,10 @@
     "lodash": "^4.17.19"
   },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@loopback/testlab": "^3.2.0",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",
     "tslib": "^2.0.0"
-  },
-  "peerDependencies": {
-    "@loopback/repository": "^2.9.0"
   },
   "files": [
     "README.md",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -21,8 +21,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/testlab": "^3.2.0",
     "@types/bson": "^4.0.2",
@@ -32,7 +36,6 @@
     "bson": "4.0.4"
   },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",
     "lodash": "^4.17.19",

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -20,6 +20,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1",
+    "@loopback/repository": "^2.9.0",
+    "@loopback/rest": "^5.2.0"
+  },
   "dependencies": {
     "@loopback/model-api-builder": "^2.1.9",
     "debug": "^4.1.1",
@@ -33,11 +38,6 @@
     "@loopback/testlab": "^3.2.0",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.27"
-  },
-  "peerDependencies": {
-    "@loopback/core": "^2.9.1",
-    "@loopback/repository": "^2.9.0",
-    "@loopback/rest": "^5.2.0"
   },
   "files": [
     "README.md",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -20,16 +20,20 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.1",
-    "@loopback/rest": "^5.2.0",
+    "@loopback/rest": "^5.2.0"
+  },
+  "dependencies": {
     "ejs": "^3.1.3",
     "swagger-ui-dist": "^3.30.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
+    "@loopback/rest": "^5.2.0",
     "@loopback/testlab": "^3.2.0",
     "@types/ejs": "^3.0.4",
     "@types/express": "^4.17.7",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -23,8 +23,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "@loopback/express": "^1.2.5",
     "@loopback/http-server": "^2.1.9",
     "@loopback/openapi-v3": "^3.4.5",
@@ -58,6 +60,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/openapi-spec-builder": "^2.1.9",
     "@loopback/repository": "^2.9.0",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -23,13 +23,16 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "debug": "^4.1.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/testlab": "^3.2.0",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.27"

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -23,14 +23,17 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.1"
+  },
   "devDependencies": {
     "@loopback/build": "^6.1.0",
+    "@loopback/core": "^2.9.1",
     "@loopback/eslint-config": "^8.0.3",
     "@loopback/testlab": "^3.2.0",
     "@types/node": "^10.17.27"
   },
   "dependencies": {
-    "@loopback/core": "^2.9.1",
     "loopback-datasource-juggler": "^4.21.2",
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
As discussed several times in the past (most recently in https://github.com/strongloop/loopback-next/pull/5927#discussion_r453727653), extensions should use framework modules from the target application via `peerDependencies`. This pull request makes that change happen.

I split the changes into three commits:

1.  Document the best practice in "Creating components"
2. Update existing packages (breaking change 💥)
3. Update CLI template

/cc @strongloop/loopback-maintainers 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
