### PR TITLE
feat(rest): optimize and tidy up middleware based sequence

### DIFF
--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -142,12 +142,22 @@ export interface InvokeMiddlewareOptions {
    * from the binding
    */
   chain?: string;
+
   /**
    * An array of group names to denote the order of execution, such as
    * `['cors', 'caching', 'rate-limiting']`.
    */
   orderedGroups?: string[];
 
+  /**
+   * An optional function to validate the sorted groups before invoking the
+   * middleware chain
+   */
+  validate?: (groups: string[]) => void;
+
+  /**
+   * Optional next handler
+   */
   next?: Next;
 }
 

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -8,6 +8,7 @@ import {
   Context,
   GenericInterceptor,
   GenericInterceptorChain,
+  GenericInterceptorOrKey,
   InvocationContext,
   Next,
   ValueOrPromise,
@@ -129,6 +130,11 @@ export class MiddlewareChain extends GenericInterceptorChain<
 > {}
 
 /**
+ * A middleware function or binding key
+ */
+export type MiddlewareOrKey = GenericInterceptorOrKey<MiddlewareContext>;
+
+/**
  * Default extension point name for middleware
  */
 export const DEFAULT_MIDDLEWARE_CHAIN = 'middlewareChain.default';
@@ -154,6 +160,12 @@ export interface InvokeMiddlewareOptions {
    * middleware chain
    */
   validate?: (groups: string[]) => void;
+
+  /**
+   * Pre-built middleware list. If set, the list will be used to create the
+   * middleware chain without discovering again within the context.
+   */
+  middlewareList?: MiddlewareOrKey[];
 
   /**
    * Optional next handler

--- a/packages/rest/src/rest.application.ts
+++ b/packages/rest/src/rest.application.ts
@@ -102,7 +102,7 @@ export class RestApplication extends Application implements HttpServerLike {
   }
 
   sequence(sequence: Constructor<SequenceHandler>): Binding {
-    return this.bind(RestBindings.SEQUENCE).toClass(sequence);
+    return this.restServer.sequence(sequence);
   }
 
   handler(handlerFn: SequenceFunction) {

--- a/packages/rest/src/rest.component.ts
+++ b/packages/rest/src/rest.component.ts
@@ -43,7 +43,6 @@ import {
   RestServer,
   RestServerConfig,
 } from './rest.server';
-import {MiddlewareSequence} from './sequence';
 import {ConsolidationEnhancer} from './spec-enhancers/consolidate.spec-enhancer';
 import {InfoSpecEnhancer} from './spec-enhancers/info.spec-enhancer';
 import {AjvFactoryProvider} from './validation/ajv-factory.provider';
@@ -120,7 +119,6 @@ export class RestComponent implements Component {
     ).tag({[CoreTags.EXTENSION_POINT]: RestTags.REST_MIDDLEWARE_CHAIN});
     app.add(invokeMiddlewareServiceBinding);
 
-    app.bind(RestBindings.SEQUENCE).toClass(MiddlewareSequence);
     const apiSpec = createEmptyApiSpec();
     // Merge the OpenAPI `servers` spec from the config into the empty one
     if (config?.openApiSpec?.servers) {

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -64,6 +64,7 @@ import {
 import {assignRouterSpec} from './router/router-spec';
 import {
   DefaultSequence,
+  MiddlewareSequence,
   RestMiddlewareGroups,
   SequenceFunction,
   SequenceHandler,
@@ -222,6 +223,8 @@ export class RestServer extends BaseMiddlewareRegistry
 
     if (config.sequence) {
       this.sequence(config.sequence);
+    } else {
+      this.sequence(MiddlewareSequence);
     }
 
     if (config.router) {
@@ -889,10 +892,14 @@ export class RestServer extends BaseMiddlewareRegistry
    * }
    * ```
    *
-   * @param value - The sequence to invoke for each incoming request.
+   * @param sequenceClass - The sequence class to invoke for each incoming request.
    */
-  public sequence(value: Constructor<SequenceHandler>) {
-    this.bind(RestBindings.SEQUENCE).toClass(value);
+  public sequence(sequenceClass: Constructor<SequenceHandler>) {
+    const sequenceBinding = createBindingFromClass(sequenceClass, {
+      key: RestBindings.SEQUENCE,
+    });
+    this.add(sequenceBinding);
+    return sequenceBinding;
   }
 
   /**

--- a/packages/rest/src/sequence.ts
+++ b/packages/rest/src/sequence.ts
@@ -12,11 +12,10 @@ import {
   ValueOrPromise,
 } from '@loopback/core';
 import {
-  discoverMiddleware,
   InvokeMiddleware,
   InvokeMiddlewareOptions,
   MiddlewareGroups,
-  MiddlewareOrKey,
+  MiddlewareView,
 } from '@loopback/express';
 import debugFactory from 'debug';
 import {RestBindings, RestTags} from './keys';
@@ -188,7 +187,7 @@ export namespace RestMiddlewareGroups {
  */
 @bind({scope: BindingScope.SINGLETON})
 export class MiddlewareSequence implements SequenceHandler {
-  private middlewareList: MiddlewareOrKey[];
+  private middlewareView: MiddlewareView;
 
   static defaultOptions: InvokeMiddlewareOptions = {
     chain: RestTags.REST_MIDDLEWARE_CHAIN,
@@ -248,8 +247,8 @@ export class MiddlewareSequence implements SequenceHandler {
     @config()
     readonly options: InvokeMiddlewareOptions = MiddlewareSequence.defaultOptions,
   ) {
-    this.middlewareList = discoverMiddleware(context, options);
-    debug('Discovered middleware', this.middlewareList);
+    this.middlewareView = new MiddlewareView(context, options);
+    debug('Discovered middleware', this.middlewareView.middlewareBindingKeys);
   }
 
   /**
@@ -285,7 +284,7 @@ export class MiddlewareSequence implements SequenceHandler {
       this.options.orderedGroups,
     );
     const options: InvokeMiddlewareOptions = {
-      middlewareList: this.middlewareList,
+      middlewareList: this.middlewareView.middlewareBindingKeys,
       validate: MiddlewareSequence.defaultOptions.validate,
       ...this.options,
     };


### PR DESCRIPTION
- Optimize middleware based sequence and its middleware providers to be singletons
  - MiddlewareSequence is now a singleton and it caches a list of middleware
  - Built-in middleware providers are now singletons
- Add the ability to validate sorted middleware groups
  - Help our developers troubleshoot misconfigured middleware group orders


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
