### PR TITLE
fix(cli): add no-translate keywords

### DIFF
--- a/packages/cli/generators/observer/index.js
+++ b/packages/cli/generators/observer/index.js
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+// no translation: Observer
 'use strict';
 const ArtifactGenerator = require('../../lib/artifact-generator');
 const debug = require('../../lib/debug')('observer-generator');

--- a/packages/cli/generators/service/index.js
+++ b/packages/cli/generators/service/index.js
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+// no translation: Service
 'use strict';
 const ArtifactGenerator = require('../../lib/artifact-generator');
 const fs = require('fs');


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

Fixes #6287 
`Service` and `Observer` should also be reserved words and not meant to be translated. Following what [this commit](https://github.com/strongloop/loopback-next/commit/c49a067cab576cb86cf00ccbef314434d46d9619) had done, add the `no translation: _reserved_words_`  as a comment at the top of the class. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
