### PR TITLE
docs: fix incorrect files paths

### DIFF
--- a/examples/file-transfer/README.md
+++ b/examples/file-transfer/README.md
@@ -11,11 +11,11 @@ This application exposes `POST /files` endpoint that accepts
 
 ## Key artifacts
 
-- [FileUploadController](src/controllers/files.controller.ts)
+- [FileUploadController](src/controllers/file-upload.controller.ts)
 
   - Expose `POST /files` endpoint to allow file uploads
 
-- [FileUploadService - an Express middleware from multer](src/services/files.service.ts)
+- [FileUploadService - an Express middleware from multer](src/services/file-upload.service.ts)
 
   - A service provider that returns a configured `multer` request handler
 
@@ -37,7 +37,7 @@ This application exposes `POST /files` endpoint that accepts
     this.configure(FILE_UPLOAD_SERVICE).to(multerOptions);
     ```
 
-- [FileDownloadController](src/controllers/files.controller.ts)
+- [FileDownloadController](src/controllers/file-download.controller.ts)
 
   - Expose `GET /files` endpoint to list uploaded files
   - Expose `GET /files/{filename}` endpoint to download a file


### PR DESCRIPTION
fix file paths in README.md file in file-transfer example

Signed-off-by: Omar Almalol <omar.alma3lol@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
