### PR TITLE
fix(docs): fix broken links

### DIFF
--- a/docs/site/Authentication-overview.md
+++ b/docs/site/Authentication-overview.md
@@ -20,7 +20,7 @@ enables identified/validated access to the protected routes.
 Authorization is a process of deciding if a user can perform an action on a
 protected resource.
 
-{% include note.html content=" For a description of an Authorization process, please see [Authorization](Loopback-component-authorization.md). " %}
+{% include note.html content=" For a description of an Authorization process, please see [Authorization](Authorization-component.md). " %}
 
 This document gives you an overview of the authentication system provided in
 LoopBack 4.

--- a/docs/site/Inside-Loopback-Application.md
+++ b/docs/site/Inside-Loopback-Application.md
@@ -115,9 +115,9 @@ The API business logic is separated between various layers in LoopBack:
 - [Models](Model.md) and [Relations](Relations.md) represent domain objects and
   provide entity relationship models.
 
-- [Repositories](https://loopback.io/doc/en/lb4/Repository.md) represent the
-  `Entity layer` for a specific model and handle all CRUD operations on the
-  model. They also use repository of other models to handle `entity relations`.
+- [Repositories](Repository.md) represent the `Entity layer` for a specific
+  model and handle all CRUD operations on the model. They also use repository of
+  other models to handle `entity relations`.
 
 ![Business Logic](imgs/shopping-business-logic.png)
 

--- a/docs/site/Querying-data.md
+++ b/docs/site/Querying-data.md
@@ -252,7 +252,7 @@ For example: `GET /api/activities/findOne?filter={"where":{"id":1234}}`
 ### Build filters with FilterBuilder
 
 Besides writing the filter yourself, you can also use
-[`FilterBuilder`](https://loopback.io/doc/en/lb4/apidocs.repository.filterbuilder.html)
+[`FilterBuilder`](https://loopback.io/doc/en/lb4/apidocs.filter.filterbuilder.html)
 to help you create or combine `where` clauses.
 
 For example, you can build the filter
@@ -279,7 +279,7 @@ const filterBuilder = new FilterBuilder();
 ```
 
 Another usage of
-[`FilterBuilder`](https://loopback.io/doc/en/lb4/apidocs.repository.filterbuilder.html)
+[`FilterBuilder`](https://loopback.io/doc/en/lb4/apidocs.filter.filterbuilder.html)
 is to combine the `where` clause by using `FilterBuilder.impose`. For example,
 
 ```ts
@@ -299,7 +299,7 @@ The `where` clauses is combined as:
 ```
 
 This also can be done with the
-[`WhereBuilder`](https://loopback.io/doc/en/lb4/apidocs.repository.wherebuilder.html).
+[`WhereBuilder`](https://loopback.io/doc/en/lb4/apidocs.filter.wherebuilder.html).
 See more examples in the [`Where Filter`](Where-filter.md#wherebuilder) page.
 
 <!-- TODO: (Agnes) need to double check.

--- a/docs/site/RBAC-with-authorization.md
+++ b/docs/site/RBAC-with-authorization.md
@@ -47,4 +47,4 @@ The architecture diagram is:
 The example is created in repository
 [access-control-migration](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration),
 and a tutorial of building it from scratch can be found in
-[access control example migration](./migration/auth/example).
+[access control example migration](./migration/auth/example.md).

--- a/docs/site/Where-filter.md
+++ b/docs/site/Where-filter.md
@@ -633,7 +633,7 @@ Or stringified JSON format:
 ## WhereBuilder
 
 You can use the
-[`WhereBuilder`](https://loopback.io/doc/en/lb4/apidocs.repository.wherebuilder.html)
+[`WhereBuilder`](https://loopback.io/doc/en/lb4/apidocs.filter.wherebuilder.html)
 to build and/or combine `where` clauses. You can build `where` clause with
 operators such as `and/or`, `gt`, etc.
 
@@ -665,7 +665,7 @@ the filter will be built as
 ```
 
 Another common usage is to combine `where` clauses with
-[`WhereBuilder.impose`](https://loopback.io/doc/en/lb4/apidocs.repository.wherebuilder.impose.html).
+[`WhereBuilder.impose`](https://loopback.io/doc/en/lb4/apidocs.filter.wherebuilder.impose.html).
 It adds a `where` object to the existing `where` filter by using the `and`
 operator. For example,
 

--- a/docs/site/Working-with-data.md
+++ b/docs/site/Working-with-data.md
@@ -78,5 +78,5 @@ See the following articles for more information:
   - [Order filter](Order-filter.md)
   - [Skip filter](Skip-filter.md)
   - [Where filter](Where-filter.md)
-- [Using database transactions](Using-database-transactions.md)
+- [Using database transactions](guides/data-access/transactions.md)
 - [Executing database commands](Executing-database-commands.md)

--- a/extensions/authentication-passport/README.md
+++ b/extensions/authentication-passport/README.md
@@ -26,7 +26,7 @@ npm i @loopback/authentication-passport --save
 
 `@loopback/authentication@3.x` allows users to register authentication
 strategies that implement the interface
-[`AuthenticationStrategy`](https://apidocs.strongloop.com/@loopback%2fdocs/authentication.html#AuthenticationStrategy)
+[`AuthenticationStrategy`](https://loopback.io/doc/en/lb4/apidocs.authentication.authenticationstrategy.html)
 
 Since `AuthenticationStrategy` describes a strategy with different contracts
 than the passport

--- a/extensions/graphql/README.md
+++ b/extensions/graphql/README.md
@@ -3,7 +3,7 @@
 This module provides integration with [GraphQL](https://graphql.org/) using
 [type-graphql](https://typegraphql.com/).
 
-![type-graphql](type-graphql.png)
+![type-graphql](https://raw.githubusercontent.com/strongloop/loopback-next/master/extensions/graphql/type-graphql.png)
 
 ## Stability: ⚠️Experimental⚠️
 


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

Ran the broken link checker, and found a few broken links. 
There seems to be some refactoring happened for the FilterBuilder and WhereBuilder, e.g. https://loopback.io/doc/en/lb4/apidocs.filter.filterbuilder.html


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
