### PR TITLE
feat(health): add option to enable/disable openapi spec

### DIFF
--- a/extensions/health/README.md
+++ b/extensions/health/README.md
@@ -56,6 +56,16 @@ http://localhost:3000/health returns health in JSON format, such as:
 }
 ```
 
+It also has to be noted, that by default the OpenAPI spec is disabled and
+therefore the endpoints will not be visible in the API explorer. The spec can be
+enabled by setting `openApiSpec` to `true`.
+
+```ts
+this.configure(HealthBindings.COMPONENT).to({
+  openApiSpec: true,
+});
+```
+
 ## Add custom `live` and `ready` checks
 
 The health component allows extra

--- a/extensions/health/src/health.component.ts
+++ b/extensions/health/src/health.component.ts
@@ -28,7 +28,7 @@ export class HealthComponent implements Component {
     @inject(CoreBindings.APPLICATION_INSTANCE)
     private application: Application,
     @config()
-    healthConfig: HealthConfig = DEFAULT_HEALTH_OPTIONS,
+    healthConfig: HealthConfig = {},
   ) {
     // Bind the HealthCheck service
     this.application

--- a/extensions/health/src/types.ts
+++ b/extensions/health/src/types.ts
@@ -11,6 +11,7 @@ export type HealthOptions = {
   healthPath: string;
   readyPath: string;
   livePath: string;
+  openApiSpec?: boolean;
 };
 
 /**
@@ -22,6 +23,7 @@ export const DEFAULT_HEALTH_OPTIONS: HealthOptions = {
   healthPath: '/health',
   readyPath: '/ready',
   livePath: '/live',
+  openApiSpec: false,
 };
 
 /**


### PR DESCRIPTION
Adds the option to enable the openapi spec which allows to show the endpoints in the API explorer.  By default it will be disabled.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
