### PR TITLE
fix(metrics): only add required artifacts to application

### DIFF
--- a/extensions/metrics/src/__tests__/acceptance/metrics-push.acceptance.ts
+++ b/extensions/metrics/src/__tests__/acceptance/metrics-push.acceptance.ts
@@ -3,11 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {CoreBindings} from '@loopback/core';
 import {RestApplication, RestServerConfig} from '@loopback/rest';
-import {givenHttpServerConfig, supertest} from '@loopback/testlab';
+import {expect, givenHttpServerConfig, supertest} from '@loopback/testlab';
 import {AddressInfo} from 'net';
 import {promisify} from 'util';
 import {MetricsBindings, MetricsComponent, MetricsOptions} from '../..';
+import {MetricsPushObserver} from '../../observers';
 import {PushGateway} from './mock-pushgateway';
 
 const gateway = new PushGateway();
@@ -44,6 +46,14 @@ describe('Metrics (with push gateway)', function () {
     const request = supertest(gwUrl);
     // Now we expect to get LoopBack metrics from the push gateway
     await request.get('/metrics').expect(200, /job="loopback"/);
+  });
+
+  it('adds MetricsPushObserver to the application', () => {
+    expect(
+      app.isBound(
+        `${CoreBindings.LIFE_CYCLE_OBSERVERS}.${MetricsPushObserver.name}`,
+      ),
+    ).to.be.true();
   });
 
   async function givenAppWithCustomConfig(config: MetricsOptions) {

--- a/extensions/metrics/src/metrics.component.ts
+++ b/extensions/metrics/src/metrics.component.ts
@@ -17,7 +17,7 @@ import {metricsControllerFactory} from './controllers';
 import {MetricsInterceptor} from './interceptors';
 import {MetricsBindings} from './keys';
 import {MetricsObserver, MetricsPushObserver} from './observers';
-import {DEFAULT_METRICS_OPTIONS, MetricsOptions} from './types';
+import {DEFAULT_METRICS_OPTIONS, MetricsConfig, MetricsOptions} from './types';
 
 /**
  * A component providing metrics for Prometheus
@@ -28,16 +28,20 @@ export class MetricsComponent implements Component {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     private application: Application,
     @config()
-    options: MetricsOptions = DEFAULT_METRICS_OPTIONS,
+    metricsConfig: MetricsConfig = {},
   ) {
-    if (!options.defaultMetrics || !options.defaultMetrics?.disabled) {
+    const options: MetricsOptions = {
+      ...DEFAULT_METRICS_OPTIONS,
+      ...metricsConfig,
+    };
+    if (options.defaultMetrics && !options.defaultMetrics.disabled) {
       this.application.lifeCycleObserver(MetricsObserver);
     }
-    if (!options.pushGateway || !options.pushGateway?.disabled) {
+    if (options.pushGateway && !options.pushGateway.disabled) {
       this.application.lifeCycleObserver(MetricsPushObserver);
     }
     this.application.add(createBindingFromClass(MetricsInterceptor));
-    if (!options.endpoint || !options.endpoint?.disabled) {
+    if (options.endpoint && !options.endpoint.disabled) {
       this.application.controller(metricsControllerFactory(options));
     }
   }

--- a/extensions/metrics/src/types.ts
+++ b/extensions/metrics/src/types.ts
@@ -5,6 +5,9 @@
 
 import {DefaultMetricsCollectorConfiguration} from 'prom-client';
 
+/**
+ * Options for metrics component
+ */
 export interface MetricsOptions {
   endpoint?: {
     disabled?: boolean;
@@ -23,6 +26,11 @@ export interface MetricsOptions {
 
   openApiSpec?: boolean;
 }
+
+/**
+ * Configuration for metrics component with optional properties
+ */
+export type MetricsConfig = Partial<MetricsOptions>;
 
 export const DEFAULT_METRICS_OPTIONS: MetricsOptions = {
   endpoint: {


### PR DESCRIPTION
This PR resolves three issues of the component:

1. The component adds `MetricsPushObserver` even if it is not configured
2. Providing custom config was overwriting whole default config instead of merging

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
