### PR TITLE
fix(docs): fix incorrect port in deployment example

### DIFF
--- a/docs/site/deployment/Deploying-with-pm2-and-nginx.md
+++ b/docs/site/deployment/Deploying-with-pm2-and-nginx.md
@@ -125,7 +125,7 @@ section of documentation for detailed instructions.
    }
    ```
 
-3. All set! Now you can hit your localhost at `http://localhost:3000/fooapi`
+3. All set! Now you can hit your localhost at `http://localhost:80/fooapi`
    (assuming nginx is listening to port 80) and your requests will be passed on
    to `pm2` process running your Loopback application.
 


### PR DESCRIPTION
Fix an example that mistakenly lists the Node application's port instead of
Nginx's when demonstrating the use of a reverse proxy. Given the original port,
the user would make requests directly to the LoopBack application and not
through the proxy as intended by the example.

Thanks!

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated
