### PR TITLE
docs: add extensions

### DIFF
--- a/docs/site/Context-explorer.md
+++ b/docs/site/Context-explorer.md
@@ -1,0 +1,10 @@
+---
+lang: en
+title: 'Context Explorer'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, Context
+layout: readme
+source: loopback-next
+file: extensions/context-explorer/README.md
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Context-explorer.html
+---

--- a/docs/site/Integrating-with-api-connect.md
+++ b/docs/site/Integrating-with-api-connect.md
@@ -1,0 +1,10 @@
+---
+lang: en
+title: 'Integrating with API Connect'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, OpenAPI, Cloud Native
+layout: readme
+source: loopback-next
+file: extensions/apiconnect/README.md
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Integrating-with-api-connect.html
+---

--- a/docs/site/Logging.md
+++ b/docs/site/Logging.md
@@ -1,0 +1,10 @@
+---
+lang: en
+title: 'Logging'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, Logging
+layout: readme
+source: loopback-next
+file: extensions/logging/README.md
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Logging.html
+---

--- a/docs/site/Pooling.md
+++ b/docs/site/Pooling.md
@@ -1,0 +1,10 @@
+---
+lang: en
+title: 'Pooling'
+keywords: LoopBack 4.0, LoopBack 4, Node.js, TypeScript, Pooling
+layout: readme
+source: loopback-next
+file: extensions/pooling/README.md
+sidebar: lb4_sidebar
+permalink: /doc/en/lb4/Pooling.html
+---

--- a/docs/site/sidebars/lb4_sidebar.yml
+++ b/docs/site/sidebars/lb4_sidebar.yml
@@ -224,6 +224,10 @@ children:
       url: Boot-and-Mount-a-LoopBack-3-application.html
       output: 'web, pdf'
 
+    - title: 'Integrating with API Connect'
+      url: Integrating-with-api-connect.html
+      output: 'web, pdf'
+
   - title: 'Creating Other Forms of APIs'
     output: 'web, pdf'
     children:
@@ -399,12 +403,24 @@ children:
         url: Metrics.html
         output: 'web, pdf'
 
+      - title: 'Pooling'
+        url: Pooling.html
+        output: 'web, pdf'
+
   - title: 'Troubleshooting'
     output: 'web, pdf'
     children:
 
     - title: 'Setting debug strings'
       url: Setting-debug-strings.html
+      output: 'web, pdf'
+
+    - title: 'Logging'
+      url: Logging.html
+      output: 'web, pdf'
+
+    - title: 'Context Explorer'
+      url: Context-explorer.html
       output: 'web, pdf'
 
 - title: 'Concepts'


### PR DESCRIPTION
Add extensions based on discussion in https://github.com/strongloop/loopback-next/pull/6081#discussion_r468262484

newly added extension:
part 1
<img width="250" alt="Screen Shot 2020-08-17 at 12 54 59 PM" src="https://user-images.githubusercontent.com/12554153/90426414-08c08000-e08f-11ea-98bf-dcc520007c49.png">

part2
<img width="288" alt="Screen Shot 2020-08-17 at 12 57 16 PM" src="https://user-images.githubusercontent.com/12554153/90426418-09591680-e08f-11ea-96c2-a6d12618154d.png">

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-next) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
