### PR TITLE
feat: allow dynamic value provider classes and classes with @inject to be booted

### DIFF
--- a/docs/site/Booting-an-Application.md
+++ b/docs/site/Booting-an-Application.md
@@ -264,9 +264,65 @@ The `datasources` object support the following options:
 Discovers and binds remote service proxies or local service classes or providers
 using `app.service()`.
 
+{% include notes.html content="
 **IMPORTANT:** For a class to be recognized by `ServiceBooter` as a service
-provider, it either has to be decorated with `@bind` or the class name must end
-with `Provider` suffix and its prototype must have a `value()` method.
+provider, it either has to be decorated with `@bind`/`@inject` or the class name
+must end with `Provider` suffix and must have a static or prototype `value()`
+method.
+" %}
+
+The following are some examples for service classes:
+
+```ts
+import {bind, BindingScope, inject, Provider} from '@loopback/core';
+
+// With `@bind`
+@bind({
+  tags: {serviceType: 'local'},
+  scope: BindingScope.SINGLETON,
+})
+export class BindableGreetingService {
+  greet(whom = 'world') {
+    return Promise.resolve(`Hello ${whom}`);
+  }
+}
+
+@bind({tags: {serviceType: 'local', name: 'CurrentDate'}})
+export class DateProvider implements Provider<Date> {
+  value(): Promise<Date> {
+    return Promise.resolve(new Date());
+  }
+}
+
+// Provider class
+export class BindableDateProvider implements Provider<Date> {
+  value(): Promise<Date> {
+    return Promise.resolve(new Date());
+  }
+}
+
+// Dynamic factory provider class
+export class DynamicDateProvider {
+  static value() {
+    return new Date();
+  }
+}
+
+// With `@inject`
+export class ServiceWithConstructorInject {
+  constructor(@inject('currentUser') private user: string) {}
+}
+
+export class ServiceWithPropertyInject {
+  @inject('currentUser') private user: string;
+}
+
+export class ServiceWithMethodInject {
+  greet(@inject('currentUser') user: string) {
+    return `Hello, ${user}`;
+  }
+}
+```
 
 #### Options
 

--- a/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, Provider} from '@loopback/core';
+import {bind, BindingScope, inject, Provider} from '@loopback/core';
 
 @bind({
   tags: {serviceType: 'local'},
@@ -31,5 +31,19 @@ export class NotBindableGreetingService {
 export class NotBindableDateProvider implements Provider<Date> {
   value(): Promise<Date> {
     return Promise.resolve(new Date());
+  }
+}
+
+export class ServiceWithConstructorInject {
+  constructor(@inject('currentUser') private user: string) {}
+}
+
+export class ServiceWithPropertyInject {
+  @inject('currentUser') private user: string;
+}
+
+export class ServiceWithMethodInject {
+  greet(@inject('currentUser') user: string) {
+    return `Hello, ${user}`;
   }
 }

--- a/packages/boot/src/__tests__/fixtures/service-dynamic-value-provider.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/service-dynamic-value-provider.artifact.ts
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: @loopback/boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export class DynamicDateProvider {
+  static value() {
+    return new Date();
+  }
+}

--- a/packages/boot/src/__tests__/integration/service.booter.integration.ts
+++ b/packages/boot/src/__tests__/integration/service.booter.integration.ts
@@ -24,6 +24,10 @@ describe('service booter integration tests', () => {
       'services.CurrentDate',
       'services.GeocoderService',
       'services.NotBindableDate',
+      'services.DynamicDate',
+      'services.ServiceWithConstructorInject',
+      'services.ServiceWithPropertyInject',
+      'services.ServiceWithMethodInject',
     ];
 
     await app.boot();
@@ -49,6 +53,14 @@ describe('service booter integration tests', () => {
     await sandbox.copyFile(
       resolve(__dirname, '../fixtures/service-provider.artifact.js'),
       'services/geocoder.service.js',
+    );
+
+    await sandbox.copyFile(
+      resolve(
+        __dirname,
+        '../fixtures/service-dynamic-value-provider.artifact.js',
+      ),
+      'services/date.service.js',
     );
 
     await sandbox.copyFile(

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -8,7 +8,9 @@ import {
   config,
   Constructor,
   CoreBindings,
+  hasInjections,
   inject,
+  isDynamicValueProviderClass,
   MetadataInspector,
 } from '@loopback/core';
 import {ApplicationWithServices} from '@loopback/service-proxy';
@@ -81,8 +83,15 @@ function isBindableClass(cls: Constructor<unknown>) {
   if (MetadataInspector.getClassMetadata(BINDING_METADATA_KEY, cls)) {
     return true;
   }
+  if (hasInjections(cls)) {
+    return true;
+  }
   if (isServiceProvider(cls)) {
     debug('Provider class found: %s', cls.name);
+    return true;
+  }
+  if (isDynamicValueProviderClass(cls)) {
+    debug('Dynamic value provider class found: %s', cls.name);
     return true;
   }
   debug('Skip class not decorated with @bind: %s', cls.name);

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -243,10 +243,13 @@ export type BindingFromClassOptions = {
  * Create a binding from a class with decorated metadata. The class is attached
  * to the binding as follows:
  * - `binding.toClass(cls)`: if `cls` is a plain class such as `MyController`
- * - `binding.toProvider(cls)`: it `cls` is a value provider class with a
+ * - `binding.toProvider(cls)`: if `cls` is a value provider class with a
  * prototype method `value()`
+ * - `binding.toDynamicValue(cls)`: if `cls` is a dynamic value provider class
+ * with a static method `value()`
  *
- * @param cls - A class. It can be either a plain class or  a value provider class
+ * @param cls - A class. It can be either a plain class, a value provider class,
+ * or a dynamic value provider class
  * @param options - Options to customize the binding key
  *
  * @typeParam T - Value type

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -10,6 +10,7 @@ import {
   Constructor,
   Context,
   createBindingFromClass,
+  DynamicValueProviderClass,
   Interceptor,
   InterceptorBindingOptions,
   JSONObject,
@@ -653,7 +654,9 @@ export interface ApplicationConfig {
 export type ControllerClass<T = any> = Constructor<T>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ServiceOrProviderClass<T = any> = Constructor<T | Provider<T>>;
+export type ServiceOrProviderClass<T = any> =
+  | Constructor<T | Provider<T>>
+  | DynamicValueProviderClass<T>;
 
 /**
  * Type description for `package.json`


### PR DESCRIPTION
This PR allows the following classes to be booted from `src/services`.

```ts
import {bind, BindingScope, inject, Provider} from '@loopback/core';

// Dynamic factory provider class
export class DynamicDateProvider {
  static value() {
    return new Date();
  }
}
// With `@inject`
export class ServiceWithConstructorInject {
  constructor(@inject('currentUser') private user: string) {}
}
export class ServiceWithPropertyInject {
  @inject('currentUser') private user: string;
}
export class ServiceWithMethodInject {
  greet(@inject('currentUser') user: string) {
    return `Hello, ${user}`;
  }
}
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
