### PR TITLE
fix(docs): remove note about explorer filter not working

### DIFF
--- a/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-controller.md
@@ -195,12 +195,9 @@ Here are some new requests you can try out:
 - `GET /todo-lists/{id}/todos` with the ID from before, and see if you get the
   todo you created from before.
 - `GET /todo-lists/{id}` with the ID from before, with the following filter
-  `{include: [{relation: 'todos'}]}`, and see if you get a `todos` property with
-  the todo created before. **Note**: this filter won't work through the API
-  explorer (See this
-  [GitHub issue](https://github.com/strongloop/loopback-next/issues/2208) for
-  details). Use the following url to test this endpoint (remember to replace
-  `{id}` with the ID from before):
+  `{"include": [{"relation": "todos"}]}`, and see if you get a `todos` property
+  with the todo created before. You can also use the following url to test this
+  endpoint (remember to replace `{id}` with the ID from before):
   http://localhost:3000/todo-lists/{id}?filter[include][][relation]=todos
 
 And there you have it! You now have the power to define APIs for related models!


### PR DESCRIPTION
Now that https://github.com/strongloop/loopback-next/issues/2208 is fixed, we can remove the note about the filter not working in API explorer.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
