### PR TITLE
fix(rest): register component for apispec

### DIFF
--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -445,6 +445,9 @@ export class RestServer extends BaseMiddlewareRegistry
 
     // TODO(bajtos) should we support API spec defined asynchronously?
     const spec: OpenApiSpec = this.getSync(RestBindings.API_SPEC);
+    if (spec.components) {
+      this._httpHandler.registerApiComponents(spec.components);
+    }
     for (const path in spec.paths) {
       for (const verb in spec.paths[path]) {
         const routeSpec: OperationObject = spec.paths[path][verb];


### PR DESCRIPTION
The components provided by `server.api()` are not registered as api definition as how controller does. This PR fixes it.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
