### PR TITLE
chore(docs): add weak relations explainer

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -6,9 +6,9 @@ sidebar: lb4_sidebar
 permalink: /doc/en/lb4/BelongsTo-relation.html
 ---
 
-{% include note.html content="There are some limitations to `Inclusion Resolver`. See [Limitations](Relations.md#limitations)." %}
-
 ## Overview
+
+{% include important.html content="Please read [Relations](Relations.md) first." %}
 
 {% include note.html content="
 This relation best works with databases that support foreign key

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -8,14 +8,14 @@ permalink: /doc/en/lb4/HasMany-relation.html
 
 ## Overview
 
+{% include important.html content="Please read [Relations](Relations.md) first." %}
+
 {% include note.html content="
 This relation best works with databases that support foreign key
 constraints (SQL).
 Using this relation with NoSQL databases will result in unexpected behavior,
 such as the ability to create a relation with a model that does not exist. We are [working on a solution](https://github.com/strongloop/loopback-next/issues/2341) to better handle this. It is fine to use this relation with NoSQL databases for purposes such as navigating related models, where the referential integrity is not critical.
 " %}
-
-{% include note.html content="There are some limitations to `Inclusion Resolver`. See [Limitations](Relations.md#limitations)." %}
 
 A `hasMany` relation denotes a one-to-many connection of a model to another
 model through referential integrity. The referential integrity is enforced by a

--- a/docs/site/HasManyThrough-relation.md
+++ b/docs/site/HasManyThrough-relation.md
@@ -8,6 +8,8 @@ permalink: /doc/en/lb4/HasManyThrough-relation.html
 
 ## Overview
 
+{% include important.html content="Please read [Relations](Relations.md) first." %}
+
 {% include note.html content="
 This relation best works with databases that support foreign key
 constraints (SQL).

--- a/docs/site/HasOne-relation.md
+++ b/docs/site/HasOne-relation.md
@@ -8,14 +8,14 @@ permalink: /doc/en/lb4/HasOne-relation.html
 
 ## Overview
 
+{% include important.html content="Please read [Relations](Relations.md) first." %}
+
 {% include note.html content="
 This relation best works with databases that support foreign key and unique
 constraints (SQL).
 Using this relation with NoSQL databases will result in unexpected behavior,
 such as the ability to create a relation with a model that does not exist. We are [working on a solution](https://github.com/strongloop/loopback-next/issues/2341) to better handle this. It is fine to use this relation with NoSQL databases for purposes such as navigating related models, where the referential integrity is not critical.
 " %}
-
-{% include note.html content="There are some limitations to `Inclusion Resolver`. See [Limitations](Relations.md#limitations)." %}
 
 A `hasOne` relation denotes a one-to-one connection of a model to another model
 through referential integrity. The referential integrity is enforced by a

--- a/docs/site/Relations.md
+++ b/docs/site/Relations.md
@@ -61,6 +61,28 @@ application.
 To generate a `HasMany`, `HasOne`, `BelongsTo`, or `hasManyThrough` relation
 through the CLI, see [Relation generator](Relation-generator.md).
 
+## Weak vs Strong Relations
+
+LoopBack 4 implements _weak relations_ with `@belongsTo()`, `@hasMany()`,
+`@hasOne`, etc. This means the constraints are enforced by LoopBack 4 itself,
+not the underlying database engine. This is useful for integrating
+cross-database relations, thereby allowing LoopBack 4 applications to partially
+take the role of a data lake.
+
+However, this means that invalid data could be keyed in outside of the LoopBack
+4 application. To resolve this issue, some LoopBack 4 connectors (such as
+[PostgreSQL](./PostgreSQL-connector.md#auto-migrateauto-update-models-with-foreign-keys)
+and
+[MySQL](MySQL-connector.md#auto-migrateauto-update-models-with-foreign-keys))
+allow defining a
+[_foreign key constraint_](https://en.wikipedia.org/wiki/Foreign_key) through
+the `@model` decorator. Please consult the respective connector documentation to
+check for compatibility.
+
+[Issue #2331](https://github.com/strongloop/loopback-next/issues/2331) tracks
+native support for foreign key constraints in relation decorators (such as
+`@belongsTo`).
+
 ## Limitations
 
 ### Filtering by parent model


### PR DESCRIPTION
This _pull request_ adds a short explainer on weak relations to remove ambiguity on how LoopBack 4 handles relations and the caveats with referential integrity.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
