### PR TITLE
feat: add `app.onStart()` and `app.onStop()` helpers

### DIFF
--- a/docs/site/Life-cycle.md
+++ b/docs/site/Life-cycle.md
@@ -189,6 +189,36 @@ export class MyComponentWithObservers implements Component {
 }
 ```
 
+### Shorthand methods
+
+In some cases, it's desirable to register a single function to be called at
+start or stop time.
+
+For example, when writing integration-level tests, we can use `app.onStop()` to
+register a cleanup routine to be invoked whenever the application is shut down.
+
+```ts
+import {Application} from '@loopback/core';
+
+describe('my test suite', () => {
+  let app: Application;
+  before(setupApp);
+  after(() => app.stop());
+
+  // the tests come here
+
+  async setupApp() {
+    app = new Application();
+    app.onStop(async cleanup() {
+      // do some cleanup
+    });
+
+    await app.boot();
+    await app.start();
+  }
+});
+```
+
 ## Discover life cycle observers
 
 The `Application` finds all bindings tagged with `CoreTags.LIFE_CYCLE_OBSERVER`

--- a/packages/context/src/value-promise.ts
+++ b/packages/context/src/value-promise.ts
@@ -302,8 +302,8 @@ export function transformValueOrPromise<T, V>(
 /**
  * A utility to generate uuid v4
  *
- * @deprecated Use [uuid](https://www.npmjs.com/package/uuid) or
- * [hyperid](https://www.npmjs.com/package/hyperid) instead.
+ * @deprecated Use `generateUniqueId`, [uuid](https://www.npmjs.com/package/uuid)
+ * or [hyperid](https://www.npmjs.com/package/hyperid) instead.
  */
 export function uuid() {
   return uuidv4();


### PR DESCRIPTION
In some cases,  it's desirable to register a single function to be called at start or stop time. For example, when writing integration-level tests, we can use `app.onStop()` to register a cleanup routine to be invoked whenever the application is shut down.

This pull request adds `app.onStart()` and `app.onStop()` methods that can be used to register life-cycle observers as plain functions.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
