### PR TITLE
chore: get rid of default banner in model and repo generators

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -118,13 +118,15 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
     let modelList, repositoryList;
 
     try {
-      modelList = await utils.getArtifactList(
+      modelList = await utils.getArtifactListWithPath(
         this.artifactInfo.modelDir,
+        this.artifactInfo.relPath,
         'model',
       );
 
-      repositoryList = await utils.getArtifactList(
+      repositoryList = await utils.getArtifactListWithPath(
         this.artifactInfo.repositoryDir,
+        this.artifactInfo.relPath,
         'repository',
         true,
       );

--- a/packages/cli/generators/model/index.js
+++ b/packages/cli/generators/model/index.js
@@ -27,11 +27,10 @@ const ERROR_NO_MODELS_FOUND = g.f('Model was not found in');
 const BASE_MODELS = ['Entity', 'Model'];
 const CLI_BASE_MODELS = [
   {
-    name: `Entity ${chalk.gray('(A persisted model with an ID)')}`,
+    name: `Entity ${chalk.gray('A persisted model with an ID')}`,
     value: 'Entity',
   },
-  {name: `Model ${chalk.gray('(A business domain object)')}`, value: 'Model'},
-  {type: 'separator', line: '----- Custom Models -----'},
+  {name: `Model ${chalk.gray('A business domain object')}`, value: 'Model'},
 ];
 const MODEL_TEMPLATE_PATH = 'model.ts.ejs';
 
@@ -100,7 +99,7 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
       type: String,
       required: false,
       description: g.f(
-        'The name of the dataSource which contains this model and suppots model discovery',
+        'The name of the dataSource which contains this model and supports model discovery',
       ),
     });
 
@@ -207,8 +206,9 @@ module.exports = class ModelGenerator extends ArtifactGenerator {
 
     try {
       debug(`model list dir ${this.artifactInfo.modelDir}`);
-      const modelList = await utils.getArtifactList(
+      const modelList = await utils.getArtifactListWithPath(
         this.artifactInfo.modelDir,
+        this.artifactInfo.relPath,
         'model',
       );
       debug(`modelist ${modelList}`);

--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -36,12 +36,6 @@ const CLI_BASE_KEY_VALUE_REPOSITORIES = [
     value: KEY_VALUE_REPOSITORY,
   },
 ];
-const CLI_BASE_SEPARATOR = [
-  {
-    type: 'separator',
-    line: g.f('----- Custom Repositories -----'),
-  },
-];
 
 const REPOSITORY_KV_TEMPLATE = 'repository-kv-template.ts.ejs';
 const REPOSITORY_CRUD_TEMPLATE = 'repository-crud-default-template.ts.ejs';
@@ -395,7 +389,6 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
     if (this.artifactInfo.repositoryTypeClass === KEY_VALUE_REPOSITORY)
       availableRepositoryList.push(...CLI_BASE_KEY_VALUE_REPOSITORIES);
     else availableRepositoryList.push(...CLI_BASE_CRUD_REPOSITORIES);
-    availableRepositoryList.push(...CLI_BASE_SEPARATOR);
 
     try {
       this.artifactInfo.baseRepositoryList = await this._findBaseClasses(

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -382,6 +382,36 @@ exports.getArtifactList = async function (
 };
 
 /**
+ * Parses the files of the target directory and returns matching JavaScript
+ * or TypeScript class with their relative path.
+ * @param {string} dir The target directory from which to load artifacts.
+ * @param {string} relPath Relative path of of the directory.
+ * @param {string} artifactType The artifact type (ex. "model", "repository")
+ * @param {boolean} addSuffix Whether or not to append the artifact type to the
+ * results. (ex. [Foo,Bar] -> [FooRepository, BarRepository])
+ * @param {Function} reader An alternate function to replace the promisified
+ * fs.readdir (useful for testing and for custom overrides).
+ */
+exports.getArtifactListWithPath = async function (
+  dir,
+  relPath,
+  artifactType,
+  addSuffix,
+  reader,
+) {
+  const paths = await exports.findArtifactPaths(dir, artifactType, reader);
+  debug('Artifacts paths found:', paths);
+  return paths.map(p => {
+    const firstWord = _.first(_.split(_.last(_.split(p, path.sep)), '.'));
+    const result = pascalCase(exports.toClassName(firstWord));
+    const suffixed = addSuffix
+      ? exports.toClassName(result) + exports.toClassName(artifactType)
+      : exports.toClassName(result);
+    return `${suffixed} ${chalk.gray(relPath + '/' + p)}`;
+  });
+};
+
+/**
  * Check package.json and dependencies.json to find out versions for generated
  * dependencies
  */


### PR DESCRIPTION
**Before**

```sh
? Please select the model base class (Use arrow keys)
❯ Entity (A persisted model with an ID)
  Model (A business domain object)
  ----- Custom Models -----
  Book
  Color
```

```sh
? Please select the repository base class (Use arrow keys)
❯ DefaultCrudRepository (Juggler bridge)
  ----- Custom Repositories -----
```

**After**

```sh
? Please select the model base class (Use arrow keys)
❯ Entity (A persisted model with an ID)
  Model (A business domain object)
  Book
  Color
```

```sh
? Please select the repository base class (Use arrow keys)
❯ DefaultCrudRepository (Juggler bridge)
```

The `----- Custom Models -----` and ` ----- Custom Repositories -----` banners are not required for users to know that the items under it as user-created (custom). They are a distraction and add 1 more step to getting to where the user wants to reach if they decide to select a user-created class.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
