### PR TITLE
docs: add operationId in spec

### DIFF
--- a/docs/site/Controller.md
+++ b/docs/site/Controller.md
@@ -197,6 +197,50 @@ export class HelloController {
 - `@param.query.number` specifies in the spec being generated that the route
   takes a parameter via query which will be a number.
 
+## Modifying Specifications Created by Controller Generator
+
+You can run generator to create REST controllers with CRUD methods. The command
+and prompts are explained in page
+[controller-generator](./Controller-generator.md#rest-controller-with-crud-methods).
+To modify the OpenAPI specifications of REST controllers, you can leverage the
+[specification enhancers](Extending-OpenAPI-specification.md).
+
+For example, the default naming convention for a path's `operationId` is
+`${controllerName}.${methodName}`. To override the `operationId` with a custom
+one `${controllerName}-${methodName}`, you can define an enhancer as:
+
+```ts
+import {bind} from '@loopback/core';
+import {
+  mergeOpenAPISpec,
+  asSpecEnhancer,
+  OASEnhancer,
+  OpenApiSpec,
+} from '@loopback/rest';
+
+/**
+ * A spec enhancer to modify `operationId` in paths
+ */
+@bind(asSpecEnhancer)
+export class OperationSpecEnhancer implements OASEnhancer {
+  name = 'operationIdEnhancer';
+  // takes in the current spec, modifies it, and returns a new one
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    const paths = spec.paths;
+    for (const path in paths) {
+      for (const op in path) {
+        const operationId = paths[path][op].operationId;
+        // change operationId from 'MyController.MyMethod' to
+        // 'MyController-MyMethod'
+        if (operationId)
+          paths[path][op].operationId = operationId.replace('.', '-');
+      }
+    }
+    return spec;
+  }
+}
+```
+
 ## Class factory to allow parameterized decorations
 
 Since decorations applied on a top-level class cannot have references to

--- a/docs/site/decorators/Decorators_openapi.md
+++ b/docs/site/decorators/Decorators_openapi.md
@@ -35,6 +35,9 @@ For example:
   paths: {
     '/greet': {
       get: {
+        // You can specify `operationId` as an universal property that's
+        // understood by other frameworks.
+        operationId: 'MyController.greet',
         'x-operation-name': 'greet',
         'x-controller-name': 'MyController',
         parameters: [{name: 'name', schema: {type: 'string'}, in: 'query'}],
@@ -76,6 +79,9 @@ your endpoint, for example:
 
 ```ts
 const spec = {
+  // You can specify `operationId` as an universal property that's
+  // understood by other frameworks.
+  operationId: 'MyController.checkExist'
   parameters: [{name: 'name', schema: {type: 'string'}, in: 'query'}],
   responses: {
     '200': {


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-next/issues/5970
Add guide for specifying `operationId` in the spec

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
