### PR TITLE
feat(cli): add vscode launch tasks in app

### DIFF
--- a/docs/site/Troubleshooting.md
+++ b/docs/site/Troubleshooting.md
@@ -100,6 +100,20 @@ To fix it, run `npm run clean` to delete all the compiled files. By doing so, it
 forces the build to generate the compiled JS files next time when you start the
 application using `npm start` or call `npm run build`.
 
+## Debugging with VS Code
+
+Each LoopBack application has a VS Code configuration file `.vscode/launch.json`
+that contains several tasks to help you debug with breakpoints:
+
+- Launch Program: Running the application.
+- Run Mocha tests: Running the tests under `src/__tests__`.
+- Attach to Progress: Attaching application to an already running program in
+  debug mode.
+
+To bring up the run view, select the "Run" icon in the activity bar on the side
+of VS Code. You can choose the right task besides the green triangle "Run"
+button.
+
 ## Submitting Sample Application for Problem Determination
 
 If you couldn't figure out what is going wrong or would like to report an issue,

--- a/packages/cli/generators/project/templates/.vscode/launch.json
+++ b/packages/cli/generators/project/templates/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/dist/index.js",
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run Mocha tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "runtimeArgs": [
+        "-r",
+        "${workspaceRoot}/node_modules/source-map-support/register"
+      ],
+      "cwd": "${workspaceRoot}",
+      "autoAttachChildProcesses": true,
+      "args": [
+        "--config",
+        "${workspaceRoot}/.mocharc.json",
+        "${workspaceRoot}/dist/__tests__/**/*.js",
+        "-t",
+        "0"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Process",
+      "port": 5858
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

connect to https://github.com/strongloop/loopback-next/issues/6463

Added "debug mocha test", "debug mocha test in current file", "debug app" in this PR.
For debugging current test, the mocha-current-file is needed. I am thinking, should we move it to `@loopback/build` to avoid duplicate?

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
