### PR TITLE
Handle missing design-time type metadata

### DIFF
--- a/docs/site/reference/error-codes.md
+++ b/docs/site/reference/error-codes.md
@@ -16,6 +16,7 @@ sets the error `code` property to a machine-readable string.
 | VALIDATION_FAILED          | The data provided by the client is not a valid entity.                                                                                                                                                    |
 | INVALID_PARAMETER_VALUE    | The value provided for a parameter of a REST endpoint is not valid. For example, a string value was provided for a numeric parameter.                                                                     |
 | MISSING_REQUIRED_PARAMETER | No value was provided for a required parameter.                                                                                                                                                           |
+| CANNOT_INFER_PROPERTY_TYPE | See below: [CANNOT_INFER_PROPERTY_TYPE](#cannot_infer_property_type)                                                                                                                                      |
 
 Besides LoopBack-specific error codes, your application can encounter low-level
 error codes from Node.js and the underlying operating system. For example, when
@@ -26,3 +27,70 @@ See the following resources for a list of low-level error codes:
 
 - [Common System Errors](https://nodejs.org/api/errors.html#errors_common_system_errors)
 - [Node.js Error Codes](https://nodejs.org/api/errors.html#errors_node_js_error_codes)
+
+## CANNOT_INFER_PROPERTY_TYPE
+
+LoopBack is using TypeScript design-time type metadata to automatically infer
+simple property types like `string`, `number` or a model class.
+
+In the following example, the type of the property `name` is inferred from
+TypeScript metadata as `string`.
+
+```ts
+@model()
+class Product {
+  @property()
+  name: string;
+}
+```
+
+Design-time property type is not available in the following cases:
+
+- The property has a type not supported by TypeScript metadata engine:
+  - `undefined`
+  - `null`
+  - complex types like arrays (`string[]`), generic types (`Partial<MyModel>`),
+    union types (`string | number`), and more.
+- The TypeScript project has not enabled the compiler option
+  `emitDecoratorMetadata`.
+- The code is written in vanilla JavaScript.
+
+<a id="cannot_infer_property_type-solutions"></a>
+
+### Solutions
+
+You have the following options how to fix the error
+`CANNOT_INFER_PROPERTY_TYPE`:
+
+1. If you are using TypeScript, make sure `emitDecoratorMetadata` is enabled in
+   your compiler options.
+
+   ```json
+   {
+     "$schema": "http://json.schemastore.org/tsconfig",
+     "compilerOptions": {
+       "emitDecoratorMetadata": true
+     }
+   }
+   ```
+
+   A typical LoopBack project is inheriting compiler options from
+   `@loopback/build`, where `emitDecoratorMetadata` is already enabled.
+
+   ```json
+   {
+     "$schema": "http://json.schemastore.org/tsconfig",
+     "extends": "@loopback/build/config/tsconfig.common.json"
+   }
+   ```
+
+2. If your property uses a complex type, then specify the type in the `type`
+   field of `@property()` definition.
+
+   ```ts
+   @model()
+   class UserProfile {
+     @property({type: 'string'})
+     hourFormat: '12h' | '24h';
+   }
+   ```

--- a/packages/context/src/inject.ts
+++ b/packages/context/src/inject.ts
@@ -627,7 +627,7 @@ export function inspectTargetType(injection: Readonly<Injection>) {
       injection.target,
       injection.member!,
     );
-    return designType.parameterTypes[
+    return designType?.parameterTypes?.[
       injection.methodDescriptorOrParameterIndex as number
     ];
   }

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -12,6 +12,7 @@ import {
   ContextTags,
   ContextView,
   createBindingFromClass,
+  DecoratorFactory,
   inject,
   InjectionMetadata,
   isDynamicValueProviderClass,
@@ -81,7 +82,7 @@ export function service(
           serviceType = MetadataInspector.getDesignTypeForMethod(
             injection.target,
             injection.member!,
-          ).parameterTypes[injection.methodDescriptorOrParameterIndex];
+          )?.parameterTypes[injection.methodDescriptorOrParameterIndex];
         } else {
           serviceType = MetadataInspector.getDesignTypeForProperty(
             injection.target,
@@ -89,6 +90,19 @@ export function service(
           );
         }
       }
+      if (serviceType === undefined) {
+        const targetName = DecoratorFactory.getTargetName(
+          injection.target,
+          injection.member,
+          injection.methodDescriptorOrParameterIndex,
+        );
+        const msg =
+          `No design-time type metadata found while inspecting ${targetName}. ` +
+          'You can either use `@service(ServiceClass)` or ensure `emitDecoratorMetadata` is enabled in your TypeScript configuration. ' +
+          'Run `tsc --showConfig` to print the final TypeScript configuration of your project.';
+        throw new Error(msg);
+      }
+
       if (serviceType === Object || serviceType === Array) {
         throw new Error(
           'Service class cannot be inferred from design type. Use @service(ServiceClass).',

--- a/packages/metadata/src/types.ts
+++ b/packages/metadata/src/types.ts
@@ -77,15 +77,18 @@ export interface MetadataMap<T> {
  */
 export interface DesignTimeMethodMetadata {
   /**
-   * Type of the method itself. It is `Function`
+   * Type of the method itself. It is `Function` for methods, `undefined` for the constructor.
    */
-  type: Function;
+  type: Function | undefined;
+
   /**
-   * An array of parameter types
+   * An array of parameter types.
    */
+
   parameterTypes: Function[];
+
   /**
-   * Return type
+   * Return type, may be `undefined` (e.g. for constructors).
    */
-  returnType: Function;
+  returnType: Function | undefined;
 }

--- a/packages/openapi-v3/src/controller-spec.ts
+++ b/packages/openapi-v3/src/controller-spec.ts
@@ -317,7 +317,7 @@ function resolveControllerSpec(constructor: Function): ControllerSpec {
       constructor.prototype,
       op,
     );
-    const paramTypes = opMetadata.parameterTypes;
+    const paramTypes = opMetadata?.parameterTypes ?? [];
 
     const isComplexType = (ctor: Function) =>
       !includes([String, Number, Boolean, Array, Object], ctor);

--- a/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
+++ b/packages/repository-json-schema/src/__tests__/integration/build-schema.integration.ts
@@ -3,13 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {MetadataInspector} from '@loopback/core';
+import {MetadataInspector, Reflector} from '@loopback/core';
 import {
   belongsTo,
   Entity,
   hasMany,
   model,
+  ModelDefinitionSyntax,
+  MODEL_KEY,
   property,
+  PropertyType,
 } from '@loopback/repository';
 import {expect} from '@loopback/testlab';
 import {
@@ -23,17 +26,41 @@ import {expectValidJsonSchema} from '../helpers/expect-valid-json-schema';
 describe('build-schema', () => {
   describe('modelToJsonSchema', () => {
     context('properties conversion', () => {
-      it('reports error for null or undefined property', () => {
-        @model()
-        class TestModel {
-          @property()
-          nul: null;
-          @property()
-          undef: undefined;
-        }
+      it('reports error for property without type (`null`)', () => {
+        // We cannot use `@model()` and `@property()` decorators because
+        // they no longer allow missing property type. Fortunately,
+        // it's possible to reproduce the problematic edge case by
+        // creating the model definition object directly.
+        class TestModel {}
+        const definition: ModelDefinitionSyntax = {
+          name: 'TestModel',
+          properties: {
+            nul: {type: (null as unknown) as PropertyType},
+          },
+        };
+        Reflector.defineMetadata(MODEL_KEY.key, definition, TestModel);
 
         expect(() => modelToJsonSchema(TestModel)).to.throw(
           /Property TestModel.nul does not have "type" in its definition/,
+        );
+      });
+
+      it('reports error for property without type (`undefined`)', () => {
+        // We cannot use `@model()` and `@property()` decorators because
+        // they no longer allow missing property type. Fortunately,
+        // it's possible to reproduce the problematic edge case by
+        // creating the model definition object directly.
+        class TestModel {}
+        const definition: ModelDefinitionSyntax = {
+          name: 'TestModel',
+          properties: {
+            undef: {type: (undefined as unknown) as PropertyType},
+          },
+        };
+        Reflector.defineMetadata(MODEL_KEY.key, definition, TestModel);
+
+        expect(() => modelToJsonSchema(TestModel)).to.throw(
+          /Property TestModel.undef does not have "type" in its definition/,
         );
       });
 

--- a/packages/repository/src/decorators/model.decorator.ts
+++ b/packages/repository/src/decorators/model.decorator.ts
@@ -87,6 +87,15 @@ export function buildModelDefinition(
     const propertyDef = propertyMap[p];
     const designType = MetadataInspector.getDesignTypeForProperty(prototype, p);
     if (!propertyDef.type) {
+      if (!designType) {
+        const err: Error & {code?: string} = new Error(
+          `The definition of model property ${modelDef.name}.${p} is missing ` +
+            '`type` field and TypeScript did not provide any design-time type. ' +
+            'Learn more at https://loopback.io/doc/en/lb4/Error-codes.html#cannot_infer_property_type',
+        );
+        err.code = 'CANNOT_INFER_PROPERTY_TYPE';
+        throw err;
+      }
       propertyDef.type = designType;
     }
     modelDef.addProperty(p, propertyDef);


### PR DESCRIPTION
- `@loopback/metadata`: Improve the typings for `getDesignTypeForProperty` and `getDesignTypeForMethod` to account for the fact that no metadata may be available when the project is written in pure JavaScript or not enabling TypeScript compiler option `emitDecoratorMetadata`.

- Other packages: Improve the code to handle the case where design-time type metadata is not available.

This work was triggered by a user reporting crash with unhelpful error message when their project did not have `emitDecoratorMetadata` enabled. 

Example error message:

```
Cannot start the application. TypeError: paramTypes is not iterable
  at resolveControllerSpec (loopback-next/packages/openapi-v3/dist/controller-spec.js:204:25)
  at Object.getControllerSpec (loopback-next/packages/openapi-v3/dist/controller-spec.js:323:16)
  at RestServer._createHttpHandler (loopback-next/packages/rest/dist/rest.server.js:289:42)
  (...)
```

**BREAKING CHANGE**

If you are consuming `@loopback/metadata` directly, then you may need to update your code to handle the case when design-time type metadata is not available. (The compiler will tell you what places to fix.)

Regular LoopBack users should not be affected as long as they update all LB packages together.

## Related issues & PRs:

- Implementing ts-mocha is throwing type errors in Inject #2764
- feat(context): add a check to see if design:type is emitted by TypeScript #2765

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
