### PR TITLE
Fixes typo in "sequence"

### DIFF
--- a/docs/site/Validation-REST-layer.md
+++ b/docs/site/Validation-REST-layer.md
@@ -180,7 +180,7 @@ of 10 digits separated by `-` after the 3rd and 6th digits.
 
 Since the error is being caught at the REST layer, the simplest way to customize
 the errors is to customize the
-[sequnce](https://loopback.io/doc/en/lb4/Sequence.html). It exists in all
+[sequence](https://loopback.io/doc/en/lb4/Sequence.html). It exists in all
 LoopBack applications scaffolded by using the `lb4` command and can be found in
 `src/sequence.ts`.
 


### PR DESCRIPTION
There is a typo in the word "sequence", it was written as "sequnce" at line 183.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [X] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
