### PR TITLE
fix(example-passport-login): import options from google oauth2

### DIFF
--- a/examples/passport-login/src/authentication-strategy-providers/google.ts
+++ b/examples/passport-login/src/authentication-strategy-providers/google.ts
@@ -6,8 +6,10 @@
 import {UserIdentityService} from '@loopback/authentication';
 import {BindingScope, inject, injectable, Provider} from '@loopback/core';
 import {Profile} from 'passport';
-import {StrategyOption} from 'passport-facebook';
-import {Strategy as GoogleStrategy} from 'passport-google-oauth2';
+import {
+  Strategy as GoogleStrategy,
+  StrategyOptions,
+} from 'passport-google-oauth2';
 import {verifyFunctionFactory} from '../authentication-strategies/types';
 import {User} from '../models';
 import {UserServiceBindings} from '../services';
@@ -18,7 +20,7 @@ export class GoogleOauth implements Provider<GoogleStrategy> {
 
   constructor(
     @inject('googleOAuth2Options')
-    public oauth2Options: StrategyOption,
+    public oauth2Options: StrategyOptions,
     @inject(UserServiceBindings.PASSPORT_USER_IDENTITY_SERVICE)
     public userService: UserIdentityService<Profile, User>,
   ) {


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

Fixes a problem reported in https://github.com/strongloop/loopback-next/issues/6217

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
