### PR TITLE
Fix order of deps-related fields on `package.json` + add automated check

### DIFF
--- a/bin/check-package-metadata.js
+++ b/bin/check-package-metadata.js
@@ -161,6 +161,8 @@ async function checkPkgsPackageJson(packages, rootPkg) {
     if (!isRepositoryDirectoryExist) {
       errors.push(`${p.name} directory doesn't exist in the monorepo`);
     }
+
+    checkDepsOrder(p, pkg, errors);
   }
 
   return errors;
@@ -199,6 +201,30 @@ async function checkPackagesMetadata() {
 
   if (errors.length) {
     throw new Error(formatErrorsText(errors));
+  }
+}
+
+function checkDepsOrder(lernaPkg, pkgJson, errors) {
+  const actualOrder = Object.keys(pkgJson).filter(k =>
+    ['dependencies', 'devDependencies', 'peerDependencies'].includes(k),
+  );
+
+  const expectedOrder = [
+    'peerDependencies',
+    'dependencies',
+    'devDependencies',
+  ].filter(k => actualOrder.includes(k));
+
+  const actualStr = actualOrder.join(' ');
+  const expectedStr = expectedOrder.join(' ');
+
+  if (actualStr !== expectedStr) {
+    const pkgPath = path.relative(lernaPkg.rootPath, lernaPkg.location);
+    errors.push(
+      `${pkgPath}/package.json has incorrect order of keys.\n` +
+        `  Actual:   ${actualStr}\n` +
+        `  Expected: ${expectedStr}`,
+    );
   }
 }
 

--- a/bin/fix-monorepo.js
+++ b/bin/fix-monorepo.js
@@ -10,14 +10,19 @@
  */
 'use strict';
 
+const path = require('path');
+
 const syncDevDeps = require('./sync-dev-deps');
 const updateMonorepo = require('./update-monorepo-file');
 
 const {
+  isJsonEqual,
+  loadLernaRepo,
   runMain,
   updatePackageDeps,
   updatePackageJson,
   updateTsProjectRefs,
+  writeJsonSync,
 } = require('../packages/monorepo');
 
 async function fixMonorepo() {
@@ -31,6 +36,57 @@ async function fixMonorepo() {
   await updateMonorepo();
   // Ensure TypeScript project references are up to date
   await updateTsProjectRefs();
+  // Ensure consistent order of keys in package.json
+  await updateOrderOfPackageJsonFields();
 }
 
 runMain(module, fixMonorepo);
+
+async function updateOrderOfPackageJsonFields() {
+  const {packages} = await loadLernaRepo();
+  for (const pkg of packages.filter(p => !p.private)) {
+    const manifest = pkg.toJSON();
+
+    // Keys to update in the desired order,
+    // filtered to those present in `package.json` only.
+    const depKeys = [
+      'peerDependencies',
+      'dependencies',
+      'devDependencies',
+    ].filter(k => k in manifest);
+
+    // Get all top-level keys like "name", "version", "dependencies"
+    let keys = Object.keys(manifest);
+    // Remove "*dependencies"
+    keys = keys.filter(k => !depKeys.includes(k));
+
+    // Find the position of "publishConfig" (if present) or "license"
+    let ix = keys.indexOf('publishConfig');
+    if (ix === -1) {
+      ix = keys.indexOf('license');
+      if (ix === -1) {
+        const relPath = path.relative(pkg.rootPath, pkg.manifestLocation);
+        throw new Error(
+          `Fatal error: ${relPath} is missing required "license" field.`,
+        );
+      }
+    }
+
+    // Insert back "*dependencies" after "publishConfig" or "license"
+    keys.splice(
+      ix + 1, // index at which to start changing the array.
+      0, // number of elements to remove
+      ...depKeys, // elements to insert
+    );
+
+    // Build a new manifest with the keys in the correct order
+    const updated = {};
+    for (const k of keys) {
+      updated[k] = manifest[k];
+    }
+
+    if (!isJsonEqual(updated, manifest)) {
+      writeJsonSync(pkg.manifestLocation, updated);
+    }
+  }
+}

--- a/bodyparsers/rest-msgpack/package.json
+++ b/bodyparsers/rest-msgpack/package.json
@@ -27,6 +27,10 @@
     "src",
     "!*/__tests__"
   ],
+  "copyright.owner": "IBM Corp.",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@loopback/core": "^2.13.0",
     "@loopback/rest": "^9.1.0"
@@ -45,9 +49,5 @@
     "@types/node": "^10.17.35",
     "@types/type-is": "^1.6.3",
     "typescript": "~4.1.2"
-  },
-  "copyright.owner": "IBM Corp.",
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,13 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "fs-extra": "^9.0.1",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7"
+  },
   "engines": {
     "node": "^10.16 || 12 || 14"
   },
@@ -26,16 +33,9 @@
     "version": "node ./bin/copy-readmes.js && node ./bin/copy-changelogs.js && cd .. && npm run tsdocs",
     "clean": "lb-clean loopback-docs*.tgz package apidocs site/readmes site/changelogs site/apidocs"
   },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "docs"
-  },
-  "dependencies": {
-    "fs-extra": "^9.0.1",
-    "tslib": "^2.0.3"
   }
 }

--- a/examples/access-control-migration/package.json
+++ b/examples/access-control-migration/package.json
@@ -13,6 +13,33 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/authentication": "^7.0.4",
+    "@loopback/authorization": "^0.7.4",
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-explorer": "^3.0.4",
+    "@loopback/security": "^0.3.4",
+    "@loopback/service-proxy": "^3.0.4",
+    "@types/bcryptjs": "2.4.2",
+    "bcryptjs": "^2.4.3",
+    "casbin": "^5.2.1",
+    "jsonwebtoken": "^8.5.1",
+    "loopback-connector-rest": "^4.0.1"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/http-caching-proxy": "^2.1.18",
+    "@loopback/testlab": "^3.2.9",
+    "@types/lodash": "^4.14.165",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "lodash": "^4.17.20",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
@@ -40,33 +67,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/access-control-migration"
-  },
-  "dependencies": {
-    "@loopback/authentication": "^7.0.4",
-    "@loopback/authorization": "^0.7.4",
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-explorer": "^3.0.4",
-    "@loopback/security": "^0.3.4",
-    "@loopback/service-proxy": "^3.0.4",
-    "@types/bcryptjs": "2.4.2",
-    "bcryptjs": "^2.4.3",
-    "casbin": "^5.2.1",
-    "jsonwebtoken": "^8.5.1",
-    "loopback-connector-rest": "^4.0.1"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/http-caching-proxy": "^2.1.18",
-    "@loopback/testlab": "^3.2.9",
-    "@types/lodash": "^4.14.165",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "lodash": "^4.17.20",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/binding-resolution/package.json
+++ b/examples/binding-resolution/package.json
@@ -36,12 +36,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "README.md",
-    "dist",
-    "src",
-    "!*/__tests__"
-  ],
   "dependencies": {
     "@loopback/boot": "^3.1.1",
     "@loopback/core": "^2.13.0",
@@ -59,5 +53,11 @@
     "source-map-support": "^0.5.19",
     "typescript": "~4.1.2"
   },
+  "files": [
+    "README.md",
+    "dist",
+    "src",
+    "!*/__tests__"
+  ],
   "copyright.owner": "IBM Corp."
 }

--- a/examples/context/package.json
+++ b/examples/context/package.json
@@ -13,6 +13,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/context": "^3.13.1",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
@@ -38,18 +50,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/context"
-  },
-  "dependencies": {
-    "@loopback/context": "^3.13.1",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/file-transfer/package.json
+++ b/examples/file-transfer/package.json
@@ -13,6 +13,24 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-explorer": "^3.0.4",
+    "multer": "^1.4.2",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/express-serve-static-core": "^4.17.13",
+    "@types/multer": "^1.4.4",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
@@ -37,24 +55,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/file-transfer"
-  },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-explorer": "^3.0.4",
-    "multer": "^1.4.2",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/express-serve-static-core": "^4.17.13",
-    "@types/multer": "^1.4.4",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -14,6 +14,26 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/graphql": "^0.2.2",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "class-transformer": "^0.3.1",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/multer": "^1.4.3",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "rimraf": "^3.0.2",
+    "source-map-support": "^0.5.19",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
@@ -47,25 +67,5 @@
     "src",
     "!*/__tests__"
   ],
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/graphql": "^0.2.2",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "class-transformer": "^0.3.1",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/multer": "^1.4.3",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "rimraf": "^3.0.2",
-    "source-map-support": "^0.5.19",
-    "typescript": "~4.1.2"
-  },
   "copyright.owner": "IBM Corp."
 }

--- a/examples/greeter-extension/package.json
+++ b/examples/greeter-extension/package.json
@@ -42,10 +42,12 @@
   "publishConfig": {
     "access": "public"
   },
-  "bugs": {
-    "url": "https://github.com/strongloop/loopback-next/issues"
+  "dependencies": {
+    "@loopback/core": "^2.13.0",
+    "chalk": "^4.1.0",
+    "debug": "^4.3.1",
+    "tslib": "^2.0.3"
   },
-  "homepage": "https://github.com/strongloop/loopback-next/tree/master/examples/greeter-extension",
   "devDependencies": {
     "@loopback/build": "^6.2.7",
     "@loopback/eslint-config": "^10.0.3",
@@ -55,10 +57,8 @@
     "eslint": "^7.14.0",
     "typescript": "~4.1.2"
   },
-  "dependencies": {
-    "@loopback/core": "^2.13.0",
-    "chalk": "^4.1.0",
-    "debug": "^4.3.1",
-    "tslib": "^2.0.3"
-  }
+  "bugs": {
+    "url": "https://github.com/strongloop/loopback-next/issues"
+  },
+  "homepage": "https://github.com/strongloop/loopback-next/tree/master/examples/greeter-extension"
 }

--- a/examples/greeting-app/package.json
+++ b/examples/greeting-app/package.json
@@ -43,10 +43,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "bugs": {
-    "url": "https://github.com/strongloop/loopback-next/issues"
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/example-greeter-extension": "^2.1.14",
+    "@loopback/rest": "^9.1.0",
+    "chalk": "^4.1.0",
+    "debug": "^4.3.1",
+    "tslib": "^2.0.3"
   },
-  "homepage": "https://github.com/strongloop/loopback-next/tree/master/examples/greeter-extension",
   "devDependencies": {
     "@loopback/build": "^6.2.7",
     "@loopback/eslint-config": "^10.0.3",
@@ -56,13 +61,8 @@
     "eslint": "^7.14.0",
     "typescript": "~4.1.2"
   },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/example-greeter-extension": "^2.1.14",
-    "@loopback/rest": "^9.1.0",
-    "chalk": "^4.1.0",
-    "debug": "^4.3.1",
-    "tslib": "^2.0.3"
-  }
+  "bugs": {
+    "url": "https://github.com/strongloop/loopback-next/issues"
+  },
+  "homepage": "https://github.com/strongloop/loopback-next/tree/master/examples/greeter-extension"
 }

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -13,6 +13,19 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/core": "^2.13.0",
+    "@loopback/rest": "^9.1.0",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
@@ -38,19 +51,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/hello-world"
-  },
-  "dependencies": {
-    "@loopback/core": "^2.13.0",
-    "@loopback/rest": "^9.1.0",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/lb3-application/package.json
+++ b/examples/lb3-application/package.json
@@ -13,34 +13,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "build": "lb-tsc",
-    "build:watch": "lb-tsc --watch",
-    "clean": "lb-clean *example-lb3-application*.tgz dist *.tsbuildinfo package",
-    "lint": "npm run prettier:check && npm run eslint",
-    "lint:fix": "npm run eslint:fix && npm run prettier:fix",
-    "prettier:cli": "lb-prettier \"**/*.ts\"",
-    "prettier:check": "npm run prettier:cli -- -l",
-    "prettier:fix": "npm run prettier:cli -- --write",
-    "eslint": "lb-eslint --report-unused-disable-directives .",
-    "eslint:fix": "npm run eslint -- --fix",
-    "pretest": "npm run rebuild",
-    "test": "lb-mocha \"dist/__tests__/**/*.js\" \"lb3app/test/*.js\"",
-    "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
-    "verify": "npm pack && tar xf loopback-lb3-application*.tgz && tree package && npm run clean",
-    "premigrate": "npm run build ",
-    "migrate": "node ./dist/migrate",
-    "preopenapi-spec": "npm run build",
-    "openapi-spec": "node ./dist/openapi-spec",
-    "rebuild": "npm run clean && npm run build",
-    "prestart": "npm run rebuild",
-    "start": "node ."
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/strongloop/loopback-next.git",
-    "directory": "examples/lb3-application"
-  },
   "dependencies": {
     "@loopback/boot": "^3.1.1",
     "@loopback/booter-lb3app": "^2.2.14",
@@ -68,6 +40,34 @@
     "lodash": "^4.17.20",
     "should": "^13.2.3",
     "typescript": "~4.1.2"
+  },
+  "scripts": {
+    "build": "lb-tsc",
+    "build:watch": "lb-tsc --watch",
+    "clean": "lb-clean *example-lb3-application*.tgz dist *.tsbuildinfo package",
+    "lint": "npm run prettier:check && npm run eslint",
+    "lint:fix": "npm run eslint:fix && npm run prettier:fix",
+    "prettier:cli": "lb-prettier \"**/*.ts\"",
+    "prettier:check": "npm run prettier:cli -- -l",
+    "prettier:fix": "npm run prettier:cli -- --write",
+    "eslint": "lb-eslint --report-unused-disable-directives .",
+    "eslint:fix": "npm run eslint -- --fix",
+    "pretest": "npm run rebuild",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\" \"lb3app/test/*.js\"",
+    "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
+    "verify": "npm pack && tar xf loopback-lb3-application*.tgz && tree package && npm run clean",
+    "premigrate": "npm run build ",
+    "migrate": "node ./dist/migrate",
+    "preopenapi-spec": "npm run build",
+    "openapi-spec": "node ./dist/openapi-spec",
+    "rebuild": "npm run clean && npm run build",
+    "prestart": "npm run rebuild",
+    "start": "node ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-next.git",
+    "directory": "examples/lb3-application"
   },
   "keywords": [
     "loopback",

--- a/examples/log-extension/package.json
+++ b/examples/log-extension/package.json
@@ -13,6 +13,22 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/core": "^2.13.0",
+    "@loopback/rest": "^9.1.0",
+    "chalk": "^4.1.0",
+    "debug": "^4.3.1",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/debug": "^4.1.5",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
@@ -43,21 +59,5 @@
   "bugs": {
     "url": "https://github.com/strongloop/loopback-next/issues"
   },
-  "homepage": "https://github.com/strongloop/loopback-next/tree/master/examples/log-extension",
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/debug": "^4.1.5",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "typescript": "~4.1.2"
-  },
-  "dependencies": {
-    "@loopback/core": "^2.13.0",
-    "@loopback/rest": "^9.1.0",
-    "chalk": "^4.1.0",
-    "debug": "^4.3.1",
-    "tslib": "^2.0.3"
-  }
+  "homepage": "https://github.com/strongloop/loopback-next/tree/master/examples/log-extension"
 }

--- a/examples/metrics-prometheus/package.json
+++ b/examples/metrics-prometheus/package.json
@@ -13,6 +13,21 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/metrics": "^0.5.1",
+    "@loopback/rest": "^9.1.0",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "acceptance": "lb-mocha \"dist/__tests__/acceptance/**/*.js\"",
     "build": "lb-tsc",
@@ -39,21 +54,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/metrics-prometheus"
-  },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/metrics": "^0.5.1",
-    "@loopback/rest": "^9.1.0",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/multi-tenancy/package.json
+++ b/examples/multi-tenancy/package.json
@@ -47,12 +47,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "README.md",
-    "dist",
-    "src",
-    "!*/__tests__"
-  ],
   "dependencies": {
     "@loopback/boot": "^3.1.1",
     "@loopback/core": "^2.13.0",
@@ -72,5 +66,11 @@
     "eslint": "^7.14.0",
     "source-map-support": "^0.5.19",
     "typescript": "~4.1.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist",
+    "src",
+    "!*/__tests__"
+  ]
 }

--- a/examples/rest-crud/package.json
+++ b/examples/rest-crud/package.json
@@ -13,6 +13,27 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-crud": "^0.8.18",
+    "@loopback/rest-explorer": "^3.0.4",
+    "loopback-connector-rest": "^4.0.1",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/http-caching-proxy": "^2.1.18",
+    "@loopback/testlab": "^3.2.9",
+    "@types/lodash": "^4.14.165",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "lodash": "^4.17.20",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
@@ -40,27 +61,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/rest-crud"
-  },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-crud": "^0.8.18",
-    "@loopback/rest-explorer": "^3.0.4",
-    "loopback-connector-rest": "^4.0.1",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/http-caching-proxy": "^2.1.18",
-    "@loopback/testlab": "^3.2.9",
-    "@types/lodash": "^4.14.165",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "lodash": "^4.17.20",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/soap-calculator/package.json
+++ b/examples/soap-calculator/package.json
@@ -20,6 +20,27 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-explorer": "^3.0.4",
+    "@loopback/service-proxy": "^3.0.4",
+    "loopback-connector-soap": "^6.0.0",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/mocha": "^8.0.4",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "mocha": "^8.2.1",
+    "source-map-support": "^0.5.19",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
@@ -43,26 +64,5 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/soap-calculator"
-  },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-explorer": "^3.0.4",
-    "@loopback/service-proxy": "^3.0.4",
-    "loopback-connector-soap": "^6.0.0",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/mocha": "^8.0.4",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "mocha": "^8.2.1",
-    "source-map-support": "^0.5.19",
-    "typescript": "~4.1.2"
   }
 }

--- a/examples/socketio/package.json
+++ b/examples/socketio/package.json
@@ -46,6 +46,9 @@
     "src",
     "!*/__tests__"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@loopback/boot": "^3.1.1",
     "@loopback/core": "^2.13.0",
@@ -67,9 +70,6 @@
     "eslint": "^7.14.0",
     "source-map-support": "^0.5.19",
     "typescript": "~4.1.2"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "copyright.owner": "IBM Corp."
 }

--- a/examples/todo-jwt/package.json
+++ b/examples/todo-jwt/package.json
@@ -13,6 +13,32 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/authentication": "^7.0.4",
+    "@loopback/authentication-jwt": "^0.7.4",
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-explorer": "^3.0.4",
+    "@loopback/security": "^0.3.4",
+    "@loopback/service-proxy": "^3.0.4",
+    "@types/bcryptjs": "^2.4.2",
+    "bcryptjs": "^2.4.3",
+    "loopback-connector-rest": "^4.0.1",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/http-caching-proxy": "^2.1.18",
+    "@loopback/testlab": "^3.2.9",
+    "@types/lodash": "^4.14.165",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "lodash": "^4.17.20",
+    "typescript": "~4.1.2"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
@@ -40,32 +66,6 @@
     "rebuild": "npm run clean && npm run build",
     "prestart": "npm run rebuild",
     "start": "node ."
-  },
-  "dependencies": {
-    "@loopback/authentication": "^7.0.4",
-    "@loopback/authentication-jwt": "^0.7.4",
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-explorer": "^3.0.4",
-    "@loopback/security": "^0.3.4",
-    "@loopback/service-proxy": "^3.0.4",
-    "@types/bcryptjs": "^2.4.2",
-    "bcryptjs": "^2.4.3",
-    "loopback-connector-rest": "^4.0.1",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/http-caching-proxy": "^2.1.18",
-    "@loopback/testlab": "^3.2.9",
-    "@types/lodash": "^4.14.165",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "lodash": "^4.17.20",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/todo-list/package.json
+++ b/examples/todo-list/package.json
@@ -13,6 +13,28 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-explorer": "^3.0.4",
+    "@loopback/service-proxy": "^3.0.4",
+    "loopback-connector-rest": "^4.0.1",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/http-caching-proxy": "^2.1.18",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/testlab": "^3.2.9",
+    "@types/lodash": "^4.14.165",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "lodash": "^4.17.20",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
@@ -40,28 +62,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/todo-list"
-  },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-explorer": "^3.0.4",
-    "@loopback/service-proxy": "^3.0.4",
-    "loopback-connector-rest": "^4.0.1",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/http-caching-proxy": "^2.1.18",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/testlab": "^3.2.9",
-    "@types/lodash": "^4.14.165",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "lodash": "^4.17.20",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -13,6 +13,29 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-explorer": "^3.0.4",
+    "@loopback/service-proxy": "^3.0.4",
+    "loopback-connector-rest": "^4.0.1",
+    "morgan": "^1.10.0",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/http-caching-proxy": "^2.1.18",
+    "@loopback/testlab": "^3.2.9",
+    "@types/lodash": "^4.14.165",
+    "@types/morgan": "^1.9.2",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "lodash": "^4.17.20",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
@@ -40,29 +63,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/todo"
-  },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-explorer": "^3.0.4",
-    "@loopback/service-proxy": "^3.0.4",
-    "loopback-connector-rest": "^4.0.1",
-    "morgan": "^1.10.0",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/http-caching-proxy": "^2.1.18",
-    "@loopback/testlab": "^3.2.9",
-    "@types/lodash": "^4.14.165",
-    "@types/morgan": "^1.9.2",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "lodash": "^4.17.20",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/validation-app/package.json
+++ b/examples/validation-app/package.json
@@ -13,6 +13,25 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/rest-explorer": "^3.0.4",
+    "@loopback/service-proxy": "^3.0.4",
+    "strong-error-handler": "^4.0.0",
+    "tslib": "^2.0.3"
+  },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/node": "^10.17.35",
+    "eslint": "^7.14.0",
+    "source-map-support": "^0.5.19",
+    "typescript": "~4.1.2"
+  },
   "scripts": {
     "build": "lb-tsc",
     "build:watch": "lb-tsc --watch",
@@ -42,25 +61,6 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "examples/validation-app"
-  },
-  "dependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/rest-explorer": "^3.0.4",
-    "@loopback/service-proxy": "^3.0.4",
-    "strong-error-handler": "^4.0.0",
-    "tslib": "^2.0.3"
-  },
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/node": "^10.17.35",
-    "eslint": "^7.14.0",
-    "source-map-support": "^0.5.19",
-    "typescript": "~4.1.2"
   },
   "keywords": [
     "loopback",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -14,22 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "build": "lb-tsc",
-    "build:webpack-node": "webpack --config-name node",
-    "build:webpack-web": "webpack --config-name web",
-    "prepack": "npm run build:webpack-web",
-    "clean": "lb-clean loopback-example-webpack*.tgz dist *.tsbuildinfo package",
-    "verify": "npm pack && tar xf loopback-example-webpack*.tgz && tree package && npm run clean",
-    "pretest": "npm run rebuild",
-    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
-    "rebuild": "npm run clean && npm run build"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/strongloop/loopback-next.git",
-    "directory": "examples/webpack"
-  },
   "dependencies": {
     "@loopback/core": "^2.13.0",
     "tslib": "^2.0.3"
@@ -49,6 +33,22 @@
     "webpack": "^5.6.0",
     "webpack-cli": "^4.2.0",
     "zombie": "^6.1.4"
+  },
+  "scripts": {
+    "build": "lb-tsc",
+    "build:webpack-node": "webpack --config-name node",
+    "build:webpack-web": "webpack --config-name web",
+    "prepack": "npm run build:webpack-web",
+    "clean": "lb-clean loopback-example-webpack*.tgz dist *.tsbuildinfo package",
+    "verify": "npm pack && tar xf loopback-example-webpack*.tgz && tree package && npm run clean",
+    "pretest": "npm run rebuild",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
+    "rebuild": "npm run clean && npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-next.git",
+    "directory": "examples/webpack"
   },
   "keywords": [
     "loopback",

--- a/extensions/apiconnect/package.json
+++ b/extensions/apiconnect/package.json
@@ -23,21 +23,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [
-    "LoopBack",
-    "IBM API Connect"
-  ],
-  "files": [
-    "README.md",
-    "dist",
-    "src",
-    "!*/__tests__"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/strongloop/loopback-next.git",
-    "directory": "extensions/apiconnect"
-  },
   "peerDependencies": {
     "@loopback/core": "^2.13.0",
     "@loopback/rest": "^9.1.0"
@@ -52,5 +37,20 @@
     "@loopback/rest": "^9.1.0",
     "@loopback/testlab": "^3.2.9",
     "@types/node": "^10.17.35"
+  },
+  "keywords": [
+    "LoopBack",
+    "IBM API Connect"
+  ],
+  "files": [
+    "README.md",
+    "dist",
+    "src",
+    "!*/__tests__"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-next.git",
+    "directory": "extensions/apiconnect"
   }
 }

--- a/extensions/authentication-passport/package.json
+++ b/extensions/authentication-passport/package.json
@@ -23,22 +23,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [
-    "Passport",
-    "Authentication",
-    "TypeScript"
-  ],
-  "files": [
-    "README.md",
-    "dist",
-    "src",
-    "!*/__tests__"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/strongloop/loopback-next.git",
-    "directory": "extensions/authentication-passport"
-  },
   "peerDependencies": {
     "@loopback/authentication": "^7.0.4",
     "@loopback/core": "^2.13.0",
@@ -76,5 +60,21 @@
     "passport-oauth2": "^1.5.0",
     "qs": "^6.9.4",
     "supertest": "^6.0.1"
+  },
+  "keywords": [
+    "Passport",
+    "Authentication",
+    "TypeScript"
+  ],
+  "files": [
+    "README.md",
+    "dist",
+    "src",
+    "!*/__tests__"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strongloop/loopback-next.git",
+    "directory": "extensions/authentication-passport"
   }
 }

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -20,6 +20,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@loopback/core": "^2.13.0"
+  },
   "dependencies": {
     "@types/cron": "^1.7.2",
     "@types/debug": "^4.1.5",
@@ -49,8 +52,5 @@
     "type": "git",
     "url": "https://github.com/strongloop/loopback-next.git",
     "directory": "extensions/cron"
-  },
-  "peerDependencies": {
-    "@loopback/core": "^2.13.0"
   }
 }

--- a/extensions/graphql/package.json
+++ b/extensions/graphql/package.json
@@ -20,30 +20,6 @@
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
-  "dependencies": {
-    "@loopback/http-server": "^2.3.2",
-    "apollo-server-express": "^2.19.0",
-    "debug": "^4.3.1",
-    "express": "^4.17.1",
-    "graphql": "^15.4.0",
-    "type-graphql": "^1.1.1"
-  },
-  "peerDependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0"
-  },
-  "devDependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/build": "^6.2.7",
-    "@loopback/core": "^2.13.0",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/repository": "^3.2.1",
-    "@loopback/rest": "^9.1.0",
-    "@loopback/testlab": "^3.2.9",
-    "@types/debug": "^4.1.5",
-    "@types/node": "^10.17.35",
-    "class-transformer": "^0.3.1"
-  },
   "keywords": [
     "LoopBack",
     "GraphQL"
@@ -56,6 +32,30 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0"
+  },
+  "dependencies": {
+    "@loopback/http-server": "^2.3.2",
+    "apollo-server-express": "^2.19.0",
+    "debug": "^4.3.1",
+    "express": "^4.17.1",
+    "graphql": "^15.4.0",
+    "type-graphql": "^1.1.1"
+  },
+  "devDependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/build": "^6.2.7",
+    "@loopback/core": "^2.13.0",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/repository": "^3.2.1",
+    "@loopback/rest": "^9.1.0",
+    "@loopback/testlab": "^3.2.9",
+    "@types/debug": "^4.1.5",
+    "@types/node": "^10.17.35",
+    "class-transformer": "^0.3.1"
   },
   "repository": {
     "type": "git",

--- a/extensions/pooling/package.json
+++ b/extensions/pooling/package.json
@@ -31,6 +31,10 @@
     "src",
     "!*/__tests__"
   ],
+  "copyright.owner": "IBM Corp.",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@loopback/core": "^2.13.0"
   },
@@ -45,9 +49,5 @@
     "@loopback/testlab": "^3.2.9",
     "@types/node": "^10.17.35",
     "typescript": "~4.1.2"
-  },
-  "copyright.owner": "IBM Corp.",
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/extensions/socketio/package.json
+++ b/extensions/socketio/package.json
@@ -19,31 +19,6 @@
   "author": "IBM Corp.",
   "copyright.owner": "IBM Corp.",
   "license": "MIT",
-  "dependencies": {
-    "@loopback/http-server": "^2.3.2",
-    "@types/cors": "^2.8.8",
-    "@types/lodash": "^4.14.165",
-    "cors": "^2.8.5",
-    "debug": "^4.3.1",
-    "lodash": "^4.17.20",
-    "socket.io": "^2.3.0"
-  },
-  "peerDependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/core": "^2.13.0"
-  },
-  "devDependencies": {
-    "@loopback/boot": "^3.1.1",
-    "@loopback/build": "^6.2.7",
-    "@loopback/core": "^2.13.0",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/debug": "^4.1.5",
-    "@types/socket.io": "^2.1.11",
-    "@types/socket.io-client": "^1.4.34",
-    "p-event": "^4.1.0",
-    "socket.io-client": "^2.3.1"
-  },
   "keywords": [
     "LoopBack",
     "Socket.IO",
@@ -60,6 +35,31 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/core": "^2.13.0"
+  },
+  "dependencies": {
+    "@loopback/http-server": "^2.3.2",
+    "@types/cors": "^2.8.8",
+    "@types/lodash": "^4.14.165",
+    "cors": "^2.8.5",
+    "debug": "^4.3.1",
+    "lodash": "^4.17.20",
+    "socket.io": "^2.3.0"
+  },
+  "devDependencies": {
+    "@loopback/boot": "^3.1.1",
+    "@loopback/build": "^6.2.7",
+    "@loopback/core": "^2.13.0",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/debug": "^4.1.5",
+    "@types/socket.io": "^2.1.11",
+    "@types/socket.io-client": "^1.4.34",
+    "p-event": "^4.1.0",
+    "socket.io-client": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,44 +9,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "engines": {
-    "node": "^10.16 || 12 || 14"
-  },
-  "files": [
-    "bin",
-    "lib",
-    "generators",
-    "intl",
-    ".yo-rc.json"
-  ],
-  "bin": {
-    "lb4": "bin/cli-main.js"
-  },
-  "main": "generators/app/index.js",
-  "keywords": [
-    "LoopBack",
-    "CLI",
-    "yeoman-generator"
-  ],
-  "devDependencies": {
-    "@loopback/build": "^6.2.7",
-    "@loopback/eslint-config": "^10.0.3",
-    "@loopback/testlab": "^3.2.9",
-    "@types/ejs": "^3.0.5",
-    "@types/fs-extra": "^9.0.4",
-    "@types/minimatch": "^3.0.3",
-    "@types/node": "^10.17.35",
-    "loopback": "^3.27.0",
-    "loopback-datasource-juggler": "^4.26.0",
-    "mem-fs": "^1.2.0",
-    "mem-fs-editor": "^7.1.0",
-    "mock-stdin": "^1.0.0",
-    "rimraf": "^3.0.2",
-    "sinon": "^9.2.1",
-    "strong-globalize-cli": "7.1.0",
-    "yeoman-assert": "^3.1.1",
-    "yeoman-test": "~2.7.0"
-  },
   "dependencies": {
     "@lerna/project": "^3.21.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.4",
@@ -89,6 +51,44 @@
     "yeoman-environment": "^2.10.3",
     "yeoman-generator": "^4.12.0"
   },
+  "devDependencies": {
+    "@loopback/build": "^6.2.7",
+    "@loopback/eslint-config": "^10.0.3",
+    "@loopback/testlab": "^3.2.9",
+    "@types/ejs": "^3.0.5",
+    "@types/fs-extra": "^9.0.4",
+    "@types/minimatch": "^3.0.3",
+    "@types/node": "^10.17.35",
+    "loopback": "^3.27.0",
+    "loopback-datasource-juggler": "^4.26.0",
+    "mem-fs": "^1.2.0",
+    "mem-fs-editor": "^7.1.0",
+    "mock-stdin": "^1.0.0",
+    "rimraf": "^3.0.2",
+    "sinon": "^9.2.1",
+    "strong-globalize-cli": "7.1.0",
+    "yeoman-assert": "^3.1.1",
+    "yeoman-test": "~2.7.0"
+  },
+  "engines": {
+    "node": "^10.16 || 12 || 14"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "generators",
+    "intl",
+    ".yo-rc.json"
+  ],
+  "bin": {
+    "lb4": "bin/cli-main.js"
+  },
+  "main": "generators/app/index.js",
+  "keywords": [
+    "LoopBack",
+    "CLI",
+    "yeoman-generator"
+  ],
   "scripts": {
     "test": "lb-mocha --lang en_US.UTF-8 \"test/**/*.js\"",
     "smoke-test": "lb-mocha --allow-console-logs \"smoke-test/**/*.smoke.js\"",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,15 +12,15 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "eslint": "^7.14.0"
+  },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-eslint-plugin": "^2.3.0",
     "eslint-plugin-mocha": "^8.0.0"
-  },
-  "peerDependencies": {
-    "eslint": "^7.14.0"
   },
   "repository": {
     "type": "git",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -30,12 +30,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "README.md",
-    "dist",
-    "src",
-    "!*/__tests__"
-  ],
   "peerDependencies": {
     "@loopback/core": "^2.13.0"
   },
@@ -64,5 +58,11 @@
     "http-errors": "^1.8.0",
     "source-map-support": "^0.5.19",
     "typescript": "~4.1.2"
-  }
+  },
+  "files": [
+    "README.md",
+    "dist",
+    "src",
+    "!*/__tests__"
+  ]
 }

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -27,6 +27,10 @@
     "src",
     "!*/__tests__"
   ],
+  "copyright.owner": "IBM Corp.",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "tslib": "^2.0.3"
   },
@@ -35,9 +39,5 @@
     "@loopback/testlab": "^3.2.9",
     "@types/node": "^10.17.35",
     "typescript": "~4.1.2"
-  },
-  "copyright.owner": "IBM Corp.",
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/monorepo/package.json
+++ b/packages/monorepo/package.json
@@ -17,6 +17,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "lerna": "^3.22.1"
+  },
   "dependencies": {
     "@lerna/filter-packages": "^3.18.0",
     "@lerna/package-graph": "^3.18.5",
@@ -24,9 +27,6 @@
     "cross-spawn": "^7.0.3",
     "debug": "^4.3.1",
     "fs-extra": "^9.0.1"
-  },
-  "peerDependencies": {
-    "lerna": "^3.22.1"
   },
   "bin": {
     "lb-run-lerna": "./lib/run-lerna.js",

--- a/packages/openapi-spec-builder/package.json
+++ b/packages/openapi-spec-builder/package.json
@@ -20,13 +20,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [
-    "Swagger",
-    "OpenAPI Spec",
-    "TypeScript",
-    "Builder",
-    "Testing"
-  ],
   "dependencies": {
     "openapi3-ts": "^2.0.0",
     "tslib": "^2.0.3"
@@ -37,6 +30,13 @@
     "@loopback/testlab": "^3.2.9",
     "@types/node": "^10.17.35"
   },
+  "keywords": [
+    "Swagger",
+    "OpenAPI Spec",
+    "TypeScript",
+    "Builder",
+    "Testing"
+  ],
   "files": [
     "README.md",
     "dist",

--- a/packages/openapi-v3/package.json
+++ b/packages/openapi-v3/package.json
@@ -7,6 +7,21 @@
   "engines": {
     "node": "^10.16 || 12 || 14"
   },
+  "scripts": {
+    "build": "lb-tsc",
+    "clean": "lb-clean loopback-openapi-v3*.tgz dist *.tsbuildinfo package",
+    "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
+    "pretest": "npm run build",
+    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
+    "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
+    "verify": "npm pack && tar xf loopback-openapi-v3*.tgz && tree package && npm run clean"
+  },
+  "author": "IBM Corp.",
+  "copyright.owner": "IBM Corp.",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@loopback/core": "^2.13.0"
   },
@@ -31,21 +46,6 @@
     "@types/json-merge-patch": "0.0.5",
     "@types/lodash": "^4.14.165",
     "@types/node": "^10.17.35"
-  },
-  "scripts": {
-    "build": "lb-tsc",
-    "clean": "lb-clean loopback-openapi-v3*.tgz dist *.tsbuildinfo package",
-    "integration": "lb-mocha \"dist/__tests__/integration/**/*.js\"",
-    "pretest": "npm run build",
-    "test": "lb-mocha \"dist/__tests__/**/*.js\"",
-    "unit": "lb-mocha \"dist/__tests__/unit/**/*.js\"",
-    "verify": "npm pack && tar xf loopback-openapi-v3*.tgz && tree package && npm run clean"
-  },
-  "author": "IBM Corp.",
-  "copyright.owner": "IBM Corp.",
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
   },
   "keywords": [
     "Swagger",

--- a/packages/repository-json-schema/package.json
+++ b/packages/repository-json-schema/package.json
@@ -20,11 +20,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [
-    "LoopBack",
-    "TypeScript",
-    "JSON Schema"
-  ],
   "peerDependencies": {
     "@loopback/core": "^2.13.0",
     "@loopback/repository": "^3.2.1"
@@ -44,6 +39,11 @@
     "@types/node": "^10.17.35",
     "ajv": "^6.12.6"
   },
+  "keywords": [
+    "LoopBack",
+    "TypeScript",
+    "JSON Schema"
+  ],
   "files": [
     "README.md",
     "dist",

--- a/packages/repository-tests/package.json
+++ b/packages/repository-tests/package.json
@@ -24,6 +24,12 @@
     "@loopback/core": "^2.13.0",
     "@loopback/repository": "^3.2.1"
   },
+  "dependencies": {
+    "@loopback/testlab": "^3.2.9",
+    "@types/debug": "^4.1.5",
+    "debug": "^4.3.1",
+    "tslib": "^2.0.3"
+  },
   "devDependencies": {
     "@loopback/build": "^6.2.7",
     "@loopback/core": "^2.13.0",
@@ -32,12 +38,6 @@
     "@types/lodash": "^4.14.165",
     "@types/node": "^10.17.35",
     "lodash": "^4.17.20"
-  },
-  "dependencies": {
-    "@loopback/testlab": "^3.2.9",
-    "@types/debug": "^4.1.5",
-    "debug": "^4.3.1",
-    "tslib": "^2.0.3"
   },
   "files": [
     "README.md",

--- a/packages/repository/package.json
+++ b/packages/repository/package.json
@@ -24,6 +24,14 @@
   "peerDependencies": {
     "@loopback/core": "^2.13.0"
   },
+  "dependencies": {
+    "@loopback/filter": "^1.2.1",
+    "@types/debug": "^4.1.5",
+    "debug": "^4.3.1",
+    "lodash": "^4.17.20",
+    "loopback-datasource-juggler": "^4.26.0",
+    "tslib": "^2.0.3"
+  },
   "devDependencies": {
     "@loopback/build": "^6.2.7",
     "@loopback/core": "^2.13.0",
@@ -34,14 +42,6 @@
     "@types/lodash": "^4.14.165",
     "@types/node": "^10.17.35",
     "bson": "4.2.0"
-  },
-  "dependencies": {
-    "@loopback/filter": "^1.2.1",
-    "@types/debug": "^4.1.5",
-    "debug": "^4.3.1",
-    "lodash": "^4.17.20",
-    "loopback-datasource-juggler": "^4.26.0",
-    "tslib": "^2.0.3"
   },
   "files": [
     "README.md",

--- a/packages/service-proxy/package.json
+++ b/packages/service-proxy/package.json
@@ -26,16 +26,16 @@
   "peerDependencies": {
     "@loopback/core": "^2.13.0"
   },
+  "dependencies": {
+    "loopback-datasource-juggler": "^4.26.0",
+    "tslib": "^2.0.3"
+  },
   "devDependencies": {
     "@loopback/build": "^6.2.7",
     "@loopback/core": "^2.13.0",
     "@loopback/eslint-config": "^10.0.3",
     "@loopback/testlab": "^3.2.9",
     "@types/node": "^10.17.35"
-  },
-  "dependencies": {
-    "loopback-datasource-juggler": "^4.26.0",
-    "tslib": "^2.0.3"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
The first commit adds a new step to `bin/check-package-metadata.js` to ensure that all public packages list deps in the following order:
1. `peerDependencies`
2. `dependencies`
3. `devDependencies`

The second commits adds a new step to `bin/fix-monorepo.js` to update all
public packages to list deps in the correct order.

The second commit fixes packages via `bin/fix-monorepo.js` to pass the new check enforced by `bin/check-package-metadata.js`.

This is a follow-up for the discussion in https://github.com/strongloop/loopback-next/pull/6288.

To keep the changes small, focused and easy to review, I am intentionally NOT fixing dependencies vs. peerDependencies. I would like to open another PR to add an automated check + fix any violations discovered (e.g. in `examples/greeter-extension`).

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
