### PR TITLE
fix: getDesignTypeForProperty

### DIFF
--- a/packages/metadata/src/__tests__/unit/inspector.unit.ts
+++ b/packages/metadata/src/__tests__/unit/inspector.unit.ts
@@ -655,44 +655,63 @@ describe('Inspector for design time metadata', () => {
     );
     const MyModel: Function = classFactory(propertyDecorator);
 
-    const meta = MetadataInspector.getDesignTypeForProperty(MyModel, 'id');
+    const meta = MetadataInspector.getDesignTypeForProperty(
+      MyModel.prototype,
+      'id',
+    );
     expect(meta).to.equal(undefined);
   });
 
   it('returns `undefined` design type for property type `null`', () => {
     class MyModel {
+      @propertyDecorator()
       prop: null;
     }
 
-    const meta = MetadataInspector.getDesignTypeForProperty(MyModel, 'prop');
+    const meta = MetadataInspector.getDesignTypeForProperty(
+      MyModel.prototype,
+      'prop',
+    );
     expect(meta).to.equal(undefined);
   });
 
   it('returns `undefined` design type for property type `undefined`', () => {
     class MyModel {
+      @propertyDecorator()
       prop: undefined;
     }
 
-    const meta = MetadataInspector.getDesignTypeForProperty(MyModel, 'prop');
+    const meta = MetadataInspector.getDesignTypeForProperty(
+      MyModel.prototype,
+      'prop',
+    );
     expect(meta).to.equal(undefined);
   });
 
   it('returns `undefined` design type for property type union', () => {
     class MyModel {
+      @propertyDecorator()
       prop: string | number;
     }
 
-    const meta = MetadataInspector.getDesignTypeForProperty(MyModel, 'prop');
-    expect(meta).to.equal(undefined);
+    const meta = MetadataInspector.getDesignTypeForProperty(
+      MyModel.prototype,
+      'prop',
+    );
+    expect(meta).to.equal(Object);
   });
 
-  it('returns `undefined` design type for property type array', () => {
+  it('returns `array` design type for property type array', () => {
     class MyModel {
+      @propertyDecorator()
       prop: string[];
     }
 
-    const meta = MetadataInspector.getDesignTypeForProperty(MyModel, 'prop');
-    expect(meta).to.equal(undefined);
+    const meta = MetadataInspector.getDesignTypeForProperty(
+      MyModel.prototype,
+      'prop',
+    );
+    expect(meta).to.equal(Array);
   });
 
   it('inspects design time type for the constructor', () => {

--- a/packages/metadata/src/inspector.ts
+++ b/packages/metadata/src/inspector.ts
@@ -211,8 +211,7 @@ export class MetadataInspector {
    * @param target - Class or prototype
    * @param propertyName - Property name
    * @returns Design time metadata. The return value is `undefined` when:
-   * - The property has type `undefined`, `null` or a complex type like
-   *   `Partial<MyModel>`, `string | number`, `string[]`.
+   * - The property has type `undefined`, `null`
    * - The TypeScript project has not enabled the compiler option `emitDecoratorMetadata`.
    * - The code is written in vanilla JavaScript.
    */


### PR DESCRIPTION
Fixes #6522
after some checks i notice:
```ts
class MyModel {
      @propertyDecorator() // with decorator
      prop: string;
}
const meta = MetadataInspector.getDesignTypeForProperty(
      MyModel.prototype,
      'prop',
);
meta // String
---
class MyModel {
      @propertyDecorator()
      prop: string;
}
const meta = MetadataInspector.getDesignTypeForProperty(
      MyModel, // without prototype
      'prop',
);
meta // always undefined
---
class MyModel { 
      prop: string; // without decorator
}
const meta = MetadataInspector.getDesignTypeForProperty(
      MyModel.prototype,
      'prop',
);
meta // always undefined
```
so https://github.com/strongloop/loopback-next/blob/master/packages/metadata/src/__tests__/unit/inspector.unit.ts#L680-L687 is a useless tests (because always is gonna be undefined)
and https://github.com/strongloop/loopback-next/blob/0396ab058bc90d1a6a3da37f10353f481003301a/packages/metadata/src/inspector.ts#L210-L217 is not true

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

