### PR TITLE
fix(example-todo-jwt): fix response in whoAmI endpoint

### DIFF
--- a/examples/todo-jwt/src/controllers/user.controller.ts
+++ b/examples/todo-jwt/src/controllers/user.controller.ts
@@ -104,9 +104,13 @@ export class UserController {
   @get('/whoAmI', {
     responses: {
       '200': {
-        description: '',
-        schema: {
-          type: 'string',
+        description: 'Return current user',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'string',
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

The OpenAPI spec created by the `todo-jwt` example is not valid because of the response object in the `/whoAmI` endpoint in `user.controller.ts`. 


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
