### PR TITLE
Reword the message printed by REST LogError action

### DIFF
--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -178,17 +178,17 @@ describe('RestServer (integration)', () => {
       console.error = consoleError;
     });
 
-    it('responds with 500 when Sequence fails with unhandled error', async () => {
+    it('responds with 500 when Sequence returns a rejected promise', async () => {
       server.handler((context, sequence) => {
         return Promise.reject(new Error('unhandled test error'));
       });
       await createClientForHandler(server.requestHandler).get('/').expect(500);
       expect(errorMsg).to.match(
-        /Unhandled error in GET \/\: 500 Error\: unhandled test error/,
+        /Request GET \/\ failed with status code 500. Error\: unhandled test error/,
       );
     });
 
-    it('hangs up socket when Sequence fails with unhandled error and headers sent', async () => {
+    it('hangs up socket when Sequence returns a rejected promise but headers were already sent', async () => {
       server.handler((context, sequence) => {
         context.response.writeHead(200);
         return Promise.reject(new Error('unhandled test error after sent'));
@@ -198,7 +198,7 @@ describe('RestServer (integration)', () => {
         createClientForHandler(server.requestHandler).get('/'),
       ).to.be.rejectedWith(/socket hang up/);
       expect(errorMsg).to.match(
-        /Unhandled error in GET \/\: 500 Error\: unhandled test error after sent/,
+        /Request GET \/\ failed with status code 500. Error\: unhandled test error/,
       );
     });
   });

--- a/packages/rest/src/providers/log-error.provider.ts
+++ b/packages/rest/src/providers/log-error.provider.ts
@@ -18,7 +18,7 @@ export class LogErrorProvider implements Provider<LogError> {
     }
 
     console.error(
-      'Unhandled error in %s %s: %s %s',
+      'Request %s %s failed with status code %s. %s',
       req.method,
       req.url,
       statusCode,


### PR DESCRIPTION
Change the message from "unhandled error" to "request failed".

The original message was often creating confusion for our users. It seemed like the error was not handled at all, when in fact it was caught by the configured error handler and converted into a proper HTTP error response.

See the discussion in https://github.com/strongloop/strong-error-handler/issues/54 and also https://github.com/strongloop/strong-error-handler/pull/91.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
