### PR TITLE
fix(rest): do not blindly override openapi spec info from package.json

### DIFF
--- a/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
+++ b/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
@@ -7,7 +7,11 @@ import {config, extensionPoint, extensions, Getter} from '@loopback/core';
 import debugModule from 'debug';
 import * as _ from 'lodash';
 import {inspect} from 'util';
-import {OpenApiSpec, SecuritySchemeObject} from '../types';
+import {
+  DEFAULT_OPENAPI_SPEC_INFO,
+  OpenApiSpec,
+  SecuritySchemeObject,
+} from '../types';
 import {OASEnhancerBindings} from './keys';
 import {OASEnhancer} from './types';
 const jsonmergepatch = require('json-merge-patch');
@@ -48,8 +52,7 @@ export class OASEnhancerService {
   private _spec: OpenApiSpec = {
     openapi: '3.0.0',
     info: {
-      title: 'LoopBack Application',
-      version: '1.0.0',
+      ...DEFAULT_OPENAPI_SPEC_INFO,
     },
     paths: {},
   };

--- a/packages/openapi-v3/src/types.ts
+++ b/packages/openapi-v3/src/types.ts
@@ -18,6 +18,11 @@ export type OpenApiSpec = OpenAPIObject;
 // Export also all spec interfaces
 export * from 'openapi3-ts';
 
+export const DEFAULT_OPENAPI_SPEC_INFO = {
+  title: 'LoopBack Application',
+  version: '1.0.0',
+};
+
 /**
  * Create an empty OpenApiSpec object that's still a valid openapi document.
  *
@@ -27,8 +32,7 @@ export function createEmptyApiSpec(): OpenApiSpec {
   return {
     openapi: '3.0.0',
     info: {
-      title: 'LoopBack Application',
-      version: '1.0.0',
+      ...DEFAULT_OPENAPI_SPEC_INFO,
     },
     paths: {},
     servers: [{url: '/'}],

--- a/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
+++ b/packages/rest/src/__tests__/unit/rest.server/rest.server.open-api-spec.unit.ts
@@ -360,6 +360,32 @@ describe('RestServer.getApiSpec()', () => {
     expect(spec.info).to.eql(EXPECTED_SPEC_INFO);
   });
 
+  it('does not override customized oas.info', async () => {
+    const EXPECTED_SPEC_INFO = {
+      title: 'My LB App',
+      version: '2.0',
+      description: 'LoopBack Test Application',
+      contact: {},
+    };
+    app.setMetadata({
+      name: 'MyApp',
+      description: 'LoopBack Test Application',
+      version: '1.0.1',
+      author: 'Barney Rubble <b@rubble.com> (http://barnyrubble.tumblr.com/)',
+    });
+    server.api({
+      openapi: '3.0.0',
+      info: {
+        title: 'My LB App',
+        version: '2.0',
+        contact: {},
+      },
+      paths: {},
+    });
+    const spec = await server.getApiSpec();
+    expect(spec.info).to.eql(EXPECTED_SPEC_INFO);
+  });
+
   it('invokes info oas enhancers with author object', async () => {
     const EXPECTED_SPEC_INFO = {
       title: 'MyApp',

--- a/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
+++ b/packages/rest/src/spec-enhancers/info.spec-enhancer.ts
@@ -15,6 +15,7 @@ import {
 import {
   asSpecEnhancer,
   ContactObject,
+  DEFAULT_OPENAPI_SPEC_INFO,
   mergeOpenAPISpec,
   OASEnhancer,
   OpenApiSpec,
@@ -44,12 +45,20 @@ export class InfoSpecEnhancer implements OASEnhancer {
     const contact: ContactObject = InfoSpecEnhancer.parseAuthor(
       this.pkg.author,
     );
+    // Only override `info` if the `spec.info` is not customized
+    const overrideInfo =
+      spec.info.title === DEFAULT_OPENAPI_SPEC_INFO.title &&
+      spec.info.version === DEFAULT_OPENAPI_SPEC_INFO.version;
     const patchSpec = {
       info: {
-        title: this.pkg.name,
-        description: this.pkg.description,
-        version: this.pkg.version,
-        contact,
+        title: overrideInfo ? this.pkg.name : spec.info.title ?? this.pkg.name,
+        description: overrideInfo
+          ? this.pkg.description
+          : spec.info.description ?? this.pkg.description,
+        version: overrideInfo
+          ? this.pkg.version
+          : spec.info.version ?? this.pkg.version,
+        contact: overrideInfo ? contact : spec.info.contact ?? contact,
       },
     };
     debug('Enhancing OpenAPI spec with %j', patchSpec);


### PR DESCRIPTION
Fixes #6310 #6215 

The built-in info spec enhancer will only override the `info` section of the OpenAPI spec if the `spec.info` has the default values: 

```ts
{
  title: 'LoopBack Application',
  version: '1.0.0',
}
```


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
