### PR TITLE
docs: updating links for jwt-authentication documentation

### DIFF
--- a/docs/site/migration/auth/authentication.md
+++ b/docs/site/migration/auth/authentication.md
@@ -260,18 +260,19 @@ the extracted services and bindings instead of unfolding all the implementation
 details. You can find a very detailed steps of creating it in
 [this tutorial](https://loopback.io/doc/en/lb4/Authentication-tutorial.html).
 
-The component consists of the following files:
+The component consists of the following files located within the
+[jwt-authentication component directory](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication):
 
 - creating the jwt authentication strategy to decode the user profile from
   token. See file
-  [jwt.auth.strategy.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/jwt.auth.strategy.ts).
+  [jwt.auth.strategy.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/services/jwt.auth.strategy.ts).
 - creating the token service to organize utils for token operations. See file
-  [jwt.service.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/jwt.service.ts).
+  [jwt.service.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/services/jwt.service.ts).
 - creating user service to organize utils for user operations. See file
-  [user.service.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/user.service.ts).
+  [user.service.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/services/user.service.ts).
 - adding OpenAPI security specification to your app so that the explorer has an
   Authorize button to setup the token for secured endpoints. See file
-  [security.spec.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/security.spec.ts).
+  [security.spec.ts](https://github.com/strongloop/loopback-next/tree/master/examples/access-control-migration/src/components/jwt-authentication/services/security.spec.ts).
 - creating bindings for the above services. See file
   [keys.ts](https://github.com/strongloop/loopback-next/blob/master/examples/access-control-migration/src/components/jwt-authentication/keys.ts).
 


### PR DESCRIPTION
Signed-off-by: Hector Leiva <hector@hectorleiva.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

There were some links in the migration documentation from Loopback 3 to Loopback 4 that were pointing to files that had moved. This PR is intended to point to the files where they currently reside now to avoid 404's for future users.

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [X] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
