### PR TITLE
feat: mark breaking changes for @loopback/rest and @loopback/authentication

### DIFF
--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -15,7 +15,8 @@ It contains:
 
 - A decorator to express an authentication requirement on controller methods
 - A provider to access method-level authentication metadata
-- An action in the REST sequence to enforce authentication
+- An action in the REST sequence to enforce authentication (**No longer needed
+  for middleware based sequence**)
 - An extension point to discover all authentication strategies and handle the
   delegation
 
@@ -40,6 +41,7 @@ into your application.
 - [add the authentication action to a custom sequence](https://loopback.io/doc/en/lb4/Authentication-component-action.html#adding-an-authentication-action-to-a-custom-sequence)
   and
   [bind the custom sequence to the application](https://loopback.io/doc/en/lb4/Authentication-component-action.html#binding-the-authenticating-sequence-to-the-application)
+  (**No longer needed for middleware based sequence**)
 - [register the authentication strategies](https://loopback.io/doc/en/lb4/Authentication-component-strategy.html)
 
 [Create and register a passport based strategy](https://loopback.io/doc/en/lb4/Authentication-passport.html)

--- a/packages/authentication/docs/authentication-action.md
+++ b/packages/authentication/docs/authentication-action.md
@@ -1,5 +1,9 @@
 ### Auth action
 
+**This is not needed for middleware-based sequence as the authentication is
+enforced by a middleware that's automatically discovered and added to the
+sequence.**
+
 ```ts
 import HttpErrors from 'http-errors';
 

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -14,6 +14,10 @@ with:
   `@loopback/openapi-v3`
 - a default sequence implementation to manage the request and response lifecycle
 
+**NOTE: Starting from 6.0.0, we have introduced a middleware-based sequence,
+which is is used as the default one for newly generated LoopBack applications
+using `lb4` command from `@loopback/cli`.**
+
 ## Installation
 
 To use this package, you'll need to install `@loopback/rest`.


### PR DESCRIPTION
For some reason, we lost the `BREAKING CHANGE` in commit logs to indicate that `@loopback/rest` and `@loopback/authentication` contains breaking changes. This PR marks such changes so that these two packages will be released as new major versions.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
