### PR TITLE
docs: restructure the concepts page

### DIFF
--- a/docs/site/Component.md
+++ b/docs/site/Component.md
@@ -1,9 +1,10 @@
 ---
 lang: en
-title: 'Components'
+title: 'Component'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Components.html
+permalink: /doc/en/lb4/Component.html
+redirect_from: /doc/en/lb4/Components.html
 ---
 
 ## Overview

--- a/docs/site/Controller.md
+++ b/docs/site/Controller.md
@@ -1,9 +1,10 @@
 ---
 lang: en
-title: 'Controllers'
+title: 'Controller'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Concepts
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Controllers.html
+permalink: /doc/en/lb4/Controller.html
+redirect_from: /doc/en/lb4/Controllers.html
 ---
 
 ## Overview

--- a/docs/site/DataSource.md
+++ b/docs/site/DataSource.md
@@ -1,9 +1,10 @@
 ---
 lang: en
-title: 'DataSources'
+title: 'DataSource'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/DataSources.html
+permalink: /doc/en/lb4/DataSource.html
+redirect_from: /doc/en/lb4/DataSources.html
 ---
 
 ## Overview

--- a/docs/site/Interceptors.md
+++ b/docs/site/Interceptors.md
@@ -1,9 +1,10 @@
 ---
 lang: en
-title: 'Interceptors'
+title: 'Interceptor'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Interceptor
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Interceptors.html
+permalink: /doc/en/lb4/Interceptor.html
+redirect_from: /doc/en/lb4/Interceptors.html
 ---
 
 ## Overview

--- a/docs/site/Repository.md
+++ b/docs/site/Repository.md
@@ -1,9 +1,10 @@
 ---
 lang: en
-title: 'Repositories'
+title: 'Repository'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Repository
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Repositories.html
+permalink: /doc/en/lb4/Repository.html
+redirect_from: /doc/en/lb4/Repositories.html
 ---
 
 A `Repository` represents a specialized `Service` interface that provides

--- a/docs/site/Route.md
+++ b/docs/site/Route.md
@@ -1,9 +1,10 @@
 ---
 lang: en
-title: 'Routes'
+title: 'Route'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Routes.html
+permalink: /doc/en/lb4/Route.html
+redirect_from: /doc/en/lb4/Routes.html
 ---
 
 ## Overview

--- a/docs/site/Service.md
+++ b/docs/site/Service.md
@@ -1,9 +1,10 @@
 ---
 lang: en
-title: 'Services'
+title: 'Service'
 keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI
 sidebar: lb4_sidebar
-permalink: /doc/en/lb4/Services.html
+permalink: /doc/en/lb4/Service.html
+redirect_from: /doc/en/lb4/Services.html
 ---
 
 ## Overview

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -63,8 +63,8 @@ We are using the documentation system based on four quadrants, as described at
 - Problem-oriented `How-to Guides` provide recipes to solve specific goals you
   may encounter while building a LoopBack project.
 
-- Understanding-oriented `Behind the scenes` pages provide background and
-  context, wider view and deeper knowledge about the framework.
+- Understanding-oriented `Concepts` pages provide the explanation of
+  architecture concepts, wider view and deeper knowledge about the framework.
 
 - Information-oriented `Reference guides` provide technical description of the
   machinery and how to use it.

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -394,7 +394,7 @@ children:
     url: Metrics.html
     output: 'web, pdf'
 
-- title: 'Behind the Scenes'
+- title: 'Concepts'
   url: Behind-the-scene.html
   output: 'web, pdf'
   children:
@@ -403,146 +403,156 @@ children:
     url: Crafting-LoopBack-4.html
     output: 'web, pdf'
 
-  - title: 'Application'
-    url: Application.html
-    output: 'web, pdf'
-
-  - title: 'Server'
-    url: Server.html
-    output: 'web, pdf'
-
-  - title: 'Controllers'
-    url: Controllers.html
-    output: 'web, pdf'
-
-  - title: 'Models'
-    url: Model.html
-    output: 'web, pdf'
-
-  - title: 'Relations'
-    url: Relations.html
+  - title: 'Core'
     output: 'web, pdf'
     children:
 
-    - title: 'HasMany Relation'
-      url: HasMany-relation.html
+    - title: 'Application'
+      url: Application.html
       output: 'web, pdf'
 
-    - title: 'BelongsTo Relation'
-      url: BelongsTo-relation.html
+    - title: 'Component'
+      url: Component.html
       output: 'web, pdf'
 
-    - title: 'HasOne Relation'
-      url: HasOne-relation.html
+    - title: 'Context'
+      url: Context.html
       output: 'web, pdf'
 
-    - title: 'HasManyThrough Relation'
-      url: HasManyThrough-relation.html
+    - title: 'Binding'
+      url: Binding.html
       output: 'web, pdf'
 
-  - title: 'DataSources'
-    url: DataSources.html
-    output: 'web, pdf'
+    - title: 'Dependency Injection'
+      url: Dependency-injection.html
+      output: 'web, pdf'
 
-  - title: 'Repositories'
-    url: Repositories.html
+    - title: 'Interceptor'
+      url: Interceptor.html
+      output: 'web, pdf'
+
+    - title: 'Life Cycle Event and Observer'
+      url: Life-cycle.html
+      output: 'web, pdf'
+
+    - title: 'Service'
+      url: Service.html
+      output: 'web, pdf'
+
+    - title: 'Booter'
+      url: Booting-an-Application.html
+      output: 'web, pdf'
+
+    - title: 'Decorators'
+      url: Decorators.html
+      output: 'web, pdf'
+      children:
+
+      - title: 'OpenAPI Decorators'
+        url: Decorators_openapi.html
+        output: 'web, pdf'
+
+      - title: 'Dependency Injection Decorator'
+        url: Decorators_inject.html
+        output: 'web, pdf'
+
+      - title: 'Authentication Decorator'
+        url: Decorators_authenticate.html
+        output: 'web, pdf'
+
+      - title: 'Service Decorators'
+        url: Decorators_service.html
+        output: 'web, pdf'
+
+      - title: 'Repository Decorators'
+        url: Decorators_repository.html
+        output: 'web, pdf'
+
+    - title: 'Mixin'
+      url: Mixin.html
+      output: 'web, pdf'
+
+  - title: 'REST APIs'
     output: 'web, pdf'
     children:
 
-  - title: 'Services'
-    url: Services.html
-    output: 'web, pdf'
+    - title: 'Server'
+      url: Server.html
+      output: 'web, pdf'
 
-  - title: 'Interceptors'
-    url: Interceptors.html
-    output: 'web, pdf'
+    - title: 'Sequence'
+      url: Sequence.html
+      output: 'web, pdf'
+      children:
 
-  - title: 'Life cycle events and observers'
-    url: Life-cycle.html
-    output: 'web, pdf'
+      - title: 'Middleware based sequence'
+        url: REST-middleware-sequence.html
+        output: 'web, pdf'
 
-  - title: 'Routes'
-    url: Routes.html
-    output: 'web, pdf'
+      - title: 'Action based sequence'
+        url: REST-action-sequence.html
+        output: 'web, pdf'
 
-  - title: 'Sequence'
-    url: Sequence.html
+      - title: 'Routing requests'
+        url: Routing-requests.html
+        output: 'web, pdf'
+
+      - title: 'Parsing requests'
+        url: Parsing-requests.html
+        output: 'web, pdf'
+
+    - title: 'Middleware'
+      url: Middleware.html
+      output: 'web, pdf'
+
+    - title: 'Route'
+      url: Route.html
+      output: 'web, pdf'
+
+    - title: 'Controller'
+      url: Controller.html
+      output: 'web, pdf'
+
+    - title: 'Request/response cycle'
+      url: Request-response-cycle.html
+      output: 'web, pdf'
+
+  - title: 'Data Access'
     output: 'web, pdf'
     children:
 
-    - title: 'Middleware based sequence'
-      url: REST-middleware-sequence.html
+    - title: 'Model'
+      url: Model.html
       output: 'web, pdf'
 
-    - title: 'Action based sequence'
-      url: REST-action-sequence.html
+    - title: 'Relations'
+      url: Relations.html
+      output: 'web, pdf'
+      children:
+
+      - title: 'HasMany Relation'
+        url: HasMany-relation.html
+        output: 'web, pdf'
+
+      - title: 'BelongsTo Relation'
+        url: BelongsTo-relation.html
+        output: 'web, pdf'
+
+      - title: 'HasOne Relation'
+        url: HasOne-relation.html
+        output: 'web, pdf'
+
+      - title: 'HasManyThrough Relation'
+        url: HasManyThrough-relation.html
+        output: 'web, pdf'
+
+    - title: 'Repository'
+      url: Repository.html
       output: 'web, pdf'
 
-    - title: 'Routing requests'
-      url: Routing-requests.html
+    - title: 'DataSource'
+      url: DataSource.html
       output: 'web, pdf'
-
-    - title: 'Parsing requests'
-      url: Parsing-requests.html
-      output: 'web, pdf'
-
-  - title: 'Middleware'
-    url: Middleware.html
-    output: 'web, pdf'
-
-  - title: 'Decorators'
-    url: Decorators.html
-    output: 'web, pdf'
-    children:
-
-    - title: 'OpenAPI Decorators'
-      url: Decorators_openapi.html
-      output: 'web, pdf'
-
-    - title: 'Dependency Injection Decorator'
-      url: Decorators_inject.html
-      output: 'web, pdf'
-
-    - title: 'Authentication Decorator'
-      url: Decorators_authenticate.html
-      output: 'web, pdf'
-
-    - title: 'Service Decorators'
-      url: Decorators_service.html
-      output: 'web, pdf'
-
-    - title: 'Repository Decorators'
-      url: Decorators_repository.html
-      output: 'web, pdf'
-
-  - title: 'Mixins'
-    url: Mixin.html
-    output: 'web, pdf'
-
-  - title: 'Context'
-    url: Context.html
-    output: 'web, pdf'
-
-  - title: 'Binding'
-    url: Binding.html
-    output: 'web, pdf'
-
-  - title: 'Dependency Injection'
-    url: Dependency-injection.html
-    output: 'web, pdf'
-    children:
-
-  - title: 'Components'
-    url: Components.html
-    output: 'web, pdf'
-
-  - title: 'Request/response cycle'
-    url: Request-response-cycle.html
-    output: 'web, pdf'
-
-  - title: 'Booting an Application'
-    url: Booting-an-Application.html
-    output: 'web, pdf'
 
 - title: 'Best practices'
   url: Best-practices.html


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-next/issues/5776

I renamed the concept items to use the singular terms.

fold subsections:
<img width="274" alt="Screen Shot 2020-08-10 at 3 31 45 PM" src="https://user-images.githubusercontent.com/12554153/89823693-ecb55f80-db1f-11ea-923e-3f89ba47f76a.png">

unfold subsections, part 1:
<img width="253" alt="Screen Shot 2020-08-10 at 3 32 10 PM" src="https://user-images.githubusercontent.com/12554153/89823692-ecb55f80-db1f-11ea-9b36-218fdd0429e9.png">

unfold subsections, part 2:
<img width="215" alt="Screen Shot 2020-08-10 at 3 32 19 PM" src="https://user-images.githubusercontent.com/12554153/89823691-ec1cc900-db1f-11ea-970f-5232cd52d3f8.png">



## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
