### PR TITLE
fix(cli): print a warning for Node.js versions that are not supported

### DIFF
--- a/packages/cli/bin/cli-main.js
+++ b/packages/cli/bin/cli-main.js
@@ -10,6 +10,7 @@ const pkg = require('../package.json');
 const semver = require('semver');
 const fs = require('fs-extra');
 const path = require('path');
+const chalk = require('chalk');
 
 const {
   tabCompletionCommands,
@@ -23,9 +24,9 @@ const nodeVer = process.versions.node;
 const requiredVer = pkg.engines.node;
 const ok = semver.satisfies(nodeVer, requiredVer);
 if (!ok) {
-  const format = 'Node.js %s is not supported. Please use a version %s.';
-  console.error(format, nodeVer, requiredVer);
-  process.exit(1);
+  const format =
+    'Node.js "%s" is not supported. Please use a version that satisfies "%s".';
+  console.warn(chalk.red(format), nodeVer, requiredVer);
 }
 
 // Intentionally have a separate `main.js` which can use JS features


### PR DESCRIPTION
Currently `lb4` exits if the Node.js version does not satisfy the range.
This PR relaxes it to be a warning so that developers can still use it
with new releases such as 15.x.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
