### PR TITLE
feat(context): propagate resolution session to dynamic value factory

### DIFF
--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -261,6 +261,7 @@ function toValueFactory<T = unknown>(
   return resolutionCtx =>
     invokeMethod(provider, 'value', resolutionCtx.context, [], {
       skipInterceptors: true,
+      session: resolutionCtx.options.session,
     });
 }
 

--- a/packages/context/src/invocation.ts
+++ b/packages/context/src/invocation.ts
@@ -8,6 +8,7 @@ import assert from 'assert';
 import debugFactory from 'debug';
 import {Context} from './context';
 import {invokeMethodWithInterceptors} from './interceptor';
+import {ResolutionSession} from './resolution-session';
 import {resolveInjectedArguments} from './resolver';
 import {transformValueOrPromise, ValueOrPromise} from './value-promise';
 
@@ -120,6 +121,7 @@ export class InvocationContext extends Context {
         targetWithMethods,
         this.methodName,
         this.args,
+        options.session,
       );
     }
     return invokeTargetMethod(
@@ -148,6 +150,10 @@ export type InvocationOptions = {
    * it's a `Route`. For injected proxies, it's a `Binding`.
    */
   source?: InvocationSource;
+  /**
+   * Resolution session
+   */
+  session?: ResolutionSession;
 };
 
 /**
@@ -177,6 +183,7 @@ export function invokeMethod(
         target,
         method,
         nonInjectedArgs,
+        options.session,
       );
     }
   }
@@ -203,6 +210,7 @@ function invokeTargetMethodWithInjection(
   target: object,
   method: string,
   nonInjectedArgs?: InvocationArgs,
+  session?: ResolutionSession,
 ): ValueOrPromise<InvocationResult> {
   const methodName = getTargetName(target, method);
   /* istanbul ignore if */
@@ -216,7 +224,7 @@ function invokeTargetMethodWithInjection(
     target,
     method,
     ctx,
-    undefined,
+    session,
     nonInjectedArgs,
   );
   const targetWithMethods = target as Record<string, Function>;


### PR DESCRIPTION
This allows parameter injection of current binding using @inject.binding
and configuration of the current binding using @config. For example,

```ts
class GreetingProvider {
  static async value(
    @inject('user') user: string,
    @inject.binding currentBinding: Binding,
    @config() cfg: GreetingConfig,
  ) {
    // ...
  }
}
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
