### PR TITLE
eslint-config: disable `createDefaultProgram`

### DIFF
--- a/packages/cli/generators/project/templates/.eslintignore
+++ b/packages/cli/generators/project/templates/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 coverage/
+.eslintrc.js

--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -29,8 +29,6 @@ module.exports = {
      * See https://github.com/typescript-eslint/typescript-eslint/issues/389
      */
     project: getProjectFile(),
-    // See https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#configuration
-    createDefaultProgram: true,
     ecmaFeatures: {
       ecmaVersion: 2017,
       jsx: false,

--- a/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
@@ -69,7 +69,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('disallows "where"', () => {
     const filter = {where: {name: 'John'}};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterExcludingWhereSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -84,7 +83,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('disallows "include"', () => {
     const filter = {include: 'orders'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterExcludingIncludeSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -99,7 +97,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "where" as an object', () => {
     const filter = {where: 'invalid-where'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -112,7 +109,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "fields" as an object', () => {
     const filter = {fields: 'invalid-fields'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -125,7 +121,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "include" as an array for models with relations', () => {
     const filter = {include: 'invalid-include'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -143,7 +138,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "offset" as an integer', () => {
     const filter = {offset: 'invalid-offset'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -156,7 +150,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "limit" as an integer', () => {
     const filter = {limit: 'invalid-limit'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -169,7 +162,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "skip" as an integer', () => {
     const filter = {skip: 'invalid-skip'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {
@@ -182,7 +174,6 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('describes "order" as an array', () => {
     const filter = {order: 'invalid-order'};
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ajv.validate(customerFilterSchema, filter);
     expect(ajv.errors ?? []).to.containDeep([
       {

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -139,13 +139,11 @@ export function RepositoryMixin<T extends MixinTarget<Application>>(
       const options = toOptions(nameOrOptions);
       // We have an instance of
       if (dataSource instanceof juggler.DataSource) {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const name = options.name || dataSource.name;
         const namespace = options.namespace ?? RepositoryBindings.DATASOURCES;
         const key = `${namespace}.${name}`;
         return this.bind(key).to(dataSource).tag(RepositoryTags.DATASOURCE);
       } else if (typeof dataSource === 'function') {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         options.name = options.name || dataSource.dataSourceName;
         const binding = createBindingFromClass(dataSource, {
           namespace: RepositoryBindings.DATASOURCES,

--- a/packages/testlab/src/test-sandbox.ts
+++ b/packages/testlab/src/test-sandbox.ts
@@ -151,7 +151,7 @@ export class TestSandbox {
       await outputFile(dest, content, {encoding: 'utf-8'});
     }
 
-    if (parse(src).ext === '.js' && pathExists(src + '.map')) {
+    if (parse(src).ext === '.js' && (await pathExists(src + '.map'))) {
       const srcMap = src + '.map';
       await appendFile(dest, `\n//# sourceMappingURL=${srcMap}`);
     }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,18 +3,22 @@
     "tsconfig.build.json is used by eslint to constrain files to be checked",
     "tsconfig.json is used by tsc"
   ],
-  "extends": "./packages/build/config/tsconfig.common.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "allowJs": true,
+    "noEmit": true
+  },
   "include": [
-    "acceptance",
-    "fixtures",
-    "benchmark",
-    "examples",
-    "packages",
-    "extensions"
+    "**/.eslintrc.js",
+    "**/*.js",
+    "**/*.ts"
   ],
   "exclude": [
     "**/node_modules/**",
     "**/dist/**",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "coverage",
+    "docs/_loopback.io",
+    "docs/_preview"
   ]
 }


### PR DESCRIPTION
While playing with eslint (https://github.com/strongloop/loopback-next/pull/5590, typescript-eslint/typescript-eslint#1192 and typescript-eslint/typescript-eslint#2094), I realized we don't have to migrate our eslint setup to project references in order to get rid of `createDefaultProgram` & its performance penalty.

In this pull request, I am proposing an alternative improvement and fixing few problems discovered by eslint along the way.

1. Add missing `await` statement to `testlab` code checking if a `.map` file exists when copying `.js` files to sandbox. The problem was discovered by the linter.
2. Update the `tsconfig` file used by `eslint` to include all files we are checking.
3. Remove `createDefaultProgram` flag from the shared/default eslint config (this is a breaking change).

Timing info (eslint with no cache):

- Before: ~3.5min
- After: ~1min

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
