### PR TITLE
feat(pooling): allow optional request context to be passed to acquire

### DIFF
--- a/extensions/pooling/README.md
+++ b/extensions/pooling/README.md
@@ -103,7 +103,9 @@ const myPoolingService = await app.get<PoolingService>(
 ### Acquire a resource instance from the pool
 
 ```ts
-const res1 = await myPoolingService.acquire();
+// The request context can be used by a factory to set up the acquired resource
+// such as security credentials
+const res1 = await myPoolingService.acquire(requestCtx);
 // Do some work with res1
 ```
 
@@ -146,17 +148,17 @@ const options: PoolingServiceOptions<ExpensiveResource> = {
       resource.status = 'destroyed';
     },
 
-    async validate(resource) {
+    async validate(resource: ExpensiveResource) {
       const result = resource.status === 'created';
       resource.status = 'validated';
       return result;
     },
 
-    acquire(resource) {
+    acquire(resource: ExpensiveResource, requestCtx: Context) {
       resource.status = 'in-use-set-by-factory';
     },
 
-    release(resource) {
+    release(resource: ExpensiveResource) {
       resource.status = 'idle-set-by-factory';
     };
   },
@@ -170,6 +172,7 @@ The resource can also implement similar methods:
 
 ```ts
 class ExpensiveResourceWithHooks extends ExpensiveResource implements Poolable {
+  private requestCtx?: Context;
   /**
    * Life cycle method to be called by `create`
    */
@@ -185,12 +188,14 @@ class ExpensiveResourceWithHooks extends ExpensiveResource implements Poolable {
     this.status = 'stopped';
   }
 
-  acquire() {
+  acquire(requestCtx: Context) {
     this.status = 'in-use';
+    this.requestCtx = requestCtx;
   }
 
   release() {
     this.status = 'idle';
+    this.requestCtx = undefined;
   }
 }
 ```


### PR DESCRIPTION
Sometimes the resource needs to the request context during acquire, for
example, to access security credentials.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
