### PR TITLE
fix(cli): change to lowercase the project name type by the user

### DIFF
--- a/packages/cli/lib/project-generator.js
+++ b/packages/cli/lib/project-generator.js
@@ -141,6 +141,8 @@ module.exports = class ProjectGenerator extends BaseGenerator {
         when: this.projectInfo.name == null,
         default:
           this.options.name || utils.toFileName(path.basename(process.cwd())),
+        filter: utils.lowerCase,
+        transformer: utils.lowerCase,
         validate: utils.validate,
       },
       {

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -17,7 +17,7 @@ const semver = require('semver');
 const regenerate = require('regenerate');
 const _ = require('lodash');
 const pascalCase = require('change-case').pascalCase;
-const lowerCase = require('change-case').lowerCase;
+const lowerCase = require('lower-case').lowerCase;
 const promisify = require('util').promisify;
 const toVarName = require('change-case').camelCase;
 const pluralize = require('pluralize');
@@ -266,6 +266,10 @@ exports.validate = function (name) {
   const isValid = validate(name).validForNewPackages;
   if (!isValid) return 'Invalid npm package name: ' + name;
   return isValid;
+};
+
+exports.gggggg = function (name) {
+  return lowerCase(name);
 };
 
 /**

--- a/packages/cli/lib/utils.js
+++ b/packages/cli/lib/utils.js
@@ -268,10 +268,6 @@ exports.validate = function (name) {
   return isValid;
 };
 
-exports.gggggg = function (name) {
-  return lowerCase(name);
-};
-
 /**
  * Adds a backslash to the start of the word if not already present
  * @param {string} httpPath


### PR DESCRIPTION
for the project generator, when the user uses a project name with uppercase letters, the project can not be created because npm packages have validation to no allow create packages with uppercase letters

The prompt was updated to add a function to transform the values typed by the user to the lowercase version and use this value as the project name

Fixes #1663
https://github.com/strongloop/loopback-next/issues/1663

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [X] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [X] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

Signed-off-by: javier santos <javier.david.santos@gmail.com>
