### PR TITLE
build: add "build & watch" task for VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -96,6 +96,24 @@
       "problemMatcher": "$tsc"
     },
     {
+      "label": "Build and watch for changes",
+      "group": "build",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "-s",
+        "build",
+        "--",
+        "--watch",
+        "--pretty",
+        "false"
+      ],
+      "problemMatcher": [
+        "$tsc-watch",
+      ]
+    },
+    {
       "label": "Clean project",
       "group": "build",
       "type": "shell",


### PR DESCRIPTION
Add a task to build the entire monorepo in a watch mode, where the compiler keeps running in background and recompiles affected files when a change is detected.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
