### PR TITLE
chore: order of id type prompt in controller generator should be in sync with model's

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -181,9 +181,9 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
         type: 'list',
         name: 'idType',
         message: g.f('What is the type of your ID?'),
-        choices: ['number', 'string', 'object'],
+        choices: ['string', 'number', 'object'],
         when: this.artifactInfo.idType === undefined,
-        default: 'number',
+        default: 'string',
       },
       {
         type: 'confirm',


### PR DESCRIPTION
The `id` type order for model generator looks like this:

```sh
? Enter the property name: id
? Property type: (Use arrow keys)
❯ string
  number
  boolean
  object
  array
  date
  buffer
```

When we revisit the `id` in the controller generator, we are prompted with this: 

```sh
? What is the type of your ID? (Use arrow keys)
❯ number
  string
  object
```

Let's follow a consistent order, it makes for a better UX. Small thing, big difference.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
