### PR TITLE
feat(openapi-v3): make `mergeOpenAPISpec` retval strongly typed

### DIFF
--- a/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
+++ b/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
@@ -117,11 +117,12 @@ export class OASEnhancerService {
  *
  * @param currentSpec The original spec
  * @param patchSpec The patch spec to be merged into the original spec
+ * @returns A new specification object created by merging the original ones.
  */
-export function mergeOpenAPISpec(
-  currentSpec: Partial<OpenApiSpec>,
-  patchSpec: Partial<OpenApiSpec>,
-) {
+export function mergeOpenAPISpec<
+  C extends Partial<OpenApiSpec>,
+  P extends Partial<OpenApiSpec>
+>(currentSpec: C, patchSpec: P): C & P {
   const mergedSpec = jsonmergepatch.merge(currentSpec, patchSpec);
   return mergedSpec;
 }


### PR DESCRIPTION
Before this change, `mergeOpenAPISpec` was using auto-inferred return type which was unfortunately `any`.

In this change, I am leveraging generics to get the following behavior:
- If both parameters are partial specs, then the result is a partial  spec too.
- If at least one of the parameters is a full spec, then the result  is a full spec too.

/cc @fennixx

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
