### PR TITLE
feat(cli): improve lb4 copyright to accept custom license-header.template

### DIFF
--- a/docs/site/Copyright-generator.md
+++ b/docs/site/Copyright-generator.md
@@ -70,6 +70,10 @@ The command prompts you for:
    =============================================================================
    ```
 
+   To avoid such prompt, create the `license-header.template` in the root
+   directory of your package, its content will be read as the license header
+   template without prompting.
+
 The default owner is `IBM Corp.` and license is `MIT` with the following
 `package.json`.
 

--- a/packages/cli/generators/copyright/header.js
+++ b/packages/cli/generators/copyright/header.js
@@ -47,11 +47,23 @@ function getCustomTemplate(customLicenseLines = []) {
 // Patterns for matching previously generated copyright headers
 const BLANK = /^\s*$/;
 
+/**
+ * Preserve characters that have special meaning for RegExp
+ * @param {string} text - Text
+ */
+function escapeRegExp(text) {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
 function getHeaderRegEx(customLicenseLines) {
-  const ANY = COPYRIGHT.concat(LICENSE, customLicenseLines).map(
-    l => new RegExp(l.replace(/<%[^>]+%>/g, '.*')),
+  const lines =
+    customLicenseLines != null && customLicenseLines.length
+      ? customLicenseLines
+      : COPYRIGHT.concat(LICENSE, customLicenseLines);
+  const regExp = lines.map(
+    l => new RegExp(escapeRegExp(l).replace(/<%[^>]+%>/g, '.*')),
   );
-  return ANY;
+  return regExp;
 }
 
 /**

--- a/packages/cli/generators/copyright/index.js
+++ b/packages/cli/generators/copyright/index.js
@@ -145,30 +145,38 @@ module.exports = class CopyrightGenerator extends BaseGenerator {
       license === 'custom' ||
       license === 'CUSTOM'
     ) {
-      this.log(
-        g.f(
-          'Please provide lines of text for the custom copyright/license headers.',
-        ),
-      );
-      const example = ` Copyright <%= owner %> <%= years %>. All Rights Reserved.
+      const templateFile = this.destinationPath('license-header.template');
+      if (this.fs.exists(templateFile)) {
+        const template = this.fs.read(templateFile);
+        customLicenseLines = template.match(/[^\r\n]+/g);
+        this.log(template);
+      } else {
+        this.log(
+          g.f(
+            'Please provide lines of text for the custom copyright/license headers.',
+          ),
+        );
+        const example = ` Copyright <%= owner %> <%= years %>. All Rights Reserved.
  Node module: <%= name %>',
  This file is licensed under the <%= license %>.
  License text available at <%= url %>`;
-      this.log(
-        chalk.green(
-          `Example (supported variables: owner/years/name):
+        this.log(
+          chalk.green(
+            `Example (supported variables: owner/years/name):
 ${example}`,
-        ),
-      );
+          ),
+        );
 
-      answers = await this.prompt([
-        {
-          type: 'editor',
-          name: 'customLicenseLines',
-          message: g.f('Custom license lines:'),
-          default: example,
-        },
-      ]);
+        answers = await this.prompt([
+          {
+            type: 'editor',
+            name: 'customLicenseLines',
+            message: g.f('Custom license lines:'),
+            default: example,
+            when: customLicenseLines.length === 0,
+          },
+        ]);
+      }
     }
 
     answers = answers || {};

--- a/packages/cli/test/fixtures/copyright/single-package/index.js
+++ b/packages/cli/test/fixtures/copyright/single-package/index.js
@@ -12,4 +12,16 @@ files.push({
   file: 'third-party.js',
   content: `module.exports = {}`,
 });
+
+files.push({
+  path: '',
+  file: 'license-header.template',
+  content: `=============================================================================
+Licensed Materials - Property of <%= owner %>
+(C) Copyright <%= owner %> <%= years %>
+US Government Users Restricted Rights - Use, duplication or disclosure
+restricted by GSA ADP Schedule Contract with <%= owner %>.
+=============================================================================`,
+});
+
 exports.SANDBOX_FILES = files;

--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -118,6 +118,32 @@ restricted by GSA ADP Schedule Contract with <%= owner %>.
     );
   });
 
+  it('updates custom copyright/license headers with template', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
+          excludePackageJSON: true,
+          additionalFiles: SANDBOX_FILES,
+        }),
+      )
+      .withOptions({
+        owner: 'ACME Inc.',
+        license: 'CUSTOM',
+        gitOnly: false,
+      });
+
+    assertHeader(
+      ['src/application.ts', 'lib/no-header.js'],
+      `=============================================================================`,
+      `Licensed Materials - Property of ACME Inc.`,
+      `(C) Copyright ACME Inc. ${year}`,
+      `US Government Users Restricted Rights - Use, duplication or disclosure`,
+      `restricted by GSA ADP Schedule Contract with ACME Inc..`,
+      `=============================================================================`,
+    );
+  });
+
   it('updates copyright/license headers with options.exclude', async () => {
     await testUtils
       .executeGenerator(generator)


### PR DESCRIPTION
This allows a `license-header.template` file from the project root directory
to be read as the custom licenese header lines.

It also fixes the header matching regex to avoid duplicate headers.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
