### PR TITLE
docs(authorization): correct typos

### DIFF
--- a/docs/site/Loopback-component-authorization.md
+++ b/docs/site/Loopback-component-authorization.md
@@ -264,7 +264,7 @@ class MyAuthorizationProvider implements Provider<Authorizer> {
 > `AuthorizationTags.AUTHORIZER` as below.
 
 ```ts
-import AuthorizationTags from '@loopback/authorization';
+import {AuthorizationTags} from '@loopback/authorization';
 let app = new Application();
 app
   .bind('authorizationProviders.my-provider')

--- a/packages/authorization/README.md
+++ b/packages/authorization/README.md
@@ -54,7 +54,7 @@ import {get} from '@loopback/rest';
 
 export class MyController {
   // user with ADMIN role can see the number of views
-  @authorize({allowRoles: ['ADMIN']})
+  @authorize({allowedRoles: ['ADMIN']})
   @get('/number-of-views')
   numOfViews(): number {
     return 100;
@@ -124,7 +124,7 @@ Controller method:
 
 ```ts
 @authenticate(‘jwt’)
-@authorize({allowRoles: ['ADMIN']})
+@authorize({allowedRoles: ['ADMIN']})
 @get('/number-of-views')
 numOfViews(): number {
   return 100;


### PR DESCRIPTION
Corrects some typos I have encountered while following the documentation.

## Checklist

👉 [I have read and signed the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [I have checked out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
