### PR TITLE
fix(docs): change to test db after booting app

### DIFF
--- a/docs/site/Testing-your-application.md
+++ b/docs/site/Testing-your-application.md
@@ -116,6 +116,8 @@ export const testdb: juggler.DataSource = new juggler.DataSource({
 });
 ```
 
+{% include important.html content="The `name` property of your test datasource must match your real datasource's name." %}
+
 ### Clean the database before each test
 
 Start with a clean database before each test. This may seem counter-intuitive:
@@ -965,8 +967,11 @@ describe('Product (acceptance)', () => {
         port: 0,
       },
     });
-    app.dataSource(testdb);
     await app.boot();
+
+    // change to use the test datasource after the app has been booted so that
+    // it is not overriden
+    app.dataSource(testdb);
     await app.start();
 
     client = createRestAppClient(app);


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-next/issues/6178

Application must be booted before changing datasource to test datasource, otherwise it'll be overridden by the real datasource.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
