### PR TITLE
fix(rest): fix incomplete hostname in regexp

### DIFF
--- a/packages/rest/src/__tests__/integration/rest.server.integration.ts
+++ b/packages/rest/src/__tests__/integration/rest.server.integration.ts
@@ -628,7 +628,7 @@ paths:
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'http://explorer.loopback.io',
+        'http://explorer\\.loopback\\.io',
         '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/openapi.json',
       ].join(''),
     );
@@ -663,8 +663,8 @@ paths:
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'https://explorer.loopback.io',
-        '\\?url=https://example.com:8080/openapi.json',
+        'https://explorer\\.loopback\\.io',
+        '\\?url=https://example\\.com:8080/openapi\\.json',
       ].join(''),
     );
     expect(response.get('Location')).match(expectedUrl);
@@ -702,8 +702,8 @@ paths:
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'https://explorer.loopback.io',
-        '\\?url=https://example.com/openapi.json',
+        'https://explorer\\.loopback\\.io',
+        '\\?url=https://example\\.com/openapi\\.json',
       ].join(''),
     );
     expect(response.get('Location')).match(expectedUrl);
@@ -720,7 +720,7 @@ paths:
       .get('/explorer')
       .set('host', '');
     await app.stop();
-    const expectedUrl = new RegExp(`\\?url=http://127.0.0.1:${port}`);
+    const expectedUrl = new RegExp(`\\?url=http://127\\.0\\.0\\.1:${port}`);
     expect(response.get('Location')).match(expectedUrl);
   });
 
@@ -739,7 +739,7 @@ paths:
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'https://petstore.swagger.io',
+        'https://petstore\\.swagger\\.io',
         '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/openapi.json',
       ].join(''),
     );
@@ -763,7 +763,7 @@ paths:
     await server.get(RestBindings.PORT);
     const expectedUrl = new RegExp(
       [
-        'http://petstore.swagger.io',
+        'http://petstore\\.swagger\\.io',
         '\\?url=http://\\d+.\\d+.\\d+.\\d+:\\d+/openapi.json',
       ].join(''),
     );


### PR DESCRIPTION
Github code scan reports the following issue:

Incomplete regular expression for hostnames
Matching a URL or hostname against a regular expression that contains an
unescaped dot as part of the hostname might match more hostnames than
expected.

See https://github.com/strongloop/loopback-next/security/code-scanning/6?query=ref%3Arefs%2Fheads%2Fmaster

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
