### PR TITLE
fix(cli): Change to lowercase the project name type by the user

### DIFF
--- a/docs/site/DEVELOPING.md
+++ b/docs/site/DEVELOPING.md
@@ -66,7 +66,7 @@ Contributor once your first commit is landed.
 ## Building the project
 
 Whenever you pull updates from GitHub or switch between feature branches, make
-sure to updated installed dependencies in all monorepo packages. The following
+sure to update installed dependencies in all monorepo packages. The following
 command will install npm dependencies for all packages and create symbolic links
 for intra-dependencies:
 
@@ -656,7 +656,7 @@ questions:
 
 - How can I find if my project is affected by this change?
 
-- What does this change means for my project? What is going to change?
+- What does this change mean for my project? What is going to change?
 
 - How can I migrate my project to the new major version? What steps do I need to
   make?
@@ -874,9 +874,9 @@ configuration, it's important to verify that all usage scenarios keep working.
 
 1.  Open any existing TypeScript file, e.g. `packages/src/index.ts`
 
-2.  Introduce two kinds linting problems - one that does and another that does
-    not require type information to be detected. For example, you can add the
-    following line at the end of the opened `index.ts`:
+2.  Introduce two kinds of linting problems - one that does and another that
+    does not require type information to be detected. For example, you can add
+    the following line at the end of the opened `index.ts`:
 
     ```ts
     const foo: any = 'bar';

--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -141,6 +141,8 @@ module.exports = class ProjectGenerator extends BaseGenerator {
         when: this.projectInfo.name == null,
         default:
           this.options.name || utils.toFileName(path.basename(process.cwd())),
+        filter: value => value.toLowerCase(),
+        transformer: value => value.toLowerCase(),
         validate: utils.validate,
       },
       {


### PR DESCRIPTION
For the project generator, when the user uses a project name with uppercase letters, the project can not be created because NPM packages have validation to no allow create packages with uppercase letters.
The prompt was updated to add a function to transform the values typed by the user to the lowercase version and use this value as the project name.

Fixes #1663
https://github.com/strongloop/loopback-next/issues/1663

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [X] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated
