### PR TITLE
[Spike][Docs] reorganize connector reference into reference, how-to guides, and tutorials

### DIFF
--- a/docs/site/Configuring-datasource.md
+++ b/docs/site/Configuring-datasource.md
@@ -1,0 +1,25 @@
+---
+lang: en
+title: 'Configuring DataSource'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, Connector, Datasource
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Configuring-datasource.html
+---
+
+## Overview
+
+{% include note.html content=" This is a placeholder page, the task of adding content is tracked by the following GitHub issue: loopback-next#6091 " %}
+
+<!-- TODO
+
+- how to configure the connector ( what properties the connector configuration
+  might take
+- how type maps ⚠️ should finish task https://github.com/strongloop/loopback-next/issues/5063
+  - to database (Database Migration), e.g String -> Varchar, Boolean -> Tinyint
+  - from database (Discovery), e.g Bigint -> int, Text -> String
+- how to customize table/column names
+- how to discover/migration tables/models
+- list connector specific topics, e.g transaction, objectId, and read should check the corresponding connector pages.
+- add links to connector reference
+- Move https://loopback.io/doc/en/lb4/DataSources.html#creating-a-datasource-at-runtime from "Datasource"
+ -->

--- a/docs/site/DataSource.md
+++ b/docs/site/DataSource.md
@@ -82,3 +82,19 @@ Attach the newly created datasource to the app by calling `app.dataSource()`.
 The `app.datasource()` method is available only on application classes
 with `RepositoryMixin` applied.
 " %}
+
+### Connector
+
+{% include note.html content=" This is a placeholder page, the task of adding content is tracked by the following GitHub issue: loopback-next#6092 " %}
+
+<!-- TODO
+
+- what is connectors
+- what role it plays in req/res cycle, and what relation it has between model and other artifacts (briefly)
+- connector types (add links ):
+  - SQL (transaction), NoSQL (freeform properties)
+  - Services connectors (service proxy) and others
+  - (optional) In-memory connector
+  - (optional) Community connector
+
+  -->

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -91,6 +91,10 @@ children:
       url: todo-list-tutorial-sqldb.html
       output: 'web, pdf'
 
+  - title: 'Connecting to Back-end Service Tutorials'
+    url: Connecting-to-back-end.html
+    output: 'web, pdf'
+
   - title: 'SOAP Web Service Tutorial'
     url: soap-calculator-tutorial.html
     output: 'web, pdf'
@@ -230,6 +234,10 @@ children:
   - title: 'Accessing Databases'
     output: 'web, pdf'
     children:
+
+    - title: 'Configuring DataSource'
+      url: Configuring-datasource.html
+      output: 'web, pdf'
 
     - title: 'Working with data'
       url: Working-with-data.html

--- a/docs/site/tutorials/connectors/Connecting-to-back-end.md
+++ b/docs/site/tutorials/connectors/Connecting-to-back-end.md
@@ -1,0 +1,18 @@
+---
+lang: en
+title: 'Connecting to Back-end Service Tutorials'
+keywords:
+  LoopBack 4.0, LoopBack 4, Node.js, TypeScript, Tutorial, Connector, Datasource
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Connecting-to-back-end.html
+---
+
+{% include note.html content=" This is a placeholder page, the task of adding content is tracked by the following GitHub issue: loopback-next#6093 " %}
+
+<!-- TODO
+
+- Briefly introduce what is connectors and what connectors LB provides.
+- List the connector tutorials we have in connector ref (MySQL, PostgreSQL, Oracle, and MongoDB)
+- Add the link to connector ref
+
+-->


### PR DESCRIPTION
Closes #5961 

## Suggestion

Currently, our connector reference sits under "Reference Guides". It's hard to find a specific connector page as the path might be `Reference Guides/Connector reference/Database Connector/MySQL connector/Tutorial`.
Here is a proposal of how to reorganize them into the four quadrants 

## REFERENCE GUIDES
keep the current connector reference as is.

## BEHIND THE SCENES
![image](https://user-images.githubusercontent.com/50331796/89461360-d41d0200-d739-11ea-8837-7e33cb87aeb6.png)

add a section or a subpage under "Behind the scene/Datasource" that talk about:
- what is connectors
- what role it plays in req/res cycle, and what relation it has between model and other artifacts (briefly)
- connector types (add links ):
  - SQL (transaction), NoSQL (freeform properties)
  - Services connectors (service proxy) and others
  - (optional) In-memory connector
  - (optional) Community connector

## HOW-TOS

![Screen Shot 2020-08-05 at 5 04 01 PM](https://user-images.githubusercontent.com/50331796/89464044-c7021200-d73d-11ea-95ae-9b71e4d6ddf1.png)


add a page "Configuring DataSource"(or a better name) under "How-tos/Access Database" that talks about common connector configurations such as:
- how to configure the connector ( what properties the connector configuration might take
- how type maps ⚠️ should finish task Add missing LoopBack 4 Types docs #5063 first
  - to database (Database Migration), e.g String -> `Varchar, Boolean -> Tinyint`
  - from database (Discovery), e.g `Bigint -> int, Text -> String`
- how to customize table/column names
- how to discover/migration tables/models
- list connector specific topics, e.g transaction, `objectId`, and readers should check the corresponding connector pages.
- add links to connector reference

## TUTORIALS
![Screen Shot 2020-08-05 at 5 11 19 PM](https://user-images.githubusercontent.com/50331796/89464557-b00fef80-d73e-11ea-9b6f-ffcf188f7205.png)

Add a page "Connect to back-end tutorial" under "Tutorials" that:
- Briefly introduce what is connectors and what connectors LB provides. 
- List the connector tutorials we have in connector ref (MySQL, PostgreSQL, Oracle, and MongoDB)
- Add the link to connector ref
