### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,17 @@ See [SECURITY.md](SECURITY.md) for more details.
 
 ### Project Maintainers
 
-|                                                  |                                                            |                                                  |
-| :----------------------------------------------: | :--------------------------------------------------------: | :----------------------------------------------: | --- |
 |                    Diana Lau                     |                         Janny Hou                          |                    Hage Yaapa                    |
+| :----------------------------------------------: | :--------------------------------------------------------: | :----------------------------------------------: |
 |      [![dhmlau]](http://github.com/dhmlau)       |         [![jannyhou]](http://github.com/jannyHou)          | [![hacksparrow]](https://github.com/hacksparrow) |
 |                    Agnes Lin                     |                       Mario Estrada                        |                   Hugo Da Roit                   |
 |    [![agnes512]](https://github.com/agnes512)    | [![marioestradarosa]](https://github.com/marioestradarosa) |        [![yaty]](https://github.com/yaty)        |
 |                 Dominique Emond                  |                       Denny Bartelt                        |               Douglas McConnachie                |
 |     [![emonddr]](https://github.com/emonddr)     |          [![derdeka]](https://github.com/derdeka)          |    [![dougal83]](https://github.com/dougal83)    |
 |                  Rifa Achrinza                   |                      Francisco Buceta                      |                  Matthew Schnee                  |
-|    [![achrinza]](https://github.com/achrinza)    |         [![frbuceta]](https://github.com/frbuceta)         |     [![mschnee]](https://github.com/mschnee)     |     |
-|                 Nora Abdelgadir                  |                           Madaky                           |                    Nico Flaig                    |     |
-| [![nabdelgadir]](https://github.com/nabdelgadir) |           [![madaky]](https://github.com/madaky)           |      [![nflaig]](https://github.com/nflaig)      |     |
+|    [![achrinza]](https://github.com/achrinza)    |         [![frbuceta]](https://github.com/frbuceta)         |     [![mschnee]](https://github.com/mschnee)     |
+|                 Nora Abdelgadir                  |                           Madaky                           |                    Nico Flaig                    |
+| [![nabdelgadir]](https://github.com/nabdelgadir) |           [![madaky]](https://github.com/madaky)           |      [![nflaig]](https://github.com/nflaig)      |
 
 See
 [all contributors](https://github.com/strongloop/loopback-next/graphs/contributors).


### PR DESCRIPTION
Signed-off-by: jannyHou <juehou@ca.ibm.com>

The project maintainers is in disorder in https://github.com/strongloop/loopback-next#project-maintainers
vscode preview looks good but the website doesn't, so I regarated the table with https://www.tablesgenerator.com


Click the new file and preview it on website: 
<img width="555" alt="Screen Shot 2020-11-26 at 9 59 37 AM" src="https://user-images.githubusercontent.com/12554153/100365936-237b8c80-2fce-11eb-9943-bdc087721ae6.png">

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
