### PR TITLE
feat(http-server): configure http.Server and Server properties

### DIFF
--- a/packages/http-server/src/__tests__/integration/http-server.integration.ts
+++ b/packages/http-server/src/__tests__/integration/http-server.integration.ts
@@ -102,6 +102,29 @@ describe('HttpServer (integration)', () => {
     await socketPromise;
   });
 
+  it('applies server properties', async () => {
+    server = new HttpServer(dummyRequestHandler, {
+      keepAliveTimeout: 101,
+      headersTimeout: 102,
+      maxConnections: 103,
+      maxHeadersCount: 104,
+      timeout: 105,
+    });
+    expect(server.server)
+      .to.have.property('keepAliveTimeout')
+      .which.is.equal(101);
+    expect(server.server)
+      .to.have.property('headersTimeout')
+      .which.is.equal(102);
+    expect(server.server)
+      .to.have.property('maxConnections')
+      .which.is.equal(103);
+    expect(server.server)
+      .to.have.property('maxHeadersCount')
+      .which.is.equal(104);
+    expect(server.server).to.have.property('timeout').which.is.equal(105);
+  });
+
   it('exports original port', async () => {
     server = new HttpServer(dummyRequestHandler, {port: 0});
     expect(server).to.have.property('port').which.is.equal(0);


### PR DESCRIPTION
Added options to configure properties that are directly set on `http.Server` and `Server`.

Signed-off-by: Yaapa Hage <hage.yaapa@in.ibm.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
