### PR TITLE
fix(context-explorer): include `public` directory in the npm package

### DIFF
--- a/extensions/context-explorer/package.json
+++ b/extensions/context-explorer/package.json
@@ -46,8 +46,8 @@
     "README.md",
     "dist",
     "src",
-    "!*/__tests__",
-    "templates"
+    "public",
+    "!*/__tests__"
   ],
   "repository": {
     "type": "git",

--- a/extensions/context-explorer/src/__tests__/integration/context-graph.integration.ts
+++ b/extensions/context-explorer/src/__tests__/integration/context-graph.integration.ts
@@ -43,7 +43,10 @@ describe('ContextGraph', () => {
 
   it('creates a dot graph with bindings', () => {
     server.bind('port').to(3000);
-    app.bind('now').toDynamicValue(() => new Date());
+    app
+      .bind('now')
+      .toDynamicValue(() => new Date())
+      .tag({serviceInterface: Date});
     const json = server.inspect();
     const graph = new ContextGraph(json);
     const dot = graph.render();
@@ -52,7 +55,7 @@ describe('ContextGraph', () => {
     label = "app";
     labelloc = "t";
     "Binding_0_0" [
-      label = "{now|{DynamicValue|Transient}}",
+      label = "{now|{DynamicValue|Transient}|serviceInterface:Date\\l}",
       shape = "record",
       style = "filled,rounded",
       fillcolor = "cyan3",

--- a/extensions/context-explorer/src/context-graph.ts
+++ b/extensions/context-explorer/src/context-graph.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingScope, ContextTags, JSONArray, JSONObject} from '@loopback/core';
-import {attribute, Digraph, ICluster, toDot, INode, IEdge} from 'ts-graphviz';
+import {attribute, Digraph, ICluster, IEdge, INode, toDot} from 'ts-graphviz';
 
 /**
  * A wrapper class for context, binding, and its level in the chain
@@ -167,7 +167,11 @@ export class ContextGraph {
     const tagPairs: string[] = [];
     if (tags) {
       for (const t in tags) {
-        tagPairs.push(`${t}:${tags[t]}`);
+        let tagVal = tags[t];
+        if (typeof tagVal === 'function') {
+          tagVal = (tagVal as Function).name;
+        }
+        tagPairs.push(`${t}:${tagVal}`);
       }
     }
     const tagLabel = tagPairs.length ? `|${tagPairs.join('\\l')}\\l` : '';


### PR DESCRIPTION
Without this fix, the `public` directory is not part of published npm package. And http://[::1]:3000/context-explorer/ reports 404 not found error.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
