### PR TITLE
docs: requiring connectors

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -299,6 +299,35 @@ To update dependencies to their latest compatible versions:
 npm run update-all-deps
 ```
 
+### Limitation of Lerna Monorepo
+
+If an application inside the `loopback-next` monorepo connects to a datasource
+like `loopback-connector-mongodb`, you need to require the module directly in
+the configuration as follow:
+
+```ts
+const config = {
+  name: 'mongo',
+  // Note the connector should be required directly here.
+  connector: require('loopback-connector-mongodb'),
+  url: '',
+  host: '127.0.0.1',
+  port: 27017,
+  user: 'test',
+  password: 'test',
+};
+```
+
+This is caused by the way how lerna installs local package dependencies as
+symbolic links. The code loading connectors is executed from
+`loopback-next/packages/repository/node_modules/loopback-datasource-juggler/lib/datasource.js`.
+While the connector is installed in examples like
+`loopback-next/examples/todo/node_modules/loopback-connector-mongodb`.
+Specifying a string name like "mongodb" will result in the code looking for
+connectors installed under the package `repository` instead of the example.
+Therefore you must explicitly specify the datasource's path in the
+configuration.
+
 ## File naming convention
 
 For consistency, we follow


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

Add instructions for requiring connectors inside monorepo's example apps.
Thanks for @bajtos 's orginal comments, summarize and add it in the doc.


> In a typical app inside our monorepo, the code loading connectors is executed from loopback-next/packages/repository/node_modules/loopback-datasource-juggler/lib/datasource.js. The connector is installed e.g. in examples/todo/node_modules/loopback-connector-mongodb. (This is caused by the way how lerna installs internal monorepo dependencies.) The solution is to change datasource configuration and replace the connector name ('mongodb') to the connector module (require('loopback-connector-mongodb')). The datasource config file is inside the example project, therefore it looks for the connector in the right node_modules folder.


## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
