### PR TITLE
chore: fix conflicting eslint rules

### DIFF
--- a/packages/eslint-config/eslintrc.js
+++ b/packages/eslint-config/eslintrc.js
@@ -57,10 +57,6 @@ module.exports = {
     // TypeScript allows the same name for namespace and function
     'no-redeclare': 'off',
 
-    // Avoid promise rewrapping
-    // https://exploringjs.com/es2016-es2017/ch_async-functions.html#_returned-promises-are-not-wrapped
-    'no-return-await': 'error',
-
     /**
      * Rules imported from eslint-config-loopback
      */
@@ -144,7 +140,11 @@ module.exports = {
     '@typescript-eslint/prefer-optional-chain': 'error',
     '@typescript-eslint/prefer-nullish-coalescing': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',
+
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/return-await.md#how-to-use
     '@typescript-eslint/return-await': 'error',
+    // note we must disable the base rule as it can report incorrect errors
+    'no-return-await': 'off',
 
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
     camelcase: 'off',


### PR DESCRIPTION
Fixes conflicting eslint rules.

`@typescript-eslint/return-await` inserts `await` and then `no-return-await` complains about it.
According to the docs `@typescript-eslint/return-await` supersedes  `no-return-await`.

In my case the conflict happened in the following code
```js
try {
  ...
} catch {
  return await this.findById(id); // <-- both plugins conflict on this line
}
```

See: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/return-await.md#how-to-use

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
