### PR TITLE
feat: make modifySpec async

### DIFF
--- a/docs/site/Extending-OpenAPI-specification.md
+++ b/docs/site/Extending-OpenAPI-specification.md
@@ -47,6 +47,7 @@ export class InfoSpecEnhancer implements OASEnhancer {
   name = 'info';
 
   // takes in the current spec, modifies it, and returns a new one
+  // NOTE: use async function if it contains async operation to the spec
   modifySpec(spec: OpenApiSpec): OpenApiSpec {
     const InfoPatchSpec = {
       info: {title: 'LoopBack Test Application', version: '1.0.1'},
@@ -66,6 +67,15 @@ export class InfoSpecEnhancer implements OASEnhancer {
   `modifySpec`.
 - It calls [`mergeOpenAPISpec`](#default-merge-function) to merge the
   specification fragment into the current spec.
+
+If you need to asynchronously update the spec, you should define the
+`modifySpec` function use keyword `async` and return a `Promise` as following:
+
+```ts
+async modifySpec(spec: OpenApiSpec): Promise<OpenApiSpec> {
+  return modifySpecAsync(spec);
+}
+```
 
 ### Default Merge Function
 

--- a/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
+++ b/packages/openapi-v3/src/enhancers/spec-enhancer.service.ts
@@ -88,7 +88,7 @@ export class OASEnhancerService {
    */
   async applyEnhancerByName(name: string): Promise<OpenApiSpec> {
     const enhancer = await this.getEnhancerByName(name);
-    if (enhancer) this._spec = enhancer.modifySpec(this._spec);
+    if (enhancer) this._spec = await enhancer.modifySpec(this._spec);
     return this._spec;
   }
 
@@ -100,7 +100,7 @@ export class OASEnhancerService {
     const enhancers = await this.getEnhancers();
     if (_.isEmpty(enhancers)) return this._spec;
     for (const e of enhancers) {
-      this._spec = e.modifySpec(this._spec);
+      this._spec = await e.modifySpec(this._spec);
     }
     debug(`Spec enhancer service, generated spec: ${inspect(this._spec)}`);
     return this._spec;

--- a/packages/openapi-v3/src/enhancers/types.ts
+++ b/packages/openapi-v3/src/enhancers/types.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {BindingTemplate, extensionFor} from '@loopback/core';
+import {BindingTemplate, extensionFor, ValueOrPromise} from '@loopback/core';
 import {OpenApiSpec} from '../types';
 import {OASEnhancerBindings} from './keys';
 
@@ -13,7 +13,7 @@ import {OASEnhancerBindings} from './keys';
  */
 export interface OASEnhancer {
   name: string;
-  modifySpec(spec: OpenApiSpec): OpenApiSpec;
+  modifySpec(spec: OpenApiSpec): ValueOrPromise<OpenApiSpec>;
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

Change `modifySpec` to be an async function to allow async spec updates.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
