### PR TITLE
fix(repository): apply `@model` to generated model class

### DIFF
--- a/packages/repository/src/__tests__/unit/model/define-model-class.unit.ts
+++ b/packages/repository/src/__tests__/unit/model/define-model-class.unit.ts
@@ -6,6 +6,7 @@
 import {expect} from '@loopback/testlab';
 import {defineModelClass, Entity, Model, ModelDefinition} from '../../..';
 import {AnyObject} from '../../../common-types';
+import {ModelMetadataHelper} from '../../../decorators';
 
 describe('defineModelClass', () => {
   it('creates a Model class', () => {
@@ -21,7 +22,7 @@ describe('defineModelClass', () => {
 
     // Verify that typedefs allows us to access static Model properties
     expect(DataTransferObject.modelName).to.equal('DataTransferObject');
-    expect(DataTransferObject.definition).to.equal(definition);
+    expect(DataTransferObject.definition).to.deepEqual(definition);
 
     // Verify that typedefs allows us to create new model instances
     const instance = new DataTransferObject({title: 'a title'});
@@ -64,7 +65,7 @@ describe('defineModelClass', () => {
 
     // Verify that typedefs allows us to access static Model properties
     expect(Product.modelName).to.equal('Product');
-    expect(Product.definition).to.equal(definition);
+    expect(Product.definition).to.deepEqual(definition);
 
     // Verify that typedefs allows us to access static Entity properties
     expect(Product.getIdProperties()).to.deepEqual(['id']);
@@ -92,7 +93,7 @@ describe('defineModelClass', () => {
 
     // Verify that typedefs allows us to access static Model properties
     expect(FreeForm.modelName).to.equal('FreeForm');
-    expect(FreeForm.definition).to.equal(definition);
+    expect(FreeForm.definition).to.deepEqual(definition);
 
     // Verify that typedefs allows us to access static Entity properties
     expect(FreeForm.getIdProperties()).to.deepEqual(['id']);
@@ -105,5 +106,19 @@ describe('defineModelClass', () => {
     expect(instance.toJSON()).to.deepEqual({id: 1, name: 'a name'});
     // Verify that typedefs allows us to access free-form properties
     expect(instance.name).to.equal('a name');
+  });
+
+  it('should add model definition in decorator metadata', () => {
+    const definition = new ModelDefinition('Book').addProperty('title', {
+      type: 'string',
+    });
+
+    const Book = defineModelClass<typeof Model, {title: string}>(
+      Model,
+      definition,
+    );
+
+    const meta = ModelMetadataHelper.getModelMetadata(Book);
+    expect(meta).to.deepEqual(definition);
   });
 });

--- a/packages/repository/src/decorators/metadata.ts
+++ b/packages/repository/src/decorators/metadata.ts
@@ -49,13 +49,13 @@ export class ModelMetadataHelper {
         // sets the metadata to a dedicated key if cached value does not exist
 
         // set ModelDefinition properties if they don't already exist
-        const meta = new ModelDefinition(Object.assign({}, modelMeta));
+        const meta = new ModelDefinition({...modelMeta});
 
         // set properties lost from creating instance of ModelDefinition
         Object.assign(meta, modelMeta);
 
         meta.properties = Object.assign(
-          <PropertyMap>{},
+          <PropertyMap>meta.properties,
           MetadataInspector.getAllPropertyMetadata(
             MODEL_PROPERTIES_KEY,
             target.prototype,
@@ -64,7 +64,7 @@ export class ModelMetadataHelper {
         );
 
         meta.relations = Object.assign(
-          <RelationDefinitionMap>{},
+          <RelationDefinitionMap>meta.relations,
           MetadataInspector.getAllPropertyMetadata(
             RELATIONS_KEY,
             target.prototype,

--- a/packages/repository/src/define-model-class.ts
+++ b/packages/repository/src/define-model-class.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import {DataObject, PrototypeOf} from './common-types';
+import {model} from './decorators';
 import {Model, ModelDefinition} from './model';
 
 /**
@@ -60,7 +61,9 @@ export function defineModelClass<
     Props
   >;
   assert.equal(modelClass.name, modelName);
-  modelClass.definition = definition;
+
+  // Apply `@model(definition)` to the generated class
+  model(definition)(modelClass);
   return modelClass;
 }
 

--- a/packages/rest/src/__tests__/integration/repository.integration.ts
+++ b/packages/rest/src/__tests__/integration/repository.integration.ts
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/rest
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {getModelSchemaRef} from '@loopback/openapi-v3';
+import {defineModelClass, Model, ModelDefinition} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+
+describe('defineModelClass', () => {
+  it('should include model definition details in generated Model class', () => {
+    const definition = new ModelDefinition('Book').addProperty('title', {
+      type: 'string',
+    });
+
+    const Book = defineModelClass<typeof Model, {title: string}>(
+      Model,
+      definition,
+    );
+
+    const schemaRef = getModelSchemaRef(Book);
+    const expected = {
+      $ref: '#/components/schemas/Book',
+      definitions: {
+        Book: {title: 'Book', type: 'object', additionalProperties: false},
+      },
+    };
+    expect(schemaRef).to.match(expected);
+  });
+});


### PR DESCRIPTION
Schema was not generated for Model classes generated by `defineModelClass()`, since it did not contain model definition details. This PR fixes it.

Addresses https://github.com/strongloop/loopback-next/issues/6001.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
