### PR TITLE
fix(rest): skip operations from api spec that matches explicit routes

### DIFF
--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -317,6 +317,7 @@ describe('RestServer.getApiSpec()', () => {
       },
       '/status': {
         get: {
+          'x-operation': status,
           responses: {},
         },
       },

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -800,11 +800,13 @@ export class RestServer extends BaseMiddlewareRegistry
    */
   async getApiSpec(requestContext?: RequestContext): Promise<OpenApiSpec> {
     let spec = await this.get<OpenApiSpec>(RestBindings.API_SPEC);
+    spec = cloneDeep(spec);
     const components = this.httpHandler.getApiComponents();
 
     // Apply deep clone to prevent getApiSpec() callers from
     // accidentally modifying our internal routing data
-    spec.paths = cloneDeep(this.httpHandler.describeApiPaths());
+    const paths = cloneDeep(this.httpHandler.describeApiPaths());
+    spec.paths = {...paths, ...spec.paths};
     if (components) {
       const defs = cloneDeep(components);
       spec.components = {...spec.components, ...defs};


### PR DESCRIPTION
`RestServer.api()` registers an open api spec with handlers/controller methods. `RestServer.getApiSpec()` populates paths from routes. When a route is added/removed from the server, it triggers recreation of `httpHandler`, which tries to set up routes from `API_SPEC` (which used to be mutated by `RestServer.getApiSpec()`). As a result, some routes does not have `x-operation` or `x-controller-name` and an error is thrown.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
