### PR TITLE
Rework fail-on-console-logs to support parallel test execution + remove extraneous logs from api-extractor

### DIFF
--- a/packages/build/src/fail-on-console-logs.js
+++ b/packages/build/src/fail-on-console-logs.js
@@ -7,18 +7,40 @@
 
 const util = require('util');
 
-const originalConsole = {
-  log: console.log,
-  error: console.error,
-  warn: console.warn,
+const mochaHooks = {
+  beforeAll: startRecording,
+  beforeEach: saveCurrentTest,
+  afterEach: checkTestFailure,
+  afterAll: stopRecordingAndReportProblems,
 };
 
-console.log = recordForbiddenCall('log');
-console.warn = recordForbiddenCall('warn');
-console.error = recordForbiddenCall('error');
+module.exports = {
+  mochaHooks,
+};
 
-const problems = [];
-const warnings = [];
+const INTERCEPTED_METHODS = ['log', 'error', 'warn'];
+const originalConsole = {};
+for (const m of INTERCEPTED_METHODS) {
+  originalConsole[m] = console[m];
+}
+
+let problems = [];
+let warnings = [];
+let currentTest;
+let someTestsFailed = false;
+
+function startRecording() {
+  problems = [];
+  warnings = [];
+
+  for (const m of INTERCEPTED_METHODS) {
+    console[m] = recordForbiddenCall(m);
+  }
+
+  process.on('warning', warning => {
+    warnings.push(warning);
+  });
+}
 
 function recordForbiddenCall(methodName) {
   return function recordForbiddenConsoleUsage(...args) {
@@ -41,14 +63,26 @@ function recordForbiddenCall(methodName) {
   };
 }
 
-process.on('warning', warning => {
-  warnings.push(warning);
-});
+/** @this {Mocha.Context} */
+function saveCurrentTest() {
+  currentTest = this.currentTest;
+}
 
-process.on('exit', code => {
+function checkTestFailure() {
+  if (currentTest.state === 'failed') someTestsFailed = true;
+}
+
+function stopRecordingAndReportProblems() {
+  // First of all, restore original console methods
+  for (const m of INTERCEPTED_METHODS) {
+    console[m] = originalConsole[m];
+  }
+
   // Don't complain about console logs when some of the tests have failed.
   // It's a common practice to add temporary console logs while troubleshooting.
-  if (code) return;
+  // NOTE: When running tests in parallel, console logs from non-failing tests
+  // executed in a different worker process are going to be still reported.
+  if (someTestsFailed) return;
 
   if (!warnings.length) {
     for (const w of warnings) {
@@ -73,6 +107,7 @@ process.on('exit', code => {
     log('\n');
   }
 
-  // ensure the process returns non-zero exit code to indicate test failure
-  process.exitCode = code || 10;
-});
+  throw new Error(
+    'Invalid usage of console logs detected. See the text above for more details.',
+  );
+}

--- a/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
+++ b/packages/tsdocs/src/__tests__/acceptance/tsdocs.acceptance.ts
@@ -42,6 +42,25 @@ describe('tsdocs', function (this: Mocha.Suite) {
     fs.emptyDirSync(path.join(MONOREPO_ROOT, 'packages/pkg1/docs'));
   });
 
+  let originalConsoleLog: typeof console.log;
+
+  before(function setupConsoleLogInterceptor() {
+    originalConsoleLog = console.log;
+    console.log = function (...args: unknown[]) {
+      const ignore =
+        args?.length &&
+        typeof args[0] === 'string' &&
+        /Analysis will use the bundled TypeScript version/.test(args[0]);
+      if (ignore) return;
+      process.stdout.write('XX: ' + require('util').inspect(args));
+      originalConsoleLog(...args);
+    };
+  });
+
+  after(function uninstallConsoleLogInterceptor() {
+    console.log = originalConsoleLog;
+  });
+
   it('runs api-extractor', async () => {
     await runExtractorForMonorepo({
       rootDir: MONOREPO_ROOT,


### PR DESCRIPTION
I noticed that `npm test` is no longer failing when unwanted console logs are printed. This problem was introduced by parallel test execution, the test suite fails when executed in serial. The first commit reworks `fail-on-console-logs.js` helper to leverage Mocha Global/Root hooks to get the desired behavior for parallel execution too.

The second commit fixes `@loopback/tsdocs` test suite to suppress console logs reported by `@microsoft/api-extractor`. I wish there was a config option to silence these logs! Unfortunately and AFAICT, api-extractor does not allow configurable handling of "Console category" messages:
https://github.com/microsoft/rushstack/blob/bdd3ee54b3a05772347baf12b0817660b07aa265/apps/api-extractor/src/collector/MessageRouter.ts#L531 As a workaround, I implemented a `console.log` interceptor that hides the messages we want to silence.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
