### PR TITLE
Add documentation for executing native database commands

### DIFF
--- a/docs/bin/build-preview-site.sh
+++ b/docs/bin/build-preview-site.sh
@@ -23,6 +23,9 @@ else
   (cd $SOURCE_DIR && git pull)
 fi
 
+echo "Pulling README files (connectors, etc.)"
+(cd $SOURCE_DIR && ./update-readmes.sh)
+
 echo "Installing setup dependencies"
 npm install --no-save js-yaml
 
@@ -58,6 +61,9 @@ rm -rf $JEKYLL_DIR/pages
 # Use `pax` because `ln` does not support directory recursion.
 mkdir $JEKYLL_DIR/pages
 (TARGET="$PWD/$JEKYLL_DIR/pages" && cd "$PWD/site" && pax -rwlpe . $TARGET)
+
+echo "Copying external README pages"
+cp $SOURCE_DIR/pages/en/lb4/readmes/*.md $JEKYLL_DIR/pages/readmes/
 
 echo "Setting up sidebar(s)"
 rm -rf $JEKYLL_DIR/_data/sidebars

--- a/docs/site/Cassandra-connector.md
+++ b/docs/site/Cassandra-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'Cassandra connector'
+lang: en
+layout: readme
+source: loopback-connector-cassandra
+keywords: LoopBack, connector
+tags: readme
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Cassandra-connector.html
+summary:
+  The Cassandra connector enables LoopBack applications to connect to Cassandra
+  data sources.
+---

--- a/docs/site/Cloudant-connector.md
+++ b/docs/site/Cloudant-connector.md
@@ -1,0 +1,18 @@
+---
+title: 'Cloudant connector'
+lang: en
+layout: readme
+source: loopback-connector-cloudant
+keywords: LoopBack, connector
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Cloudant-connector.html
+summary:
+  The Cloudant connector enables LoopBack applications to connect to Cloudant
+  data sources.
+---
+
+{% include see-also.html content="
+
+- [Getting Started with LoopBack and IBM Cloudant](https://developer.ibm.com/bluemix/2015/09/10/getting-started-node-js-loopback-framework-ibm-cloudant/)
+  " %}

--- a/docs/site/DB2-connector.md
+++ b/docs/site/DB2-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'IBM Db2 connector'
+lang: en
+layout: readme
+source: loopback-connector-db2
+keywords: LoopBack
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/DB2-connector.html
+summary:
+  The Db2 connector enables LoopBack applications to connect to Db2 data
+  sources.
+---

--- a/docs/site/DB2-for-i-connector.md
+++ b/docs/site/DB2-for-i-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'IBM Db2 for i connector'
+lang: en
+layout: readme
+source: loopback-connector-ibmi
+keywords: LoopBack
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/DB2-for-i-connector.html
+summary:
+  The loopback-connector-ibmi connector enables LoopBack applications to connect
+  to IBM® Db2® for i data sources.
+---

--- a/docs/site/DB2-for-z-OS-connector.md
+++ b/docs/site/DB2-for-z-OS-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'IBM Db2 for z/OS connector'
+lang: en
+layout: readme
+source: loopback-connector-db2z
+keywords: LoopBack
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/DB2-for-z-OS-connector.html
+summary:
+  The loopback-connector-db2z connector enables LoopBack applications to connect
+  to IBM® Db2® for z/OS® data sources.
+---

--- a/docs/site/Example-kv-connector.md
+++ b/docs/site/Example-kv-connector.md
@@ -1,0 +1,11 @@
+---
+title: 'KV connector example'
+lang: en
+layout: readme
+source: loopback-example-kv-connectors
+keywords: LoopBack
+tags: example_app
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Example-kv-connector.html
+summary: A simple example of using the LoopBack KV connectors.
+---

--- a/docs/site/Executing-database-commands.md
+++ b/docs/site/Executing-database-commands.md
@@ -1,0 +1,61 @@
+---
+lang: en
+title: 'Executing database commands'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Executing-database-commands.html
+---
+
+## Overview
+
+{% include warning.html content="In general, it is always better to perform
+database actions through `Repository` methods. Directly executing native database
+commands may lead to unexpected results and other issues." %}
+
+When you project outgrows built-in `Repository` methods, you can execute native
+database commands to implement more complex data queries and manipulations, for
+example execute a custom SQL query or invoke a MongoDB command.
+
+LoopBack provides two APIs:
+
+- DataSource-level `execute()` method
+- Repository-level `execute()` method
+
+Both methods offer the same set of signatures, the implementation in Repository
+is just a thin wrapper delegating the task to DataSource.
+
+Example use:
+
+```ts
+const result = await repository.execute('SELECT * FROM Products');
+```
+
+See API docs for parameter reference, additional information and examples:
+
+- [SQL variant](./apidocs/repository.defaultcrudrepository.execute.md)
+- [MongoDB variant](./apidocs/repository.defaultcrudrepository.execute_1.md)
+- [Generic variant](./apidocs/repository.defaultcrudrepository.execute_2.md)
+
+{% include important.html content="Each connector implements a slightly
+different flavor of `execute()` to match the capabilities supported by the
+database engine. Please refer to connector documentation to learn more about
+the expected parameters and command/query syntax to use.
+" %}
+
+## Supported connectors
+
+Not all connectors support execution of native database commands. Check your
+connector's documentation to learn more. The following connectors are known to
+support `execute` method.
+
+<!-- Keep the entries sorted lexicographically (A-Z) -->
+
+- [IBM DB2](./DB2-connector.md)
+- [IBM DB2 for i](./DB2-for-i-connector.md)
+- [IBM DB2 for z/OS](./DB2-for-z-OS-connector.md)
+- [Oracle](./Oracle-connector.md)
+- [Microsoft SQL](./SQL-Server-connector.md)
+- [MongoDB](./MongoDB-connector.md)
+- [MySQL](./MySQL-connector.md)
+- [PostgreSQL](./PostgreSQL-connector.md)
+- [SQLite3](./SQLite3.md)

--- a/docs/site/Installing-the-Oracle-connector.md
+++ b/docs/site/Installing-the-Oracle-connector.md
@@ -1,0 +1,20 @@
+---
+title: 'Installing the Oracle connector'
+lang: en
+layout: navgroup
+navgroup: oracle
+source: loopback-oracle-installer
+keywords: LoopBack
+tags:
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Installing-the-Oracle-connector.html
+summary:
+  The loopback-oracle-installer module takes care of binary dependencies
+  and simplifies the process of installing the Oracle connector.
+---
+
+{% include tip.html content="
+Use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
+to easily install and troubleshoot installing `loopback-oracle-installer`
+and the Oracle data source connector.
+" %}

--- a/docs/site/JSON-RPC-connector.md
+++ b/docs/site/JSON-RPC-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'JSON-RPC connector'
+lang: en
+layout: readme
+source: loopback-connector-jsonrpc
+keywords: LoopBack, connector
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/JSON-RPC-connector.html
+summary:
+  The LoopBack JSON-RPC Connector enables LoopBack applications to call JSON-RPC
+  services.
+---

--- a/docs/site/MQLight-connector.md
+++ b/docs/site/MQLight-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'MQLight connector'
+lang: en
+layout: readme
+source: loopback-connector-mqlight
+keywords: LoopBack, connector
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/MQLight-connector.html
+summary:
+  The MQ Light connector enables LoopBack applications to use the MQ Light
+  messaging API.
+---

--- a/docs/site/Memory-connector.md
+++ b/docs/site/Memory-connector.md
@@ -1,0 +1,125 @@
+---
+title: 'Memory connector'
+lang: en
+layout: page
+keywords: LoopBack
+tags: connectors
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Memory-connector.html
+summary:
+  The built-in memory connector is a persistent data source for development and
+  testing.
+---
+
+## Overview
+
+LoopBack's built-in memory connector enables you to test your application
+without connecting to an actual persistent data source such as a database.
+Although the memory connector is very well tested it is not suitable for
+production.
+
+The memory connector supports:
+
+- Standard query and create, read, update, and delete operations, so you can
+  test models against an in-memory data source.
+- Geo-filtering when using the `find()` operation with an attached model.
+  See [GeoPoint class](http://apidocs.loopback.io/loopback-datasource-juggler/#geopoint) for
+  more information on geo-filtering.
+
+{% include important.html content=" The memory connector is designed for
+development and testing of a single-process application without setting up a
+database. It cannot be used in a cluster as the worker processes will have their
+own isolated data not shared in the cluster.
+
+You can persist data between application restarts using the `file` property. See
+[Data persistence](#data-persistence) for more information. " %}
+
+## Creating a data source
+
+By default, an application created with the
+[Application generator](Application-generator.html) has a memory data source
+defined; for example:
+
+{% include code-caption.html content="/server/datasources.json" %}
+
+```javascript
+"db": {
+    "name": "db",
+    "connector": "memory"
+}
+```
+
+Use the [Data source generator](Data-source-generator.html) to add a new memory
+data source to your application.
+
+### Memory connector properties
+
+<table>
+  <tbody>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td>name</td>
+      <td>String</td>
+      <td>Name by which you refer to the data source.</td>
+    </tr>
+    <tr>
+      <td>connector</td>
+      <td>String</td>
+      <td>Must be "memory" to use the memory connector.</td>
+    </tr>
+    <tr>
+      <td>file</td>
+      <td>String</td>
+      <td>
+        <p>Path to file where the connector will store data, relative to application root directory.</p>
+        <p>NOTE: The connector will create the file if necessary, but the directory containing the file must exist.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+{% include important.html content="
+If you specify the file property, the connector will save data there that will persist when you restart the application.
+Otherwise, the memory connector does not persist data after an application stops.
+" %}
+
+## Data persistence
+
+By default, data in the memory connector are transient. When an application
+using the memory connector exits, all model instances are lost. To maintain data
+across application restarts, specify a JSON file in which to store the data with
+the `file` property when creating the data source.
+
+The simplest way to do this is by editing `server/datasources.json`; for
+example:
+
+{% include code-caption.html content="server/datasources.json" %}
+
+```javascript
+{
+  "db": {
+    "name": "db",
+    "connector": "memory",
+    "file": "mydata.json"
+  }
+}
+```
+
+You can also set the persistence file in a boot script; for example:
+
+{% include code-caption.html content="server/boot/script.js" %}
+
+```javascript
+var memory = loopback.createDataSource({
+  connector: loopback.Memory,
+  file: 'mydata.json',
+});
+```
+
+When the application exits, the memory connector will then store data in the
+`mydata.json` file, and when it restarts will load the saved data from that
+file.

--- a/docs/site/MongoDB-connector.md
+++ b/docs/site/MongoDB-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'MongoDB connector'
+lang: en
+layout: readme
+source: loopback-connector-mongodb
+keywords: LoopBack, connector
+tags: readme
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/MongoDB-connector.html
+summary:
+  The MongoDB connector enables LoopBack applications to connect to MongoDB data
+  sources.
+---

--- a/docs/site/MySQL-connector.md
+++ b/docs/site/MySQL-connector.md
@@ -1,0 +1,16 @@
+---
+title: 'MySQL connector'
+lang: en
+layout: readme
+source: loopback-connector-mysql
+keywords: LoopBack
+tags: connectors
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/MySQL-connector.html
+summary:
+  The MySQL connector enables LoopBack applications to connect to MySQL  data
+  sources.
+---
+
+{% include important.html content="The MySQL connector requires MySQL 5.0+.
+" %}

--- a/docs/site/OpenAPI-connector.md
+++ b/docs/site/OpenAPI-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'OpenAPI connector'
+lang: en
+layout: readme
+source: loopback-connector-openapi
+keywords: LoopBack, connector
+tags: readme
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/OpenAPI-connector.html
+summary:
+  The OpenAPI connector enables LoopBack applications to connect to OpenAPI data
+  sources.
+---

--- a/docs/site/Oracle-connector.md
+++ b/docs/site/Oracle-connector.md
@@ -1,0 +1,20 @@
+---
+title: 'Oracle connector'
+lang: en
+layout: navgroup
+navgroup: oracle
+source: loopback-connector-oracle
+keywords: LoopBack
+tags: connectors
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Oracle-connector.html
+summary:
+  The Oracle connector enables LoopBack applications to connect to Oracle data
+  sources.
+---
+
+{% include tip.html content="
+Use the [Oracle installer command](Oracle-installer-command.html), `lb oracle`,
+to easily install and troubleshoot installing `loopback-oracle-installer`
+and the Oracle data source connector.
+" %}

--- a/docs/site/PostgreSQL-connector.md
+++ b/docs/site/PostgreSQL-connector.md
@@ -1,0 +1,16 @@
+---
+title: 'PostgreSQL connector'
+lang: en
+layout: readme
+source: loopback-connector-postgresql
+keywords: LoopBack
+tags: connectors
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/PostgreSQL-connector.html
+summary:
+  The PostgreSQL connector enables LoopBack applications to connect to
+  PostgreSQL data sources.
+---
+
+{% include note.html content="The PostgreSQL connector requires PostgreSQL 8.x or 9.x.
+" %}

--- a/docs/site/REST-connector.md
+++ b/docs/site/REST-connector.md
@@ -1,0 +1,13 @@
+---
+title: 'REST connector'
+lang: en
+layout: readme
+source: loopback-connector-rest
+keywords: LoopBack, REST
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/REST-connector.html
+summary:
+  The REST connector enables LoopBack applications to interact with other (third
+  party) REST APIs.
+---

--- a/docs/site/Redis-connector.md
+++ b/docs/site/Redis-connector.md
@@ -1,0 +1,102 @@
+---
+title: 'Redis connector'
+lang: en
+layout: page
+toc: false
+keywords: LoopBack
+tags: connectors
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Redis-connector.html
+summary:
+  The Redis connector enables LoopBack applications to connect to Redis data
+  sources.
+---
+
+{% include content/strongloop-labs.html lang=page.lang %}
+
+{% include toc.html %}
+
+{% include note.html content="The Redis connector requires Redis 3.0.3+.
+" %}
+
+## Installation
+
+In your application root directory, enter this command to install the connector:
+
+```shell
+$ npm install loopback-connector-redis --save
+```
+
+This will install the module and add it as a dependency to the
+application's [`package.json`](package.json) file.
+
+## Creating a Redis data source
+
+Use the [data source generator](Data-source-generator.html) to add a Redis data
+source to your application. When prompted for the connector, choose **other,**
+then enter **redis** for the connector name. The entry in the application's
+`server/datasources.json` will look like this:
+
+{% include code-caption.html content="server/datasources.json" %}
+
+```javascript
+"redisDS": {
+  "name": "redisDS",
+  "connector": "redis",
+}
+```
+
+Edit `datasources.json` to add other properties that enable you to connect the
+data source to a Redis database.
+
+### Properties
+
+<table>
+  <tbody>
+    <tr>
+      <th>Property</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+    <tr>
+      <td>connector</td>
+      <td>String</td>
+      <td>
+        <p>Connector name, either "loopback-connector-redis" or "redis"</p>
+      </td>
+    </tr>
+    <tr>
+      <td>database</td>
+      <td>String</td>
+      <td>Database name</td>
+    </tr>
+    <tr>
+      <td>host</td>
+      <td>String</td>
+      <td>
+        Database host name. For connector versions <= v0.1.0, when this property is set, 
+        the port property **must also** be set.
+      </td>
+    </tr>
+    <tr>
+      <td>password</td>
+      <td>String</td>
+      <td>Password to connect to database</td>
+    </tr>
+    <tr>
+      <td>port</td>
+      <td>Number</td>
+      <td>Database TCP port</td>
+    </tr>
+    <tr>
+      <td>url</td>
+      <td>String</td>
+      <td>Use instead host and port properties.</td>
+    </tr>
+    <tr>
+      <td>username</td>
+      <td>String</td>
+      <td>Username to connect to database</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/site/SOAP-connector.md
+++ b/docs/site/SOAP-connector.md
@@ -1,0 +1,15 @@
+---
+title: 'SOAP connector'
+lang: en
+layout: readme
+source: loopback-connector-soap
+keywords: LoopBack, connector
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/SOAP-connector.html
+summary:
+  The SOAP connector enables LoopBack applications to interact with SOAP-based
+  web services.
+---
+
+{% include navgroups/soap.md %}

--- a/docs/site/SQL-Server-connector.md
+++ b/docs/site/SQL-Server-connector.md
@@ -1,0 +1,16 @@
+---
+title: 'SQL Server connector'
+lang: en
+layout: readme
+source: loopback-connector-mssql
+keywords: LoopBack
+tags: connectors
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/SQL-Server-connector.html
+summary:
+  The SQL Server connector enables LoopBack applications to connect to Microsoft
+  SQL Server data sources.
+---
+
+{% include note.html content="The SQL Server connector requires SQL Server 2005+.
+" %}

--- a/docs/site/SQLite3.md
+++ b/docs/site/SQLite3.md
@@ -1,0 +1,13 @@
+---
+title: 'SQLite3 connector'
+lang: en
+layout: readme
+source: loopback-connector-sqlite3
+keywords: LoopBack, connector
+tags: readme
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/SQLite3.html
+summary:
+  The SQLite3 connector enables LoopBack applications to connect to SQLite3 data
+  sources.
+---

--- a/docs/site/Working-with-data.md
+++ b/docs/site/Working-with-data.md
@@ -79,3 +79,4 @@ See the following articles for more information:
   - [Skip filter](Skip-filter.html)
   - [Where filter](Where-filter.html)
 - [Using database transactions](Using-database-transactions.html)
+- [Executing database commands](Executing-database-commands.md)

--- a/docs/site/kv-redis-connector.md
+++ b/docs/site/kv-redis-connector.md
@@ -1,0 +1,11 @@
+---
+title: 'Redis key-value connector'
+lang: en
+layout: readme
+source: loopback-connector-kv-redis
+keywords: LoopBack, connector
+tags: [connectors, readme]
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/kv-redis-connector.html
+summary: NOTE&#58; This documentation page is an incomplete work in progress.
+---

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -242,6 +242,10 @@ children:
       url: Database-migrations.html
       output: 'web, pdf'
 
+    - title: 'Executing database commands'
+      url: Executing-database-commands
+      output: 'web, pdf'
+
   - title: 'Using TypeORM'
     output: 'web, pdf'
     children:


### PR DESCRIPTION
The first commit adds connector README layout files from loopback.io, the second commit updates docs preview build script to include connector READMEs in the preview site too. These changes together makes it easier to preview connector-related changes via `npm run docs:start`.

The last commit adds a new page `Executing database commands`, see #3342.

I am intentionally not including connector-specific examples, my plan is to add them to individual connector README files.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
