### PR TITLE
chore(context): fix GenericInterceptor tsdoc generation

### DIFF
--- a/packages/context/src/interceptor-chain.ts
+++ b/packages/context/src/interceptor-chain.ts
@@ -29,6 +29,7 @@ export type Next = () => ValueOrPromise<NonVoid>;
  * It serves as the base interface for various types of interceptors, such
  * as method invocation interceptor or request/response processing interceptor.
  *
+ * @remarks
  * We choose `NonVoid` as the return type to avoid possible bugs that an
  * interceptor forgets to return the value from `next()`. For example, the code
  * below will fail to compile.


### PR DESCRIPTION
Fixes tsdoc rendering issue by moving the code block into `@remarks`:

![image](https://user-images.githubusercontent.com/25147899/93729551-985dcf00-fbf7-11ea-9bf8-68fab4a22f62.png)

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
