### PR TITLE
docs: reorganize error-codes page

### DIFF
--- a/docs/site/reference/error-codes.md
+++ b/docs/site/reference/error-codes.md
@@ -10,23 +10,23 @@ redirect_from: /doc/en/lb4/Error-handling.html
 In order to allow clients to reliably detect individual error causes, LoopBack
 sets the error `code` property to a machine-readable string.
 
-| Error code                 | Description                                                                                                                                                                                               |
-| :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ENTITY_NOT_FOUND           | The entity (model) was not found. This error is returned for example by [`EntityCrudRepository.prototype.findById`](https://loopback.io/doc/en/lb4/apidocs.repository.entitycrudrepository.findbyid.html) |
-| VALIDATION_FAILED          | The data provided by the client is not a valid entity.                                                                                                                                                    |
-| INVALID_PARAMETER_VALUE    | The value provided for a parameter of a REST endpoint is not valid. For example, a string value was provided for a numeric parameter.                                                                     |
-| MISSING_REQUIRED_PARAMETER | No value was provided for a required parameter.                                                                                                                                                           |
-| CANNOT_INFER_PROPERTY_TYPE | See below: [CANNOT_INFER_PROPERTY_TYPE](#cannot_infer_property_type)                                                                                                                                      |
+## ENTITY_NOT_FOUND
 
-Besides LoopBack-specific error codes, your application can encounter low-level
-error codes from Node.js and the underlying operating system. For example, when
-a connector is not able to reach the database, an error with code `ECONNREFUSED`
-is returned.
+The entity (model) was not found. This error is returned for example by
+[`EntityCrudRepository.prototype.findById`](https://loopback.io/doc/en/lb4/apidocs.repository.entitycrudrepository.findbyid.html).
 
-See the following resources for a list of low-level error codes:
+## VALIDATION_FAILED
 
-- [Common System Errors](https://nodejs.org/api/errors.html#errors_common_system_errors)
-- [Node.js Error Codes](https://nodejs.org/api/errors.html#errors_node_js_error_codes)
+The data provided by the client is not a valid entity.
+
+## INVALID_PARAMETER_VALUE
+
+The value provided for a parameter of a REST endpoint is not valid. For example,
+a string value was provided for a numeric parameter.
+
+## MISSING_REQUIRED_PARAMETER
+
+No value was provided for a required parameter.
 
 ## CANNOT_INFER_PROPERTY_TYPE
 
@@ -94,3 +94,15 @@ You have the following options how to fix the error
      hourFormat: '12h' | '24h';
    }
    ```
+
+## Other error codes
+
+Besides LoopBack-specific error codes, your application can encounter low-level
+error codes from Node.js and the underlying operating system. For example, when
+a connector is not able to reach the database, an error with code `ECONNREFUSED`
+is returned.
+
+See the following resources for a list of low-level error codes:
+
+- [Common System Errors](https://nodejs.org/api/errors.html#errors_common_system_errors)
+- [Node.js Error Codes](https://nodejs.org/api/errors.html#errors_node_js_error_codes)


### PR DESCRIPTION
Rework the table into a list of h2 sections. The new format makes it easy to share URLs pointing to individual error codes.

This is a follow-up for #6293.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
