### PR TITLE
feat(context): add binding.toInjectable shortcut

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -179,6 +179,41 @@ binding.toProvider(MyValueProvider);
 The provider class serves as the wrapper to declare dependency injections. If
 dependency is not needed, `toDynamicValue` can be used instead.
 
+#### An injectable class
+
+An injectable class is one of the following types of classes optionally
+decorated with `@injectable`.
+
+- A class
+- A provider class
+- A dynamic value factory class
+
+The `toInjectable()` method is a shortcut to bind such classes using
+`toClass/toProvider/toDynamicValue` respectively by introspecting the class,
+including the binding metadata added by `@injectable`.
+
+```ts
+@injectable({scope: BindingScope.SINGLETON})
+class MyController {
+  constructor(@inject('my-options') private options: MyOptions) {
+    // ...
+  }
+}
+
+binding.toInjectable(MyController);
+```
+
+The code above is similar as follows:
+
+```ts
+const binding = createBindingFromClass(MyController);
+```
+
+{% include note.html content="
+If `binding.toClass(MyController)` is used, the binding scope set by
+`@injectable` is NOT honored.
+" %}
+
 #### An alias
 
 An alias is the key with optional path to resolve the value from another

--- a/packages/context/src/binding-inspector.ts
+++ b/packages/context/src/binding-inspector.ts
@@ -170,6 +170,7 @@ export function removeNameAndKeyTags(binding: Binding<unknown>) {
  */
 export function bindingTemplateFor<T>(
   cls: Constructor<T | Provider<T>> | DynamicValueProviderClass<T>,
+  options?: BindingFromClassOptions,
 ): BindingTemplate<T> {
   const spec = getBindingMetadata(cls);
   debug('class %s has binding metadata', cls.name, spec);
@@ -181,6 +182,9 @@ export function bindingTemplateFor<T>(
     if (spec?.target !== cls) {
       // Remove name/key tags inherited from base classes
       binding.apply(removeNameAndKeyTags);
+    }
+    if (options != null) {
+      applyClassBindingOptions(binding, options);
     }
   };
 }
@@ -260,10 +264,9 @@ export function createBindingFromClass<T>(
 ): Binding<T> {
   debug('create binding from class %s with options', cls.name, options);
   try {
-    const templateFn = bindingTemplateFor(cls);
+    const templateFn = bindingTemplateFor(cls, options);
     const key = buildBindingKey(cls, options);
     const binding = Binding.bind<T>(key).apply(templateFn);
-    applyClassBindingOptions(binding, options);
     return binding;
   } catch (err) {
     err.message += ` (while building binding for class ${cls.name})`;

--- a/packages/context/src/binding.ts
+++ b/packages/context/src/binding.ts
@@ -5,6 +5,7 @@
 
 import debugFactory from 'debug';
 import {EventEmitter} from 'events';
+import {bindingTemplateFor} from './binding-inspector';
 import {BindingAddress, BindingKey} from './binding-key';
 import {Context} from './context';
 import {inspectInjections} from './inject';
@@ -840,6 +841,36 @@ export class Binding<T = BoundValue> extends EventEmitter {
         options.session,
       );
     });
+    return this;
+  }
+
+  /**
+   * Bind to a class optionally decorated with `@injectable`. Based on the
+   * introspection of the class, it calls `toClass/toProvider/toDynamicValue`
+   * internally. The current binding key will be preserved (not being overridden
+   * by the key inferred from the class or options).
+   *
+   * This is similar to {@link createBindingFromClass} but applies to an
+   * existing binding.
+   *
+   * @example
+   *
+   * ```ts
+   * @injectable({scope: BindingScope.SINGLETON, tags: {service: 'MyService}})
+   * class MyService {
+   *   // ...
+   * }
+   *
+   * const ctx = new Context();
+   * ctx.bind('services.MyService').toInjectable(MyService);
+   * ```
+   *
+   * @param ctor - A class decorated with `@injectable`.
+   */
+  toInjectable(
+    ctor: DynamicValueProviderClass<T> | Constructor<T | Provider<T>>,
+  ) {
+    this.apply(bindingTemplateFor(ctor));
     return this;
   }
 


### PR DESCRIPTION
Some developers forget to use `createBindingFromClass` and use `toClass`
or `toProvider` directly. In such cases, the metadata from `@injectable`
are not honored. This shortcut method makes it easy to bind all types of
injectable classes.

```ts
@injectable({scope: BindingScope.SINGLETON, tags: {x: 1}})
      class MyInjectableService {
        constructor(@inject('msg') private _msg: string) {}

        getMessage(): string {
          return 'hello ' + this._msg;
        }
      }
      const serviceBinding = ctx
        .bind('myService')
        .toInjectable(MyInjectableService);
```

Please note that `ctx.bind('myService').toClass(MyInjectableService)` does NOT honor `@injectable`.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
