### PR TITLE
Add types to the model configuration for autocompletion

### DIFF
--- a/packages/repository/src/model.ts
+++ b/packages/repository/src/model.ts
@@ -48,6 +48,36 @@ export interface PropertyDefinition {
 }
 
 /**
+ * Defining the settings for a model
+ * See https://loopback.io/doc/en/lb4/Model.html#supported-entries-of-model-definition
+ */
+export interface ModelSettings {
+  /**
+   * Description of the model
+   */
+  description?: string;
+  /**
+   * Prevent clients from setting the auto-generated ID value manually
+   */
+  forceId?: boolean;
+  /**
+   * Hides properties from response bodies
+   */
+  hiddenProperties?: string[];
+  /**
+   * Scope enables you to set a scope that will apply to every query made by the model's repository
+   */
+  scope?: object;
+  /**
+   * Specifies whether the model accepts only predefined properties or not
+   */
+  strict?: boolean | 'filter';
+
+  // Other variable settings
+  [name: string]: any;
+}
+
+/**
  * See https://github.com/strongloop/loopback-datasource-juggler/issues/432
  */
 export interface PropertyForm {
@@ -70,7 +100,7 @@ export type RelationDefinitionMap = {
 export interface ModelDefinitionSyntax {
   name: string;
   properties?: {[name: string]: PropertyDefinition | PropertyType};
-  settings?: {[name: string]: any};
+  settings?: ModelSettings;
   relations?: RelationDefinitionMap;
   jsonSchema?: JsonSchemaWithExtensions;
   [attribute: string]: any;
@@ -82,7 +112,7 @@ export interface ModelDefinitionSyntax {
 export class ModelDefinition {
   readonly name: string;
   properties: {[name: string]: PropertyDefinition};
-  settings: {[name: string]: any};
+  settings: ModelSettings;
   relations: RelationDefinitionMap;
   // indexes: Map<string, any>;
   [attribute: string]: any; // Other attributes


### PR DESCRIPTION
Signed-off-by: Francisco Buceta <frbuceta@gmail.com>

The properties have been added to the types for the configuration of the model and thus have autocompletion in the most modern IDE's

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
