### PR TITLE
feat(context): introduce new binding scopes

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -211,8 +211,11 @@ We allow a binding to be resolved within a context using one of the following
 scopes:
 
 - BindingScope.TRANSIENT (default)
-- BindingScope.CONTEXT
+- BindingScope.CONTEXT (deprecated to favor APPLICATION/SERVER/REQUEST)
 - BindingScope.SINGLETON
+- BindingScope.APPLICATION
+- BindingScope.SERVER
+- BindingScope.REQUEST
 
 For a complete list of descriptions, please see
 [BindingScope](https://loopback.io/doc/en/lb4/apidocs.context.bindingscope.html).
@@ -379,14 +382,225 @@ To understand the difference between `@bind()/@injectable` and `ctx.bind()`, see
 [Configure binding attributes for a class](#configure-binding-attributes-for-a-class).
 " %}
 
-### Refresh a binding with SINGLETON or CONTEXT scope
+There are some limitation of `SINGLETON`, `CONTEXT`, and `TRANSIENT` scopes.
+Consider the following typical context hierarchy formed by a LoopBack REST
+application:
 
-`SINGLETON` and `CONTEXT` scopes can be used to minimize the number of value
-instances created for a given binding. But sometimes we would like to force
-reloading of a binding when its configuration or dependencies are changed. For
-example, a logging provider can be refreshed to pick up a new logging level. The
-same functionality can be achieved with `TRANSIENT` scope but with much more
-overhead.
+```ts
+// We have a context chain: invocationCtx -> requestCtx -> serverCtx -> appCtx
+appCtx
+  .bind('services.MyService')
+  .toClass(MyService)
+  .inScope(BindingScope.TRANSIENT);
+```
+
+We use `TRANSIENT` scope for controllers/services so that each request will get
+a new instance. But if a controller/service is resolved within the
+`invocationCtx` (by interceptors), a new instance will be created again.
+
+```ts
+// In a middleware
+const serviceInst1 = requestCtx.get<MyService>('services.MyService');
+// In an interceptor
+const serviceInst2 = invocationCtx.get<MyService>('services.MyService');
+// serviceInst2 is a new instance and it's NOT the same as serviceInst1
+```
+
+It can also happen with dependency injections:
+
+```ts
+class MyMiddlewareProvider implements Provider<Middleware> {
+  constructor(@inject('services.MyService') private myService) {}
+}
+
+class MyInterceptor {
+  constructor(@inject('services.MyService') private myService) {}
+}
+
+// For the same request, the middleware and interceptor will receive two different
+// instances of `MyService`
+```
+
+Ideally, we should get the same instance at the subtree of the `requestCtx`.
+Even worse, resolving a binding twice in the same reqCtx will get two different
+instances too.
+
+Neither `SINGLETON` or `CONTEXT` can satisfy this requirement. Typically,
+controllers/servers are discovered and loaded into the application context.
+Those from components such as RestComponent also contribute bindings to the
+`appCtx` instead of `serverCtx`. With `SINGLETON` scope, we will get one
+instance at the `appCtx` level. With `CONTEXT` scope, we will get one instance
+per context. A set of fine-grained scopes has been introduced to allow better
+scoping of binding resolutions.
+
+- BindingScope.APPLICATION
+- BindingScope.SERVER
+- BindingScope.REQUEST
+
+The scopes above are checked against the context hierarchy to find the first
+matching context for a given scope in the chain. Resolved binding values will be
+cached and shared on the scoped context. This ensures a binding to have the same
+value for the scoped context.
+
+{% include note.html content="In some cases (especially for tests), no context
+with `REQUEST` scope exists in the chain. The resolution falls back to the
+current context. This behavior makes it easy to use `REQUEST` as the default
+scope for controllers and other artifacts.
+" %}
+
+```ts
+// We have a context chain: invocationCtx -> requestCtx -> serverCtx -> appCtx
+appCtx
+  .bind('services.MyService')
+  .toClass(MyService)
+  .inScope(BindingScope.REQUEST);
+```
+
+Now the same instance of MyService will be resolved in the `MyMiddleware` and
+`MyInterceptor`.
+
+### Resolve a binding value by key and scope within a context hierarchy
+
+Binding resolution happens explicitly with `ctx.get()`, `ctx.getSync()`, or
+`binding.getValue(ctx)`. It may be also triggered with dependency injections
+when a class is instantiated or a method is invoked.
+
+Within a context hierarchy, resolving a binding involves the following context
+objects, which can be the same or different depending on the context chain and
+binding scopes.
+
+Let's assume we have a context chain configured as follows:
+
+```ts
+import {Context} from '@loopback/core';
+
+const appCtx = new Context('application');
+appCtx.scope = BindingScope.APPLICATION;
+
+const serverCtx = new Context(appCtx, 'server');
+serverCtx.scope = BindingScope.SERVER;
+
+const reqCtx = new Context(serverCtx, 'request');
+reqCtx.scope = BindingScope.REQUEST;
+```
+
+1.  The owner context
+
+    The owner context is the context in which a binding is registered by
+    `ctx.bind()` or `ctx.add()` APIs.
+
+    Let's add some bindings to the context chain.
+
+    ```ts
+    appCtx.bind('foo.app').to('app.bar');
+    serverCtx.bind('foo.server').to('server.bar');
+    ```
+
+    The owner context for the code snippet above will be:
+
+    - 'foo.app': appCtx
+    - 'foo.server': serverCtx
+
+2.  The current context
+
+    The current context is either the one that is explicitly passed in APIs that
+    starts the resolution or implicitly used to inject dependencies. For
+    dependency injections, it will be the resolution context of the owning class
+    binding. For example, the current context is `reqCtx` for the statement
+    below:
+
+    ```ts
+    const val = await reqCtx.get('foo.app');
+    ```
+
+3.  The resolution context
+
+    The resolution context is the context in the chain that will be used to find
+    bindings by key. Only the resolution context itself and its ancestors are
+    visible for the binding resolution.
+
+    The resolution context is determined for a binding key as follows:
+
+    a. Find the first binding with the given key in the current context or its
+    ancestors recursively
+
+    b. Use the scope of binding found to locate the resolution context:
+
+    - Use the `current context` for `CONTEXT` and `TRANSIENT` scopes
+    - Use the `owner context` for `SINGLETON` scope
+    - Use the first context that matches the binding scope in the chain starting
+      from the current context and traversing to its ancestors for
+      `APPLICATION`, `SERVER` and `REQUEST` scopes
+
+    For example:
+
+    ```ts
+    import {generateUniqueId} from '@loopback/core';
+
+    appCtx.bind('foo').to('app.bar');
+    serverCtx
+      .bind('foo')
+      .toDynamicValue(() => `foo.server.${generateUniqueId()}`)
+      .inScope(BindingScope.SERVER);
+
+    serverCtx
+      .bind('xyz')
+      .toDynamicValue(() => `abc.server.${generateUniqueId()}`)
+      .inScope(BindingScope.SINGLETON);
+
+    const val = await reqCtx.get('foo');
+    const appVal = await appCtx.get('foo');
+    const xyz = await reqCtx.get('xyz');
+    ```
+
+    For `const val = await reqCtx.get('foo');`, the binding will be `foo`
+    (scope=SERVER) in the `serverCtx` and resolution context will be
+    `serverCtx`.
+
+    For `const appVal = await appCtx.get('foo');`, the binding will be `foo`
+    (scope=TRANSIENT) in the `appCtx` and resolution context will be `appCtx`.
+
+    For `const xyz = await reqCtx.get('xyz');`, the binding will be `xyz`
+    (scope=SINGLETON) in the `serverCtx` and resolution context will be
+    `serverCtx`.
+
+    For dependency injections, the `current context` will be the
+    `resolution context` of the class binding that declares injections. The
+    `resolution context` will be located for each injection. If the bindings to
+    be injected is NOT visible (either the key does not exist or only exists in
+    descendant) to the `resolution context`, an error will be reported.
+
+{% include note.html content="If the owner context happens to be same as the
+resolution context, the `APPLICATION/SERVER/REQUEST` scope is equivalent as
+`SINGLETON` scope. For example, the following two bindings behave the same way
+as each other.
+
+```ts
+let count = 0;
+appCtx
+  .bind('app.counter')
+  .toDynamicValue(() => count++)
+  .inScope(BindingScope.APPLICATION);
+```
+
+```ts
+let count = 0;
+appCtx
+  .bind('app.counter')
+  .toDynamicValue(() => count++)
+  .inScope(BindingScope.SINGLETON);
+```
+
+" %}
+
+### Refresh a binding with non-transient scopes
+
+`SINGLETON`/`CONTEXT`/`APPLICATION`/`SERVER` scopes can be used to minimize the
+number of value instances created for a given binding. But sometimes we would
+like to force reloading of a binding when its configuration or dependencies are
+changed. For example, a logging provider can be refreshed to pick up a new
+logging level. The same functionality can be achieved with `TRANSIENT` scope but
+with much more overhead.
 
 The `binding.refresh()` method invalidates the cache so that its value will be
 reloaded next time.

--- a/examples/binding-resolution/src/application.ts
+++ b/examples/binding-resolution/src/application.ts
@@ -4,15 +4,17 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BootMixin} from '@loopback/boot';
-import {ApplicationConfig} from '@loopback/core';
+import {ApplicationConfig, BindingScope} from '@loopback/core';
 import {RestApplication} from '@loopback/rest';
 import {
   RestExplorerBindings,
   RestExplorerComponent,
 } from '@loopback/rest-explorer';
 import path from 'path';
+import {APPLICATION_COUNTER, REQUEST_COUNTER, SERVER_COUNTER} from './keys';
 import {SpyMiddlewareProvider} from './middleware/spy.middleware';
 import {MySequence} from './sequence';
+import {CounterProvider} from './services';
 
 export {ApplicationConfig};
 
@@ -24,6 +26,16 @@ export class BindingDemoApplication extends BootMixin(RestApplication) {
     this.sequence(MySequence);
 
     this.middleware(SpyMiddlewareProvider);
+
+    this.bind(APPLICATION_COUNTER)
+      .toProvider(CounterProvider)
+      .inScope(BindingScope.APPLICATION);
+    this.bind(SERVER_COUNTER)
+      .toProvider(CounterProvider)
+      .inScope(BindingScope.SERVER);
+    this.bind(REQUEST_COUNTER)
+      .toProvider(CounterProvider)
+      .inScope(BindingScope.REQUEST);
 
     // Set up default home page
     this.static('/', path.join(__dirname, '../public'));

--- a/examples/binding-resolution/src/controllers/ping.controller.ts
+++ b/examples/binding-resolution/src/controllers/ping.controller.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Binding, BindingScope, Context, inject} from '@loopback/core';
+import {
+  Binding,
+  BindingScope,
+  Context,
+  inject,
+  injectable,
+} from '@loopback/core';
 import {
   get,
   RequestContext,
@@ -11,7 +17,7 @@ import {
   RestBindings,
 } from '@loopback/rest';
 import {LOGGER_SERVICE} from '../keys';
-import {bindingScope, logContext, Logger, logContexts} from '../util';
+import {bindingScope, count, logContext, logContexts, Logger} from '../util';
 
 /**
  * OpenAPI response for ping()
@@ -43,7 +49,7 @@ const PING_RESPONSE: ResponseObject = {
 /**
  * A simple controller to bounce back http requests
  */
-@bind({scope: bindingScope(BindingScope.TRANSIENT)})
+@injectable({scope: bindingScope('PingController', BindingScope.TRANSIENT)})
 export class PingController {
   constructor(
     // Inject the resolution context and current binding for logging purpose
@@ -66,12 +72,13 @@ export class PingController {
       '200': PING_RESPONSE,
     },
   })
-  ping(
+  async ping(
     // Use method parameter injection to receive the request context
     // This works regardless of the binding scope for `PingController`
     @inject(RestBindings.Http.CONTEXT) requestCtx: RequestContext,
-  ): object {
+  ): Promise<object> {
     logContext('Request', requestCtx, this.binding, this.logger);
+    await count(requestCtx, 'PingController');
     // Reply with a greeting, the current time, the url, and request headers
     const result = {
       greeting: 'Hello from LoopBack',

--- a/examples/binding-resolution/src/interceptors/spy.interceptor.ts
+++ b/examples/binding-resolution/src/interceptors/spy.interceptor.ts
@@ -9,14 +9,18 @@ import {
   Provider,
   ValueOrPromise,
 } from '@loopback/core';
-import {bindingScope, logContext, logContexts} from '../util';
+import {bindingScope, count, logContext, logContexts} from '../util';
 
 /**
  * This class will be bound to the application as an `Interceptor` during
  * `boot`
  */
-@globalInterceptor('spy', {tags: {name: 'Spy'}}, {scope: bindingScope()})
-export class SpyInterceptor implements Provider<Interceptor> {
+@globalInterceptor(
+  'spy',
+  {tags: {name: 'Spy'}},
+  {scope: bindingScope('SpyInterceptor')},
+)
+export class SpyInterceptorProvider implements Provider<Interceptor> {
   // Inject the resolution context and current binding for logging purpose
   constructor(
     @inject.context()
@@ -48,6 +52,7 @@ export class SpyInterceptor implements Provider<Interceptor> {
   ) {
     try {
       logContext('Invocation', invocationCtx, this.binding);
+      await count(invocationCtx, 'SpyInterceptor');
       // Add pre-invocation logic here
       const result = await next();
       // Add post-invocation logic here

--- a/examples/binding-resolution/src/keys.ts
+++ b/examples/binding-resolution/src/keys.ts
@@ -4,6 +4,15 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingKey} from '@loopback/core';
+import {Counter} from './services';
 import {Logger} from './util';
 
 export const LOGGER_SERVICE = BindingKey.create<Logger>('services.Logger');
+
+export const APPLICATION_COUNTER = BindingKey.create<Counter>(
+  'application.counter',
+);
+
+export const SERVER_COUNTER = BindingKey.create<Counter>('server.counter');
+
+export const REQUEST_COUNTER = BindingKey.create<Counter>('request.counter');

--- a/examples/binding-resolution/src/middleware/spy.middleware.ts
+++ b/examples/binding-resolution/src/middleware/spy.middleware.ts
@@ -3,18 +3,27 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {bind, Binding, Context, inject, Provider} from '@loopback/core';
+import {Binding, Context, inject, injectable, Provider} from '@loopback/core';
 import {asMiddleware, Middleware, RestMiddlewareGroups} from '@loopback/rest';
 import {LOGGER_SERVICE} from '../keys';
-import {bindingScope, logContext, logRequest, logContexts} from '../util';
+import {
+  bindingScope,
+  count,
+  logContext,
+  logContexts,
+  logRequest,
+} from '../util';
 
-@bind(
+@injectable(
   asMiddleware({
     group: 'spy',
     upstreamGroups: RestMiddlewareGroups.AUTHENTICATION,
     downstreamGroups: RestMiddlewareGroups.INVOKE_METHOD,
   }),
-  {tags: {name: 'Spy'}, scope: bindingScope()},
+  {
+    tags: {name: 'Spy'},
+    scope: bindingScope('SpyMiddleware'),
+  },
 )
 export class SpyMiddlewareProvider implements Provider<Middleware> {
   constructor(
@@ -40,6 +49,8 @@ export class SpyMiddlewareProvider implements Provider<Middleware> {
       // NOTE: It will be too late to do so in an interceptor as interceptors
       // are invoked after the controller instance is resolved.
       ctx.bind(LOGGER_SERVICE).toAlias('services.RequestLoggerService');
+
+      await count(ctx, 'SpyMiddleware');
       const result = await next();
       return result;
     };

--- a/examples/binding-resolution/src/services/counter.service.ts
+++ b/examples/binding-resolution/src/services/counter.service.ts
@@ -1,0 +1,36 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/example-binding-resolution
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Binding, Context, inject, Provider} from '@loopback/core';
+import {logContexts} from '../util';
+
+export class Counter {
+  constructor(public readonly scope: string, public value: number) {}
+
+  inc() {
+    this.value++;
+  }
+}
+
+/**
+ * A counter implementation
+ */
+export class CounterProvider implements Provider<Counter> {
+  private readonly counter: Counter;
+  constructor(
+    // Inject the resolution context and current binding for logging purpose
+    @inject.context()
+    resolutionCtx: Context,
+    @inject.binding()
+    private binding: Binding<unknown>,
+  ) {
+    logContexts(resolutionCtx, binding);
+    this.counter = new Counter(`${this.binding.key}@${this.binding.scope}`, 0);
+  }
+
+  value() {
+    return this.counter;
+  }
+}

--- a/examples/binding-resolution/src/services/index.ts
+++ b/examples/binding-resolution/src/services/index.ts
@@ -1,1 +1,7 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/example-binding-resolution
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+export * from './counter.service';
 export * from './logger.service';

--- a/examples/binding-resolution/src/services/logger.service.ts
+++ b/examples/binding-resolution/src/services/logger.service.ts
@@ -4,18 +4,18 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  bind,
   Binding,
   BindingScope,
   Context,
   ContextTags,
   inject,
+  injectable,
   Provider,
 } from '@loopback/core';
 import {RequestContext, RestBindings} from '@loopback/rest';
 import {format} from 'util';
 import {LOGGER_SERVICE} from '../keys';
-import {log, Logger, logContexts} from '../util';
+import {log, logContexts, Logger} from '../util';
 
 /**
  * A default stateless logger
@@ -25,7 +25,7 @@ import {log, Logger, logContexts} from '../util';
  * The logger implementation is stateless. We use SINGLETON scope so that only
  * one instance will be created to minimize the overhead.
  */
-@bind({
+@injectable({
   scope: BindingScope.SINGLETON,
   // Set binding key to `LOGGER_SERVICE`
   tags: {[ContextTags.KEY]: LOGGER_SERVICE},
@@ -57,7 +57,7 @@ export class LoggerService implements Provider<Logger> {
  * instance will be created for each request and the corresponding request
  * context can be injected into the request logger.
  */
-@bind({scope: BindingScope.TRANSIENT})
+@injectable({scope: BindingScope.TRANSIENT})
 export class RequestLoggerService implements Provider<Logger> {
   constructor(
     // Inject the resolution context and current binding for logging purpose

--- a/extensions/graphql/src/graphql.container.ts
+++ b/extensions/graphql/src/graphql.container.ts
@@ -5,6 +5,7 @@
 
 import {
   Binding,
+  BindingScope,
   Constructor,
   Context,
   createBindingFromClass,
@@ -57,6 +58,9 @@ export class LoopBackContainer implements ContainerType {
       resolverClass,
       resolverData,
     );
+    if (reqCtx == null) {
+      resolutionCtx.scope = BindingScope.REQUEST;
+    }
     const resolverBinding = createBindingFromClass(resolverClass, {
       defaultNamespace: GraphQLBindings.RESOLVERS,
     });

--- a/extensions/graphql/src/graphql.server.ts
+++ b/extensions/graphql/src/graphql.server.ts
@@ -56,8 +56,7 @@ export class GraphQLServer extends Context implements Server {
     parent?: Context,
   ) {
     super(parent, 'graphql-server');
-
-    // An internal express application for GraphQL only
+    this.scope = BindingScope.SERVER;
     this.expressApp = express();
     if (options.expressSettings) {
       for (const p in options.expressSettings) {

--- a/packages/context/src/__tests__/unit/binding.unit.ts
+++ b/packages/context/src/__tests__/unit/binding.unit.ts
@@ -113,6 +113,21 @@ describe('Binding', () => {
       expect(binding.scope).to.equal(BindingScope.TRANSIENT);
     });
 
+    it('sets the request binding scope', () => {
+      binding.inScope(BindingScope.REQUEST);
+      expect(binding.scope).to.equal(BindingScope.REQUEST);
+    });
+
+    it('sets the application binding scope', () => {
+      binding.inScope(BindingScope.APPLICATION);
+      expect(binding.scope).to.equal(BindingScope.APPLICATION);
+    });
+
+    it('sets the server binding scope', () => {
+      binding.inScope(BindingScope.SERVER);
+      expect(binding.scope).to.equal(BindingScope.SERVER);
+    });
+
     it('triggers changed event', () => {
       const events = listenOnBinding();
       binding.inScope(BindingScope.TRANSIENT);

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -58,6 +58,10 @@ export enum BindingScope {
   TRANSIENT = 'Transient',
 
   /**
+   * @deprecated Finer-grained scopes such as `APPLICATION`, `SERVER`, or
+   * `REQUEST` should be used instead to ensure the scope of sharing of resolved
+   * binding values.
+   *
    * The binding provides a value as a singleton within each local context. The
    * value is calculated only once per context and cached for subsequential
    * uses. Child contexts have their own value and do not share with their
@@ -79,6 +83,7 @@ export enum BindingScope {
    * 3. `'b1'` is resolved in `app` but not in `req2`, a new value `2` is
    * calculated and used for `req2` afterward
    * - req2.get('b1') ==> 2 (always)
+   *
    */
   CONTEXT = 'Context',
 
@@ -104,6 +109,62 @@ export enum BindingScope {
    * - req2.get('b1') ==> 0 (always)
    */
   SINGLETON = 'Singleton',
+
+  /*
+   * The following scopes are checked against the context hierarchy to find
+   * the first matching context for a given scope in the chain. Resolved binding
+   * values will be cached and shared on the scoped context. This ensures a
+   * binding to have the same value for the scoped context.
+   */
+
+  /**
+   * Application scope
+   *
+   * @remarks
+   * The binding provides an application-scoped value within the context
+   * hierarchy. Resolved value for this binding will be cached and shared for
+   * the same application context (denoted by its scope property set to
+   * `BindingScope.APPLICATION`).
+   *
+   */
+  APPLICATION = 'Application',
+
+  /**
+   * Server scope
+   *
+   * @remarks
+   * The binding provides an server-scoped value within the context hierarchy.
+   * Resolved value for this binding will be cached and shared for the same
+   * server context (denoted by its scope property set to
+   * `BindingScope.SERVER`).
+   *
+   * It's possible that an application has more than one servers configured,
+   * such as a `RestServer` and a `GrpcServer`. Both server contexts are created
+   * with `scope` set to `BindingScope.SERVER`. Depending on where a binding
+   * is resolved:
+   * - If the binding is resolved from the RestServer or below, it will be
+   * cached using the RestServer context as the key.
+   * - If the binding is resolved from the GrpcServer or below, it will be
+   * cached using the GrpcServer context as the key.
+   *
+   * The same binding can resolved/shared/cached for all servers, each of which
+   * has its own value for the binding.
+   */
+  SERVER = 'Server',
+
+  /**
+   * Request scope
+   *
+   * @remarks
+   * The binding provides an request-scoped value within the context hierarchy.
+   * Resolved value for this binding will be cached and shared for the same
+   * request context (denoted by its scope property set to
+   * `BindingScope.REQUEST`).
+   *
+   * The `REQUEST` scope is very useful for controllers, services and artifacts
+   * that want to have a single instance/value for a given request.
+   */
+  REQUEST = 'Request',
 }
 
 /**
@@ -352,23 +413,18 @@ export class Binding<T = BoundValue> extends EventEmitter {
 
   /**
    * Cache the resolved value by the binding scope
-   * @param ctx - The current context
+   * @param resolutionCtx - The resolution context
    * @param result - The calculated value for the binding
    */
   private _cacheValue(
-    ctx: Context,
+    resolutionCtx: Context,
     result: ValueOrPromise<T>,
   ): ValueOrPromise<T> {
     // Initialize the cache as a weakmap keyed by context
     if (!this._cache) this._cache = new WeakMap<Context, ValueOrPromise<T>>();
-    if (this.scope === BindingScope.SINGLETON) {
-      // Cache the value
-      this._cache.set(ctx.getOwnerContext(this.key)!, result);
-    } else if (this.scope === BindingScope.CONTEXT) {
-      // Cache the value at the current context
-      this._cache.set(ctx, result);
+    if (this.scope !== BindingScope.TRANSIENT) {
+      this._cache.set(resolutionCtx!, result);
     }
-    // Do not cache for `TRANSIENT`
     return result;
   }
 
@@ -383,7 +439,7 @@ export class Binding<T = BoundValue> extends EventEmitter {
 
   /**
    * Invalidate the binding cache so that its value will be reloaded next time.
-   * This is useful to force reloading a singleton when its configuration or
+   * This is useful to force reloading a cached value when its configuration or
    * dependencies are changed.
    * **WARNING**: The state held in the cached value will be gone.
    *
@@ -391,15 +447,11 @@ export class Binding<T = BoundValue> extends EventEmitter {
    */
   refresh(ctx: Context) {
     if (!this._cache) return;
-    if (this.scope === BindingScope.SINGLETON) {
-      // Cache the value
-      const ownerCtx = ctx.getOwnerContext(this.key);
-      if (ownerCtx != null) {
-        this._cache.delete(ownerCtx);
+    if (this.scope !== BindingScope.TRANSIENT) {
+      const resolutionCtx = ctx.getResolutionContext(this);
+      if (resolutionCtx != null) {
+        this._cache.delete(resolutionCtx);
       }
-    } else if (this.scope === BindingScope.CONTEXT) {
-      // Cache the value at the current context
-      this._cache.delete(ctx);
     }
   }
 
@@ -451,22 +503,20 @@ export class Binding<T = BoundValue> extends EventEmitter {
     if (debug.enabled) {
       debug('Get value for binding %s', this.key);
     }
+
+    const options = asResolutionOptions(optionsOrSession);
+    const resolutionCtx = this.getResolutionContext(ctx, options);
+    if (resolutionCtx == null) return undefined;
     // First check cached value for non-transient
     if (this._cache) {
-      if (this.scope === BindingScope.SINGLETON) {
-        const ownerCtx = ctx.getOwnerContext(this.key);
-        if (ownerCtx && this._cache.has(ownerCtx)) {
-          return this._cache.get(ownerCtx)!;
-        }
-      } else if (this.scope === BindingScope.CONTEXT) {
-        if (this._cache.has(ctx)) {
-          return this._cache.get(ctx)!;
+      if (this.scope !== BindingScope.TRANSIENT) {
+        if (resolutionCtx && this._cache.has(resolutionCtx)) {
+          return this._cache.get(resolutionCtx)!;
         }
       }
     }
-    const options = asResolutionOptions(optionsOrSession);
-    const resolutionCtx = {
-      context: ctx,
+    const resolutionMetadata = {
+      context: resolutionCtx!,
       binding: this,
       options,
     };
@@ -477,23 +527,60 @@ export class Binding<T = BoundValue> extends EventEmitter {
           // We already test `this._getValue` is a function. It's safe to assert
           // that `this._getValue` is not undefined.
           return this._getValue!({
-            ...resolutionCtx,
+            ...resolutionMetadata,
             options: optionsWithSession,
           });
         },
         this,
         options.session,
       );
-      return this._cacheValue(ctx, result);
+      return this._cacheValue(resolutionCtx!, result);
     }
     // `@inject.binding` adds a binding without _getValue
     if (options.optional) return undefined;
     return Promise.reject(
       new ResolutionError(
         `No value was configured for binding ${this.key}.`,
-        resolutionCtx,
+        resolutionMetadata,
       ),
     );
+  }
+
+  /**
+   * Locate and validate the resolution context
+   * @param ctx - Current context
+   * @param options - Resolution options
+   */
+  private getResolutionContext(ctx: Context, options: ResolutionOptions) {
+    const resolutionCtx = ctx.getResolutionContext(this);
+    switch (this.scope) {
+      case BindingScope.APPLICATION:
+      case BindingScope.SERVER:
+      case BindingScope.REQUEST:
+        if (resolutionCtx == null) {
+          const msg =
+            `Binding "${this.key}" in context "${ctx.name}" cannot` +
+            ` be resolved in scope "${this.scope}"`;
+          if (options.optional) {
+            debug(msg);
+            return undefined;
+          }
+          throw new Error(msg);
+        }
+    }
+
+    const ownerCtx = ctx.getOwnerContext(this.key);
+    if (ownerCtx != null && !ownerCtx.isVisibleTo(resolutionCtx!)) {
+      const msg =
+        `Resolution context "${resolutionCtx?.name}" does not have ` +
+        `visibility to binding "${this.key} (scope:${this.scope})" in context "${ownerCtx.name}"`;
+      if (options.optional) {
+        debug(msg);
+        return undefined;
+      }
+      throw new Error(msg);
+    }
+    return resolutionCtx;
   }
 
   /**

--- a/packages/context/src/resolver.ts
+++ b/packages/context/src/resolver.ts
@@ -6,7 +6,6 @@
 import {DecoratorFactory} from '@loopback/metadata';
 import assert from 'assert';
 import debugModule from 'debug';
-import {BindingScope} from './binding';
 import {isBindingAddress} from './binding-filter';
 import {BindingAddress} from './binding-key';
 import {Context} from './context';
@@ -98,11 +97,8 @@ function resolveContext(
   session?: ResolutionSession,
 ) {
   const currentBinding = session?.currentBinding;
-  if (
-    currentBinding == null ||
-    currentBinding.scope !== BindingScope.SINGLETON
-  ) {
-    // No current binding or its scope is not `SINGLETON`
+  if (currentBinding == null) {
+    // No current binding
     return ctx;
   }
 
@@ -113,9 +109,9 @@ function resolveContext(
     typeof injection.methodDescriptorOrParameterIndex !== 'number';
 
   if (isConstructorOrPropertyInjection) {
-    // Set context to the owner context of the current binding for constructor
-    // or property injections against a singleton
-    ctx = ctx.getOwnerContext(currentBinding.key)!;
+    // Set context to the resolution context of the current binding for
+    // constructor or property injections against a singleton
+    ctx = ctx.getResolutionContext(currentBinding)!;
   }
   return ctx;
 }

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -116,6 +116,7 @@ export class Application extends Context implements LifeCycleObserver {
   constructor(configOrParent?: ApplicationConfig | Context, parent?: Context) {
     // super() has to be first statement for a constructor
     super(...buildConstructorArgs(configOrParent, parent));
+    this.scope = BindingScope.APPLICATION;
 
     this.options =
       configOrParent instanceof Context ? {} : configOrParent ?? {};

--- a/packages/express/src/express.server.ts
+++ b/packages/express/src/express.server.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Context, CoreBindings, inject, Server} from '@loopback/core';
+import {
+  BindingScope,
+  Context,
+  CoreBindings,
+  inject,
+  Server,
+} from '@loopback/core';
 import {HttpOptions, HttpServer, HttpsOptions} from '@loopback/http-server';
 import debugFactory from 'debug';
 import express from 'express';
@@ -51,6 +57,7 @@ export class ExpressServer extends BaseMiddlewareRegistry implements Server {
     parent?: Context,
   ) {
     super(parent);
+    this.scope = BindingScope.SERVER;
     let basePath = config?.basePath ?? '';
     // Trim leading and trailing `/`
     basePath = basePath.replace(/(^\/)|(\/$)/, '');

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -5,6 +5,7 @@
 
 import {
   BindingAddress,
+  BindingScope,
   Context,
   GenericInterceptor,
   GenericInterceptorChain,
@@ -57,6 +58,7 @@ export class MiddlewareContext extends Context implements HandlerContext {
     name?: string,
   ) {
     super(parent, name);
+    this.scope = BindingScope.REQUEST;
     this.setupBindings();
     onFinished(this.response, () => {
       this.responseFinished = true;

--- a/packages/rest/src/rest.server.ts
+++ b/packages/rest/src/rest.server.ts
@@ -211,6 +211,7 @@ export class RestServer
     config: RestServerConfig = {},
   ) {
     super(app);
+    this.scope = BindingScope.SERVER;
 
     this.config = resolveRestServerConfig(config);
 


### PR DESCRIPTION
Implements https://github.com/strongloop/loopback-next/issues/6325

# Current issues
Consider the following context hierarchy: invocationCtx -> requestCtx -> serverCtx -> appCtx, we use `Transient` scope for controllers/services so that each request will get a new instance. But if a controller/service is resolved within the `invocationCtx` (interceptors), a new instance will be created again. Ideally, we should get the same instance at the subtree of the `requestCtx`. Even worse, resolving a binding twice in the same `reqCtx` will get two different instances too.

Neither `Singleton` or `Context` can satisfy this requirement. Typically, controllers/servers are discovered and loaded into the application context. Those from components such as `RestComponent` also contribute bindings to the `appCtx` instead of `serverCtx`. `Singleton` will get one instance at the `appCtx` level while `Context` will get one instance per context.

# Proposed solution

When you build a chain of context objects, each context can define its `scope` property, such as `APPLICATION`, `SERVER`, and `REQUEST`. Then binding resolution will try to find the matching context with the same scope and use it as the key to share resolved values. This is probably the `CONTEXT` scope should have been.

Existing scopes such as `SINGLETON` and `TRANSIENT` will work as-is.

I'll update the docs if we agree on the direction.

# Questions

1. Do we want to make binding scopes extensible? At this point, it's an `enum`. We'll have change its type to `string` and introduce a `BindingScopeResolver`:

```
export interface BindingScopeResolver {
  getScopedContext(ctx: Context, scope: BindingScope): Context | undefined;
}
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
