### PR TITLE
fix: appropriate type prompt for lb4 extension command

### DIFF
--- a/packages/cli/generators/extension/index.js
+++ b/packages/cli/generators/extension/index.js
@@ -33,12 +33,12 @@ module.exports = class ExtensionGenerator extends ProjectGenerator {
 
   promptProjectName() {
     if (this.shouldExit()) return;
-    return super.promptProjectName();
+    return super.promptProjectName('Extension');
   }
 
   promptProjectDir() {
     if (this.shouldExit()) return;
-    return super.promptProjectDir();
+    return super.promptProjectDir('Extension');
   }
 
   promptComponent() {

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -131,13 +131,19 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     });
   }
 
-  promptProjectName() {
+  promptProjectName(projectType) {
     if (this.shouldExit()) return false;
+    let namePrompt = 'Project name:';
+    let descriptionPrompt = 'Project description:';
+    if (projectType) {
+      namePrompt = `${projectType} name:`;
+      descriptionPrompt = `${projectType} description:`;
+    }
     const prompts = [
       {
         type: 'input',
         name: 'name',
-        message: g.f('Project name:'),
+        message: g.f(namePrompt),
         when: this.projectInfo.name == null,
         default:
           this.options.name || utils.toFileName(path.basename(process.cwd())),
@@ -146,7 +152,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
       {
         type: 'input',
         name: 'description',
-        message: g.f('Project description:'),
+        message: g.f(descriptionPrompt),
         when: this.projectInfo.description == null,
         default: this.options.name || this.appname,
       },
@@ -157,13 +163,17 @@ module.exports = class ProjectGenerator extends BaseGenerator {
     });
   }
 
-  promptProjectDir() {
+  promptProjectDir(projectType) {
     if (this.shouldExit()) return false;
+    let dirPrompt = 'Project root directory:';
+    if (projectType) {
+      dirPrompt = `${projectType} root directory:`;
+    }
     const prompts = [
       {
         type: 'input',
         name: 'outdir',
-        message: g.f('Project root directory:'),
+        message: g.f(dirPrompt),
         when:
           this.projectInfo.outdir == null ||
           // prompts if option was set to a directory that already exists


### PR DESCRIPTION
Use "Extension" instead of "Project" with `lb4 extension`.

**Before**

```sh
$ lb4 extension search
? Project description: search
? Project root directory: search
```

**After**

```sh
$ lb4 extension search
? Extension description: search
? Extension root directory: search
```

"Project" is used for creating apps. Using it also with extensions makes the user wonder if they are creating another app within the current app. Even if the command is run outside the app dir, it should make itself obvious that it is creating an extension. 

For users who have frequently used `lb4 app`, "Project" is app. Running `lb4 extension` and seeing "Project" is very confusing.



<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
