### PR TITLE
feat: add @injectable to be preferred over `@bind`

### DIFF
--- a/docs/site/Accessing-http-request-response.md
+++ b/docs/site/Accessing-http-request-response.md
@@ -112,9 +112,9 @@ request/response/context objects via method parameter injection.
 
 ```ts
 import {Request, RestBindings} from '@loopback/rest';
-import {bind, inject, BindingScope} from '@loopback/core';
+import {injectable, inject, BindingScope} from '@loopback/core';
 
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class PingController {
 
   ping(

--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -300,7 +300,7 @@ The `SINGLETON` scope is useful for some use cases, such as:
 
     ```ts
     // Mark the controller class a candidate for singleton binding
-    @bind({scope: BindingScope.SINGLETON})
+    @injectable({scope: BindingScope.SINGLETON})
     export class GreetingController {
       greet(name: string) {
         return `Hello, ${name}`;
@@ -314,7 +314,7 @@ The `SINGLETON` scope is useful for some use cases, such as:
     `GreetingController` per request.
 
     ```ts
-    // createBindingFromClass() respects `@bind` and sets the binding scope to `SINGLETON'
+    // createBindingFromClass() respects `@injectable` and sets the binding scope to `SINGLETON'
     const binding = ctx.add(createBindingFromClass(GreetingController));
     const c1 = ctx.getSync(binding.key);
     const c2 = ctx.getSync(binding.key);
@@ -375,7 +375,7 @@ can be different from the context (such as `application`) used to instantiate
 the class as a singleton.
 
 {% include note.html content="
-To understand the difference between `@bind()` and `ctx.bind()`, see
+To understand the difference between `@bind()/@injectable` and `ctx.bind()`, see
 [Configure binding attributes for a class](#configure-binding-attributes-for-a-class).
 " %}
 
@@ -517,20 +517,20 @@ Classes can be discovered and bound to the application context during `boot`. In
 addition to conventions, it's often desirable to allow certain binding
 attributes, such as scope and tags, to be specified as metadata for the class.
 When the class is bound, these attributes are honored to create a binding. You
-can use `@bind` decorator to configure how to bind a class.
+can use `@injectable` decorator to configure how to bind a class.
 
 ```ts
-import {bind, BindingScope} from '@loopback/core';
+import {injectable, BindingScope} from '@loopback/core';
 
-// @bind() accepts scope and tags
-@bind({
+// @injectable() accepts scope and tags
+@injectable({
   scope: BindingScope.SINGLETON,
   tags: ['service'],
 })
 export class MyService {}
 
 // @binding.provider is a shortcut for a provider class
-@bind.provider({
+@injectable.provider({
   tags: {
     key: 'my-date-provider',
   },
@@ -541,13 +541,13 @@ export class MyDateProvider implements Provider<Date> {
   }
 }
 
-@bind({
+@injectable({
   tags: ['controller', {name: 'my-controller'}],
 })
 export class MyController {}
 
-// @bind() can take one or more binding template functions
-@bind(binding => binding.tag('controller', {name: 'your-controller'})
+// @injectable() can take one or more binding template functions
+@injectable(binding => binding.tag('controller', {name: 'your-controller'})
 export class YourController {}
 ```
 
@@ -583,25 +583,25 @@ parameter of `BindingFromClassOptions` type with the following settings:
 - defaultNamespace: Default namespace if namespace or namespace tag does not
   exist
 - defaultScope: Default scope if the binding does not have an explicit scope
-  set. The `scope` from `@bind` of the bound class takes precedence.
+  set. The `scope` from `@injectable` of the bound class takes precedence.
 
-{% include note.html content=" The `@bind` decorator only adds metadata to the
-class. It does NOT automatically bind the class to a context. To bind a class
-with `@bind` decoration, the following step needs to happen explicitly or
-implicitly by a [booter](Booting-an-Application.md#booters).
+{% include note.html content=" The `@injectable` decorator only adds metadata to
+the class. It does NOT automatically bind the class to a context. To bind a
+class with `@injectable` decoration, the following step needs to happen
+explicitly or implicitly by a [booter](Booting-an-Application.md#booters).
 
 ```ts
 const binding = createBindingFromClass(AClassOrProviderWithBindDecoration);
 ctx.add(binding);
 ```
 
-The metadata added by `@bind` is **NOT** inspected/honored by `toClass` or
+The metadata added by `@injectable` is **NOT** inspected/honored by `toClass` or
 `toProvider`. Be warned that the example below does NOT set up the binding per
-`@bind` decoration:
+`@injectable` decoration:
 
 ```ts
 const binding = ctx.bind('my-key').toClass(MyService);
-// The binding is NOT configured based on the `@bind` decoration on MyService.
+// The binding is NOT configured based on the `@injectable` decoration on MyService.
 // The scope is BindingScope.TRANSIENT (not BindingScope.SINGLETON).
 // There is no tag named 'service' for the binding either.
 ```
@@ -614,7 +614,7 @@ provider for bindings.
 1. The class for `toClass()`
 
    ```ts
-   @bind({tags: {greeting: 'a'}})
+   @injectable({tags: {greeting: 'a'}})
    class Greeter {
      constructor(@inject('currentUser') private user: string) {}
 
@@ -632,7 +632,7 @@ provider for bindings.
 2. The class for `toProvider()`
 
 ```ts
-@bind({tags: {greeting: 'b'}})
+@injectable({tags: {greeting: 'b'}})
 class GreetingProvider implements Provider<string> {
   constructor(@inject('currentUser') private user: string) {}
 
@@ -650,7 +650,7 @@ ctx.add(binding);
 3. The class for `toDynamicValue()`
 
 ```ts
-@bind({tags: {greeting: 'c'}})
+@injectable({tags: {greeting: 'c'}})
 class DynamicGreetingProvider {
   static value(@inject('currentUser') user: string) {
     return `Hello, ${this.user}`;
@@ -663,10 +663,10 @@ const binding = createBindingFromClass(GreetingProvider);
 ctx.add(binding);
 ```
 
-The `@bind` is optional for such classes. But it's usually there to provide
-additional metadata such as scope and tags for the binding. Without `@bind`,
-`createFromClass` simply calls underlying `toClass`, `toProvider`, or
-`toDynamicValue` based on the class signature.
+The `@injectable` is optional for such classes. But it's usually there to
+provide additional metadata such as scope and tags for the binding. Without
+`@injectable`, `createFromClass` simply calls underlying `toClass`,
+`toProvider`, or `toDynamicValue` based on the class signature.
 
 #### When to call createBindingFromClass
 

--- a/docs/site/Booting-an-Application.md
+++ b/docs/site/Booting-an-Application.md
@@ -266,18 +266,18 @@ using `app.service()`.
 
 {% include notes.html content="
 **IMPORTANT:** For a class to be recognized by `ServiceBooter` as a service
-provider, it either has to be decorated with `@bind`/`@inject` or the class name
-must end with `Provider` suffix and must have a static or prototype `value()`
-method.
+provider, it either has to be decorated with `@injectable`/`@inject` or the
+class name must end with `Provider` suffix and must have a static or prototype
+`value()` method.
 " %}
 
 The following are some examples for service classes:
 
 ```ts
-import {bind, BindingScope, inject, Provider} from '@loopback/core';
+import {injectable, BindingScope, inject, Provider} from '@loopback/core';
 
-// With `@bind`
-@bind({
+// With `@injectable`
+@injectable({
   tags: {serviceType: 'local'},
   scope: BindingScope.SINGLETON,
 })
@@ -287,7 +287,7 @@ export class BindableGreetingService {
   }
 }
 
-@bind({tags: {serviceType: 'local', name: 'CurrentDate'}})
+@injectable({tags: {serviceType: 'local', name: 'CurrentDate'}})
 export class DateProvider implements Provider<Date> {
   value(): Promise<Date> {
     return Promise.resolve(new Date());

--- a/docs/site/Controller.md
+++ b/docs/site/Controller.md
@@ -221,7 +221,7 @@ import {
 /**
  * A spec enhancer to modify `operationId` in paths
  */
-@bind(asSpecEnhancer)
+@injectable(asSpecEnhancer)
 export class OperationSpecEnhancer implements OASEnhancer {
   name = 'operationIdEnhancer';
   // takes in the current spec, modifies it, and returns a new one

--- a/docs/site/Extending-Model-API-builder.md
+++ b/docs/site/Extending-Model-API-builder.md
@@ -46,7 +46,7 @@ so it can be used as an API builder option.
 import {bind} from '@loopback/core';
 import {asModelApiBulder, ModelApiBuilder} from '@loopback/model-api-builder';
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 export class SampleApiBuilder implements ModelApiBuilder {}
 ```
 
@@ -63,7 +63,7 @@ import {
 import {ApplicationWithRepositories} from '@loopback/repository';
 import {Model} from '@loopback/rest';
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 export class SampleApiBuilder implements ModelApiBuilder {
   readonly pattern: string = 'Sample'; // put the name of your builder here
 
@@ -86,7 +86,7 @@ export interface SampleApiConfig extends ModelApiConfig {
   // add configuration options here
 }
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 export class SampleApiBuilder implements ModelApiBuilder {
   // other code here
 }

--- a/docs/site/Extending-OpenAPI-specification.md
+++ b/docs/site/Extending-OpenAPI-specification.md
@@ -41,7 +41,7 @@ import {
 /**
  * A spec enhancer to add OpenAPI info spec
  */
-@bind(asSpecEnhancer)
+@injectable(asSpecEnhancer)
 export class InfoSpecEnhancer implements OASEnhancer {
   // give your enhancer a proper name
   name = 'info';
@@ -81,8 +81,8 @@ merge two json objects. You can find its usage in the
 
 ### Registering an Enhancer
 
-After decorating your enhancer properly with `@bind(asSpecEnhancer)`, you can
-bind it to your application as follows:
+After decorating your enhancer properly with `@injectable(asSpecEnhancer)`, you
+can bind it to your application as follows:
 
 ```ts
 import {createBindingFromClass} from '@loopback/core';

--- a/docs/site/Interceptor-generator.md
+++ b/docs/site/Interceptor-generator.md
@@ -60,7 +60,7 @@ The generated class looks like:
 import {
   /* inject, */
   globalInterceptor,
-  bind,
+  injectable,
   Interceptor,
   Provider,
 } from '@loopback/core';
@@ -112,7 +112,7 @@ export class TestInterceptor implements Provider<Interceptor> {
 ```ts
 import {
   /* inject, */
-  bind,
+  injectable,
   Interceptor,
   Provider,
 } from '@loopback/core';
@@ -121,7 +121,7 @@ import {
  * This class will be bound to the application as a global `Interceptor` during
  * `boot`
  */
-@bind({tags: {key: TestInterceptor.BINDING_KEY}})
+@injectable({tags: {key: TestInterceptor.BINDING_KEY}})
 export class TestInterceptor implements Provider<Interceptor> {
   static readonly BINDING_KEY = `interceptors.${TestInterceptor.name}`;
 

--- a/docs/site/Life-cycle.md
+++ b/docs/site/Life-cycle.md
@@ -262,14 +262,14 @@ app
   .apply(asLifeCycleObserver);
 ```
 
-The observer class can also be decorated with `@bind` to provide binding
+The observer class can also be decorated with `@injectable` to provide binding
 metadata.
 
 ```ts
-import {bind, createBindingFromClass} from '@loopback/core';
+import {injectable, createBindingFromClass} from '@loopback/core';
 import {CoreTags, asLifeCycleObserver} from '@loopback/core';
 
-@bind(
+@injectable(
   {
     tags: {
       [CoreTags.LIFE_CYCLE_OBSERVER_GROUP]: 'g1',

--- a/docs/site/REST-middleware-sequence.md
+++ b/docs/site/REST-middleware-sequence.md
@@ -379,7 +379,7 @@ cascading style. The order of groups is determined by two factors:
       middleware
 
       ```ts
-      @bind(
+      @injectable(
         asMiddleware({
           chain: RestTags.REST_MIDDLEWARE_CHAIN,
           group: 'authentication',
@@ -394,7 +394,7 @@ cascading style. The order of groups is determined by two factors:
       this middleware
 
       ```ts
-      @bind(
+      @injectable(
         asMiddleware({
           group: 'sendResponse',
           downstreamGroups: ['cors', 'invokeMethod'],

--- a/docs/site/extending/rest-api.md
+++ b/docs/site/extending/rest-api.md
@@ -59,7 +59,7 @@ import {RestApplication} from '@loopback/rest';
 import {MyComponentBindings} from './my-component.keys.ts';
 import {definePingController} from './controllers/ping.controller-factory.ts';
 
-@bind({tags: {[ContextTags.KEY]: MyComponentBindings.COMPONENT.key}})
+@injectable({tags: {[ContextTags.KEY]: MyComponentBindings.COMPONENT.key}})
 export class MyComponent implements Component {
   constructor(
     @config(),
@@ -99,7 +99,7 @@ The example below shows a component that always contributed a `ping` endpoint
 and sometimes contributes a `stats` endpoint, depending on the configuration.
 
 ```ts
-import {bind, config, ContextTags} from '@loopback/core';
+import {injectable, config, ContextTags} from '@loopback/core';
 import {MyComponentBindings} from './my-component.keys.ts';
 import {PingController, StatsController} from './controllers';
 
@@ -107,7 +107,7 @@ export interface MyComponentConfig {
   stats: boolean;
 }
 
-@bind({tags: {[ContextTags.KEY]: MyComponentBindings.COMPONENT.key}})
+@injectable({tags: {[ContextTags.KEY]: MyComponentBindings.COMPONENT.key}})
 export class MyComponent implements Component {
   constructor(
     @config()

--- a/docs/site/migration/auth/passport.md
+++ b/docs/site/migration/auth/passport.md
@@ -142,7 +142,7 @@ You can configure the authentication endpoints with the following steps:
 /**
  * basic passport strategy
  */
-@bind(asAuthStrategy)
+@injectable(asAuthStrategy)
 export class BasicStrategy implements AuthenticationStrategy {
   name = 'basic';
   passportstrategy: Strategy;
@@ -335,7 +335,7 @@ You can configure the authentication endpoints with the following steps:
   [@loopback/authentication-passport](https://loopback.io/doc/en/lb4/Authentication-passport.html).
 
 ```ts
-@bind(
+@injectable(
   asAuthStrategy,
   extensionFor(PassportAuthenticationBindings.OAUTH2_STRATEGY),
 )

--- a/docs/site/migration/components/project-layout.md
+++ b/docs/site/migration/components/project-layout.md
@@ -59,11 +59,11 @@ The component class is usually implemented inside
 
 ```ts
 import {Application, Component, CoreBindings} from '@loopback/core';
-import {bind, config, ContextTags, inject} from '@loopback/core';
+import {injectable, config, ContextTags, inject} from '@loopback/core';
 import {MetricsBindings} from './keys';
 import {DEFAULT_METRICS_OPTIONS, MetricsOptions} from './types';
 
-@bind({tags: {[ContextTags.KEY]: MetricsBindings.COMPONENT}})
+@injectable({tags: {[ContextTags.KEY]: MetricsBindings.COMPONENT}})
 export class MetricsComponent implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/docs/site/migration/components/rest-api.md
+++ b/docs/site/migration/components/rest-api.md
@@ -139,9 +139,9 @@ How to migrate such components:
 An example implementation of the ping service class:
 
 ```ts
-import {bind, BindingScope} from '@loopback/core';
+import {injectable, BindingScope} from '@loopback/core';
 
-@bind({scope: BindingScope.TRANSIENT})
+@injectable({scope: BindingScope.TRANSIENT})
 export class PingService {
   ping() {
     return {status: 'ok'};
@@ -152,13 +152,13 @@ export class PingService {
 An example implementation of the ping controller factory:
 
 ```ts
-import {bind, BindingScope, Constructor, inject} from '@loopback/core';
+import {injectable, BindingScope, Constructor, inject} from '@loopback/core';
 import {get} from '@loopback/rest';
 import {PingBindings} from '../ping.keys';
 import {PingService} from '../services/ping.service.ts';
 
 export function definePingController(basePath: string): Constructor<unknown> {
-  @bind({scope: BindingScope.SINGLETON})
+  @injectable({scope: BindingScope.SINGLETON})
   class PingController {
     constructor(
       @inject(PingBindings.PING_SERVICE)
@@ -185,7 +185,7 @@ import {PingBindings} from './keys';
 import {PingService} from './services/ping.service.ts';
 import {PingComponentConfig} from './types';
 
-@bind({tags: {[ContextTags.KEY]: PingBindings.COMPONENT.key}})
+@injectable({tags: {[ContextTags.KEY]: PingBindings.COMPONENT.key}})
 export class PingComponent implements Component {
   constructor(
     @config(),

--- a/docs/site/tutorials/core/10-advanced-recipes.md
+++ b/docs/site/tutorials/core/10-advanced-recipes.md
@@ -22,7 +22,7 @@ You can create your own
 
    ```ts
    export function globalInterceptor(group?: string) {
-     bind({tags: [ContextTags.GLOBAL_INTERCEPTOR]});
+     injectable({tags: [ContextTags.GLOBAL_INTERCEPTOR]});
    }
    ```
 
@@ -93,7 +93,7 @@ configuration object to be injected as instructed by `@config`.
 /**
  * A greeter implementation for Chinese.
  */
-@bind(asGreeter)
+@injectable(asGreeter)
 export class ChineseGreeter implements Greeter {
   language = 'zh';
   constructor(

--- a/docs/site/tutorials/core/4-dependency-injection.md
+++ b/docs/site/tutorials/core/4-dependency-injection.md
@@ -70,7 +70,7 @@ locating the dependent artifacts. For example:
    ```
 
    ```ts
-   @bind(asGlobalInterceptor('caching'))
+   @injectable(asGlobalInterceptor('caching'))
    export class CachingInterceptor implements Provider<Interceptor> {
      constructor(
        @inject(CACHING_SERVICE) private cachingService: CachingService,

--- a/docs/site/tutorials/core/5-extension-point-extension.md
+++ b/docs/site/tutorials/core/5-extension-point-extension.md
@@ -163,7 +163,7 @@ knowing much about one another.
 
 ```ts
 import {Greeter, asGreeter} from '../types';
-import {bind, inject} from '@loopback/core';
+import {injectable, inject} from '@loopback/core';
 /**
  * Options for the Chinese greeter
  */
@@ -174,7 +174,7 @@ export interface ChineseGreeterOptions {
 /**
  * A greeter implementation for Chinese
  */
-@bind(asGreeter)
+@injectable(asGreeter)
 export class ChineseGreeter implements Greeter {
   language = 'zh';
   constructor(
@@ -194,7 +194,7 @@ export class ChineseGreeter implements Greeter {
 ```
 
 Please note we use
-[`@bind`](https://loopback.io/doc/en/lb4/Binding.html#configure-binding-attributes-for-a-class)
+[`@injectable`](https://loopback.io/doc/en/lb4/Binding.html#configure-binding-attributes-for-a-class)
 to customize how the class can be bound. In this case, `asGreeter` is a binding
 template function, which is equivalent as configuring a binding with
 `{extensionFor: 'greeter'}` tag and in the `SINGLETON` scope.

--- a/docs/site/tutorials/core/8-configuration.md
+++ b/docs/site/tutorials/core/8-configuration.md
@@ -15,7 +15,7 @@ specify the greeting phrase or the name should come first.
 /**
  * A greeter implementation for Chinese.
  */
-@bind(asGreeter)
+@injectable(asGreeter)
 export class ChineseGreeter implements Greeter {
   language = 'zh';
   constructor(

--- a/examples/context/src/find-bindings.ts
+++ b/examples/context/src/find-bindings.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingFilter,
   BindingTemplate,
   Context,
   createBindingFromClass,
   filterByTag,
+  injectable,
 } from '@loopback/context';
 
 interface Greeter {
@@ -31,7 +31,7 @@ class ChineseGreeter implements Greeter {
   }
 }
 
-@bind(asGreeter)
+@injectable(asGreeter)
 class EnglishGreeter implements Greeter {
   language = 'en';
   greet(name: string) {

--- a/examples/context/src/interceptor-proxy.ts
+++ b/examples/context/src/interceptor-proxy.ts
@@ -6,12 +6,12 @@
 import {
   asGlobalInterceptor,
   AsyncProxy,
-  bind,
   BindingKey,
   BindingScope,
   Context,
   createBindingFromClass,
   inject,
+  injectable,
   Interceptor,
   InvocationContext,
   Provider,
@@ -33,7 +33,7 @@ const TRACING_INTERCEPTOR = BindingKey.create<Interceptor>(
 const CONVERTER = BindingKey.create<Converter>('converter');
 const GREETER = BindingKey.create<Greeter>('greeter');
 
-@bind(asGlobalInterceptor('tracing'))
+@injectable(asGlobalInterceptor('tracing'))
 class TracingInterceptor implements Provider<Interceptor> {
   constructor(
     @inject(REQUEST_ID_GENERATOR) private generator: RequestIdGenerator,

--- a/examples/context/src/parameterized-decoration.ts
+++ b/examples/context/src/parameterized-decoration.ts
@@ -4,13 +4,13 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingAddress,
   BindingTag,
   Constructor,
   Context,
   createBindingFromClass,
   inject,
+  injectable,
 } from '@loopback/context';
 
 /**
@@ -29,7 +29,7 @@ function createClassWithDecoration(
   bindingKeyForName: BindingAddress<string>,
   ...tags: BindingTag[]
 ): Constructor<Greeter> {
-  @bind({tags})
+  @injectable({tags})
   class GreeterTemplate implements Greeter {
     constructor(@inject(bindingKeyForName) private userName: string) {}
 

--- a/examples/file-transfer/src/services/file-upload.service.ts
+++ b/examples/file-transfer/src/services/file-upload.service.ts
@@ -4,10 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingScope,
   config,
   ContextTags,
+  injectable,
   Provider,
 } from '@loopback/core';
 import multer from 'multer';
@@ -17,7 +17,7 @@ import {FileUploadHandler} from '../types';
 /**
  * A provider to return an `Express` request handler from `multer` middleware
  */
-@bind({
+@injectable({
   scope: BindingScope.TRANSIENT,
   tags: {[ContextTags.KEY]: FILE_UPLOAD_SERVICE},
 })

--- a/examples/graphql/src/repositories/recipe.repository.ts
+++ b/examples/graphql/src/repositories/recipe.repository.ts
@@ -4,10 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingScope,
   ContextTags,
   inject,
+  injectable,
   LifeCycleObserver,
   lifeCycleObserver,
 } from '@loopback/core';
@@ -17,7 +17,7 @@ import {RecipesDataSource} from '../datasources/recipes.datasource';
 import {RecipeInput} from '../graphql-types/recipe-input';
 import {Recipe} from '../graphql-types/recipe-type';
 
-@bind({
+@injectable({
   scope: BindingScope.SINGLETON,
   tags: {[ContextTags.NAMESPACE]: RepositoryBindings.REPOSITORIES},
 })

--- a/examples/graphql/src/services/recipe.service.ts
+++ b/examples/graphql/src/services/recipe.service.ts
@@ -3,10 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {asService, bind} from '@loopback/core';
+import {asService, injectable} from '@loopback/core';
 import {Recipe} from '../graphql-types/recipe-type';
 
-@bind(asService(RecipeService))
+@injectable(asService(RecipeService))
 export class RecipeService {
   ratingsCount(recipe: Recipe, minRate: number): number {
     return recipe.ratings.filter(rating => rating >= minRate).length;

--- a/examples/greeter-extension/README.md
+++ b/examples/greeter-extension/README.md
@@ -169,7 +169,7 @@ knowing much about one another.
 
 ```ts
 import {Greeter, asGreeter} from '../types';
-import {bind, config} from '@loopback/core';
+import {injectable, config} from '@loopback/core';
 
 /**
  * Options for the Chinese greeter
@@ -182,7 +182,7 @@ export interface ChineseGreeterOptions {
 /**
  * A greeter implementation for Chinese
  */
-@bind(asGreeter)
+@injectable(asGreeter)
 export class ChineseGreeter implements Greeter {
   language = 'zh';
 
@@ -204,7 +204,7 @@ export class ChineseGreeter implements Greeter {
 ```
 
 Please note we use
-[`@bind`](https://loopback.io/doc/en/lb4/Binding.html#configure-binding-attributes-for-a-class)
+[`@injectable`](https://loopback.io/doc/en/lb4/Binding.html#configure-binding-attributes-for-a-class)
 to customize how the class can be bound. In this case, `asGreeter` is a binding
 template function, which is equivalent as configuring a binding with
 `{extensionFor: 'greeter'}` tag and in the `SINGLETON` scope.

--- a/examples/greeter-extension/src/__tests__/acceptance/greeter-extension.acceptance.ts
+++ b/examples/greeter-extension/src/__tests__/acceptance/greeter-extension.acceptance.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, createBindingFromClass} from '@loopback/core';
+import {createBindingFromClass, injectable} from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import chalk from 'chalk';
 import {
@@ -48,7 +48,7 @@ describe('greeter-extension-pont', () => {
     /**
      * A greeter implementation for French
      */
-    @bind(asGreeter)
+    @injectable(asGreeter)
     class FrenchGreeter implements Greeter {
       language = 'fr';
 

--- a/examples/greeter-extension/src/greeters/greeter-cn.ts
+++ b/examples/greeter-extension/src/greeters/greeter-cn.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, config} from '@loopback/core';
+import {config, injectable} from '@loopback/core';
 import {asGreeter, Greeter} from '../types';
 
 /**
@@ -17,7 +17,7 @@ export interface ChineseGreeterOptions {
 /**
  * A greeter implementation for Chinese.
  */
-@bind(asGreeter)
+@injectable(asGreeter)
 export class ChineseGreeter implements Greeter {
   language = 'zh';
 

--- a/examples/greeter-extension/src/greeters/greeter-en.ts
+++ b/examples/greeter-extension/src/greeters/greeter-en.ts
@@ -1,15 +1,14 @@
+import {injectable} from '@loopback/core';
 // Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/example-greeter-extension
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
-
-import {bind} from '@loopback/core';
 import {asGreeter, Greeter} from '../types';
 
 /**
  * A greeter implementation for English
  */
-@bind(asGreeter)
+@injectable(asGreeter)
 export class EnglishGreeter implements Greeter {
   language = 'en';
 

--- a/examples/greeting-app/src/caching-service.ts
+++ b/examples/greeting-app/src/caching-service.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, config, ContextView} from '@loopback/core';
+import {BindingScope, config, ContextView, injectable} from '@loopback/core';
 import debugFactory from 'debug';
 import {Message} from './types';
 const debug = debugFactory('greeter-extension');
@@ -19,7 +19,7 @@ export interface CachingServiceOptions {
 /**
  * Message caching service
  */
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class CachingService {
   private timer: NodeJS.Timer;
   private store: Map<string, Message> = new Map();

--- a/examples/greeting-app/src/interceptors/caching.interceptor.ts
+++ b/examples/greeting-app/src/interceptors/caching.interceptor.ts
@@ -5,8 +5,8 @@
 
 import {
   asGlobalInterceptor,
-  bind,
   inject,
+  injectable,
   Interceptor,
   InvocationContext,
   InvocationResult,
@@ -20,7 +20,7 @@ import {CACHING_SERVICE} from '../keys';
 
 const debug = debugFactory('greeter-extension');
 
-@bind(asGlobalInterceptor('caching'))
+@injectable(asGlobalInterceptor('caching'))
 export class CachingInterceptor implements Provider<Interceptor> {
   constructor(
     @inject(CACHING_SERVICE) private cachingService: CachingService,

--- a/examples/metrics-prometheus/src/services/greeting.service.ts
+++ b/examples/metrics-prometheus/src/services/greeting.service.ts
@@ -3,11 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, ContextTags} from '@loopback/core';
+import {ContextTags, injectable} from '@loopback/core';
 import {promisify} from 'util';
 const sleep = promisify(setTimeout);
 
-@bind({tags: {[ContextTags.NAMESPACE]: 'services'}})
+@injectable({tags: {[ContextTags.NAMESPACE]: 'services'}})
 export class GreetingService {
   async greet(name: string) {
     const ts = new Date().toISOString();

--- a/examples/passport-login/src/authentication-strategies/basic.ts
+++ b/examples/passport-login/src/authentication-strategies/basic.ts
@@ -3,21 +3,21 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {AuthenticationStrategy, asAuthStrategy} from '@loopback/authentication';
+import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
 import {StrategyAdapter} from '@loopback/authentication-passport';
-import {Request, RedirectRoute} from '@loopback/rest';
-import {UserProfile} from '@loopback/security';
-import {User} from '../models';
-import {bind} from '@loopback/core';
-import {BasicStrategy as Strategy} from 'passport-http';
+import {injectable} from '@loopback/core';
 import {repository} from '@loopback/repository';
+import {RedirectRoute, Request} from '@loopback/rest';
+import {UserProfile} from '@loopback/security';
+import {BasicStrategy as Strategy} from 'passport-http';
+import {User} from '../models';
 import {UserRepository} from '../repositories';
 import {mapProfile} from './types';
 
 /**
  * basic passport strategy
  */
-@bind(asAuthStrategy)
+@injectable(asAuthStrategy)
 export class BasicStrategy implements AuthenticationStrategy {
   name = 'basic';
   passportstrategy: Strategy;

--- a/examples/passport-login/src/authentication-strategies/facebook.ts
+++ b/examples/passport-login/src/authentication-strategies/facebook.ts
@@ -5,15 +5,14 @@
 
 import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
 import {StrategyAdapter} from '@loopback/authentication-passport';
-import {Strategy} from 'passport-facebook';
-import {bind, inject, extensionFor} from '@loopback/core';
+import {extensionFor, inject, injectable} from '@loopback/core';
+import {RedirectRoute, Request} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
+import {Strategy} from 'passport-facebook';
 import {User} from '../models';
-import {Request, RedirectRoute} from '@loopback/rest';
-import {PassportAuthenticationBindings} from './types';
-import {mapProfile} from './types';
+import {mapProfile, PassportAuthenticationBindings} from './types';
 
-@bind(
+@injectable(
   asAuthStrategy,
   extensionFor(PassportAuthenticationBindings.OAUTH2_STRATEGY),
 )

--- a/examples/passport-login/src/authentication-strategies/google.ts
+++ b/examples/passport-login/src/authentication-strategies/google.ts
@@ -5,15 +5,14 @@
 
 import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
 import {StrategyAdapter} from '@loopback/authentication-passport';
-import {Strategy} from 'passport-google-oauth2';
-import {bind, inject, extensionFor} from '@loopback/core';
+import {extensionFor, inject, injectable} from '@loopback/core';
+import {RedirectRoute, Request} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
+import {Strategy} from 'passport-google-oauth2';
 import {User} from '../models';
-import {Request, RedirectRoute} from '@loopback/rest';
-import {PassportAuthenticationBindings} from './types';
-import {mapProfile} from './types';
+import {mapProfile, PassportAuthenticationBindings} from './types';
 
-@bind(
+@injectable(
   asAuthStrategy,
   extensionFor(PassportAuthenticationBindings.OAUTH2_STRATEGY),
 )

--- a/examples/passport-login/src/authentication-strategies/local.ts
+++ b/examples/passport-login/src/authentication-strategies/local.ts
@@ -3,17 +3,17 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {AuthenticationStrategy, asAuthStrategy} from '@loopback/authentication';
+import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
 import {StrategyAdapter} from '@loopback/authentication-passport';
-import {Request, RedirectRoute} from '@loopback/rest';
-import {UserProfile, securityId} from '@loopback/security';
-import {User} from '../models';
-import {bind} from '@loopback/core';
-import {Strategy, IVerifyOptions} from 'passport-local';
+import {injectable} from '@loopback/core';
 import {repository} from '@loopback/repository';
+import {RedirectRoute, Request} from '@loopback/rest';
+import {securityId, UserProfile} from '@loopback/security';
+import {IVerifyOptions, Strategy} from 'passport-local';
+import {User} from '../models';
 import {UserRepository} from '../repositories';
 
-@bind(asAuthStrategy)
+@injectable(asAuthStrategy)
 export class LocalAuthStrategy implements AuthenticationStrategy {
   name = 'local';
   passportstrategy: Strategy;

--- a/examples/passport-login/src/authentication-strategies/oauth2.ts
+++ b/examples/passport-login/src/authentication-strategies/oauth2.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {AuthenticationStrategy, asAuthStrategy} from '@loopback/authentication';
+import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
 import {StrategyAdapter} from '@loopback/authentication-passport';
-import {Strategy} from 'passport-oauth2';
-import {Request, RedirectRoute} from '@loopback/rest';
+import {extensions, Getter, inject, injectable} from '@loopback/core';
+import {RedirectRoute, Request} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
+import {Strategy} from 'passport-oauth2';
 import {User} from '../models';
-import {inject, bind, extensions, Getter} from '@loopback/core';
-import {PassportAuthenticationBindings, mapProfile} from './types';
+import {mapProfile, PassportAuthenticationBindings} from './types';
 
-@bind(asAuthStrategy)
+@injectable(asAuthStrategy)
 export class Oauth2AuthStrategy implements AuthenticationStrategy {
   name = 'oauth2';
   protected strategy: StrategyAdapter<User>;

--- a/examples/passport-login/src/authentication-strategies/session.ts
+++ b/examples/passport-login/src/authentication-strategies/session.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {AuthenticationStrategy, asAuthStrategy} from '@loopback/authentication';
-import {RedirectRoute, RequestWithSession, HttpErrors} from '@loopback/rest';
+import {asAuthStrategy, AuthenticationStrategy} from '@loopback/authentication';
+import {injectable} from '@loopback/core';
+import {repository} from '@loopback/repository';
+import {HttpErrors, RedirectRoute, RequestWithSession} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
 import {User} from '../models';
-import {bind} from '@loopback/core';
-import {repository} from '@loopback/repository';
 import {UserRepository} from '../repositories';
 import {mapProfile} from './types';
 
-@bind(asAuthStrategy)
+@injectable(asAuthStrategy)
 export class SessionStrategy implements AuthenticationStrategy {
   name = 'session';
 

--- a/examples/passport-login/src/authentication-strategy-providers/facebook.express-mw.ts
+++ b/examples/passport-login/src/authentication-strategy-providers/facebook.express-mw.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 const passport = require('passport');
-import {inject, Provider, bind, BindingScope} from '@loopback/core';
-import {Strategy as FacebookStrategy} from 'passport-facebook';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
 import {ExpressRequestHandler} from '@loopback/rest';
+import {Strategy as FacebookStrategy} from 'passport-facebook';
 
-@bind.provider({scope: BindingScope.SINGLETON})
+@injectable.provider({scope: BindingScope.SINGLETON})
 export class FacebookOauth2ExpressMiddleware
   implements Provider<ExpressRequestHandler> {
   constructor(

--- a/examples/passport-login/src/authentication-strategy-providers/facebook.ts
+++ b/examples/passport-login/src/authentication-strategy-providers/facebook.ts
@@ -3,16 +3,15 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Profile} from 'passport';
 import {UserIdentityService} from '@loopback/authentication';
-import {User} from '../models';
-import {StrategyOption} from 'passport-facebook';
-import {inject, Provider, bind, BindingScope} from '@loopback/core';
-import {UserServiceBindings} from '../services';
-import {Strategy as FacebookStrategy} from 'passport-facebook';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
+import {Profile} from 'passport';
+import {Strategy as FacebookStrategy, StrategyOption} from 'passport-facebook';
 import {verifyFunctionFactory} from '../authentication-strategies/types';
+import {User} from '../models';
+import {UserServiceBindings} from '../services';
 
-@bind.provider({scope: BindingScope.SINGLETON})
+@injectable.provider({scope: BindingScope.SINGLETON})
 export class FacebookOauth implements Provider<FacebookStrategy> {
   strategy: FacebookStrategy;
 

--- a/examples/passport-login/src/authentication-strategy-providers/google.express-mw.ts
+++ b/examples/passport-login/src/authentication-strategy-providers/google.express-mw.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 const passport = require('passport');
-import {inject, Provider, bind, BindingScope} from '@loopback/core';
-import {Strategy as GoogleStrategy} from 'passport-google-oauth2';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
 import {ExpressRequestHandler} from '@loopback/rest';
+import {Strategy as GoogleStrategy} from 'passport-google-oauth2';
 
-@bind.provider({scope: BindingScope.SINGLETON})
+@injectable.provider({scope: BindingScope.SINGLETON})
 export class GoogleOauth2ExpressMiddleware
   implements Provider<ExpressRequestHandler> {
   constructor(

--- a/examples/passport-login/src/authentication-strategy-providers/google.ts
+++ b/examples/passport-login/src/authentication-strategy-providers/google.ts
@@ -3,16 +3,16 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Profile} from 'passport';
 import {UserIdentityService} from '@loopback/authentication';
-import {User} from '../models';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
+import {Profile} from 'passport';
 import {StrategyOption} from 'passport-facebook';
-import {inject, Provider, bind, BindingScope} from '@loopback/core';
-import {UserServiceBindings} from '../services';
 import {Strategy as GoogleStrategy} from 'passport-google-oauth2';
 import {verifyFunctionFactory} from '../authentication-strategies/types';
+import {User} from '../models';
+import {UserServiceBindings} from '../services';
 
-@bind.provider({scope: BindingScope.SINGLETON})
+@injectable.provider({scope: BindingScope.SINGLETON})
 export class GoogleOauth implements Provider<GoogleStrategy> {
   strategy: GoogleStrategy;
 

--- a/examples/passport-login/src/authentication-strategy-providers/oauth2.express-mw.ts
+++ b/examples/passport-login/src/authentication-strategy-providers/oauth2.express-mw.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 const passport = require('passport');
-import {inject, Provider, BindingScope, bind} from '@loopback/core';
-import {Strategy as OAuth2Strategy} from 'passport-oauth2';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
 import {ExpressRequestHandler} from '@loopback/rest';
+import {Strategy as OAuth2Strategy} from 'passport-oauth2';
 
-@bind.provider({scope: BindingScope.SINGLETON})
+@injectable.provider({scope: BindingScope.SINGLETON})
 export class CustomOauth2ExpressMiddleware
   implements Provider<ExpressRequestHandler> {
   constructor(

--- a/examples/passport-login/src/authentication-strategy-providers/oauth2.ts
+++ b/examples/passport-login/src/authentication-strategy-providers/oauth2.ts
@@ -3,21 +3,21 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Profile} from 'passport';
 import {UserIdentityService} from '@loopback/authentication';
-import {User} from '../models';
-import {inject, Provider, BindingScope, bind} from '@loopback/core';
-import {UserServiceBindings} from '../services';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
+import {Profile} from 'passport';
 import {
   Strategy as OAuth2Strategy,
   StrategyOptions as OAuth2StrategyOptions,
 } from 'passport-oauth2';
 import {
-  verifyFunctionFactory,
   ProfileFunction,
+  verifyFunctionFactory,
 } from '../authentication-strategies/types';
+import {User} from '../models';
+import {UserServiceBindings} from '../services';
 
-@bind.provider({scope: BindingScope.SINGLETON})
+@injectable.provider({scope: BindingScope.SINGLETON})
 export class CustomOauth2 implements Provider<OAuth2Strategy> {
   strategy: OAuth2Strategy;
 

--- a/examples/validation-app/src/interceptors/validate-phone-num.interceptor.ts
+++ b/examples/validation-app/src/interceptors/validate-phone-num.interceptor.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
+  injectable,
   Interceptor,
   InvocationContext,
   InvocationResult,
@@ -17,7 +17,7 @@ import {CoffeeShop} from '../models';
  * This class will be bound to the application as an `Interceptor` during
  * `boot`
  */
-@bind({tags: {key: ValidatePhoneNumInterceptor.BINDING_KEY}})
+@injectable({tags: {key: ValidatePhoneNumInterceptor.BINDING_KEY}})
 export class ValidatePhoneNumInterceptor implements Provider<Interceptor> {
   static readonly BINDING_KEY = `interceptors.${ValidatePhoneNumInterceptor.name}`;
 

--- a/examples/validation-app/src/middleware/validation-error.middleware.ts
+++ b/examples/validation-app/src/middleware/validation-error.middleware.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, inject, Provider} from '@loopback/core';
+import {inject, injectable, Provider} from '@loopback/core';
 import {
   asMiddleware,
   ErrorWriterOptions,
@@ -16,7 +16,7 @@ import {
   RestMiddlewareGroups,
 } from '@loopback/rest';
 
-@bind(
+@injectable(
   asMiddleware({
     group: 'validationError',
     upstreamGroups: RestMiddlewareGroups.SEND_RESPONSE,

--- a/extensions/apiconnect/src/apiconnect.spec-enhancer.ts
+++ b/extensions/apiconnect/src/apiconnect.spec-enhancer.ts
@@ -5,10 +5,10 @@
 
 import {
   ApplicationMetadata,
-  bind,
   config,
   CoreBindings,
   inject,
+  injectable,
 } from '@loopback/core';
 import {asSpecEnhancer, OASEnhancer, OpenAPIObject} from '@loopback/rest';
 
@@ -23,7 +23,7 @@ export type ApiConnectSpecOptions = {
  * An OpenAPI spec enhancer to add `x-ibm-configuration` extension required
  * by API Connect
  */
-@bind(asSpecEnhancer)
+@injectable(asSpecEnhancer)
 export class ApiConnectSpecEnhancer implements OASEnhancer {
   name = 'IBM API Connect';
 

--- a/extensions/authentication-jwt/src/services/refreshtoken.service.ts
+++ b/extensions/authentication-jwt/src/services/refreshtoken.service.ts
@@ -1,5 +1,5 @@
 import {TokenService} from '@loopback/authentication';
-import {bind, BindingScope, inject, uuid} from '@loopback/core';
+import {BindingScope, inject, injectable, uuid} from '@loopback/core';
 import {repository} from '@loopback/repository';
 import {HttpErrors} from '@loopback/rest';
 import {securityId, UserProfile} from '@loopback/security';
@@ -9,7 +9,6 @@ import {
   TokenServiceBindings,
   UserServiceBindings,
 } from '../keys';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {RefreshToken, RefreshTokenRelations} from '../models';
 import {RefreshTokenRepository} from '../repositories';
 import {TokenObject} from '../types';
@@ -18,7 +17,7 @@ const jwt = require('jsonwebtoken');
 const signAsync = promisify(jwt.sign);
 const verifyAsync = promisify(jwt.verify);
 
-@bind({scope: BindingScope.TRANSIENT})
+@injectable({scope: BindingScope.TRANSIENT})
 export class RefreshtokenService {
   constructor(
     @inject(RefreshTokenServiceBindings.REFRESH_SECRET)
@@ -106,7 +105,9 @@ export class RefreshtokenService {
    * Verify the validity of a refresh token, and make sure it exists in backend.
    * @param refreshToken
    */
-  async verifyToken(refreshToken: string) {
+  async verifyToken(
+    refreshToken: string,
+  ): Promise<RefreshToken & RefreshTokenRelations> {
     try {
       await verifyAsync(refreshToken, this.refreshSecret);
       const userRefreshData = await this.refreshTokenRepository.findOne({

--- a/extensions/authentication-jwt/src/services/security.spec.enhancer.ts
+++ b/extensions/authentication-jwt/src/services/security.spec.enhancer.ts
@@ -1,9 +1,8 @@
+import {injectable} from '@loopback/core';
 // Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: @loopback/authentication-jwt"
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
-
-import {bind} from '@loopback/core';
 import {
   asSpecEnhancer,
   mergeOpenAPISpec,
@@ -39,7 +38,7 @@ export const SECURITY_SCHEME_SPEC: SecuritySchemeObjects = {
  * A spec enhancer to add bearer token OpenAPI security entry to
  * `spec.component.securitySchemes`
  */
-@bind(asSpecEnhancer)
+@injectable(asSpecEnhancer)
 export class SecuritySpecEnhancer implements OASEnhancer {
   name = 'bearerAuth';
 

--- a/extensions/context-explorer/src/context-explorer.component.ts
+++ b/extensions/context-explorer/src/context-explorer.component.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Component,
   config,
   ContextTags,
   CoreBindings,
   inject,
+  injectable,
 } from '@loopback/core';
 import {RestApplication} from '@loopback/rest';
 import path from 'path';
@@ -20,7 +20,7 @@ import {ContextExplorerConfig} from './types';
 /**
  * A component providing a self-hosted API Explorer.
  */
-@bind({tags: {[ContextTags.KEY]: ContextExplorerBindings.COMPONENT.key}})
+@injectable({tags: {[ContextTags.KEY]: ContextExplorerBindings.COMPONENT.key}})
 export class ContextExplorerComponent implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/extensions/cron/src/decorators/cron-job.decorator.ts
+++ b/extensions/cron/src/decorators/cron-job.decorator.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingSpec} from '@loopback/core';
+import {BindingSpec, injectable} from '@loopback/core';
 import {asCronJob} from '../types';
 
 /**
@@ -22,5 +22,5 @@ import {asCronJob} from '../types';
  * @param specs - Extra binding specs
  */
 export function cronJob(...specs: BindingSpec[]) {
-  return bind(asCronJob, ...specs);
+  return injectable(asCronJob, ...specs);
 }

--- a/extensions/health/src/controllers/health.controller.ts
+++ b/extensions/health/src/controllers/health.controller.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {HealthChecker} from '@cloudnative/health';
-import {bind, BindingScope, Constructor, inject} from '@loopback/core';
+import {BindingScope, Constructor, inject, injectable} from '@loopback/core';
 import {get} from '@loopback/rest';
 import {HealthBindings} from '../keys';
 import {DEFAULT_HEALTH_OPTIONS, HealthOptions} from '../types';
@@ -22,7 +22,7 @@ export function createHealthController(
   /**
    * Controller for health endpoints
    */
-  @bind({scope: BindingScope.SINGLETON})
+  @injectable({scope: BindingScope.SINGLETON})
   class HealthController {
     constructor(
       @inject(HealthBindings.HEALTH_CHECKER)

--- a/extensions/health/src/health.component.ts
+++ b/extensions/health/src/health.component.ts
@@ -6,13 +6,13 @@
 import {HealthChecker} from '@cloudnative/health';
 import {
   Application,
-  bind,
   BindingScope,
   Component,
   config,
   ContextTags,
   CoreBindings,
   inject,
+  injectable,
 } from '@loopback/core';
 import {createHealthController} from './controllers';
 import {HealthBindings} from './keys';
@@ -22,7 +22,7 @@ import {DEFAULT_HEALTH_OPTIONS, HealthConfig, HealthOptions} from './types';
 /**
  * A component providing health status
  */
-@bind({tags: {[ContextTags.KEY]: HealthBindings.COMPONENT}})
+@injectable({tags: {[ContextTags.KEY]: HealthBindings.COMPONENT}})
 export class HealthComponent implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/extensions/logging/src/interceptors/logging.interceptor.ts
+++ b/extensions/logging/src/interceptors/logging.interceptor.ts
@@ -5,11 +5,11 @@
 
 import {
   asGlobalInterceptor,
-  bind,
   BindingScope,
   config,
   ContextTags,
   inject,
+  injectable,
   Interceptor,
   InvocationContext,
   Provider,
@@ -24,7 +24,7 @@ import {LoggingBindings} from '../keys';
 /**
  * A local interceptor that provides logging for method invocations.
  */
-@bind({
+@injectable({
   tags: {[ContextTags.KEY]: LoggingBindings.WINSTON_INVOCATION_LOGGER},
   scope: BindingScope.SINGLETON,
 })
@@ -74,7 +74,7 @@ export interface AccessLogOptions extends morgan.Options<Request, Response> {
 /**
  * A global interceptor that provides logging for http requests/responses.
  */
-@bind(asGlobalInterceptor('logging'), {
+@injectable(asGlobalInterceptor('logging'), {
   tags: {
     [ContextTags.KEY]: LoggingBindings.WINSTON_HTTP_ACCESS_LOGGER,
     // Only apply to invocations from REST routes

--- a/extensions/logging/src/logging.component.ts
+++ b/extensions/logging/src/logging.component.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Binding,
   Component,
   config,
   ContextTags,
   extensionFor,
+  injectable,
   ProviderMap,
 } from '@loopback/core';
 import {FluentSenderProvider, FluentTransportProvider} from './fluent';
@@ -37,7 +37,7 @@ export type LoggingComponentConfig = {
 /**
  * A component providing logging facilities
  */
-@bind({tags: {[ContextTags.KEY]: LoggingBindings.COMPONENT}})
+@injectable({tags: {[ContextTags.KEY]: LoggingBindings.COMPONENT}})
 export class LoggingComponent implements Component {
   providers: ProviderMap;
   bindings: Binding<unknown>[];

--- a/extensions/metrics/src/controllers/metrics.controller.ts
+++ b/extensions/metrics/src/controllers/metrics.controller.ts
@@ -3,14 +3,14 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, Constructor, inject} from '@loopback/core';
+import {BindingScope, Constructor, inject, injectable} from '@loopback/core';
 import {get, Response, RestBindings} from '@loopback/rest';
 import {register} from 'prom-client';
 
 export function metricsControllerFactory(
   basePath = '/metrics',
 ): Constructor<unknown> {
-  @bind({scope: BindingScope.SINGLETON})
+  @injectable({scope: BindingScope.SINGLETON})
   class MetricsController {
     @get(basePath, {
       responses: {},

--- a/extensions/metrics/src/interceptors/metrics.interceptor.ts
+++ b/extensions/metrics/src/interceptors/metrics.interceptor.ts
@@ -5,8 +5,8 @@
 
 import {
   asGlobalInterceptor,
-  bind,
   BindingScope,
+  injectable,
   Interceptor,
   InvocationContext,
   Provider,
@@ -20,7 +20,7 @@ import {Counter, Gauge, Histogram, register, Summary} from 'prom-client';
  * a method is invoked. Please collect metrics at other places
  * if you want to cover more than just method invocations.
  */
-@bind(asGlobalInterceptor('metrics'), {scope: BindingScope.SINGLETON})
+@injectable(asGlobalInterceptor('metrics'), {scope: BindingScope.SINGLETON})
 export class MetricsInterceptor implements Provider<Interceptor> {
   private static gauge: Gauge<'targetName'>;
 

--- a/extensions/metrics/src/metrics.component.ts
+++ b/extensions/metrics/src/metrics.component.ts
@@ -5,13 +5,13 @@
 
 import {
   Application,
-  bind,
   Component,
   config,
   ContextTags,
   CoreBindings,
   createBindingFromClass,
   inject,
+  injectable,
 } from '@loopback/core';
 import {metricsControllerFactory} from './controllers';
 import {MetricsInterceptor} from './interceptors';
@@ -22,7 +22,7 @@ import {DEFAULT_METRICS_OPTIONS, MetricsOptions} from './types';
 /**
  * A component providing metrics for Prometheus
  */
-@bind({tags: {[ContextTags.KEY]: MetricsBindings.COMPONENT}})
+@injectable({tags: {[ContextTags.KEY]: MetricsBindings.COMPONENT}})
 export class MetricsComponent implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/extensions/pooling/src/pooling.ts
+++ b/extensions/pooling/src/pooling.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingAddress,
   BindingScope,
   config,
   Context,
   inject,
+  injectable,
   LifeCycleObserver,
   ValueOrPromise,
 } from '@loopback/core';
@@ -135,7 +135,7 @@ export async function getPooledValue<T>(
  *
  * The pool service observes life cycle events to start and stop.
  */
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class PoolingService<T> implements LifeCycleObserver {
   private readonly factory: PoolFactory<T>;
   /**

--- a/packages/authentication/src/__tests__/fixtures/strategies/basic-strategy.ts
+++ b/packages/authentication/src/__tests__/fixtures/strategies/basic-strategy.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, inject} from '@loopback/core';
+import {inject, injectable} from '@loopback/core';
 import {
   asSpecEnhancer,
   HttpErrors,
@@ -22,7 +22,7 @@ export interface BasicAuthenticationStrategyCredentials {
   password: string;
 }
 
-@bind(asAuthStrategy, asSpecEnhancer)
+@injectable(asAuthStrategy, asSpecEnhancer)
 export class BasicAuthenticationStrategy
   implements AuthenticationStrategy, OASEnhancer {
   name = 'basic';

--- a/packages/authentication/src/__tests__/fixtures/strategies/jwt-strategy.ts
+++ b/packages/authentication/src/__tests__/fixtures/strategies/jwt-strategy.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, inject} from '@loopback/core';
+import {inject, injectable} from '@loopback/core';
 import {
   asSpecEnhancer,
   HttpErrors,
@@ -17,7 +17,7 @@ import {asAuthStrategy, AuthenticationStrategy} from '../../../types';
 import {JWTAuthenticationStrategyBindings} from '../keys';
 import {JWTService} from '../services/jwt-service';
 
-@bind(asAuthStrategy, asSpecEnhancer)
+@injectable(asAuthStrategy, asSpecEnhancer)
 export class JWTAuthenticationStrategy
   implements AuthenticationStrategy, OASEnhancer {
   name = 'jwt';

--- a/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
+++ b/packages/authentication/src/__tests__/unit/types/register-authentication-strategy.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Context, createBindingFromClass} from '@loopback/core';
+import {Context, createBindingFromClass, injectable} from '@loopback/core';
 import {
   asSpecEnhancer,
   OASEnhancer,
@@ -54,7 +54,7 @@ describe('registerAuthenticationStrategy', () => {
     );
   });
 
-  @bind(asAuthStrategy, asSpecEnhancer)
+  @injectable(asAuthStrategy, asSpecEnhancer)
   class MyAuthenticationStrategy
     implements AuthenticationStrategy, OASEnhancer {
     name: 'my-auth';

--- a/packages/authentication/src/authentication.component.ts
+++ b/packages/authentication/src/authentication.component.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Component, ContextTags} from '@loopback/core';
+import {Component, ContextTags, injectable} from '@loopback/core';
 import {AuthenticationBindings} from './keys';
 import {
   AuthenticateActionProvider,
@@ -12,7 +12,7 @@ import {
   AuthMetadataProvider,
 } from './providers';
 
-@bind({tags: {[ContextTags.KEY]: AuthenticationBindings.COMPONENT}})
+@injectable({tags: {[ContextTags.KEY]: AuthenticationBindings.COMPONENT}})
 export class AuthenticationComponent implements Component {
   providers = {
     [AuthenticationBindings.AUTH_ACTION.key]: AuthenticateActionProvider,

--- a/packages/authentication/src/providers/auth-action.provider.ts
+++ b/packages/authentication/src/providers/auth-action.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Getter, inject, Provider, Setter} from '@loopback/core';
+import {Getter, inject, injectable, Provider, Setter} from '@loopback/core';
 import {
   asMiddleware,
   Middleware,
@@ -113,7 +113,7 @@ export class AuthenticateActionProvider implements Provider<AuthenticateFn> {
   }
 }
 
-@bind(
+@injectable(
   asMiddleware({
     group: RestMiddlewareGroups.AUTHENTICATION,
     upstreamGroups: [RestMiddlewareGroups.FIND_ROUTE],

--- a/packages/authorization/src/authorization-component.ts
+++ b/packages/authorization/src/authorization-component.ts
@@ -4,16 +4,16 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Binding,
   Component,
   ContextTags,
   createBindingFromClass,
+  injectable,
 } from '@loopback/core';
 import {AuthorizationInterceptor} from './authorize-interceptor';
 import {AuthorizationBindings} from './keys';
 
-@bind({tags: {[ContextTags.KEY]: AuthorizationBindings.COMPONENT.key}})
+@injectable({tags: {[ContextTags.KEY]: AuthorizationBindings.COMPONENT.key}})
 export class AuthorizationComponent implements Component {
   bindings: Binding[] = [createBindingFromClass(AuthorizationInterceptor)];
 }

--- a/packages/authorization/src/authorize-interceptor.ts
+++ b/packages/authorization/src/authorize-interceptor.ts
@@ -5,10 +5,10 @@
 
 import {
   asGlobalInterceptor,
-  bind,
   BindingAddress,
   config,
   Context,
+  injectable,
   Interceptor,
   InvocationContext,
   Next,
@@ -30,7 +30,7 @@ import {createPrincipalFromUserProfile} from './util';
 
 const debug = debugFactory('loopback:authorization:interceptor');
 
-@bind(asGlobalInterceptor('authorization'))
+@injectable(asGlobalInterceptor('authorization'))
 export class AuthorizationInterceptor implements Provider<Interceptor> {
   private options: AuthorizationOptions;
 

--- a/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/bindable-classes.artifact.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, inject, Provider} from '@loopback/core';
+import {injectable, BindingScope, inject, Provider} from '@loopback/core';
 
-@bind({
+@injectable({
   tags: {serviceType: 'local'},
   scope: BindingScope.SINGLETON,
 })
@@ -15,7 +15,7 @@ export class BindableGreetingService {
   }
 }
 
-@bind({tags: {serviceType: 'local', name: 'CurrentDate'}})
+@injectable({tags: {serviceType: 'local', name: 'CurrentDate'}})
 export class DateProvider implements Provider<Date> {
   value(): Promise<Date> {
     return Promise.resolve(new Date());

--- a/packages/boot/src/__tests__/fixtures/non-global-interceptor.artifact.ts
+++ b/packages/boot/src/__tests__/fixtures/non-global-interceptor.artifact.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
+  injectable,
   Interceptor,
   InvocationContext,
   InvocationResult,
@@ -16,7 +16,7 @@ import {
  * This class will be bound to the application as a global `Interceptor` during
  * `boot`
  */
-@bind({tags: {namespace: 'interceptors', name: 'myInterceptor'}})
+@injectable({tags: {namespace: 'interceptors', name: 'myInterceptor'}})
 export class MyInterceptor implements Provider<Interceptor> {
   /*
   constructor() {}

--- a/packages/boot/src/__tests__/fixtures/stub-model-api-builder.ts
+++ b/packages/boot/src/__tests__/fixtures/stub-model-api-builder.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Component, createBindingFromClass} from '@loopback/core';
+import {Component, createBindingFromClass, injectable} from '@loopback/core';
 import {
   asModelApiBuilder,
   ModelApiBuilder,
@@ -14,7 +14,7 @@ import {BooterApp} from './application';
 
 export const buildCalls: object[] = [];
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 class StubModelApiBuilder implements ModelApiBuilder {
   readonly pattern: string = 'stub';
   async build(
@@ -32,7 +32,7 @@ export class StubModelApiBuilderComponent implements Component {
 
 export const samePatternBuildCalls: object[] = [];
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 class SamePatternModelApiBuilder implements ModelApiBuilder {
   readonly pattern: string = 'same';
   async build(
@@ -50,7 +50,7 @@ export class SamePatternModelApiBuilderComponent implements Component {
 
 export const similarPatternBuildCalls: object[] = [];
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 class SimilarPatternModelApiBuilder implements ModelApiBuilder {
   readonly pattern: string = 'same';
   async build(

--- a/packages/boot/src/__tests__/unit/boot.custom-binding.component.unit.ts
+++ b/packages/boot/src/__tests__/unit/boot.custom-binding.component.unit.ts
@@ -5,11 +5,11 @@
 
 import {
   Application,
-  bind,
   BindingKey,
   BindingScope,
   Component,
   ContextTags,
+  injectable,
 } from '@loopback/core';
 import {expect} from '@loopback/testlab';
 import {BootBindings, BootMixin} from '../../';
@@ -49,7 +49,7 @@ describe('boot.component unit tests', () => {
   const CustomBinding = BindingKey.create<CustomBoundComponent>(
     'io.loopback.custom.binding.CustomBoundComponent',
   );
-  @bind({
+  @injectable({
     tags: {[ContextTags.KEY]: CustomBinding},
     scope: BindingScope.SINGLETON,
   })

--- a/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
+++ b/packages/boot/src/__tests__/unit/mixins/boot.mixin.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, bind, BindingKey, ContextTags} from '@loopback/core';
+import {Application, BindingKey, ContextTags, injectable} from '@loopback/core';
 import {expect, sinon} from '@loopback/testlab';
 import {BootBindings, Booter, BootMixin} from '../../..';
 
@@ -32,7 +32,7 @@ describe('BootMixin unit tests', () => {
     expect(booter).to.be.an.instanceOf(TestBooter);
   });
 
-  it('binds booter with `@bind` from app.booters()', async () => {
+  it('binds booter with `@injectable` from app.booters()', async () => {
     app.booters(TestBooterWithBind);
     const booterBinding = app.getBinding(
       `${BootBindings.BOOTERS}.TestBooterWithBind`,
@@ -40,7 +40,7 @@ describe('BootMixin unit tests', () => {
     expect(booterBinding.tagMap).to.containEql({artifactType: 'xsd'});
   });
 
-  it('binds booter with `@bind` using a custom binding key', async () => {
+  it('binds booter with `@injectable` using a custom binding key', async () => {
     const testApp = new AppWithBootMixin();
     testApp.bind(BootBindings.PROJECT_ROOT).to(__dirname);
     testApp.booters(TestBooterWithCustomBindingKey);
@@ -110,7 +110,7 @@ describe('BootMixin unit tests', () => {
     }
   }
 
-  @bind({tags: {artifactType: 'xsd'}})
+  @injectable({tags: {artifactType: 'xsd'}})
   class TestBooterWithBind implements Booter {
     configured = false;
 
@@ -122,7 +122,7 @@ describe('BootMixin unit tests', () => {
   const CustomBinding = BindingKey.create<TestBooterWithCustomBindingKey>(
     'io.loopback.custom.binding.TestBooterWithCustomBindingKey',
   );
-  @bind({
+  @injectable({
     tags: {
       [ContextTags.KEY]: CustomBinding,
       artifactType: 'bmp',

--- a/packages/boot/src/booters/service.booter.ts
+++ b/packages/boot/src/booters/service.booter.ts
@@ -94,6 +94,6 @@ function isBindableClass(cls: Constructor<unknown>) {
     debug('Dynamic value provider class found: %s', cls.name);
     return true;
   }
-  debug('Skip class not decorated with @bind: %s', cls.name);
+  debug('Skip class not decorated with @injectable: %s', cls.name);
   return false;
 }

--- a/packages/boot/src/types.ts
+++ b/packages/boot/src/types.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Binding,
   BindingSpec,
   Constructor,
   ContextTags,
+  injectable,
 } from '@loopback/core';
 import {BootBindings, BootTags} from './keys';
 
@@ -160,7 +160,7 @@ export interface Bootable {
  * @param specs - Extra specs for the binding
  */
 export function booter(artifactNamespace: string, ...specs: BindingSpec[]) {
-  return bind(
+  return injectable(
     {
       tags: {
         artifactNamespace,

--- a/packages/cli/generators/extension/templates/src/component.ts.ejs
+++ b/packages/cli/generators/extension/templates/src/component.ts.ejs
@@ -2,7 +2,6 @@ import {
   Application,
   injectable,
   Component,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   config,
   ContextTags,
   CoreBindings,

--- a/packages/cli/generators/extension/templates/src/component.ts.ejs
+++ b/packages/cli/generators/extension/templates/src/component.ts.ejs
@@ -1,6 +1,6 @@
 import {
   Application,
-  bind,
+  injectable,
   Component,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   config,
@@ -12,7 +12,7 @@ import {<%= project.bindingsNamespace %>} from './keys'
 import {<%= project.defaultOptions %>, <%= project.optionsInterface %>} from './types';
 
 // Configure the binding for <%= project.componentName %>
-@bind({tags: {[ContextTags.KEY]: <%= project.bindingsNamespace %>.COMPONENT}})
+@injectable({tags: {[ContextTags.KEY]: <%= project.bindingsNamespace %>.COMPONENT}})
 export class <%= project.componentName %> implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/packages/cli/generators/interceptor/templates/interceptor-template.ts.ejs
+++ b/packages/cli/generators/interceptor/templates/interceptor-template.ts.ejs
@@ -3,7 +3,7 @@ import {
 <% if (isGlobal) { -%>
   globalInterceptor,
 <% } else { -%>
-  bind,
+  injectable,
 <% } -%>
   Interceptor,
   InvocationContext,
@@ -19,7 +19,7 @@ import {
 <% if (isGlobal) { -%>
 @globalInterceptor('<%= group %>', {tags: {name: '<%= name %>'}})
 <% } else { -%>
-@bind({tags: {key: <%= className %>.BINDING_KEY}})
+@injectable({tags: {key: <%= className %>.BINDING_KEY}})
 <% } -%>
 export class <%= className %> implements Provider<Interceptor> {
 <% if (!isGlobal) { -%>

--- a/packages/cli/generators/service/templates/local-service-class-template.ts.ejs
+++ b/packages/cli/generators/service/templates/local-service-class-template.ts.ejs
@@ -1,6 +1,6 @@
-import {bind, /* inject, */ BindingScope} from '@loopback/core';
+import {injectable, /* inject, */ BindingScope} from '@loopback/core';
 
-@bind({scope: BindingScope.TRANSIENT})
+@injectable({scope: BindingScope.TRANSIENT})
 export class <%= className %>Service {
   constructor(/* Add @inject to inject parameters */) {}
 

--- a/packages/cli/generators/service/templates/local-service-provider-template.ts.ejs
+++ b/packages/cli/generators/service/templates/local-service-provider-template.ts.ejs
@@ -1,4 +1,4 @@
-import {bind, /* inject, */ BindingScope, Provider} from '@loopback/core';
+import {injectable, /* inject, */ BindingScope, Provider} from '@loopback/core';
 
 /*
  * Fix the service type. Possible options can be:
@@ -8,7 +8,7 @@ import {bind, /* inject, */ BindingScope, Provider} from '@loopback/core';
  */
 export type <%= className %> = unknown;
 
-@bind({scope: BindingScope.TRANSIENT})
+@injectable({scope: BindingScope.TRANSIENT})
 export class <%= className %>Provider implements Provider<<%= className %>> {
   constructor(/* Add @inject to inject parameters */) {}
 

--- a/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/interceptor.integration.snapshots.js
@@ -193,7 +193,7 @@ export * from './my-interceptor.interceptor';
 exports[`lb4 interceptor valid generation of interceptors generates a non-global interceptor from CLI 1`] = `
 import {
   /* inject, */
-  bind,
+  injectable,
   Interceptor,
   InvocationContext,
   InvocationResult,
@@ -205,7 +205,7 @@ import {
  * This class will be bound to the application as an \`Interceptor\` during
  * \`boot\`
  */
-@bind({tags: {key: MyInterceptorInterceptor.BINDING_KEY}})
+@injectable({tags: {key: MyInterceptorInterceptor.BINDING_KEY}})
 export class MyInterceptorInterceptor implements Provider<Interceptor> {
   static readonly BINDING_KEY = \`interceptors.\${MyInterceptorInterceptor.name}\`;
 
@@ -256,7 +256,7 @@ export * from './my-interceptor.interceptor';
 exports[`lb4 interceptor valid generation of interceptors generates a non-global interceptor with prompts 1`] = `
 import {
   /* inject, */
-  bind,
+  injectable,
   Interceptor,
   InvocationContext,
   InvocationResult,
@@ -268,7 +268,7 @@ import {
  * This class will be bound to the application as an \`Interceptor\` during
  * \`boot\`
  */
-@bind({tags: {key: MyInterceptorInterceptor.BINDING_KEY}})
+@injectable({tags: {key: MyInterceptorInterceptor.BINDING_KEY}})
 export class MyInterceptorInterceptor implements Provider<Interceptor> {
   static readonly BINDING_KEY = \`interceptors.\${MyInterceptorInterceptor.name}\`;
 

--- a/packages/context/src/__tests__/acceptance/bind-decorator.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/bind-decorator.acceptance.ts
@@ -5,21 +5,21 @@
 
 import {expect} from '@loopback/testlab';
 import {
-  bind,
   BindingScope,
   Context,
   createBindingFromClass,
+  injectable,
   Provider,
 } from '../..';
 
-describe('@bind - customize classes with binding attributes', () => {
-  @bind({
+describe('@injectable - customize classes with binding attributes', () => {
+  @injectable({
     scope: BindingScope.SINGLETON,
     tags: ['service'],
   })
   class MyService {}
 
-  @bind.provider({
+  @injectable.provider({
     tags: {
       key: 'my-date-provider',
     },
@@ -30,7 +30,7 @@ describe('@bind - customize classes with binding attributes', () => {
     }
   }
 
-  @bind({
+  @injectable({
     tags: ['controller', {name: 'my-controller', type: 'controller'}],
   })
   class MyController {}
@@ -81,7 +81,7 @@ describe('@bind - customize classes with binding attributes', () => {
   });
 
   describe('binding scope', () => {
-    @bind({
+    @injectable({
       // Explicitly set the binding scope to be `SINGLETON` as the developer
       // choose to implement the controller as a singleton without depending
       // on request specific information
@@ -89,7 +89,7 @@ describe('@bind - customize classes with binding attributes', () => {
     })
     class MySingletonController {}
 
-    it('allows singleton controller with @bind', () => {
+    it('allows singleton controller with @injectable', () => {
       const binding = createBindingFromClass(MySingletonController, {
         type: 'controller',
       });
@@ -98,14 +98,14 @@ describe('@bind - customize classes with binding attributes', () => {
       expect(binding.scope).to.equal(BindingScope.SINGLETON);
     });
 
-    it('honors binding scope from @bind over defaultScope', () => {
+    it('honors binding scope from @injectable over defaultScope', () => {
       const binding = createBindingFromClass(MySingletonController, {
         defaultScope: BindingScope.TRANSIENT,
       });
       expect(binding.scope).to.equal(BindingScope.SINGLETON);
     });
 
-    it('honors binding scope from @bind', () => {
+    it('honors binding scope from @injectable', () => {
       const binding = createBindingFromClass(MySingletonController);
       expect(binding.scope).to.equal(BindingScope.SINGLETON);
     });

--- a/packages/context/src/__tests__/acceptance/binding-decorator.feature.md
+++ b/packages/context/src/__tests__/acceptance/binding-decorator.feature.md
@@ -1,4 +1,4 @@
-# Feature: @bind for classes representing various artifacts
+# Feature: @injectable for classes representing various artifacts
 
 - In order to automatically bind classes for various artifacts to a context
 - As a developer
@@ -31,15 +31,16 @@ example, it's impossible for the bootstrapper to infer that `LogProvider` is a
 provider so that the class can be bound using
 `ctx.bind('providers.LogProvider').toProvider(LogProvider)`.
 
-Developers can help the bootstrapper by decorating these classes with `@bind`.
+Developers can help the bootstrapper by decorating these classes with
+`@injectable`.
 
 ```ts
-@bind({tags: ['log']})
+@injectable({tags: ['log']})
 export class LogController {}
 
 export const LOG_LEVEL = 'info';
 
-@bind.provider(tags: ['log']})
+@injectable.provider(tags: ['log']})
 export class LogProvider implements Provider<Logger> {
   value() {
     return msg => console.log(msg);
@@ -47,6 +48,6 @@ export class LogProvider implements Provider<Logger> {
 }
 ```
 
-Please note that we don't intend to use `@bind` to help the bootstrapper
-discover such artifacts. The purpose of `@bind` is to allow developers to
+Please note that we don't intend to use `@injectable` to help the bootstrapper
+discover such artifacts. The purpose of `@injectable` is to allow developers to
 provide more metadata on how the class should be bound.

--- a/packages/context/src/__tests__/unit/binding-decorator.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-decorator.unit.ts
@@ -5,191 +5,208 @@
 
 import {expect} from '@loopback/testlab';
 import {
-  bind,
+  bind as bindDecorator,
   Binding,
   BindingScope,
   BindingScopeAndTags,
   BindingTemplate,
   bindingTemplateFor,
   Constructor,
+  injectable as injectableDecorator,
   Provider,
 } from '../..';
 
-describe('@bind', () => {
-  const expectedScopeAndTags = {
-    tags: {rest: 'rest'},
-    scope: BindingScope.SINGLETON,
-  };
-
-  it('decorates a class', () => {
-    const spec = {
-      tags: ['rest'],
+function testBindingDecorator(
+  injectable: typeof injectableDecorator,
+  name: '@injectable' | '@bind',
+) {
+  describe(name, () => {
+    const expectedScopeAndTags = {
+      tags: {rest: 'rest'},
       scope: BindingScope.SINGLETON,
     };
 
-    @bind(spec)
-    class MyController {}
+    it('decorates a class', () => {
+      const spec = {
+        tags: ['rest'],
+        scope: BindingScope.SINGLETON,
+      };
 
-    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
-  });
+      @injectable(spec)
+      class MyController {}
 
-  it('allows inheritance for certain tags and scope', () => {
-    const spec = {
-      tags: ['rest'],
-      scope: BindingScope.SINGLETON,
-    };
-
-    @bind(spec)
-    class MyController {}
-
-    class MySubController extends MyController {}
-
-    expect(inspectScopeAndTags(MySubController)).to.eql(expectedScopeAndTags);
-  });
-
-  it('ignores `name` and `key` from base class', () => {
-    const spec = {
-      tags: [
-        'rest',
-        {
-          name: 'my-controller',
-          key: 'controllers.my-controller',
-        },
-      ],
-      scope: BindingScope.SINGLETON,
-    };
-
-    @bind(spec)
-    class MyController {}
-
-    @bind()
-    class MySubController extends MyController {}
-
-    const result = inspectScopeAndTags(MySubController);
-    expect(result).to.containEql(expectedScopeAndTags);
-    expect(result.tags).to.not.containEql({
-      name: 'my-controller',
+      expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
     });
-    expect(result.tags).to.not.containEql({
-      key: 'controllers.my-controller',
+
+    it('allows inheritance for certain tags and scope', () => {
+      const spec = {
+        tags: ['rest'],
+        scope: BindingScope.SINGLETON,
+      };
+
+      @injectable(spec)
+      class MyController {}
+
+      class MySubController extends MyController {}
+
+      expect(inspectScopeAndTags(MySubController)).to.eql(expectedScopeAndTags);
     });
-  });
 
-  it('accepts template functions', () => {
-    const spec: BindingTemplate = binding => {
-      binding.tag('rest').inScope(BindingScope.SINGLETON);
-    };
+    it('ignores `name` and `key` from base class', () => {
+      const spec = {
+        tags: [
+          'rest',
+          {
+            name: 'my-controller',
+            key: 'controllers.my-controller',
+          },
+        ],
+        scope: BindingScope.SINGLETON,
+      };
 
-    @bind(spec)
-    class MyController {}
+      @injectable(spec)
+      class MyController {}
 
-    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
-  });
+      @injectable()
+      class MySubController extends MyController {}
 
-  it('accepts multiple scope/tags', () => {
-    @bind({tags: 'rest'}, {scope: BindingScope.SINGLETON})
-    class MyController {}
-
-    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
-  });
-
-  it('accepts multiple template functions', () => {
-    @bind(
-      binding => binding.tag('rest'),
-      binding => binding.inScope(BindingScope.SINGLETON),
-    )
-    class MyController {}
-
-    expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
-  });
-
-  it('accepts both template functions and tag/scopes', () => {
-    const spec: BindingTemplate = binding => {
-      binding.tag('rest').inScope(BindingScope.SINGLETON);
-    };
-
-    @bind(spec, {tags: [{name: 'my-controller'}]})
-    class MyController {}
-
-    expect(inspectScopeAndTags(MyController)).to.eql({
-      tags: {rest: 'rest', name: 'my-controller'},
-      scope: BindingScope.SINGLETON,
+      const result = inspectScopeAndTags(MySubController);
+      expect(result).to.containEql(expectedScopeAndTags);
+      expect(result.tags).to.not.containEql({
+        name: 'my-controller',
+      });
+      expect(result.tags).to.not.containEql({
+        key: 'controllers.my-controller',
+      });
     });
-  });
 
-  it('allows the decorator to be applied multiple times', () => {
-    const spec: BindingTemplate = binding => {
-      binding.tag('rest').inScope(BindingScope.SINGLETON);
-    };
+    it('accepts template functions', () => {
+      const spec: BindingTemplate = binding => {
+        binding.tag('rest').inScope(BindingScope.SINGLETON);
+      };
 
-    @bind(spec)
-    @bind({tags: [{name: 'my-controller'}]})
-    class MyController {}
+      @injectable(spec)
+      class MyController {}
 
-    expect(inspectScopeAndTags(MyController)).to.eql({
-      tags: {rest: 'rest', name: 'my-controller'},
-      scope: BindingScope.SINGLETON,
+      expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
     });
-  });
 
-  it('allows the decorator to override metadata from others', () => {
-    @bind({scope: BindingScope.SINGLETON, tags: {rest: 'rest', grpc: false}})
-    @bind({
-      scope: BindingScope.TRANSIENT,
-      tags: {name: 'my-controller', grpc: true},
-    })
-    class MyController {}
+    it('accepts multiple scope/tags', () => {
+      @injectable({tags: 'rest'}, {scope: BindingScope.SINGLETON})
+      class MyController {}
 
-    expect(inspectScopeAndTags(MyController)).to.eql({
-      tags: {rest: 'rest', name: 'my-controller', grpc: false},
-      scope: BindingScope.SINGLETON,
+      expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
     });
-  });
 
-  it('decorates a provider classes', () => {
-    const spec = {
-      tags: ['rest'],
-      scope: BindingScope.CONTEXT,
-    };
+    it('accepts multiple template functions', () => {
+      @injectable(
+        binding => binding.tag('rest'),
+        binding => binding.inScope(BindingScope.SINGLETON),
+      )
+      class MyController {}
 
-    @bind.provider(spec)
-    class MyProvider implements Provider<string> {
-      value() {
-        return 'my-value';
+      expect(inspectScopeAndTags(MyController)).to.eql(expectedScopeAndTags);
+    });
+
+    it('accepts both template functions and tag/scopes', () => {
+      const spec: BindingTemplate = binding => {
+        binding.tag('rest').inScope(BindingScope.SINGLETON);
+      };
+
+      @injectable(spec, {tags: [{name: 'my-controller'}]})
+      class MyController {}
+
+      expect(inspectScopeAndTags(MyController)).to.eql({
+        tags: {rest: 'rest', name: 'my-controller'},
+        scope: BindingScope.SINGLETON,
+      });
+    });
+
+    it('allows the decorator to be applied multiple times', () => {
+      const spec: BindingTemplate = binding => {
+        binding.tag('rest').inScope(BindingScope.SINGLETON);
+      };
+
+      @injectable(spec)
+      @injectable({tags: [{name: 'my-controller'}]})
+      class MyController {}
+
+      expect(inspectScopeAndTags(MyController)).to.eql({
+        tags: {rest: 'rest', name: 'my-controller'},
+        scope: BindingScope.SINGLETON,
+      });
+    });
+
+    it('allows the decorator to override metadata from others', () => {
+      @injectable({
+        scope: BindingScope.SINGLETON,
+        tags: {rest: 'rest', grpc: false},
+      })
+      @injectable({
+        scope: BindingScope.TRANSIENT,
+        tags: {name: 'my-controller', grpc: true},
+      })
+      class MyController {}
+
+      expect(inspectScopeAndTags(MyController)).to.eql({
+        tags: {rest: 'rest', name: 'my-controller', grpc: false},
+        scope: BindingScope.SINGLETON,
+      });
+    });
+
+    it('decorates a provider classes', () => {
+      const spec = {
+        tags: ['rest'],
+        scope: BindingScope.CONTEXT,
+      };
+
+      @injectable.provider(spec)
+      class MyProvider implements Provider<string> {
+        value() {
+          return 'my-value';
+        }
       }
-    }
 
-    expect(inspectScopeAndTags(MyProvider)).to.eql({
-      tags: {rest: 'rest', type: 'provider', provider: 'provider'},
-      scope: BindingScope.CONTEXT,
+      expect(inspectScopeAndTags(MyProvider)).to.eql({
+        tags: {rest: 'rest', type: 'provider', provider: 'provider'},
+        scope: BindingScope.CONTEXT,
+      });
     });
-  });
 
-  it('recognizes provider classes', () => {
-    const spec = {
-      tags: ['rest', {type: 'provider'}],
-      scope: BindingScope.CONTEXT,
-    };
+    it('recognizes provider classes', () => {
+      const spec = {
+        tags: ['rest', {type: 'provider'}],
+        scope: BindingScope.CONTEXT,
+      };
 
-    @bind(spec)
-    class MyProvider implements Provider<string> {
-      value() {
-        return 'my-value';
+      @injectable(spec)
+      class MyProvider implements Provider<string> {
+        value() {
+          return 'my-value';
+        }
       }
-    }
 
-    expect(inspectScopeAndTags(MyProvider)).to.eql({
-      tags: {rest: 'rest', type: 'provider', provider: 'provider'},
-      scope: BindingScope.CONTEXT,
+      expect(inspectScopeAndTags(MyProvider)).to.eql({
+        tags: {rest: 'rest', type: 'provider', provider: 'provider'},
+        scope: BindingScope.CONTEXT,
+      });
     });
-  });
 
-  function inspectScopeAndTags(cls: Constructor<unknown>): BindingScopeAndTags {
-    const templateFn = bindingTemplateFor(cls);
-    const bindingTemplate = new Binding('template').apply(templateFn);
-    return {
-      scope: bindingTemplate.scope,
-      tags: bindingTemplate.tagMap,
-    };
-  }
-});
+    function inspectScopeAndTags(
+      cls: Constructor<unknown>,
+    ): BindingScopeAndTags {
+      const templateFn = bindingTemplateFor(cls);
+      const bindingTemplate = new Binding('template').apply(templateFn);
+      return {
+        scope: bindingTemplate.scope,
+        tags: bindingTemplate.tagMap,
+      };
+    }
+  });
+}
+
+// Test @injectable
+testBindingDecorator(injectableDecorator, '@injectable');
+
+// Test @bind
+testBindingDecorator(bindDecorator, '@bind');

--- a/packages/context/src/__tests__/unit/binding-inspector.unit.ts
+++ b/packages/context/src/__tests__/unit/binding-inspector.unit.ts
@@ -5,7 +5,6 @@
 
 import {expect} from '@loopback/testlab';
 import {
-  bind,
   BindingFromClassOptions,
   BindingScope,
   BindingScopeAndTags,
@@ -13,6 +12,7 @@ import {
   Context,
   ContextTags,
   createBindingFromClass,
+  injectable,
   isProviderClass,
   Provider,
 } from '../..';
@@ -25,7 +25,7 @@ describe('createBindingFromClass()', () => {
       scope: BindingScope.SINGLETON,
     };
 
-    @bind(spec)
+    @injectable(spec)
     class MyController {}
 
     const ctx = new Context();
@@ -40,7 +40,7 @@ describe('createBindingFromClass()', () => {
     expect(ctx.getSync(binding.key)).to.be.instanceof(MyController);
   });
 
-  it('inspects classes without @bind', () => {
+  it('inspects classes without @injectable', () => {
     class MyController {}
 
     const ctx = new Context();
@@ -50,13 +50,13 @@ describe('createBindingFromClass()', () => {
     expect(ctx.getSync(binding.key)).to.be.instanceof(MyController);
   });
 
-  it('supports options to customize class bindings with @bind', () => {
+  it('supports options to customize class bindings with @injectable', () => {
     const spec: BindingScopeAndTags = {
       tags: {name: 'my-controller', rest: 'rest'},
       scope: BindingScope.SINGLETON,
     };
 
-    @bind(spec)
+    @injectable(spec)
     class MyController {}
 
     const ctx = new Context();
@@ -71,7 +71,7 @@ describe('createBindingFromClass()', () => {
     });
   });
 
-  it('supports options to customize class bindings without @bind', () => {
+  it('supports options to customize class bindings without @injectable', () => {
     class MyController {}
 
     const ctx = new Context();
@@ -96,7 +96,7 @@ describe('createBindingFromClass()', () => {
       scope: BindingScope.CONTEXT,
     };
 
-    @bind.provider(spec)
+    @injectable.provider(spec)
     class MyProvider implements Provider<string> {
       value() {
         return 'my-value';
@@ -122,7 +122,7 @@ describe('createBindingFromClass()', () => {
       scope: BindingScope.CONTEXT,
     };
 
-    @bind(spec)
+    @injectable(spec)
     class MyProvider implements Provider<string> {
       value() {
         return 'my-value';
@@ -142,7 +142,7 @@ describe('createBindingFromClass()', () => {
     expect(ctx.getSync(binding.key)).to.eql('my-value');
   });
 
-  it('recognizes provider classes without @bind', () => {
+  it('recognizes provider classes without @injectable', () => {
     class MyProvider implements Provider<string> {
       value() {
         return 'my-value';
@@ -161,7 +161,7 @@ describe('createBindingFromClass()', () => {
       scope: BindingScope.CONTEXT,
     };
 
-    @bind(spec)
+    @injectable(spec)
     class MyProvider {
       static value() {
         return 'my-value';
@@ -187,7 +187,7 @@ describe('createBindingFromClass()', () => {
       scope: BindingScope.CONTEXT,
     };
 
-    @bind(spec)
+    @injectable(spec)
     class MyProvider {
       static value(@inject('prefix') prefix: string) {
         return `[${prefix}] my-value`;
@@ -208,7 +208,7 @@ describe('createBindingFromClass()', () => {
     expect(ctx.getSync(binding.key)).to.eql('[abc] my-value');
   });
 
-  it('recognizes dynamic value provider classes without @bind', () => {
+  it('recognizes dynamic value provider classes without @injectable', () => {
     class MyProvider {
       static value() {
         return 'my-value';
@@ -230,7 +230,7 @@ describe('createBindingFromClass()', () => {
       },
     };
 
-    @bind(spec)
+    @injectable(spec)
     class MyController {}
 
     const binding = givenBindingFromClass(MyController);
@@ -247,15 +247,15 @@ describe('createBindingFromClass()', () => {
   it('defaults type to class', () => {
     const spec: BindingScopeAndTags = {};
 
-    @bind(spec)
+    @injectable(spec)
     class MyClass {}
 
     const binding = givenBindingFromClass(MyClass);
     expect(binding.key).to.eql('classes.MyClass');
   });
 
-  it('honors namespace with @bind', () => {
-    @bind({tags: {namespace: 'services'}})
+  it('honors namespace with @injectable', () => {
+    @injectable({tags: {namespace: 'services'}})
     class MyService {}
 
     const ctx = new Context();
@@ -278,7 +278,7 @@ describe('createBindingFromClass()', () => {
   it('honors default namespace with options', () => {
     class MyService {}
 
-    @bind({tags: {[ContextTags.NAMESPACE]: 'my-services'}})
+    @injectable({tags: {[ContextTags.NAMESPACE]: 'my-services'}})
     class MyServiceWithNS {}
 
     const ctx = new Context();
@@ -305,9 +305,9 @@ describe('createBindingFromClass()', () => {
   it('includes class name in error messages', () => {
     expect(() => {
       // Reproduce a problem that @bajtos encountered when the project
-      // was not built correctly and somehow `@bind` was called with `undefined`
+      // was not built correctly and somehow `@injectable` was called with `undefined`
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      @bind(undefined as any)
+      @injectable(undefined as any)
       class MyClass {}
 
       return createBindingFromClass(MyClass);

--- a/packages/context/src/binding-decorator.ts
+++ b/packages/context/src/binding-decorator.ts
@@ -17,9 +17,11 @@ import {
 import {Constructor} from './value-promise';
 
 /**
- * Decorator factory for `@bind`
+ * Decorator factory for `@injectable`
  */
-class BindDecoratorFactory extends ClassDecoratorFactory<BindingMetadata> {
+class InjectableDecoratorFactory extends ClassDecoratorFactory<
+  BindingMetadata
+> {
   mergeWithInherited(inherited: BindingMetadata, target: Function) {
     if (inherited) {
       return {
@@ -54,8 +56,9 @@ class BindDecoratorFactory extends ClassDecoratorFactory<BindingMetadata> {
  *
  * @example
  * ```ts
- * @bind((binding) => {binding.inScope(BindingScope.SINGLETON).tag('controller')}
+ * @injectable((binding) => {binding.inScope(BindingScope.SINGLETON).tag('controller')}
  * )
+ * @injectable({scope: BindingScope.SINGLETON})
  * export class MyController {
  * }
  * ```
@@ -63,7 +66,7 @@ class BindDecoratorFactory extends ClassDecoratorFactory<BindingMetadata> {
  * @param specs - A list of binding scope/tags or template functions to
  * configure the binding
  */
-export function bind(...specs: BindingSpec[]): ClassDecorator {
+export function injectable(...specs: BindingSpec[]): ClassDecorator {
   const templateFunctions = specs.map(t => {
     if (typeof t === 'function') {
       return t;
@@ -79,18 +82,21 @@ export function bind(...specs: BindingSpec[]): ClassDecorator {
       target: cls,
     };
 
-    const decorator = BindDecoratorFactory.createDecorator(
+    const decorator = InjectableDecoratorFactory.createDecorator(
       BINDING_METADATA_KEY,
       spec,
-      {decoratorName: '@bind'},
+      {decoratorName: '@injectable'},
     );
     decorator(target);
   };
 }
 
-export namespace bind {
+/**
+ * A namespace to host shortcuts for `@injectable`
+ */
+export namespace injectable {
   /**
-   * `@bind.provider` to denote a provider class
+   * `@injectable.provider` to denote a provider class
    *
    * A list of binding scope/tags or template functions to configure the binding
    */
@@ -101,7 +107,7 @@ export namespace bind {
       if (!isProviderClass(target)) {
         throw new Error(`Target ${target} is not a Provider`);
       }
-      bind(
+      injectable(
         // Set up the default for providers
         asProvider(target),
         // Call other template functions
@@ -109,4 +115,24 @@ export namespace bind {
       )(target);
     };
   }
+}
+
+/**
+ * `@bind` is now an alias to {@link injectable} for backward compatibility
+ * {@inheritDoc injectable}
+ */
+export function bind(...specs: BindingSpec[]): ClassDecorator {
+  return injectable(...specs);
+}
+
+/**
+ * Alias namespace `bind` to `injectable` for backward compatibility
+ *
+ * It should have the same members as `bind`.
+ */
+export namespace bind {
+  /**
+   * {@inheritDoc injectable.provider}
+   */
+  export const provider = injectable.provider;
 }

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -21,7 +21,7 @@ import {Constructor} from './value-promise';
 const debug = debugFactory('loopback:context:binding-inspector');
 
 /**
- * Binding metadata from `@bind`
+ * Binding metadata from `@injectable`
  *
  * @typeParam T - Value type
  */
@@ -53,7 +53,7 @@ export type BindingScopeAndTags = {
 };
 
 /**
- * Specification of parameters for `@bind()`
+ * Specification of parameters for `@injectable()`
  */
 export type BindingSpec<T = unknown> = BindingTemplate<T> | BindingScopeAndTags;
 
@@ -164,7 +164,7 @@ export function removeNameAndKeyTags(binding: Binding<unknown>) {
 /**
  * Get the binding template for a class with binding metadata
  *
- * @param cls - A class with optional `@bind`
+ * @param cls - A class with optional `@injectable`
  *
  * @typeParam T - Value type
  */

--- a/packages/context/src/interceptor.ts
+++ b/packages/context/src/interceptor.ts
@@ -14,7 +14,7 @@ import {
 import assert from 'assert';
 import debugFactory from 'debug';
 import {Binding, BindingTemplate} from './binding';
-import {bind} from './binding-decorator';
+import {injectable} from './binding-decorator';
 import {
   BindingFromClassOptions,
   BindingSpec,
@@ -159,7 +159,7 @@ export function asGlobalInterceptor(group?: string): BindingTemplate {
  * @param specs - Extra binding specs
  */
 export function globalInterceptor(group?: string, ...specs: BindingSpec[]) {
-  return bind(asGlobalInterceptor(group), ...specs);
+  return injectable(asGlobalInterceptor(group), ...specs);
 }
 
 /**

--- a/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
+++ b/packages/core/src/__tests__/acceptance/extension-point.acceptance.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Binding,
   BindingScope,
   BINDING_METADATA_KEY,
@@ -13,6 +12,7 @@ import {
   ContextView,
   createBindingFromClass,
   Getter,
+  injectable,
   MetadataInspector,
 } from '@loopback/context';
 import {expect} from '@loopback/testlab';
@@ -62,7 +62,7 @@ describe('extension point', () => {
         public greeters: Getter<Greeter[]>;
       }
 
-      // `@extensionPoint` is a sugar decorator for `@bind`
+      // `@extensionPoint` is a sugar decorator for `@injectable`
       const binding = createBindingFromClass(GreetingService, {
         key: 'greeter-service',
       });
@@ -93,7 +93,7 @@ describe('extension point', () => {
         }
       }
 
-      // `@extensionPoint` is a sugar decorator for `@bind`
+      // `@extensionPoint` is a sugar decorator for `@injectable`
       const binding = createBindingFromClass(GreetingService, {
         key: 'greeter-service',
       });
@@ -119,7 +119,7 @@ describe('extension point', () => {
         public greeters: Greeter[];
       }
 
-      // `@extensionPoint` is a sugar decorator for `@bind`
+      // `@extensionPoint` is a sugar decorator for `@injectable`
       const binding = createBindingFromClass(GreetingService, {
         key: 'greeter-service',
       });
@@ -221,7 +221,10 @@ describe('extension point', () => {
     });
 
     it('allows an extension to contribute to multiple extension points', () => {
-      @bind(extensionFor('extensionPoint-1'), extensionFor('extensionPoint-2'))
+      @injectable(
+        extensionFor('extensionPoint-1'),
+        extensionFor('extensionPoint-2'),
+      )
       class MyExtension {}
       const binding = createBindingFromClass(MyExtension);
       expect(binding.tagMap[CoreTags.EXTENSION_FOR]).to.eql([
@@ -283,7 +286,7 @@ describe('extension point', () => {
         @extensions() getMyExtensions: Getter<MyExtension[]>;
       }
 
-      @bind(extensionFor('extensionPoint-1', 'extensionPoint-2'))
+      @injectable(extensionFor('extensionPoint-1', 'extensionPoint-2'))
       class MyExtension {}
 
       ctx.add(

--- a/packages/core/src/__tests__/unit/application-lifecycle.unit.ts
+++ b/packages/core/src/__tests__/unit/application-lifecycle.unit.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingScope,
   Constructor,
   Context,
   createBindingFromClass,
+  injectable,
 } from '@loopback/context';
 import {expect} from '@loopback/testlab';
 import {
@@ -192,8 +192,8 @@ describe('Application life cycle', () => {
       expect(binding.key).to.eql('my-observers.my-observer');
     });
 
-    it('honors @bind', async () => {
-      @bind({
+    it('honors @injectable', async () => {
+      @injectable({
         tags: {
           [CoreTags.LIFE_CYCLE_OBSERVER]: CoreTags.LIFE_CYCLE_OBSERVER,
           [CoreTags.LIFE_CYCLE_OBSERVER_GROUP]: 'my-group',

--- a/packages/core/src/__tests__/unit/application.unit.ts
+++ b/packages/core/src/__tests__/unit/application.unit.ts
@@ -5,13 +5,13 @@
 
 import {
   asGlobalInterceptor,
-  bind,
   Binding,
   BindingScope,
   BindingTag,
   Context,
   ContextTags,
   inject,
+  injectable,
   Interceptor,
   InvocationContext,
   Next,
@@ -81,7 +81,7 @@ describe('Application', () => {
     });
 
     it('binds a singleton controller', () => {
-      @bind({scope: BindingScope.SINGLETON})
+      @injectable({scope: BindingScope.SINGLETON})
       class MySingletonController {}
 
       const binding = app.controller(MySingletonController);
@@ -119,7 +119,7 @@ describe('Application', () => {
     });
 
     it('binds a transient component', () => {
-      @bind({scope: BindingScope.TRANSIENT})
+      @injectable({scope: BindingScope.TRANSIENT})
       class MyTransientComponent {}
 
       const binding = app.component(MyTransientComponent);
@@ -180,8 +180,8 @@ describe('Application', () => {
       expect(app.getSync('my-provider')).to.be.eql('my-str');
     });
 
-    it('binds classes with @bind from a component', () => {
-      @bind({scope: BindingScope.SINGLETON, tags: ['foo']})
+    it('binds classes with @injectable from a component', () => {
+      @injectable({scope: BindingScope.SINGLETON, tags: ['foo']})
       class MyClass {}
 
       class MyComponentWithClasses implements Component {
@@ -208,8 +208,8 @@ describe('Application', () => {
       ).to.be.exactly(MyService);
     });
 
-    it('binds services with @bind from a component', () => {
-      @bind({scope: BindingScope.TRANSIENT, tags: ['foo']})
+    it('binds services with @injectable from a component', () => {
+      @injectable({scope: BindingScope.TRANSIENT, tags: ['foo']})
       class MyService {}
 
       class MyComponentWithServices implements Component {
@@ -224,7 +224,7 @@ describe('Application', () => {
     });
 
     it('honors tags when binding providers from a component', () => {
-      @bind({tags: ['foo']})
+      @injectable({tags: ['foo']})
       class MyProvider implements Provider<string> {
         value() {
           return 'my-str';
@@ -266,7 +266,7 @@ describe('Application', () => {
     });
 
     it('binds a server with a different scope than SINGLETON', async () => {
-      @bind({scope: BindingScope.TRANSIENT})
+      @injectable({scope: BindingScope.TRANSIENT})
       class TransientServer extends FakeServer {}
 
       const binding = app.server(TransientServer);
@@ -343,7 +343,7 @@ describe('Application', () => {
     });
 
     it('binds a singleton service', () => {
-      @bind({scope: BindingScope.SINGLETON})
+      @injectable({scope: BindingScope.SINGLETON})
       class MySingletonService {}
 
       const binding = app.service(MySingletonService);
@@ -352,7 +352,7 @@ describe('Application', () => {
     });
 
     it('binds a service provider', () => {
-      @bind({tags: {date: 'now', namespace: 'localServices'}})
+      @injectable({tags: {date: 'now', namespace: 'localServices'}})
       class MyServiceProvider implements Provider<Date> {
         value() {
           return new Date();
@@ -368,7 +368,7 @@ describe('Application', () => {
     });
 
     it('binds a service provider with name tag', () => {
-      @bind({tags: {date: 'now', name: 'my-service'}})
+      @injectable({tags: {date: 'now', name: 'my-service'}})
       class MyServiceProvider implements Provider<Date> {
         value() {
           return new Date();
@@ -497,7 +497,7 @@ describe('Application', () => {
       return undefined;
     }
 
-    @bind(asGlobalInterceptor())
+    @injectable(asGlobalInterceptor())
     class LogInterceptorProvider implements Provider<Interceptor> {
       value() {
         return logInterceptor;

--- a/packages/core/src/__tests__/unit/lifecycle-registry.unit.ts
+++ b/packages/core/src/__tests__/unit/lifecycle-registry.unit.ts
@@ -4,10 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingScope,
   Context,
   createBindingFromClass,
+  injectable,
 } from '@loopback/context';
 import {expect} from '@loopback/testlab';
 import {promisify} from 'util';
@@ -167,7 +167,7 @@ describe('LifeCycleRegistry', () => {
   }
 
   function givenObserver(name: string, group = '') {
-    @bind({tags: {[CoreTags.LIFE_CYCLE_OBSERVER_GROUP]: group}})
+    @injectable({tags: {[CoreTags.LIFE_CYCLE_OBSERVER_GROUP]: group}})
     class MyObserver implements LifeCycleObserver {
       start() {
         events.push(`${name}-start`);
@@ -185,7 +185,7 @@ describe('LifeCycleRegistry', () => {
   }
 
   function givenAsyncObserver(name: string, group = '', delayInMs = 0) {
-    @bind({tags: {[CoreTags.LIFE_CYCLE_OBSERVER_GROUP]: group}})
+    @injectable({tags: {[CoreTags.LIFE_CYCLE_OBSERVER_GROUP]: group}})
     class MyAsyncObserver implements LifeCycleObserver {
       async start() {
         await sleep(delayInMs);

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -468,7 +468,7 @@ export class Application extends Context implements LifeCycleObserver {
    *
    * ```ts
    * // Define a class to be bound via ctx.toClass()
-   * @bind({scope: BindingScope.SINGLETON})
+   * @injectable({scope: BindingScope.SINGLETON})
    * export class LogService {
    *   log(msg: string) {
    *     console.log(msg);

--- a/packages/core/src/extension-point.ts
+++ b/packages/core/src/extension-point.ts
@@ -5,7 +5,6 @@
 
 import {
   assertTargetType,
-  bind,
   Binding,
   BindingFilter,
   BindingFromClassOptions,
@@ -20,6 +19,7 @@ import {
   filterByTag,
   includesTagValue,
   inject,
+  injectable,
   Injection,
   ResolutionSession,
 } from '@loopback/context';
@@ -42,7 +42,7 @@ import {CoreTags} from './keys';
  * @param name - Name of the extension point
  */
 export function extensionPoint(name: string, ...specs: BindingSpec[]) {
-  return bind({tags: {[CoreTags.EXTENSION_POINT]: name}}, ...specs);
+  return injectable({tags: {[CoreTags.EXTENSION_POINT]: name}}, ...specs);
 }
 
 /**

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Binding,
   BindingSpec,
   BindingTagFilter,
   Constructor,
   filterByTag,
+  injectable,
   ValueOrPromise,
 } from '@loopback/context';
 import {CoreTags} from './keys';
@@ -73,7 +73,7 @@ export const lifeCycleObserverFilter: BindingTagFilter = filterByTag(
  * @param specs - Optional bindings specs
  */
 export function lifeCycleObserver(group = '', ...specs: BindingSpec[]) {
-  return bind(
+  return injectable(
     asLifeCycleObserver,
     {
       tags: {

--- a/packages/model-api-builder/README.md
+++ b/packages/model-api-builder/README.md
@@ -27,7 +27,7 @@ import {
   ModelApiConfig,
 } from '@loopback/model-api-builder';
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 export class SampleApiBuilder implements ModelApiBuilder {
   readonly pattern: string = 'Sample';
 

--- a/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/info.spec.extension.ts
+++ b/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/info.spec.extension.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind} from '@loopback/core';
-import debugModule from 'debug';
+import {injectable} from '@loopback/core';
+import debugFactory from 'debug';
 import {inspect} from 'util';
 import {
   asSpecEnhancer,
@@ -12,12 +12,13 @@ import {
   OASEnhancer,
   OpenApiSpec,
 } from '../../../..';
-const debug = debugModule('loopback:openapi:spec-enhancer');
+
+const debug = debugFactory('loopback:openapi:spec-enhancer');
 
 /**
  * A spec enhancer to add OpenAPI info spec
  */
-@bind(asSpecEnhancer)
+@injectable(asSpecEnhancer)
 export class InfoSpecEnhancer implements OASEnhancer {
   name = 'info';
 

--- a/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/security.spec.extension.ts
+++ b/packages/openapi-v3/src/__tests__/unit/enhancers/fixtures/security.spec.extension.ts
@@ -3,8 +3,8 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind} from '@loopback/core';
-import debugModule from 'debug';
+import {injectable} from '@loopback/core';
+import debugFactory from 'debug';
 import {inspect} from 'util';
 import {
   mergeOpenAPISpec,
@@ -13,7 +13,7 @@ import {
 } from '../../../..';
 import {asSpecEnhancer, OASEnhancer} from '../../../../enhancers/types';
 import {OpenApiSpec} from '../../../../types';
-const debug = debugModule('loopback:openapi:spec-enhancer');
+const debug = debugFactory('loopback:openapi:spec-enhancer');
 
 export type SecuritySchemeObjects = {
   [securityScheme: string]: SecuritySchemeObject | ReferenceObject;
@@ -31,7 +31,7 @@ export const SECURITY_SCHEME_SPEC: SecuritySchemeObjects = {
  * A spec enhancer to add bearer token OpenAPI security entry to
  * `spec.component.securitySchemes`
  */
-@bind(asSpecEnhancer)
+@injectable(asSpecEnhancer)
 export class SecuritySpecEnhancer implements OASEnhancer {
   name = 'security';
 

--- a/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
+++ b/packages/repository/src/__tests__/unit/mixins/repository.mixin.unit.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Application, bind, BindingScope, Component} from '@loopback/core';
+import {Application, BindingScope, Component, injectable} from '@loopback/core';
 import {expect, sinon} from '@loopback/testlab';
 import {
   Class,
@@ -33,7 +33,7 @@ describe('RepositoryMixin', () => {
   });
 
   it('binds singleton repository from app.repository()', () => {
-    @bind({scope: BindingScope.SINGLETON})
+    @injectable({scope: BindingScope.SINGLETON})
     class SingletonNoteRepo extends NoteRepo {}
 
     const myApp = new AppWithRepoMixin();

--- a/packages/rest-crud/src/crud-rest.api-builder.ts
+++ b/packages/rest-crud/src/crud-rest.api-builder.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingSelector,
   Constructor,
   ControllerClass,
   inject,
+  injectable,
 } from '@loopback/core';
 import {
   asModelApiBuilder,
@@ -33,7 +33,7 @@ export interface ModelCrudRestApiConfig extends ModelApiConfig {
   basePath: string;
 }
 
-@bind(asModelApiBuilder)
+@injectable(asModelApiBuilder)
 export class CrudRestApiBuilder implements ModelApiBuilder {
   readonly pattern: string = 'CrudRest';
 

--- a/packages/rest-explorer/src/rest-explorer.component.ts
+++ b/packages/rest-explorer/src/rest-explorer.component.ts
@@ -4,12 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Component,
   config,
   ContextTags,
   CoreBindings,
   inject,
+  injectable,
 } from '@loopback/core';
 import {createControllerFactoryForClass, RestApplication} from '@loopback/rest';
 import {ExplorerController} from './rest-explorer.controller';
@@ -21,7 +21,7 @@ const swaggerUI = require('swagger-ui-dist');
 /**
  * A component providing a self-hosted API Explorer.
  */
-@bind({tags: {[ContextTags.KEY]: RestExplorerBindings.COMPONENT.key}})
+@injectable({tags: {[ContextTags.KEY]: RestExplorerBindings.COMPONENT.key}})
 export class RestExplorerComponent implements Component {
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)

--- a/packages/rest/src/__tests__/unit/rest.server/fixtures/info.spec.extension.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/fixtures/info.spec.extension.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind} from '@loopback/core';
+import {injectable} from '@loopback/core';
 import debugFactory from 'debug';
 import {inspect} from 'util';
 import {
@@ -18,7 +18,7 @@ const debug = debugFactory('loopback:openapi:spec-enhancer');
 /**
  * A spec enhancer to add OpenAPI info spec
  */
-@bind(asSpecEnhancer)
+@injectable(asSpecEnhancer)
 export class TestInfoSpecEnhancer implements OASEnhancer {
   name = 'info-test';
 

--- a/packages/rest/src/providers/find-route.provider.ts
+++ b/packages/rest/src/providers/find-route.provider.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, Context, inject, Provider} from '@loopback/core';
+import {
+  BindingScope,
+  Context,
+  inject,
+  injectable,
+  Provider,
+} from '@loopback/core';
 import {asMiddleware, Middleware} from '@loopback/express';
 import debugFactory from 'debug';
 import {HttpHandler} from '../http-handler';
@@ -32,7 +38,7 @@ export class FindRouteProvider implements Provider<FindRoute> {
   }
 }
 
-@bind(
+@injectable(
   asMiddleware({
     group: RestMiddlewareGroups.FIND_ROUTE,
     chain: RestTags.REST_MIDDLEWARE_CHAIN,

--- a/packages/rest/src/providers/invoke-method.provider.ts
+++ b/packages/rest/src/providers/invoke-method.provider.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, Context, inject, Provider} from '@loopback/core';
+import {
+  BindingScope,
+  Context,
+  inject,
+  injectable,
+  Provider,
+} from '@loopback/core';
 import {asMiddleware, Middleware} from '@loopback/express';
 import debugFactory from 'debug';
 import {RestBindings, RestTags} from '../keys';
@@ -25,7 +31,7 @@ export class InvokeMethodProvider implements Provider<InvokeMethod> {
   }
 }
 
-@bind(
+@injectable(
   asMiddleware({
     group: RestMiddlewareGroups.INVOKE_METHOD,
     upstreamGroups: RestMiddlewareGroups.PARSE_PARAMS,

--- a/packages/rest/src/providers/log-error.provider.ts
+++ b/packages/rest/src/providers/log-error.provider.ts
@@ -3,10 +3,10 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, Provider} from '@loopback/core';
+import {BindingScope, injectable, Provider} from '@loopback/core';
 import {LogError, Request} from '../types';
 
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class LogErrorProvider implements Provider<LogError> {
   value(): LogError {
     return (err, statusCode, req) => this.action(err, statusCode, req);

--- a/packages/rest/src/providers/parse-params.provider.ts
+++ b/packages/rest/src/providers/parse-params.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, inject, Provider} from '@loopback/core';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
 import {asMiddleware, Middleware} from '@loopback/express';
 import debugFactory from 'debug';
 import {RequestBodyParser} from '../body-parsers';
@@ -43,7 +43,7 @@ export class ParseParamsProvider implements Provider<ParseParams> {
   }
 }
 
-@bind(
+@injectable(
   asMiddleware({
     group: RestMiddlewareGroups.PARSE_PARAMS,
     upstreamGroups: RestMiddlewareGroups.FIND_ROUTE,

--- a/packages/rest/src/providers/reject.provider.ts
+++ b/packages/rest/src/providers/reject.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, inject, Provider} from '@loopback/core';
+import {BindingScope, inject, injectable, Provider} from '@loopback/core';
 import {HttpError} from 'http-errors';
 import {ErrorWriterOptions, writeErrorToResponse} from 'strong-error-handler';
 import {RestBindings} from '../keys';
@@ -15,7 +15,7 @@ const codeToStatusCodeMap: {[key: string]: number} = {
   ENTITY_NOT_FOUND: 404,
 };
 
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class RejectProvider implements Provider<Reject> {
   constructor(
     @inject(RestBindings.SequenceActions.LOG_ERROR)

--- a/packages/rest/src/providers/send.provider.ts
+++ b/packages/rest/src/providers/send.provider.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, BindingScope, Provider} from '@loopback/core';
+import {BindingScope, injectable, Provider} from '@loopback/core';
 import {asMiddleware, Middleware} from '@loopback/express';
 import {RestBindings, RestTags} from '../keys';
 import {RestMiddlewareGroups} from '../sequence';
@@ -16,14 +16,14 @@ import {writeResultToResponse} from '../writer';
  * @returns The handler function that will populate the
  * response with operation results.
  */
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class SendProvider implements Provider<Send> {
   value() {
     return writeResultToResponse;
   }
 }
 
-@bind(
+@injectable(
   asMiddleware({
     group: RestMiddlewareGroups.SEND_RESPONSE,
     downstreamGroups: [

--- a/packages/rest/src/sequence.ts
+++ b/packages/rest/src/sequence.ts
@@ -4,11 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingScope,
   config,
   Context,
   inject,
+  injectable,
   ValueOrPromise,
 } from '@loopback/core';
 import {
@@ -185,7 +185,7 @@ export namespace RestMiddlewareGroups {
 /**
  * A sequence implementation using middleware chains
  */
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class MiddlewareSequence implements SequenceHandler {
   private middlewareView: MiddlewareView;
 

--- a/packages/rest/src/spec-enhancers/consolidate.spec-enhancer.ts
+++ b/packages/rest/src/spec-enhancers/consolidate.spec-enhancer.ts
@@ -5,10 +5,10 @@
 
 import {
   ApplicationConfig,
-  bind,
   BindingScope,
   CoreBindings,
   inject,
+  injectable,
 } from '@loopback/core';
 import {
   asSpecEnhancer,
@@ -58,7 +58,7 @@ const debug = debugFactory('loopback:openapi:spec-enhancer:consolidate');
  * When comparing schemas to avoid naming collisions, the description field
  * is ignored.
  */
-@bind(asSpecEnhancer, {scope: BindingScope.SINGLETON})
+@injectable(asSpecEnhancer, {scope: BindingScope.SINGLETON})
 export class ConsolidationEnhancer implements OASEnhancer {
   name = 'consolidate';
   disabled: boolean;

--- a/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
+++ b/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
@@ -5,10 +5,10 @@
 
 import {
   ApplicationMetadata,
-  bind,
   BindingScope,
   CoreBindings,
   inject,
+  injectable,
   JSONObject,
   JSONValue,
 } from '@loopback/core';
@@ -27,7 +27,7 @@ const debug = debugFactory('loopback:openapi:spec-enhancer:info');
  * An OpenAPI spec enhancer to populate `info` with application metadata
  * (package.json).
  */
-@bind(asSpecEnhancer, {scope: BindingScope.SINGLETON})
+@injectable(asSpecEnhancer, {scope: BindingScope.SINGLETON})
 export class InfoSpecEnhancer implements OASEnhancer {
   name = 'info';
 

--- a/packages/rest/src/validation/ajv-factory.provider.ts
+++ b/packages/rest/src/validation/ajv-factory.provider.ts
@@ -4,10 +4,10 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   BindingScope,
   filterByTag,
   inject,
+  injectable,
   Provider,
 } from '@loopback/core';
 import AjvCtor from 'ajv';
@@ -30,7 +30,7 @@ export const DEFAULT_AJV_VALIDATION_OPTIONS: ValidationOptions = {
 /**
  * A provider class that instantiate an AJV instance
  */
-@bind({scope: BindingScope.SINGLETON})
+@injectable({scope: BindingScope.SINGLETON})
 export class AjvFactoryProvider implements Provider<AjvFactory> {
   constructor(
     @inject(

--- a/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
+++ b/packages/service-proxy/src/__tests__/unit/mixin/service.mixin.unit.ts
@@ -5,9 +5,9 @@
 
 import {
   Application,
-  bind,
   BindingScope,
   Component,
+  injectable,
   Provider,
 } from '@loopback/core';
 import {expect} from '@loopback/testlab';
@@ -39,7 +39,7 @@ describe('ServiceMixin', () => {
   });
 
   it('binds singleton service from app.serviceProvider()', async () => {
-    @bind({scope: BindingScope.SINGLETON})
+    @injectable({scope: BindingScope.SINGLETON})
     class SingletonGeocoderServiceProvider extends GeocoderServiceProvider {}
     const myApp = new AppWithServiceMixin();
 


### PR DESCRIPTION
1. Introduce `@injectable` to be a drop-in replacement of `@bind`
2. Keep `@bind` for backward compatibility
3. Replace references to `@bind` as much as we can in docs and code

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
