### PR TITLE
fix(docs): rename legacy juggler to juggler

### DIFF
--- a/docs/site/Appsody-LoopBack.md
+++ b/docs/site/Appsody-LoopBack.md
@@ -304,7 +304,7 @@ below.
 ```
 ? Please select the datasource DbDatasource
 ? Select the model(s) you want to generate a repository Todo
-? Please select the repository base class DefaultCrudRepository (Legacy juggler bridge)
+? Please select the repository base class DefaultCrudRepository (Juggler bridge)
    create src/repositories/todo.repository.ts
    update src/repositories/index.ts
 

--- a/docs/site/Behind-the-scene.md
+++ b/docs/site/Behind-the-scene.md
@@ -40,9 +40,8 @@ responsibilities for typical API and/or Microservice applications.
 - [**Model**](Model.md): The definition of an object in respect to the
   datasource juggler. The `@loopback/repository` module provides special
   decorators for adding metadata to TypeScript/JavaScript classes to use them
-  with the legacy implementation of DataSource Juggler. In addition,
-  `@loopback/repository-json-schema` module uses the decorators' metadata to
-  build a matching JSON Schema.
+  with DataSource Juggler. In addition, `@loopback/repository-json-schema`
+  module uses the decorators' metadata to build a matching JSON Schema.
 
 - [**DataSources**](DataSources.md): A named configuration for a Connector
   instance that represents data in an external system.

--- a/docs/site/Crafting-LoopBack-4.md
+++ b/docs/site/Crafting-LoopBack-4.md
@@ -282,7 +282,7 @@ Here are the stages we are marching through toward the final version of LoopBack
     - Introduce repositories to represent data access patterns such as CRUD or
       Key/Value stores
     - Provide a reference implementation of CRUD and KV flavors of repository
-      interfaces using the legacy juggler and connectors
+      interfaces using juggler and connectors
     - Refactor/rewrite the juggler into separate modules
       - Typing system
       - Model and relation definition

--- a/docs/site/Repositories.md
+++ b/docs/site/Repositories.md
@@ -38,9 +38,9 @@ See more examples at:
 
 ## Installation
 
-Legacy juggler support has been enabled in `loopback-next` and can be imported
-from the `@loopback/repository` package. In order to do this, save
-`@loopback/repository` as a dependency in your application.
+Juggler support has been enabled in `loopback-next` and can be imported from the
+`@loopback/repository` package. In order to do this, save `@loopback/repository`
+as a dependency in your application.
 
 You can then install your favorite connector by saving it as part of your
 application dependencies.
@@ -98,7 +98,7 @@ INSERT statement, which can be executed through MySQL driver for Node.js.
 
 When a `DataSource` is instantiated, the configuration properties will be used
 to initialize the connector to connect to the backend system. You can define a
-DataSource using legacy Juggler in your LoopBack 4 app as follows:
+DataSource using Juggler in your LoopBack 4 app as follows:
 
 {% include code-caption.html content="src/datsources/db.datasource.ts" %}
 
@@ -155,9 +155,9 @@ Account.definition = new ModelDefinition({
 
 ## Define repositories
 
-Use `DefaultCrudRepository` class to create a repository leveraging the legacy
-juggler bridge and binding your Entity-based class with a datasource you have
-configured earlier. It's recommended that you use
+Use `DefaultCrudRepository` class to create a repository leveraging juggler
+bridge and binding your Entity-based class with a datasource you have configured
+earlier. It's recommended that you use
 [Dependency Injection](Dependency-injection.md) to retrieve your datasource.
 
 TypeScript version:

--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -585,7 +585,7 @@ describe('Person (unit)', () => {
 ```
 
 Writing a unit test for custom repository methods is not as straightforward
-because `CrudRepository` is based on legacy
+because `CrudRepository` is based on
 [loopback-datasource-juggler](https://github.com/strongloop/loopback-datasource-juggler)
 which was not designed with dependency injection in mind. Instead, use
 integration tests to verify the implementation of custom repository methods. For

--- a/docs/site/migration/auth/authentication.md
+++ b/docs/site/migration/auth/authentication.md
@@ -186,7 +186,7 @@ cd myLB4App
 $ lb4 repository
 ? Please select the datasource DbDatasource
 ? Select the model(s) you want to generate a repository User, UserCredentials
-? Please select the repository base class DefaultCrudRepository (Legacy juggler bridge)
+? Please select the repository base class DefaultCrudRepository (Juggler bridge)
 ```
 
 Create the user controller for CRUD operations:

--- a/docs/site/migration/auth/example.md
+++ b/docs/site/migration/auth/example.md
@@ -549,7 +549,7 @@ Create corresponding repositories:
 $ lb4 repository
 ? Please select the datasource DbDatasource
 ? Select the model(s) you want to generate a repository Project, Team, UserCredentials, User
-? Please select the repository base class DefaultCrudRepository (Legacy juggler bridge)
+? Please select the repository base class DefaultCrudRepository (Juggler bridge)
 ```
 
 Create relations:

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-has-one-relation.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-has-one-relation.md
@@ -62,7 +62,7 @@ Using `lb4 repository`, let's create the repository:
 lb4 repository
 ? Please select the datasource DbDatasource
 ? Select the model(s) you want to generate a repository TodoListImage
-? Please select the repository base class DefaultCrudRepository (Legacy juggler bridge)
+? Please select the repository base class DefaultCrudRepository (Juggler bridge)
    create src/repositories/todo-list-image.repository.ts
    update src/repositories/index.ts
 

--- a/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-repository.md
@@ -29,8 +29,7 @@ datasources.
 lb4 repository
 ? Please select the datasource DbDatasource
 ? Select the model(s) you want to generate a repository TodoList
-? Please select the repository base class DefaultCrudRepository (Legacy juggler
-bridge)
+? Please select the repository base class DefaultCrudRepository (Juggler bridge)
    create src/repositories/todo-list.repository.ts
    update src/repositories/index.ts
 

--- a/docs/site/tutorials/todo/todo-tutorial-repository.md
+++ b/docs/site/tutorials/todo/todo-tutorial-repository.md
@@ -33,8 +33,7 @@ list of available datasources.
 lb4 repository
 ? Please select the datasource DbDatasource
 ? Select the model(s) you want to generate a repository Todo
-? Please select the repository base class DefaultCrudRepository (Legacy juggler
-bridge)
+? Please select the repository base class DefaultCrudRepository (Juggler bridge)
 
    create src/repositories/todo.repository.ts
    update src/repositories/index.ts

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -24,7 +24,7 @@ const KEY_VALUE_REPOSITORY = 'DefaultKeyValueRepository';
 const BASE_REPOSITORIES = [DEFAULT_CRUD_REPOSITORY, KEY_VALUE_REPOSITORY];
 const CLI_BASE_CRUD_REPOSITORIES = [
   {
-    name: `${DEFAULT_CRUD_REPOSITORY} ${chalk.gray('(Legacy juggler bridge)')}`,
+    name: `${DEFAULT_CRUD_REPOSITORY} ${chalk.gray('(Juggler bridge)')}`,
     value: DEFAULT_CRUD_REPOSITORY,
   },
 ];

--- a/packages/repository/DEVELOPING.md
+++ b/packages/repository/DEVELOPING.md
@@ -4,8 +4,8 @@
 
 In `lb4`, we introduce the concept of
 [`repository`](https://loopback.io/doc/en/lb4/Repositories.html). In order to
-implement this new feature `repository`, we are using legacy juggler bridge as a
-(temporary) solution. Each model has two **parallel classes**:
+implement this new feature `repository`, we are using juggler bridge. Each model
+has two **parallel classes**:
 
 - The class defined by the app developers using decorators and
   `class MyModel extends Entity` syntax.
@@ -29,9 +29,5 @@ are different:
 Hope this example shows the idea that even they both use the `base model` from
 Juggler, LB4 model doesn't use, or even have access to some fields/entries in
 the Juggler model!
-
-As mentioned before, we are using the legacy juggler bridge as a temporary
-solution. This may change in the future since the Juggler is pretty.. you know,
-legacy. However, it's important to realize how LB4 deals with models.
 
 Happy coding :D

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -6,8 +6,7 @@ This module provides a common set of interfaces for interacting with databases.
 
 **NOTE**: This module is experimental and evolving. It is likely going to be
 refactored and decomposed into multiple modules as we refine the story based on
-the legacy `loopback-datasource-juggler` and connector modules from LoopBack
-3.x.
+`loopback-datasource-juggler` and connector modules from LoopBack 3.x.
 
 This module provides data access facilities to various databases and services as
 well as the constructs for modeling and accessing those data.

--- a/packages/repository/README.md
+++ b/packages/repository/README.md
@@ -4,10 +4,6 @@ This module provides a common set of interfaces for interacting with databases.
 
 ## Overview
 
-**NOTE**: This module is experimental and evolving. It is likely going to be
-refactored and decomposed into multiple modules as we refine the story based on
-`loopback-datasource-juggler` and connector modules from LoopBack 3.x.
-
 This module provides data access facilities to various databases and services as
 well as the constructs for modeling and accessing those data.
 

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -6,11 +6,6 @@
 /**
  * A common set of interfaces for interacting with databases.
  *
- * @remarks
- * *NOTE:* This module is experimental and evolving. It is likely going to be
- * refactored and decomposed into multiple modules as we refine the story based
- * on the loopback-datasource-juggler and connector modules from LoopBack 3.x.
- *
  * This module provides data access facilities to various databases and services
  * as well as the constructs for modeling and accessing those data.
  *

--- a/packages/repository/src/index.ts
+++ b/packages/repository/src/index.ts
@@ -9,8 +9,7 @@
  * @remarks
  * *NOTE:* This module is experimental and evolving. It is likely going to be
  * refactored and decomposed into multiple modules as we refine the story based
- * on the legacy loopback-datasource-juggler and connector modules from LoopBack
- * 3.x.
+ * on the loopback-datasource-juggler and connector modules from LoopBack 3.x.
  *
  * This module provides data access facilities to various databases and services
  * as well as the constructs for modeling and accessing those data.


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/5558

I also renamed it in the CLI.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
