### PR TITLE
fix(docs): fix formatting in note

### DIFF
--- a/docs/site/Binding.md
+++ b/docs/site/Binding.md
@@ -55,18 +55,18 @@ There are a few ways to create a binding:
   context.bind('my-key');
   ```
 
-  {% include note.html content="The `@loopback/core` package re-exports all
-  public APIs of `@loopback/context`. For consistency, we recommend the usage of
-  `@loopback/core` for imports in LoopBack modules and applications unless they
-  depend on `@loopback/context` explicitly. The two statements below are
-  equivalent:
+{% include note.html content="The `@loopback/core` package re-exports all public
+APIs of `@loopback/context`. For consistency, we recommend the usage of
+`@loopback/core` for imports in LoopBack modules and applications unless they
+depend on `@loopback/context` explicitly. The two statements below are
+equivalent:
 
-  ```ts
-  import {inject} from '@loopback/context';
-  import {inject} from '@loopback/core';
-  ```
+```ts
+import {inject} from '@loopback/context';
+import {inject} from '@loopback/core';
+```
 
-  " %}
+" %}
 
 ## How to set up a binding?
 


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

supersede https://github.com/strongloop/loopback-next/pull/6783

It seems like note.html doesn't quite work when it's indented. So remove the indentation in the Binding page:
<img width="881" alt="Screen Shot 2020-11-16 at 1 23 36 PM" src="https://user-images.githubusercontent.com/25489897/99292756-a4d56100-280f-11eb-9822-1a09a2b7060c.png">

cc @mrfarhadir 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
