### PR TITLE
feat: move framework packages to `peerDependencies`

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -23,9 +23,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "@loopback/security": "^0.2.18",
     "@types/express": "^4.17.8",
     "@types/lodash": "^4.14.161",
@@ -34,8 +36,10 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/openapi-spec-builder": "^2.1.13",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/node": "^10.17.29",
     "jsonwebtoken": "^8.5.1"

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -23,14 +23,17 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@loopback/security": "^0.2.18",
     "debug": "^4.1.1",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/testlab": "^3.2.4",
     "@types/debug": "^4.1.5",
     "@types/node": "10.17.29",

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -23,8 +23,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@loopback/model-api-builder": "^2.1.13",
     "@loopback/repository": "^2.11.2",
     "@loopback/service-proxy": "^2.3.8",
@@ -36,6 +38,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/rest": "^6.2.0",
     "@loopback/rest-crud": "^0.8.13",

--- a/packages/booter-lb3app/package.json
+++ b/packages/booter-lb3app/package.json
@@ -20,6 +20,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/boot": "^2.5.1",
+    "@loopback/core": "^2.9.5",
+    "@loopback/rest": "^6.2.0"
+  },
   "dependencies": {
     "@types/express": "^4.17.8",
     "debug": "^4.1.1",
@@ -27,11 +32,6 @@
     "loopback-swagger": "^5.9.0",
     "swagger2openapi": "^7.0.0",
     "tslib": "^2.0.1"
-  },
-  "peerDependencies": {
-    "@loopback/boot": "^2.5.1",
-    "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0"
   },
   "devDependencies": {
     "@loopback/boot": "^2.5.1",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -36,8 +36,10 @@
     "src",
     "!*/__tests__"
   ],
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@loopback/http-server": "^2.2.0",
     "@types/body-parser": "^1.19.0",
     "@types/express": "^4.17.8",
@@ -53,6 +55,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/testlab": "^3.2.4",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.29",

--- a/packages/model-api-builder/package.json
+++ b/packages/model-api-builder/package.json
@@ -24,6 +24,9 @@
     "@loopback/core": "^2.9.5",
     "@loopback/repository": "^2.11.2"
   },
+  "dependencies": {
+    "tslib": "^2.0.1"
+  },
   "devDependencies": {
     "@loopback/build": "^1.7.1",
     "@loopback/core": "^2.9.5",
@@ -40,8 +43,5 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "packages/model-api-builder"
-  },
-  "dependencies": {
-    "tslib": "^2.0.1"
   }
 }

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -7,8 +7,10 @@
   "engines": {
     "node": ">=10.16"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@loopback/repository-json-schema": "^2.4.10",
     "debug": "^4.1.1",
     "http-status": "^1.4.2",
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/openapi-spec-builder": "^2.1.13",
     "@loopback/repository": "^2.11.2",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -25,16 +25,20 @@
     "TypeScript",
     "JSON Schema"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.5",
-    "@loopback/repository": "^2.11.2",
+    "@loopback/repository": "^2.11.2"
+  },
+  "dependencies": {
     "@types/json-schema": "^7.0.6",
     "debug": "^4.1.1",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
+    "@loopback/repository": "^2.11.2",
     "@loopback/testlab": "^3.2.4",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.29",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -20,8 +20,13 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5",
+    "@loopback/repository": "^2.11.2"
+  },
   "devDependencies": {
     "@loopback/build": "^1.7.1",
+    "@loopback/core": "^2.9.5",
     "@loopback/repository": "^2.11.2",
     "@types/debug": "^4.1.5",
     "@types/lodash": "^4.14.161",
@@ -29,14 +34,10 @@
     "lodash": "^4.17.20"
   },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@loopback/testlab": "^3.2.4",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",
     "tslib": "^2.0.1"
-  },
-  "peerDependencies": {
-    "@loopback/repository": "^2.11.2"
   },
   "files": [
     "README.md",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -21,8 +21,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/testlab": "^3.2.4",
     "@types/bson": "^4.0.2",
@@ -32,7 +36,6 @@
     "bson": "4.1.0"
   },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@loopback/filter": "^1.0.0",
     "@types/debug": "^4.1.5",
     "debug": "^4.1.1",

--- a/packages/rest-crud/package.json
+++ b/packages/rest-crud/package.json
@@ -20,6 +20,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5",
+    "@loopback/repository": "^2.11.2",
+    "@loopback/rest": "^6.2.0"
+  },
   "dependencies": {
     "@loopback/model-api-builder": "^2.1.13",
     "debug": "^4.1.1",
@@ -33,11 +38,6 @@
     "@loopback/testlab": "^3.2.4",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.29"
-  },
-  "peerDependencies": {
-    "@loopback/core": "^2.9.5",
-    "@loopback/repository": "^2.11.2",
-    "@loopback/rest": "^6.2.0"
   },
   "files": [
     "README.md",

--- a/packages/rest-explorer/package.json
+++ b/packages/rest-explorer/package.json
@@ -20,16 +20,20 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@loopback/core": "^2.9.5",
-    "@loopback/rest": "^6.2.0",
+    "@loopback/rest": "^6.2.0"
+  },
+  "dependencies": {
     "ejs": "^3.1.5",
     "swagger-ui-dist": "3.32.5",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
+    "@loopback/rest": "^6.2.0",
     "@loopback/testlab": "^3.2.4",
     "@types/ejs": "^3.0.4",
     "@types/express": "^4.17.8",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -23,8 +23,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "@loopback/express": "^1.4.1",
     "@loopback/http-server": "^2.2.0",
     "@loopback/openapi-v3": "^3.4.9",
@@ -58,6 +60,7 @@
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/openapi-spec-builder": "^2.1.13",
     "@loopback/repository": "^2.11.2",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -23,13 +23,16 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "debug": "^4.1.1",
     "tslib": "^2.0.1"
   },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/testlab": "^3.2.4",
     "@types/debug": "^4.1.5",
     "@types/node": "^10.17.29"

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -23,14 +23,17 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.9.5"
+  },
   "devDependencies": {
     "@loopback/build": "^6.2.2",
+    "@loopback/core": "^2.9.5",
     "@loopback/eslint-config": "^9.0.2",
     "@loopback/testlab": "^3.2.4",
     "@types/node": "^10.17.29"
   },
   "dependencies": {
-    "@loopback/core": "^2.9.5",
     "loopback-datasource-juggler": "^4.24.0",
     "tslib": "^2.0.1"
   },


### PR DESCRIPTION
> As discussed several times in the past (most recently in [#5927 (comment)](https://github.com/strongloop/loopback-next/pull/5927#discussion_r453727653)), extensions should use framework modules from the target application via `peerDependencies`. 

This PR is the last spin-off from #5959 which was too difficult to get landed because of merge conflicts. In this patch, I have updated dependencies in all `extension/*` packages.

Please read #5959  for the original discussion around this proposal. We have reached consensus to follow this new direction, so I hope we can get this PR landed quickly.

The first commit moves dependencies to `peerDependencies`. The second commit is a small cleanup to ensure all `package/*/package.json` files are using the same order of `peerDependencies`, `dependencies` and `devDependencies`.

Close #5959

**BREAKING CHANGE**

Components no longer install core framework packages as their own dependencies, they use the framework packages provided by the target application instead.

If you are getting `npm install` errors after upgrade, then make sure your project lists all dependencies required by the extensions you are using.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
