### PR TITLE
feat: move framework packages to `peerDependencies`

### DIFF
--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -38,14 +38,18 @@
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "extensions/apiconnect"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/node": "^10.17.29"
   }

--- a/extensions/authentication-jwt/package.json
+++ b/extensions/authentication-jwt/package.json
@@ -20,22 +20,27 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/authentication": "^6.0.1",
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "@loopback/security": "^0.2.18",
-    "@loopback/service-proxy": "^2.3.8",
     "@types/bcryptjs": "2.4.2",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
+    "@loopback/authentication": "^6.0.1",
     "@loopback/boot": "^2.5.1",
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/repository": "^2.11.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/rest-explorer": "^2.2.10",
+    "@loopback/service-proxy": "^2.3.8",
     "@loopback/testlab": "^2.0.2",
     "@types/lodash": "^4.14.161",
     "@types/node": "^10.17.29",

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -39,20 +39,25 @@
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "extensions/authentication-passport"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/authentication": "^6.0.1",
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "@loopback/security": "^0.2.18",
     "passport": "^0.4.1",
     "tslib": "^2.0.1",
     "util-promisifyall": "^1.0.6"
   },
   "devDependencies": {
+    "@loopback/authentication": "^6.0.1",
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/mock-oauth2-provider": "^0.1.7",
     "@loopback/openapi-spec-builder": "^2.1.13",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/lodash": "^4.14.161",

--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -20,15 +20,19 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "ts-graphviz": "^0.13.2",
     "viz.js": "^2.1.2"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/node": "^10.17.29"
   },

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -21,7 +21,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@types/cron": "^1.7.2",
     "@types/debug": "^4.1.5",
     "cron": "^1.8.2",
@@ -30,6 +29,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/testlab": "^3.2.4",
     "@types/node": "^10.17.29"
@@ -49,5 +49,8 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "extensions/cron"
+  },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
   }
 }

--- a/extensions/health/package.json
+++ b/extensions/health/package.json
@@ -21,15 +21,19 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5",
+    "@loopback/rest": "^6.2.0"
+  },
   "dependencies": {
     "@cloudnative/health": "^2.1.2",
-    "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/node": "^10.17.29"
   },

--- a/extensions/logging/package.json
+++ b/extensions/logging/package.json
@@ -20,9 +20,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "fluent-logger": "^3.4.1",
     "morgan": "^1.10.0",
     "tslib": "^2.0.1",
@@ -31,7 +33,9 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/morgan": "^1.9.1",
     "@types/node": "^10.17.29"

--- a/extensions/metrics/package.json
+++ b/extensions/metrics/package.json
@@ -20,15 +20,19 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "prom-client": "^12.0.0",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/express": "^4.17.8",
     "@types/node": "^10.17.29",

--- a/extensions/pooling/package.json
+++ b/extensions/pooling/package.json
@@ -31,14 +31,17 @@
     "src",
     "!*/__tests__"
   ],
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@types/generic-pool": "^3.1.9",
     "generic-pool": "^3.7.1",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/testlab": "^3.2.4",
     "@types/node": "^10.17.29",
     "typescript": "~4.0.2"

--- a/extensions/typeorm/package.json
+++ b/extensions/typeorm/package.json
@@ -21,21 +21,26 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/boot": "^2.5.1",
+    "@loopback/core": "^2.9.5",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
+    "tslib": "^2.0.1",
+    "typeorm": "^0.2.25"
+  },
   "devDependencies": {
+    "@loopback/boot": "^2.5.1",
     "@loopback/build": "^5.4.3",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/repository": "^2.11.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/json-schema": "^7.0.6",
     "@types/node": "^10.17.29",
     "sqlite3": "^5.0.0"
-  },
-  "dependencies": {
-    "@loopback/boot": "^2.5.1",
-    "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
-    "tslib": "^2.0.1",
-    "typeorm": "^0.2.25"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
> As discussed several times in the past (most recently in [#5927 (comment)](https://github.com/strongloop/loopback-next/pull/5927#discussion_r453727653)), extensions should use framework modules from the target application via `peerDependencies`. 

This PR is a spin-off from #5959 which is becoming too difficult to get landed because of merge conflicts. In this patch, I have updated dependencies in all `extension/*` packages.

Please read #5959  for the original discussion around this proposal. We have reached consensus to follow this new direction, so I hope we can get this PR landed quickly.

**BREAKING CHANGE**

Extensions no longer install framework packages as their own dependencies, they use the framework packages provided by the target application instead.

If you are getting `npm install` errors after upgrade, then make sure your project lists all dependencies required by the extensions you are using.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
