### PR TITLE
feat(rest): improve validation errors for invalid parameter value

### DIFF
--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -187,7 +187,7 @@ async function coerceObject(
       data,
       schema,
       {},
-      {...options, coerceTypes: true, source: 'parameter'},
+      {...options, coerceTypes: true, source: 'parameter', name: spec.name},
     );
   }
 

--- a/packages/rest/src/rest-http-error.ts
+++ b/packages/rest/src/rest-http-error.ts
@@ -11,7 +11,7 @@ export namespace RestHttpErrors {
     name: string,
     extraProperties?: Props,
   ): HttpErrors.HttpError & Props {
-    const msg = `Invalid data ${JSON.stringify(data)} for parameter ${name}!`;
+    const msg = `Invalid data ${JSON.stringify(data)} for parameter "${name}".`;
     return Object.assign(
       new HttpErrors.BadRequest(msg),
       {
@@ -51,11 +51,15 @@ export namespace RestHttpErrors {
 
   export const INVALID_REQUEST_BODY_MESSAGE =
     'The request body is invalid. See error object `details` property for more info.';
-  export function invalidRequestBody(): HttpErrors.HttpError {
+
+  export function invalidRequestBody(
+    details: ValidationErrorDetails[],
+  ): HttpErrors.HttpError & {details: ValidationErrorDetails[]} {
     return Object.assign(
       new HttpErrors.UnprocessableEntity(INVALID_REQUEST_BODY_MESSAGE),
       {
         code: 'VALIDATION_FAILED',
+        details,
       },
     );
   }

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -117,6 +117,11 @@ export interface ValueValidationOptions extends ValidationOptions {
    * 'query', 'cookie', etc...
    */
   source?: string;
+
+  /**
+   * Parameter name, as provided in `ParameterObject#name` property.
+   */
+  name?: string;
 }
 
 /**


### PR DESCRIPTION
Rework the validation code to use exiting `RestHttpErrors.invalidData` error instead of a custom `BadRequest` error. This way the error object includes the parameter name in the error message & properties and has a machine-readable `code` property.

See also #5808 which introduced parameter coercion.

Surprisingly, all existing tests are passing with my change in place, so I didn't make any changes in the test suite. Please let me know if you think I should write a new test 🤷🏻 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
