### PR TITLE
docs: fix broken link for interceptors

### DIFF
--- a/docs/site/Interceptor-generator.md
+++ b/docs/site/Interceptor-generator.md
@@ -10,8 +10,8 @@ permalink: /doc/en/lb4/Interceptor-generator.html
 
 ### Synopsis
 
-Adds a new [interceptor](Interceptors.md#global-interceptors) class to a
-LoopBack application.
+Adds a new [interceptor](Interceptor.md#global-interceptors) class to a LoopBack
+application.
 
 ```sh
 lb4 interceptor [--global] [--group <group>] [<name>]

--- a/docs/site/LB3-vs-LB4-request-response-cycle.md
+++ b/docs/site/LB3-vs-LB4-request-response-cycle.md
@@ -53,7 +53,7 @@ API.
 Using [Controllers](./Controller.md) is the recommended way for creating custom
 (and REST) endpoints on your application. Its support for
 [dependency injection](./Dependency-injection.md) and
-[Interceptors](./Interceptors.md) makes it a very powerful extension mechanism.
+[Interceptors](./Interceptor.md) makes it a very powerful extension mechanism.
 
 In LoopBack 4
 [middleware.json](https://loopback.io/doc/en/lb3/middleware.json.html) is not
@@ -364,7 +364,7 @@ of the following reasons:
    endpoint's OpenAPI spec
 4. Controller routes are included in the auto-generated OpenAPI spec document
 
-[Interceptors](./Interceptors.md) can intercept execution of controller methods,
+[Interceptors](./Interceptor.md) can intercept execution of controller methods,
 thus have access to the request and response objects.
 
 #### Data coercion and validation
@@ -479,7 +479,7 @@ Similarly, various other repository methods in LoopBack 4 can be overriden to
 access the model data in the context of their operation.
 
 {% include tip.html content="
-[Interceptors](./Interceptors.md)
+[Interceptors](./Interceptor.md)
 may also be used to access the user submitted data in some cases." %}
 
 ## Summary

--- a/docs/site/REST-action-sequence.md
+++ b/docs/site/REST-action-sequence.md
@@ -361,7 +361,7 @@ action calls the handler function for the route with the request specific
 context and the arguments for the function. It is important to note that
 controller methods use `invokeMethod` from `@loopback/core` and can be used with
 global and custom interceptors. See
-[Interceptor docs](Interceptors.md#use-invokemethod-to-apply-interceptors) for
+[Interceptor docs](Interceptor.md#use-invokemethod-to-apply-interceptors) for
 more details. The request flow for two route flavours is explained below.
 
 For controller methods:

--- a/docs/site/REST-middleware-sequence.md
+++ b/docs/site/REST-middleware-sequence.md
@@ -750,7 +750,7 @@ action calls the handler function for the route with the request specific
 context and the arguments for the function. It is important to note that
 controller methods use `invokeMethod` from `@loopback/core` and can be used with
 global and custom interceptors. See
-[Interceptor docs](Interceptors.md#use-invokemethod-to-apply-interceptors) for
+[Interceptor docs](Interceptor.md#use-invokemethod-to-apply-interceptors) for
 more details. The request flow for two route flavours is explained below.
 
 For controller methods:

--- a/docs/site/migration/models/remoting-hooks.md
+++ b/docs/site/migration/models/remoting-hooks.md
@@ -53,17 +53,17 @@ specifier. In general, there are three kinds of hook scopes:
   User.beforeRemote('login', handlerFn);
   ```
 
-LoopBack 4 provides [Interceptors](../../Interceptors.md) feature to enable
+LoopBack 4 provides [Interceptors](../../Interceptor.md) feature to enable
 application developers to implement similar functionality.
 
-- [**Global interceptors**](../../Interceptors.md#global-interceptors) are
+- [**Global interceptors**](../../Interceptor.md#global-interceptors) are
   executed for _every_ request handled by a LoopBack 4 controller method or a
   LoopBack 4 route handler. They correspond to LoopBack 3 **global hooks**.
-- [**Class level interceptors**](../../Interceptors.md#class-level-interceptors)
+- [**Class level interceptors**](../../Interceptor.md#class-level-interceptors)
   are executed for requests handled by the given
   [Controller](../../Controller.md) class. They correspond to LoopBack 3 **model
   level hooks**.
-- [**Method level interceptors**](../../Interceptors.md#method-level-interceptors)
+- [**Method level interceptors**](../../Interceptor.md#method-level-interceptors)
   are executed only for request handled by the given controller method. They
   correspond to LoopBack 3 **method level hooks**.
 
@@ -173,7 +173,7 @@ instructions on how to map LoopBack 3 context properties to LoopBack 4.
 ## Migrating global hooks
 
 Global remoting hooks should be rewritten to
-[global interceptors](../../Interceptors.md#global-interceptors). You can use
+[global interceptors](../../Interceptor.md#global-interceptors). You can use
 [Interceptor generator CLI](../../Interceptor-generator.md) to create the
 necessary infrastructure for each hook.
 
@@ -189,7 +189,7 @@ $ lb4 interceptor
 
 Global interceptors are sorted by the order of an array of group names
 bound to ContextBindings.GLOBAL_INTERCEPTOR_ORDERED_GROUPS.
-See https://loopback.io/doc/en/lb4/Interceptors.md#order-of-invocation-for-interceptors.
+See https://loopback.io/doc/en/lb4/Interceptor.md#order-of-invocation-for-interceptors.
 
 ? Group name for the global interceptor: ('')
   create src/interceptors/global-logger.interceptor.ts
@@ -208,8 +208,8 @@ map LoopBack 3 context properties to LoopBack 4.
 ## Migrating model level hooks
 
 Model level hooks should be rewritten to
-[class interceptors](../../Interceptors.md#class-level-interceptors). You can
-use [Interceptor generator CLI](../../Interceptor-generator.md) to create the
+[class interceptors](../../Interceptor.md#class-level-interceptors). You can use
+[Interceptor generator CLI](../../Interceptor-generator.md) to create the
 necessary infrastructure for each hook.
 
 {% include tip.html content=" In LoopBack 3, we use the term _model level_ hook,
@@ -254,7 +254,7 @@ export class ProductController {
 ## Migrating method level hooks
 
 Method level hooks should be rewritten to
-[method interceptors](../../Interceptors.md#method-level-interceptors). You can
+[method interceptors](../../Interceptor.md#method-level-interceptors). You can
 use [Interceptor generator CLI](../../Interceptor-generator.md) to create the
 necessary infrastructure for each hook.
 


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

Fix the broken links caused by "Interceptors" --> "Interceptor"
Vefified other broken links in https://github.com/strongloop/loopback-next/pull/6085 are already fixed

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
