### PR TITLE
feat(metrics): add option to enable/disable openapi spec

### DIFF
--- a/extensions/metrics/README.md
+++ b/extensions/metrics/README.md
@@ -47,6 +47,16 @@ this.configure(MetricsBindings.COMPONENT).to({
 });
 ```
 
+It also has to be noted, that by default the OpenAPI spec is disabled and
+therefore the metrics endpoint will not be visible in the API explorer. The spec
+can be enabled by setting `openApiSpec` to `true`.
+
+```ts
+this.configure(MetricsBindings.COMPONENT).to({
+  openApiSpec: true,
+});
+```
+
 ## Metrics Collected
 
 There are three types of metrics being collected by this component:

--- a/extensions/metrics/src/controllers/metrics.controller.ts
+++ b/extensions/metrics/src/controllers/metrics.controller.ts
@@ -4,18 +4,59 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {BindingScope, Constructor, inject, injectable} from '@loopback/core';
-import {get, Response, RestBindings} from '@loopback/rest';
+import {
+  get,
+  OperationObject,
+  Response,
+  ResponseObject,
+  RestBindings,
+} from '@loopback/rest';
 import {register} from 'prom-client';
+import {DEFAULT_METRICS_OPTIONS, MetricsOptions} from '../types';
+
+/**
+ * OpenAPI definition of metrics response
+ */
+const metricsResponse: ResponseObject = {
+  description: 'Metrics Response',
+  content: {
+    'text/plain': {
+      schema: {
+        type: 'string',
+      },
+    },
+  },
+};
+
+/**
+ * OpenAPI spec for metrics endpoint
+ */
+const metricsSpec: OperationObject = {
+  responses: {
+    '200': metricsResponse,
+  },
+};
+
+/**
+ * OpenAPI spec to hide endpoints
+ */
+const hiddenSpec: OperationObject = {
+  responses: {},
+  'x-visibility': 'undocumented',
+};
 
 export function metricsControllerFactory(
-  basePath = '/metrics',
+  options: MetricsOptions = DEFAULT_METRICS_OPTIONS,
 ): Constructor<unknown> {
+  const basePath = options.endpoint?.basePath ?? '/metrics';
+  const spec = options.openApiSpec ? metricsSpec : hiddenSpec;
+
+  /**
+   * Controller for metrics endpoint
+   */
   @injectable({scope: BindingScope.SINGLETON})
   class MetricsController {
-    @get(basePath, {
-      responses: {},
-      'x-visibility': 'undocumented',
-    })
+    @get(basePath, spec)
     report(@inject(RestBindings.Http.RESPONSE) res: Response) {
       // Set the content type from the register
       res.contentType(register.contentType);

--- a/extensions/metrics/src/metrics.component.ts
+++ b/extensions/metrics/src/metrics.component.ts
@@ -38,9 +38,7 @@ export class MetricsComponent implements Component {
     }
     this.application.add(createBindingFromClass(MetricsInterceptor));
     if (!options.endpoint || !options.endpoint?.disabled) {
-      this.application.controller(
-        metricsControllerFactory(options.endpoint?.basePath),
-      );
+      this.application.controller(metricsControllerFactory(options));
     }
   }
 }

--- a/extensions/metrics/src/types.ts
+++ b/extensions/metrics/src/types.ts
@@ -20,6 +20,8 @@ export interface MetricsOptions {
     url: string;
     interval?: number;
   };
+
+  openApiSpec?: boolean;
 }
 
 export const DEFAULT_METRICS_OPTIONS: MetricsOptions = {
@@ -27,4 +29,5 @@ export const DEFAULT_METRICS_OPTIONS: MetricsOptions = {
     basePath: '/metrics',
   },
   defaultMetrics: {},
+  openApiSpec: false,
 };


### PR DESCRIPTION
Adds the option to enable the openapi spec which allows to show the metrics endpoint in the API explorer. By default it will be disabled.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
