### PR TITLE
feat(rest): further sanitize json parsing by rejecting prohibited keys

### DIFF
--- a/examples/todo/src/__tests__/acceptance/test-helper.ts
+++ b/examples/todo/src/__tests__/acceptance/test-helper.ts
@@ -8,7 +8,7 @@ import {
   createRestAppClient,
   givenHttpServerConfig,
 } from '@loopback/testlab';
-import {TodoListApplication} from '../../application';
+import {TodoListApplication} from '../..';
 
 export async function setupApplication(): Promise<AppWithClient> {
   const app = new TodoListApplication({

--- a/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo/src/__tests__/acceptance/todo.acceptance.ts
@@ -4,7 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {EntityNotFoundError} from '@loopback/repository';
-import {Request, Response} from '@loopback/rest';
+import {Request, Response, RestBindings} from '@loopback/rest';
 import {
   Client,
   createRestAppClient,
@@ -179,6 +179,61 @@ describe('TodoApplication', () => {
     it('returns 404 when deleting a todo that does not exist', async () => {
       await client.del(`/todos/99999`).expect(404);
     });
+
+    it('rejects request with invalid keys - constructor.prototype', async () => {
+      const res = await client
+        .get(
+          '/todos?filter={"offset":0,"limit":100,"skip":0,' +
+            '"where":{"constructor.prototype":{"toString":"def"}},' +
+            '"fields":{"title":true,"id":true}}',
+        )
+        .expect(400);
+      expect(res.body?.error).to.containEql({
+        statusCode: 400,
+        name: 'BadRequestError',
+        code: 'INVALID_PARAMETER_VALUE',
+        details: {
+          syntaxError:
+            'JSON string cannot contain "constructor.prototype" key.',
+        },
+      });
+    });
+
+    it('rejects request with invalid keys - __proto__', async () => {
+      const res = await client
+        .get(
+          '/todos?filter={"offset":0,"limit":100,"skip":0,' +
+            '"where":{"__proto__":{"toString":"def"}},' +
+            '"fields":{"title":true,"id":true}}',
+        )
+        .expect(400);
+      expect(res.body?.error).to.containEql({
+        statusCode: 400,
+        name: 'BadRequestError',
+        code: 'INVALID_PARAMETER_VALUE',
+        details: {
+          syntaxError: 'JSON string cannot contain "__proto__" key.',
+        },
+      });
+    });
+
+    it('rejects request with prohibited keys - badKey', async () => {
+      const res = await client
+        .get(
+          '/todos?filter={"offset":0,"limit":100,"skip":0,' +
+            '"where":{"badKey":{"toString":"def"}},' +
+            '"fields":{"title":true,"id":true}}',
+        )
+        .expect(400);
+      expect(res.body?.error).to.containEql({
+        statusCode: 400,
+        name: 'BadRequestError',
+        code: 'INVALID_PARAMETER_VALUE',
+        details: {
+          syntaxError: 'JSON string cannot contain "badKey" key.',
+        },
+      });
+    });
   });
 
   context('allows logging to be reconfigured', () => {
@@ -341,6 +396,12 @@ describe('TodoApplication', () => {
   async function givenRunningApplicationWithCustomConfiguration() {
     app = new TodoListApplication({
       rest: givenHttpServerConfig(),
+    });
+
+    app.bind(RestBindings.REQUEST_BODY_PARSER_OPTIONS).to({
+      validation: {
+        prohibitedKeys: ['badKey'],
+      },
     });
 
     await app.boot();

--- a/packages/rest/src/parse-json.ts
+++ b/packages/rest/src/parse-json.ts
@@ -13,14 +13,36 @@
 // replacement for `JSON.parse` but we need to instruct `body-parser` to honor
 // a `reviver` function.
 
+const isMatched = (key: string, pattern: string) =>
+  pattern === key || key.indexOf(`${pattern}.`) === 0;
+
 /**
  * Factory to create a reviver function for `JSON.parse` to sanitize keys
  * @param reviver - Reviver function
+ * @param prohibitedKeys - An array of keys to be rejected
  */
-export function sanitizeJsonParse(reviver?: (key: any, value: any) => any) {
+export function sanitizeJsonParse(
+  reviver?: (key: any, value: any) => any,
+  prohibitedKeys?: string[],
+) {
   return (key: string, value: any) => {
-    if (key === '__proto__')
-      throw new Error('JSON string cannot contain "__proto__" key.');
+    if (key === '__proto__') {
+      // Reject `__proto__`
+      throw new Error(`JSON string cannot contain "${key}" key.`);
+    }
+    if (
+      key === 'constructor' &&
+      value != null &&
+      Object.keys(value).some(k => isMatched(k, 'prototype'))
+    ) {
+      // Reject `constructor/prototype.*`
+      throw new Error(
+        `JSON string cannot contain "constructor.prototype" key.`,
+      );
+    }
+    if (prohibitedKeys?.some(pattern => isMatched(key, pattern))) {
+      throw new Error(`JSON string cannot contain "${key}" key.`);
+    }
     if (reviver) {
       return reviver(key, value);
     } else {
@@ -30,13 +52,20 @@ export function sanitizeJsonParse(reviver?: (key: any, value: any) => any) {
 }
 
 /**
- *
+ * Parse a json string that rejects prohibited keys
  * @param text - JSON string
  * @param reviver - Optional reviver function for `JSON.parse`
+ * @param prohibitedKeys - An array of keys to be rejected
  */
 export function parseJson(
   text: string,
   reviver?: (key: any, value: any) => any,
+  prohibitedKeys?: string[],
 ) {
-  return JSON.parse(text, sanitizeJsonParse(reviver));
+  prohibitedKeys = [
+    '__proto__',
+    'constructor.prototype',
+    ...(prohibitedKeys ?? []),
+  ];
+  return JSON.parse(text, sanitizeJsonParse(reviver, prohibitedKeys));
 }

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -84,7 +84,7 @@ async function buildOperationArguments(
     }
     const spec = paramSpec as ParameterObject;
     const rawValue = getParamFromRequest(spec, request, pathParams);
-    const coercedValue = await coerceParameter(rawValue, spec);
+    const coercedValue = await coerceParameter(rawValue, spec, options);
     paramArgs.push(coercedValue);
   }
 

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -156,6 +156,11 @@ export interface ValidationOptions extends ajv.Options {
    * A factory to create Ajv instance
    */
   ajvFactory?: (options: ajv.Options) => Ajv;
+
+  /**
+   * An array of keys to be rejected, such as `__proto__`.
+   */
+  prohibitedKeys?: string[];
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
- reject __proto__ and constructor by default
- allow json parse options to provide additional prohibitedKeys

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
