### PR TITLE
chore: enable renovate automerge for patch/minor versions or devDependencies

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -5,57 +5,60 @@
     "group:recommended",
     "helpers:disableTypesNodeMajor"
   ],
-
   "ignorePaths": [
     "**/node_modules/**",
     "**/__tests__/**",
     "**/test/**"
   ],
-
   "automerge": false,
   "branchPrefix": "renovate/",
   "ignoreUnstable": true,
   "rangeStrategy": "bump",
   "statusCheckVerify": true,
   "updateNotScheduled": true,
-
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": "before 5am on monday"
   },
-
   "prConcurrentLimit": 5,
   "prCreation": "immediate",
   "prHourlyLimit": 2,
-
   "semanticCommits": true,
   "semanticCommitType": "chore",
   "semanticCommitScope": null,
-
   "separateMajorMinor": true,
   "separateMinorPatch": false,
-
-  "packageRules": [{
-    "packageNames": [
-      "@microsoft/api-extractor",
-      "@microsoft/api-documenter"
-    ],
-    "groupName": "api-extractor packages"
-  },
-  {
-    "packageNames": [
-      "@types/express",
-      "@types/express-serve-static-core"
-    ],
-    "groupName": "@types/express* packages"
-  }
+  "packageRules": [
+    {
+      "packageNames": [
+        "@microsoft/api-extractor",
+        "@microsoft/api-documenter"
+      ],
+      "groupName": "api-extractor packages"
+    },
+    {
+      "packageNames": [
+        "@types/express",
+        "@types/express-serve-static-core"
+      ],
+      "groupName": "@types/express* packages"
+    },
+    {
+      "updateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "automerge": true
+    }
   ],
-
   "travis": {
     "enabled": true,
-    "supportPolicy": ["lts", "current"]
+    "supportPolicy": [
+      "lts",
+      "current"
+    ]
   },
-
   "masterIssue": true,
   "masterIssueApproval": false,
   "masterIssueAutoclose": true


### PR DESCRIPTION
This PR configures Renovate Bot to automatically merge PRs if:

1. CI is green
2. It updates to a new patch/minor version or only for devDependencies

See https://docs.renovatebot.com/configuration-options/#automerge

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
