### PR TITLE
feat(rest): improve route description to include verb and path

### DIFF
--- a/packages/rest/src/__tests__/integration/http-handler.integration.ts
+++ b/packages/rest/src/__tests__/integration/http-handler.integration.ts
@@ -524,7 +524,8 @@ describe('HttpHandler', () => {
 
       await client.get('/hello').expect(404, {
         error: {
-          message: 'Controller method not found: TestController.unknownMethod',
+          message:
+            'Controller method not found: get /hello => TestController.unknownMethod',
           name: 'NotFoundError',
           statusCode: 404,
         },

--- a/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/controller-route.unit.ts
@@ -116,8 +116,12 @@ describe('ControllerRoute', () => {
       myControllerFactory,
       'greet',
     );
-    expect(route.toString()).to.equal('MyRoute - get /greet');
-    expect(new RouteSource(route).toString()).to.equal('get /greet');
+    expect(route.toString()).to.equal(
+      'MyRoute - get /greet => MyController.greet',
+    );
+    expect(new RouteSource(route).toString()).to.equal(
+      'MyRoute - get /greet => MyController.greet',
+    );
   });
 
   describe('updateBindings()', () => {

--- a/packages/rest/src/__tests__/unit/router/handler-route.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/handler-route.unit.ts
@@ -33,11 +33,22 @@ describe('HandlerRoute', () => {
   });
 
   describe('toString', () => {
-    it('implements toString', () => {
+    it('implements toString for anonymous handler', () => {
       const spec = anOperationSpec().build();
       const route = new Route('get', '/greet', spec, () => {});
-      expect(route.toString()).to.equal('Route - get /greet');
-      expect(new RouteSource(route).toString()).to.equal('get /greet');
+      expect(route.toString()).to.equal('Route - get /greet => () => { }');
+      expect(new RouteSource(route).toString()).to.equal(
+        'Route - get /greet => () => { }',
+      );
+    });
+
+    it('implements toString for named handler', () => {
+      const spec = anOperationSpec().build();
+      const route = new Route('get', '/greet', spec, function process() {});
+      expect(route.toString()).to.equal('Route - get /greet => process');
+      expect(new RouteSource(route).toString()).to.equal(
+        'Route - get /greet => process',
+      );
     });
   });
 });

--- a/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
+++ b/packages/rest/src/__tests__/unit/router/routing-table.unit.ts
@@ -69,7 +69,7 @@ function runTestsWithRouter(router: RestRouter) {
     expect(route).to.be.instanceOf(ControllerRoute);
     expect(route).to.have.property('spec').containEql(spec.paths['/hello'].get);
     expect(route).to.have.property('pathParams');
-    expect(route.describe()).to.equal('TestController.greet');
+    expect(route.describe()).to.equal('get /hello => TestController.greet');
   });
 
   it('finds simple "GET /my/hello" endpoint', () => {
@@ -98,7 +98,7 @@ function runTestsWithRouter(router: RestRouter) {
     expect(route).to.be.instanceOf(ControllerRoute);
     expect(route).to.have.property('spec').containEql(spec.paths['/hello'].get);
     expect(route).to.have.property('pathParams');
-    expect(route.describe()).to.equal('TestController.greet');
+    expect(route.describe()).to.equal('get /my/hello => TestController.greet');
   });
 
   it('finds simple "GET /hello/world" endpoint', () => {
@@ -122,7 +122,9 @@ function runTestsWithRouter(router: RestRouter) {
       .to.have.property('spec')
       .containEql(spec.paths['/hello/world'].get);
     expect(route).to.have.property('pathParams', {});
-    expect(route.describe()).to.equal('TestController.greetWorld');
+    expect(route.describe()).to.equal(
+      'get /hello/world => TestController.greetWorld',
+    );
   });
 
   it('finds simple "GET /add/{arg1}/{arg2}" endpoint', () => {

--- a/packages/rest/src/providers/invoke-method.provider.ts
+++ b/packages/rest/src/providers/invoke-method.provider.ts
@@ -45,13 +45,7 @@ export class InvokeMethodMiddlewareProvider implements Provider<Middleware> {
         RestBindings.Operation.PARAMS,
       );
       if (debug.enabled) {
-        debug(
-          'Invoking method %s for %s %s with',
-          route.describe(),
-          ctx.request.method,
-          ctx.request.originalUrl,
-          params,
-        );
+        debug('Invoking method %s with', route.describe(), params);
       }
       try {
         const retVal = await this.invokeMethod(route, params);
@@ -61,7 +55,9 @@ export class InvokeMethodMiddlewareProvider implements Provider<Middleware> {
         }
         return retVal;
       } catch (err) {
-        debug('Error', err);
+        if (debug.enabled) {
+          debug('Error thrown from %s', route.describe(), err);
+        }
         throw err;
       }
     };

--- a/packages/rest/src/router/base-route.ts
+++ b/packages/rest/src/router/base-route.ts
@@ -36,11 +36,11 @@ export abstract class BaseRoute implements RouteEntry {
   ): Promise<OperationRetval>;
 
   describe(): string {
-    return `"${this.verb} ${this.path}"`;
+    return `${this.verb} ${this.path}`;
   }
 
   toString() {
-    return `${this.constructor.name} - ${this.verb} ${this.path}`;
+    return `${this.constructor.name} - ${this.describe()}`;
   }
 }
 
@@ -48,6 +48,6 @@ export class RouteSource implements InvocationSource<RouteEntry> {
   type = 'route';
   constructor(readonly value: RouteEntry) {}
   toString() {
-    return `${this.value.verb} ${this.value.path}`;
+    return this.value.toString();
   }
 }

--- a/packages/rest/src/router/controller-route.ts
+++ b/packages/rest/src/router/controller-route.ts
@@ -101,7 +101,7 @@ export class ControllerRoute<T> extends BaseRoute {
   }
 
   describe(): string {
-    return `${this._controllerName}.${this._methodName}`;
+    return `${super.describe()} => ${this._controllerName}.${this._methodName}`;
   }
 
   updateBindings(requestContext: Context) {

--- a/packages/rest/src/router/handler-route.ts
+++ b/packages/rest/src/router/handler-route.ts
@@ -20,7 +20,9 @@ export class Route extends BaseRoute {
   }
 
   describe(): string {
-    return this._handler.name || super.describe();
+    return `${super.describe()} => ${
+      this._handler.name || this._handler.toString()
+    }`;
   }
 
   updateBindings(requestContext: Context) {

--- a/packages/rest/src/router/redirect-route.ts
+++ b/packages/rest/src/router/redirect-route.ts
@@ -42,7 +42,7 @@ export class RedirectRoute implements RouteEntry, ResolvedRoute {
   }
 
   describe(): string {
-    return `RedirectRoute from "${this.sourcePath}" to "${this.targetLocation}"`;
+    return `Redirect: "${this.sourcePath}" => "${this.targetLocation}"`;
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

Improve `RouteEntry.describe()` to be `<verb> <path> => <target handler/controller method>`

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
