### PR TITLE
feat(rest): remove support for HTTP redirect to an external API Explorer

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -182,16 +182,19 @@ dependency is not needed, `toDynamicValue` can be used instead.
 #### An alias
 
 An alias is the key with optional path to resolve the value from another
-binding. For example, if we want to get options from RestServer for the API
-explorer, we can configure the `apiExplorer.options` to be resolved from
-`servers.RestServer.options#apiExplorer`.
+binding. For example, if we want to get options from RestServer for the OpenAPI
+Spec endpoints, we can configure the `openApiSpec.options` to be resolved from
+`servers.RestServer.options#openApiSpec`.
 
 ```ts
-ctx.bind('servers.RestServer.options').to({apiExplorer: {path: '/explorer'}});
 ctx
-  .bind('apiExplorer.options')
-  .toAlias('servers.RestServer.options#apiExplorer');
-const apiExplorerOptions = await ctx.get('apiExplorer.options'); // => {path: '/explorer'}
+  .bind('servers.RestServer.options')
+  .to({openApiSpec: {setServersFromRequest: true}});
+ctx
+  .bind('openApiSpec.options')
+  .toAlias('servers.RestServer.options#openApiSpec');
+const openApiSpecOptions = await ctx.get('openApiSpec.options');
+// => {setServersFromRequest: true}
 ```
 
 ### Configure the scope

--- a/docs/site/Server.md
+++ b/docs/site/Server.md
@@ -76,53 +76,16 @@ const app = new RestApplication({
 
 ### Configure the API Explorer
 
-LoopBack allows externally hosted API Explorer UI to render the OpenAPI
-endpoints for a REST server. Such URLs can be specified with `rest.apiExplorer`:
-
-- url: URL for the hosted API Explorer UI, default to
-  `https://explorer.loopback.io`.
-- httpUrl: URL for the API explorer served over plain http to deal with mixed
-  content security imposed by browsers as the spec is exposed over `http` by
-  default. See https://github.com/strongloop/loopback-next/issues/1603. Default
-  to the value of `url`.
-
-```ts
-const app = new RestApplication({
-  rest: {
-    apiExplorer: {
-      url: 'https://petstore.swagger.io',
-      httpUrl: 'http://petstore.swagger.io',
-    },
-  },
-});
-```
-
-#### Disable redirect to API Explorer
-
-To disable redirect to the externally hosted API Explorer, set the config option
-`rest.apiExplorer.disabled` to `true`.
-
-```ts
-const app = new RestApplication({
-  rest: {
-    apiExplorer: {
-      disabled: true,
-    },
-  },
-});
-```
-
-{% include note.html content="To completely disable API Explorer, we also need
-to [disable the self-hosted REST API Explorer extension](./Self-hosted-REST-API-Explorer.md#disable-self-hosted-api-explorer)." %}
-
-### Use a self-hosted API Explorer
-
-Hosting the API Explorer at an external URL has a few downsides, for example a
-working internet connection is required to explore the API. As a recommended
-alternative, LoopBack comes with an extension that provides a self-hosted
-Explorer UI. Please refer to
+Starting from `@loopback/rest` version `7.0.0`, LoopBack no longer supports
+automatic redirect to an externally hosted API Explorer UI. Instead, we provide
+an extension that implements a self-hosted API Explorer UI. Please refer to
 [Self-hosted REST API Explorer](./Self-hosted-REST-API-Explorer.md) for more
 details.
+
+By default, applications scaffolded using `lb4 app` are coming with a
+pre-configured API Explorer. See
+[disable the self-hosted REST API Explorer extension](./Self-hosted-REST-API-Explorer.md#disable-self-hosted-api-explorer)
+for instructions on how to disable this pre-configured API Explorer.
 
 ### Customize CORS
 
@@ -247,7 +210,7 @@ for more details.
 | cors                | CorsOptions               | Specify the CORS options.                                                                                                                                                                                                                                                                                                           |
 | sequence            | SequenceHandler           | Use a custom SequenceHandler to change the behavior of the RestServer for the request-response lifecycle.                                                                                                                                                                                                                           |
 | openApiSpec         | OpenApiSpecOptions        | Customize how OpenAPI spec is served                                                                                                                                                                                                                                                                                                |
-| apiExplorer         | ApiExplorerOptions        | Customize how API explorer is served                                                                                                                                                                                                                                                                                                |
+| apiExplorer         | ApiExplorerOptions        | **(DEPRECATED)** Customize how API explorer is served                                                                                                                                                                                                                                                                               |
 | requestBodyParser   | RequestBodyParserOptions  | Customize how request body is parsed                                                                                                                                                                                                                                                                                                |
 | router              | RouterOptions             | Customize how trailing slashes are used for routing                                                                                                                                                                                                                                                                                 |
 | listenOnStart       | boolean (default to true) | Control if the server should listen on http/https when it's started                                                                                                                                                                                                                                                                 |


### PR DESCRIPTION
A bit of history: Back in 2017/2018, we wanted to offer REST API Explorer early on, because we considered it a cornerstone of developer experience. The framework did not provide all the necessary infrastructure yet, therefore we decided to take a short-cut and host swagger-ui at loopback.io. Eventually, we implemented self-hosted REST API Explorer towards the end of 2018 and kept support for external API Explorer for backwards compatibility.

I feel it's past time to drop that legacy. Since we will are already introducing breaking changes in #6288 that will trigger a semver-major release of `@loopback/rest`, I'd like to take this opportunity to get rid of external API explorer too.

**BREAKING CHANGE**

LoopBack no longer supports automatic redirect to an externally hosted API Explorer UI. Instead, we provide  an extension that implements a self-hosted API Explorer UI. See the following documentation page for instructions on setting up a self-hosted API Explorer:

- https://loopback.io/doc/en/lb4/Self-hosted-rest-api-explorer.html

By default, applications scaffolded using `lb4 app` are coming with a pre-configured API Explorer. If you have scaffolded your application with `@loopback/cli` version `1.2.0` (published in Nov 2018) or later, then no changes are necessary in your project.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
