### PR TITLE
feat(cli): leave numbers in dirname alone

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -169,7 +169,7 @@ module.exports = class ProjectGenerator extends BaseGenerator {
           // prompts if option was set to a directory that already exists
           utils.validateNotExisting(this.projectInfo.outdir) !== true,
         validate: utils.validateNotExisting,
-        default: utils.toFileName(this.projectInfo.name),
+        default: this.projectInfo.name && this.projectInfo.name.toLowerCase(),
       },
     ];
 

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -216,6 +216,45 @@ describe('app-generator with default values', () => {
   });
 });
 
+/** For testing if the app names with numbers are untouched */
+describe('app-generator with numbers in app name', () => {
+  const rootDir = path.join(__dirname, '../../../../../');
+  const defaultValProjPath = path.join(rootDir, 'sandbox/lb4-example');
+  const sandbox = path.join(rootDir, 'sandbox');
+  const pathToDefValApp = path.join(defaultValProjPath, 'lb4-example');
+  const cwd = process.cwd();
+  const defaultValProps = {
+    name: 'lb4-example',
+    description: 'An app to test out default values',
+    outdir: '',
+  };
+
+  before(async () => {
+    // lb4-example should not exist at this point
+    assert.equal(fs.existsSync(defaultValProjPath), false);
+    assert.equal(fs.existsSync(pathToDefValApp), false);
+    return (
+      helpers
+        .run(generator)
+        .inDir(defaultValProjPath)
+        // Mark it private to prevent accidental npm publication
+        .withOptions({private: true})
+        .withPrompts(defaultValProps)
+    );
+  });
+
+  it('scaffold a new app for lb4-example', async () => {
+    // lb4-example should be created at this point
+    assert.equal(fs.existsSync(pathToDefValApp), true);
+  });
+
+  after(() => {
+    process.chdir(sandbox);
+    build.clean(['node', 'run-clean', defaultValProjPath]);
+    process.chdir(cwd);
+  });
+});
+
 /** For testing the support of tilde path as the input of project path.
  * Use different paths to test out the support of `~` when the test runs outside of home dir.
  */


### PR DESCRIPTION
Address https://github.com/strongloop/loopback-next/issues/6224.

We should simply lowercase the app name and use it as the dir name, `toFileName()` is best applicable to  "real" files only.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
