### PR TITLE
fix: allow array query parameter for a single value

### DIFF
--- a/packages/rest/src/__tests__/acceptance/coercion/coercion.acceptance.ts
+++ b/packages/rest/src/__tests__/acceptance/coercion/coercion.acceptance.ts
@@ -144,6 +144,14 @@ describe('Coercion', () => {
     ) {
       return filter;
     }
+
+    @get('/array-parameters-from-query')
+    getArrayFromQuery(
+      @param.array('stringArray', 'query', {type: 'string'})
+      stringArray: string[],
+    ) {
+      return stringArray;
+    }
   }
 
   it('coerces parameter in path from string to number', async () => {
@@ -281,6 +289,30 @@ describe('Coercion', () => {
     expect(response.body.error.message).to.match(
       /Invalid data.* for parameter "filter"/,
     );
+  });
+
+  describe('coerces array parameters', () => {
+    it('coerces a single value into an array with one item', async () => {
+      const response = await client
+        .get('/array-parameters-from-query')
+        .query({
+          stringArray: 'hello',
+        })
+        .expect(200);
+
+      expect(response.body).to.eql(['hello']);
+    });
+
+    it('preserves array values as arrays', async () => {
+      const response = await client
+        .get('/array-parameters-from-query')
+        .query({
+          stringArray: ['hello', 'loopback', 'world'],
+        })
+        .expect(200);
+
+      expect(response.body).to.eql(['hello', 'loopback', 'world']);
+    });
   });
 
   async function givenAClient() {

--- a/packages/rest/src/coercion/coerce-parameter.ts
+++ b/packages/rest/src/coercion/coerce-parameter.ts
@@ -95,6 +95,9 @@ export async function coerceParameter(
     case 'password':
       result = coerceString(data, spec);
       break;
+    case 'array':
+      result = coerceArray(data, spec);
+      break;
   }
 
   if (result != null) {
@@ -103,6 +106,7 @@ export async function coerceParameter(
       await validateParam(spec, data, options);
       return result;
     }
+
     result = await validateParam(spec, result, options);
   }
   return result;
@@ -195,6 +199,15 @@ async function coerceObject(input: string | object, spec: ParameterObject) {
 
   if (typeof data !== 'object' || Array.isArray(data))
     throw RestHttpErrors.invalidData(input, spec.name);
+
+  return data;
+}
+
+function coerceArray(data: string | object, spec: ParameterObject) {
+  if (spec.in === 'query') {
+    if (data == null || Array.isArray(data)) return data;
+    return [data];
+  }
 
   return data;
 }


### PR DESCRIPTION
PR fixes an issue where by passing only a single query parameter throws an error with code `INVALID_PARAMETER_VALUE` and message `should be array`

Fixes: #6514

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
