### PR TITLE
feat(cli): add exit option to mocharc template in generator

### DIFF
--- a/packages/cli/generators/project/templates/.mocharc.json
+++ b/packages/cli/generators/project/templates/.mocharc.json
@@ -1,4 +1,5 @@
 {
+  "exit": true,
   "recursive": true,
   "require": "source-map-support/register"
 }

--- a/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/app.integration.snapshots.js
@@ -7,6 +7,16 @@
 
 'use strict';
 
+exports[`app-generator specific files creates .mocharc.json 1`] = `
+{
+  "exit": true,
+  "recursive": true,
+  "require": "source-map-support/register"
+}
+
+`;
+
+
 exports[`app-generator specific files generates all the proper files 1`] = `
 # my-app
 

--- a/packages/cli/test/integration/generators/app.integration.js
+++ b/packages/cli/test/integration/generators/app.integration.js
@@ -93,6 +93,10 @@ describe('app-generator specific files', () => {
   it('creates .gitignore', () => {
     assert.fileContent('.gitignore', /^\*\.tsbuildinfo$/m);
   });
+
+  it('creates .mocharc.json', () => {
+    assertFilesToMatchSnapshot({}, '.mocharc.json');
+  });
 });
 
 describe('app-generator with docker disabled', () => {


### PR DESCRIPTION
Add exit option to mocharc.json template in generator cli.

Ref #2403 

Signed-off-by: Simon Mezzomo <simlt@users.noreply.github.com>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
