### PR TITLE
fix: monorepo, package metadata scripts' filepath on Windows

### DIFF
--- a/bin/check-package-metadata.js
+++ b/bin/check-package-metadata.js
@@ -44,7 +44,7 @@ async function checkMonorepoFile(packages, rootPath) {
   const monorepoFile = await fs.readFile('docs/site/MONOREPO.md', 'utf8');
 
   for (const p of packages) {
-    const packagePath = path.relative(rootPath, p.location);
+    const packagePath = path.relative(rootPath, p.location).replace(/\\/g, '/');
 
     const packageExists =
       monorepoFile.includes(p.name) || monorepoFile.includes(packagePath);
@@ -73,7 +73,7 @@ async function checkCodeOwnersFile(packages, rootPath) {
       continue;
     }
 
-    const packagePath = path.relative(rootPath, p.location);
+    const packagePath = path.relative(rootPath, p.location).replace(/\\/g, '/');
 
     if (!codeOwnersFile.includes(packagePath)) {
       errors.push(`${p.name} is not added in the CODEOWNERS.md file`);

--- a/bin/update-monorepo-file.js
+++ b/bin/update-monorepo-file.js
@@ -19,7 +19,7 @@ const MONOREPO_FILE_DIST = 'docs/site';
 const MONOREPO_FILE_NAME = 'MONOREPO.md';
 
 function getPackageRelativeUri(pkg) {
-  return path.relative(pkg.rootPath, pkg.location);
+  return path.relative(pkg.rootPath, pkg.location).replace(/\\/g, '/');
 }
 
 async function getSortedPackages() {


### PR DESCRIPTION
see: https://github.com/strongloop/loopback-next/pull/6155#issuecomment-678593502

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
