### PR TITLE
fix(docs): fix debug string typo

### DIFF
--- a/docs/site/Setting-debug-strings.md
+++ b/docs/site/Setting-debug-strings.md
@@ -158,7 +158,7 @@ of the `@loopback/cli` module.
     <tr>
       <td></td>
       <td>src/binding.ts</td>
-      <td>loopback:context:bindging</td>
+      <td>loopback:context:binding</td>
     </tr>
     <tr>
       <td></td>


### PR DESCRIPTION
Fix typo in debug strings

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
