### PR TITLE
Shorten time before marking issues/PRs as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,7 +20,7 @@ staleLabel: stale
 issues:
 
   # Number of days of inactivity before an issue becomes stale
-  daysUntilStale: 360
+  daysUntilStale: 180
   # Comment to post when marking an issue as stale. Set to `false` to disable
   markComment: >
     This issue has been marked stale because it has not seen activity within

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,7 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 360
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 30
-# Issues with these labels will never be considered stale
+# Configuration for Stale Bot
+# Learn more at https://github.com/probot/stale
+
+# Issues and pull requests with these labels will never be considered stale
 exemptLabels:
   - planning
   - committed
@@ -13,16 +12,45 @@ exemptLabels:
   - p1
   - major
   - good first issue
-# Label to use when marking an issue as stale
+
+# Label to use when marking an issue or a PR as stale
 staleLabel: stale
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been marked stale because it has not seen activity within
-  six months. If you believe this to be in error, please contact one of the code owners,
-  listed in the `CODEOWNERS` file at the top-level of this repository.
-  This issue will be closed within 30 days of being stale.
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: >
-  This issue has been closed due to continued inactivity. Thank you for your understanding.
-  If you believe this to be in error, please contact one of the code owners,
-  listed in the `CODEOWNERS` file at the top-level of this repository.
+
+# Configuration for issues
+issues:
+
+  # Number of days of inactivity before an issue becomes stale
+  daysUntilStale: 360
+  # Comment to post when marking an issue as stale. Set to `false` to disable
+  markComment: >
+    This issue has been marked stale because it has not seen activity within
+    six months. If you believe this to be in error, please contact one of the code owners,
+    listed in the `CODEOWNERS` file at the top-level of this repository.
+    This issue will be closed within 30 days of being stale.
+
+  # Number of days of inactivity before a stale issue is closed
+  daysUntilClose: 30
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    This issue has been closed due to continued inactivity. Thank you for your understanding.
+    If you believe this to be in error, please contact one of the code owners,
+    listed in the `CODEOWNERS` file at the top-level of this repository.
+
+# Configuration for pull requests
+pulls:
+
+  # Number of days of inactivity before a PR becomes stale
+  daysUntilStale: 60
+  # Comment to post when marking a PR as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been marked stale because it has not seen activity
+    within two months. It will be closed within 14 days of being stale
+    unless there is new activity.
+
+  # Number of days of inactivity before a stale PR is closed
+  daysUntilClose: 14
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    This pull request has been closed due to continued inactivity. If you are
+    interested in finishing the proposed changes, then feel free to re-open
+    this pull request or open a new one.


### PR DESCRIPTION
As we discussed in yesterday's Maintainers Call, I am proposing few changes in our Stale Bot configuration.

The first commit refactors `stale.yaml` to introduce three sections:
- shared config common to both issues and pull requests
- config for issues (kept as is)
- config for pull requests (marking as stale after 60 days, closing after 14 days)

The second commit reduces the time in which an issue is marked as stale from 360 down to 180 days, to match the text in the mark comment ("six months").

@strongloop/loopback-maintainers PTAL.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
