### PR TITLE
fix(rest): code block in interface apidoc

### DIFF
--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -1070,12 +1070,15 @@ const OPENAPI_SPEC_MAPPING: {[key: string]: OpenApiSpecForm} = {
 export interface OpenApiSpecOptions {
   /**
    * Mapping of urls to spec forms, by default:
-   * ```
+   * <br>
    * {
+   *   <br>
    *   '/openapi.json': {version: '3.0.0', format: 'json'},
+   *   <br>
    *   '/openapi.yaml': {version: '3.0.0', format: 'yaml'},
+   *   <br>
    * }
-   * ```
+   *
    */
   endpointMapping?: {[key: string]: OpenApiSpecForm};
 


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-next/issues/5756

Display the code block in a readable way:

**Before:**
<img width="870" alt="Screen Shot 2020-06-16 at 3 48 23 PM" src="https://user-images.githubusercontent.com/25489897/84821259-d63fcb80-afe8-11ea-86b7-d6bbfd1faf2c.png">

**After:**
<img width="733" alt="Screen Shot 2020-07-30 at 12 53 08 PM" src="https://user-images.githubusercontent.com/12554153/88953127-720a5b80-d266-11ea-9997-4f19bdec213b.png">

I tried a lot to show them as code, but none of them works. So as a workaround, I reformatted the doc to fix the table display and make it readable.
See explanation in the next comment.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
