### PR TITLE
docs: fix 'handling errors' link in the docs

### DIFF
--- a/docs/site/REST-action-sequence.md
+++ b/docs/site/REST-action-sequence.md
@@ -588,5 +588,4 @@ In LoopBack, we use async functions instead of callbacks and thus can use simple
 sequence actions. A typical Sequence implementation then passes these errors to
 the Sequence action `reject`.
 
-You can learn more about error handling in
-[Handling errors](Sequence.md#handling-errors).
+You can learn more about error handling in [Handling errors](#handling-errors).

--- a/docs/site/REST-middleware-sequence.md
+++ b/docs/site/REST-middleware-sequence.md
@@ -977,8 +977,7 @@ In LoopBack, we use async functions instead of callbacks and thus can use simple
 sequence actions. A typical Sequence implementation then passes these errors to
 the Sequence action `reject`.
 
-You can learn more about error handling in
-[Handling errors](Sequence.md#handling-errors).
+You can learn more about error handling in [Handling errors](#handling-errors).
 
 ```
 

--- a/docs/site/Using-strong-error-handler.md
+++ b/docs/site/Using-strong-error-handler.md
@@ -17,8 +17,9 @@ In LoopBack 4, the request handling process starts with the app's
 [sequence](https://loopback.io/doc/en/lb4/Sequence.html), a simple class with
 five injected helper methods in the constructor. It is the gatekeeper of all
 requests to the app. Errors are handled by one of the Sequence actions,
-[`reject`](Sequence.md#handling-errors), which calls `strong-error-handler`
-package to send back an HTTP response describing the error.
+[`reject`](REST-middleware-sequence.md#handling-errors), which calls
+`strong-error-handler` package to send back an HTTP response describing the
+error.
 
 LoopBack 4 apps require 3.x versions of `strong-error-handler`.
 
@@ -35,8 +36,11 @@ details of any error objects to the client in the HTTP responses. Once the
 app.bind(RestBindings.ERROR_WRITER_OPTIONS).to({debug: true});
 ```
 
-Please check [Sequence - Handling errors](Sequence.md#handling-errors) section
-for usages and examples of these two modes.
+Please check the
+[Action based Sequence for REST Server - Handling errors](REST-action-sequence.md#handling-errors)
+and
+[Middleware-based Sequence for REST Server - Handling errors](REST-middleware-sequence.md#handling-errors)
+sections for usages and examples of these two modes.
 
 In general, `reject` is executed in `try {} catch(err) {}` block.
 `strong-error-handler` is the last utility to be used.


### PR DESCRIPTION
Fix 'Handling Errors' link in a few places
in the documentation.

Related to: https://github.com/strongloop/loopback-next/issues/6627 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
