### PR TITLE
chore(metadata): fix tsdocs for DecoratorFactory.getTargetName

### DIFF
--- a/packages/metadata/src/decorator-factory.ts
+++ b/packages/metadata/src/decorator-factory.ts
@@ -121,17 +121,21 @@ export class DecoratorFactory<
   }
 
   /**
-   * Get the qualified name of a decoration target. For example:
-   * ```
-   * class MyClass
-   * MyClass.constructor[0] // First parameter of the constructor
-   * MyClass.myStaticProperty
-   * MyClass.myStaticMethod()
-   * MyClass.myStaticMethod[0] // First parameter of the myStaticMethod
-   * MyClass.prototype.myProperty
-   * MyClass.prototype.myMethod()
-   * MyClass.prototype.myMethod[1] // Second parameter of myMethod
-   * ```
+   * Get the qualified name of a decoration target.
+   *
+   * @remarks
+   *
+   * Example of target names:
+   *
+   * - class MyClass
+   * - MyClass.constructor[0] // First parameter of the constructor
+   * - MyClass.myStaticProperty
+   * - MyClass.myStaticMethod()
+   * - MyClass.myStaticMethod[0] // First parameter of the myStaticMethod
+   * - MyClass.prototype.myProperty
+   * - MyClass.prototype.myMethod()
+   * - MyClass.prototype.myMethod[1] // Second parameter of myMethod
+   *
    * @param target - Class or prototype of a class
    * @param member - Optional property/method name
    * @param descriptorOrIndex - Optional method descriptor or parameter index


### PR DESCRIPTION
This change corrects the rendering of
https://loopback.io/doc/en/lb4/apidocs.metadata.decoratorfactory.html

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
