### PR TITLE
fix: pin swagger-ui-dist to v3.30.0

### DIFF
--- a/packages/rest-explorer/package-lock.json
+++ b/packages/rest-explorer/package-lock.json
@@ -42,9 +42,9 @@
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.8",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
-			"integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
+			"version": "4.17.9",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
+			"integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -577,9 +577,9 @@
 			}
 		},
 		"swagger-ui-dist": {
-			"version": "3.30.1",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.30.1.tgz",
-			"integrity": "sha512-yxSMgkcuDFtTR4ExMUJEDAulzpQA243+vdew4Khp+oT4YnZ0mjf85eLm/SUWs2Ol0HZPHed6uEUhsDj5OWcuKw=="
+			"version": "3.30.0",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.30.0.tgz",
+			"integrity": "sha512-S8eqXrAjwcriY968zV6OauZEKDQZ4uobJKHNpUFt/4UXxZEvuX0Ujjc5eZ3T+42g9Ccb71KKmX9M3eQwpyP/lQ=="
 		},
 		"toidentifier": {
 			"version": "1.0.0",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -24,7 +24,7 @@
     "@loopback/core": "^2.9.2",
     "@loopback/rest": "^5.2.1",
     "ejs": "^3.1.3",
-    "swagger-ui-dist": "^3.30.1",
+    "swagger-ui-dist": "3.30.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Related to https://github.com/swagger-api/swagger-ui/issues/6249

When clicked on the /ping controller, there is only loading icon. 
![image (5)](https://user-images.githubusercontent.com/25489897/88193234-6b973680-cc0b-11ea-81e7-49e4c41f8ae2.png)

This fix is suggested by @raymondfeng to revert to use 3.30.0.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
