### PR TITLE
chore(rest): add message change to BREAKING CHANGES

### DIFF
--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -24,12 +24,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
+* **rest:** Message printed by REST LogError action changed from
+`Unhandled error` to `Request failed`. Message pattern rules
+(e.g. alerting rules) based on this pattern need to be updated accordingly.
 * **rest:** If you use one of the built-in action providers as the base
 class, this commit will break you as the signature of the base class has
 changed. Otherwise the code should be backward compatible for existing
 applications.
-
-Signed-off-by: Raymond Feng <enjoyjava@gmail.com>
 
 
 
@@ -84,8 +85,6 @@ const paramDef2: ParameterObject = {
 }
 ```
 
-Signed-off-by: Renovate Bot <bot@renovateapp.com>
-
 
 
 
@@ -124,8 +123,6 @@ target application instead.
 If you are getting `npm install` errors after upgrade, then make sure
 your project lists all dependencies required by the extensions you are
 using.
-
-Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>
 
 
 


### PR DESCRIPTION
adding the message change to BREAKING CHANGES, as it might potentially break existing alerting rules based on this message pattern