### PR TITLE
feat(filter): introduce simpler syntax for inclusion

### DIFF
--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -506,8 +506,6 @@ export class OrderRepository extends DefaultCrudRepository {
   ];
   ```
 
-{% include note.html content="The query syntax is a slightly different from LB3. We are also thinking about simplifying the query syntax. Check our GitHub issue for more information: [Simpler Syntax for Inclusion](https://github.com/strongloop/loopback-next/issues/3205)" %}
-
 Here is a diagram to make this more intuitive:
 
 ![Graph](./imgs/belongsTo-relation-graph.png)

--- a/docs/site/BelongsTo-relation.md
+++ b/docs/site/BelongsTo-relation.md
@@ -411,13 +411,13 @@ allows users to retrieve all orders along with their related customers through
 the following code at the repository level:
 
 ```ts
-orderRepo.find({include: [{relation: 'customer'}]});
+orderRepo.find({include: ['customer']});
 ```
 
 or use APIs with controllers:
 
 ```
-GET http://localhost:3000/orders?filter[include][][relation]=customer
+GET http://localhost:3000/orders?filter[include][]=customer
 ```
 
 ### Enable/disable the inclusion resolvers
@@ -464,13 +464,13 @@ export class OrderRepository extends DefaultCrudRepository {
   if you process data at the repository level:
 
   ```ts
-  orderRepository.find({include: [{relation: 'customer'}]});
+  orderRepository.find({include: ['customer']});
   ```
 
   this is the same as the url:
 
   ```
-  GET http://localhost:3000/orders?filter[include][][relation]=customer
+  GET http://localhost:3000/orders?filter[include][]=customer
   ```
 
   which returns:

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -513,13 +513,13 @@ allows users to retrieve all customers along with their related orders through
 the following code at the repository level:
 
 ```ts
-customerRepo.find({include: [{relation: 'orders'}]});
+customerRepo.find({include: ['orders']});
 ```
 
 or use APIs with controllers:
 
 ```
-GET http://localhost:3000/customers?filter[include][][relation]=orders
+GET http://localhost:3000/customers?filter[include][]=orders
 ```
 
 ### Enable/disable the inclusion resolvers
@@ -565,13 +565,13 @@ export class CustomerRepository extends DefaultCrudRepository {
   if you process data at the repository level:
 
   ```ts
-  customerRepository.find({include: [{relation: 'orders'}]});
+  customerRepository.find({include: ['orders']});
   ```
 
   this is the same as the url:
 
   ```
-  GET http://localhost:3000/customers?filter[include][][relation]=orders
+  GET http://localhost:3000/customers?filter[include][]=orders
   ```
 
   which returns:
@@ -618,7 +618,7 @@ To query **multiple relations**, for example, return all customers including
 their orders and address, in Node API:
 
 ```ts
-customerRepo.find({include: [{relation: 'orders'}, {relation: 'address'}]});
+customerRepo.find({include: ['orders', 'address']});
 ```
 
 Equivalently, with url, you can do:
@@ -663,7 +663,7 @@ customerRepo.find({
     {
       relation: 'orders',
       scope: {
-        include: [{relation: 'manufacturers'}],
+        include: ['manufacturers'],
       },
     },
   ],
@@ -722,7 +722,7 @@ customerRepo.find({
       relation: 'orders',
       scope: {
         where: {name: 'ToysRUs'},
-        include: [{relation: 'manufacturers'}],
+        include: ['manufacturers'],
       },
     },
   ],

--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -594,9 +594,6 @@ export class CustomerRepository extends DefaultCrudRepository {
   ];
   ```
 
-{% include note.html content="The query syntax is a slightly different from LB3. We are also thinking about simplifying the query syntax. Check our GitHub issue for more information:
-[Simpler Syntax for Inclusion](https://github.com/strongloop/loopback-next/issues/3205)" %}
-
 Here is a diagram to make this more intuitive:
 
 ![Graph](./imgs/hasMany-relation-graph.png)

--- a/docs/site/HasManyThrough-relation.md
+++ b/docs/site/HasManyThrough-relation.md
@@ -553,9 +553,6 @@ export class DoctorRepository extends DefaultCrudRepository<
   ];
   ```
 
-{% include note.html content="The query syntax is a slightly different from LB3. We are also working on simplifying the query syntax. Check our GitHub issue for more information:
-[Simpler Syntax for Inclusion](https://github.com/strongloop/loopback-next/issues/3205)" %}
-
 - You can delete a relation from `inclusionResolvers` to disable the inclusion
   for a certain relation. e.g
   `doctorRepository.inclusionResolvers.delete('patients')`

--- a/docs/site/HasManyThrough-relation.md
+++ b/docs/site/HasManyThrough-relation.md
@@ -464,13 +464,13 @@ allows users to retrieve all doctors along with their related patients through
 the following code at the repository level:
 
 ```ts
-doctorRepository.find({include: [{relation: 'patients'}]});
+doctorRepository.find({include: ['patients']});
 ```
 
 or use APIs with controllers:
 
 ```
-GET http://localhost:3000/doctors?filter[include][][relation]=patients
+GET http://localhost:3000/doctors?filter[include][]=patients
 ```
 
 ### Enable/disable the inclusion resolvers
@@ -527,13 +527,13 @@ export class DoctorRepository extends DefaultCrudRepository<
   if you process data at the repository level:
 
   ```ts
-  doctorRepository.find({include: [{relation: 'patients'}]});
+  doctorRepository.find({include: ['patients']});
   ```
 
   this is the same as the url:
 
   ```
-  GET http://localhost:3000/doctors?filter[include][][relation]=patients
+  GET http://localhost:3000/doctors?filter[include][]=patients
   ```
 
   which returns:

--- a/docs/site/HasOne-relation.md
+++ b/docs/site/HasOne-relation.md
@@ -591,9 +591,6 @@ export class SupplierRepository extends DefaultCrudRepository {
   ];
   ```
 
-{% include note.html content="The query syntax is a slightly different from LB3. We are also thinking about simplifying the query syntax. Check our GitHub issue for more information:
-[Simpler Syntax for Inclusion](https://github.com/strongloop/loopback-next/issues/3205)" %}
-
 Here is a diagram to make this more intuitive:
 
 ![Graph](./imgs/hasOne-relation-graph.png)

--- a/docs/site/HasOne-relation.md
+++ b/docs/site/HasOne-relation.md
@@ -513,13 +513,13 @@ allows users to retrieve all suppliers along with their related accounts through
 the following code at the repository level:
 
 ```ts
-supplierRepo.find({include: [{relation: 'account'}]});
+supplierRepo.find({include: ['account']});
 ```
 
 or use APIs with controllers:
 
 ```
-GET http://localhost:3000/suppliers?filter[include][][relation]=account
+GET http://localhost:3000/suppliers?filter[include][]=account
 ```
 
 ### Enable/disable the inclusion resolvers
@@ -565,13 +565,13 @@ export class SupplierRepository extends DefaultCrudRepository {
   if you process data at the repository level:
 
   ```ts
-  supplierRepository.find({include: [{relation: 'account'}]});
+  supplierRepository.find({include: ['account']});
   ```
 
   this is the same as the url:
 
   ```
-  GET http://localhost:3000/suppliers?filter[include][][relation]=account
+  GET http://localhost:3000/suppliers?filter[include][]=account
   ```
 
   which returns:
@@ -615,13 +615,13 @@ To query **multiple relations**, for example, return all Suppliers including
 their orders and address, in Node API:
 
 ```ts
-customerRepo.find({include: [{relation: 'orders'}, {relation: 'address'}]});
+customerRepo.find({include: ['orders', 'address']});
 ```
 
 Equivalently, with url, you can do:
 
 ```
-GET http://localhost:3000/customers?filter[include][0][relation]=orders&filter[include][1][relation]=address
+GET http://localhost:3000/customers?filter[include][0]=orders&filter[include][1]=address
 ```
 
 This gives
@@ -660,7 +660,7 @@ customerRepo.find({
     {
       relation: 'orders',
       scope: {
-        include: [{relation: 'manufacturers'}],
+        include: ['manufacturers'],
       },
     },
   ],

--- a/docs/site/Include-filter.md
+++ b/docs/site/Include-filter.md
@@ -21,11 +21,27 @@ To query one relation:
 
 ```ts
 {
+  include: ['relationName'];
+}
+```
+
+or
+
+```ts
+{
   include: [{relation: 'relationName'}];
 }
 ```
 
 To query multiple relations:
+
+```ts
+{
+  include: ['relationName1', 'relationName2'];
+}
+```
+
+or
 
 ```ts
 {
@@ -39,7 +55,7 @@ To query nested relations, use the scope field:
 {
     relation: 'relationName',
     scope: {
-    include: [{relation: 'nestedRelationName'}],
+      include: ['nestedRelationName'],
     },
 }
 ```
@@ -51,9 +67,12 @@ Where:
 
 ### REST API
 
-To query one relation: `/modelName?filter[include][][relation]=_relationName_`
+To query one relation: `/modelName?filter[include][]=_relationName_` or
+`/modelName?filter[include][][relation]=_relationName_`
 
 To query multiple relations:
+`/modelName?filter[include][0]=_relationName1_&filter[include][1]=_relationName2_`
+or
 `/modelName?filter[include][0][relation]=_relationName1_&filter[include][1][relation]=_relationName2_`
 
 To query nested relations, as the url would get too long, we recommend to encode
@@ -103,16 +122,16 @@ and call `/modelName?filter=<encodedFilter>`
 {% include code-caption.html content="Node.js API" %}
 
 ```ts
-await customerRepository.find({include: [{relation: 'orders'}]});
+await customerRepository.find({include: ['orders']});
 ```
 
 {% include code-caption.html content="REST" %}
 
-`/customers?filter[include][][relation]=orders`
+`/customers?filter[include][]=orders`
 
 Or stringified JSON format:
 
-`/customers?filter={"include":[{"relation":"orders"}]}`
+`/customers?filter={"include":["orders"]}`
 
 Result:
 
@@ -132,13 +151,13 @@ Result:
 
 ```ts
 await customerRepository.find({
-  include: [{relation: 'orders'}, {relation: 'address'}],
+  include: ['orders', 'address'],
 });
 ```
 
 {% include code-caption.html content="REST" %}
 
-`/customers?filter[include][0][relation]=orders?filter[include][1][relation]=address`
+`/customers?filter[include][]=orders&filter[include][]=address`
 
 Result:
 
@@ -288,19 +307,19 @@ model.
 
 Return all customers including their reviews:
 
-`/customers?filter[include][][relation]=reviews`
+`/customers?filter[include][]=reviews`
 
 Return all customers including their reviews and also their orders:
 
-`/customers?filter[include][0][relation]=reviews?filter[include][1][relation]=orders`
+`/customers?filter[include][]=reviews&filter[include][]=orders`
 
 Return all customers whose age is 21, including their reviews:
 
-`/customers?filter[include][][relation]=reviews&filter[where][age]=21`
+`/customers?filter[include][]=reviews&filter[where][age]=21`
 
 Return first two customers including their reviews:
 
-`/customers?filter[include][][relation]=reviews&filter[limit]=2`
+`/customers?filter[include][]=reviews&filter[limit]=2`
 
 **See also**:
 [Querying related models](HasMany-relation.md#querying-related-models).

--- a/examples/passport-login/src/authentication-strategies/basic.ts
+++ b/examples/passport-login/src/authentication-strategies/basic.ts
@@ -84,14 +84,7 @@ export class BasicStrategy implements AuthenticationStrategy {
         where: {
           email: username,
         },
-        include: [
-          {
-            relation: 'profiles',
-          },
-          {
-            relation: 'credentials',
-          },
-        ],
+        include: ['profiles', 'credentials'],
       })
       .then((users: User[]) => {
         if (!users || !users.length) {

--- a/examples/passport-login/src/authentication-strategies/local.ts
+++ b/examples/passport-login/src/authentication-strategies/local.ts
@@ -75,14 +75,7 @@ export class LocalAuthStrategy implements AuthenticationStrategy {
         where: {
           email: username,
         },
-        include: [
-          {
-            relation: 'profiles',
-          },
-          {
-            relation: 'credentials',
-          },
-        ],
+        include: ['profiles', 'credentials'],
       })
       .then((users: User[]) => {
         const AUTH_FAILED_MESSAGE = 'User Name / Password not matching';

--- a/examples/passport-login/src/controllers/user.controller.ts
+++ b/examples/passport-login/src/controllers/user.controller.ts
@@ -141,11 +141,7 @@ export class UserLoginController {
     const user = await this.userRepository.findById(
       parseInt(profile[securityId]),
       {
-        include: [
-          {
-            relation: 'profiles',
-          },
-        ],
+        include: ['profiles'],
       },
     );
     return user.profiles;

--- a/examples/passport-login/src/services/user.service.ts
+++ b/examples/passport-login/src/services/user.service.ts
@@ -89,11 +89,7 @@ export class PassportUserIdentityService
     }
     if (!userId) console.log('user id is empty');
     return this.userRepository.findById(parseInt(userId), {
-      include: [
-        {
-          relation: 'profiles',
-        },
-      ],
+      include: ['profiles'],
     });
   }
 

--- a/examples/todo-list/src/__tests__/acceptance/todo-list.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo-list.acceptance.ts
@@ -199,7 +199,7 @@ describe('TodoListApplication', () => {
   it('includes Todos in query result', async () => {
     const list = await givenTodoListInstance(todoListRepo);
     const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
-    const filter = JSON.stringify({include: [{relation: 'todos'}]});
+    const filter = JSON.stringify({include: ['todos']});
 
     const response = await client.get('/todo-lists').query({filter: filter});
 

--- a/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
+++ b/examples/todo-list/src/__tests__/acceptance/todo.acceptance.ts
@@ -171,7 +171,7 @@ describe('TodoListApplication', () => {
   it('includes TodoList in query result', async () => {
     const list = await givenTodoListInstance(todoListRepo);
     const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
-    const filter = JSON.stringify({include: [{relation: 'todoList'}]});
+    const filter = JSON.stringify({include: ['todoList']});
 
     const response = await client.get('/todos').query({filter: filter});
 

--- a/examples/todo-list/src/__tests__/integration/todo-list-image.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo-list-image.repository.integration.ts
@@ -42,7 +42,7 @@ describe('TodoListImageRepository', () => {
     });
 
     const response = await todoListImageRepo.find({
-      include: [{relation: 'todoList'}],
+      include: ['todoList'],
     });
 
     expect(toJSON(response)).to.deepEqual([
@@ -60,7 +60,7 @@ describe('TodoListImageRepository', () => {
     });
 
     const response = await todoListImageRepo.findById(image.id, {
-      include: [{relation: 'todoList'}],
+      include: ['todoList'],
     });
 
     expect(toJSON(response)).to.deepEqual({
@@ -76,7 +76,7 @@ describe('TodoListImageRepository', () => {
     });
 
     const response = await todoListImageRepo.findOne({
-      include: [{relation: 'todoList'}],
+      include: ['todoList'],
     });
 
     expect(toJSON(response)).to.deepEqual({

--- a/examples/todo-list/src/__tests__/integration/todo-list.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo-list.repository.integration.ts
@@ -42,7 +42,7 @@ describe('TodoListRepository', () => {
     const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
 
     const response = await todoListRepo.find({
-      include: [{relation: 'todos'}],
+      include: ['todos'],
     });
 
     expect(toJSON(response)).to.deepEqual([
@@ -58,7 +58,7 @@ describe('TodoListRepository', () => {
     const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
 
     const response = await todoListRepo.findById(list.id, {
-      include: [{relation: 'todos'}],
+      include: ['todos'],
     });
 
     expect(toJSON(response)).to.deepEqual({
@@ -73,7 +73,7 @@ describe('TodoListRepository', () => {
 
     const response = await todoListRepo.findOne({
       where: {id: list.id},
-      include: [{relation: 'todos'}],
+      include: ['todos'],
     });
 
     expect(toJSON(response)).to.deepEqual({
@@ -89,7 +89,7 @@ describe('TodoListRepository', () => {
     });
 
     const response = await todoListRepo.find({
-      include: [{relation: 'image'}],
+      include: ['image'],
     });
 
     expect(toJSON(response)).to.deepEqual([
@@ -107,7 +107,7 @@ describe('TodoListRepository', () => {
     });
 
     const response = await todoListRepo.findById(list.id, {
-      include: [{relation: 'image'}],
+      include: ['image'],
     });
 
     expect(toJSON(response)).to.deepEqual({
@@ -123,7 +123,7 @@ describe('TodoListRepository', () => {
     });
 
     const response = await todoListRepo.findOne({
-      include: [{relation: 'image'}],
+      include: ['image'],
     });
 
     expect(toJSON(response)).to.deepEqual({
@@ -140,7 +140,7 @@ describe('TodoListRepository', () => {
     });
 
     const response = await todoListRepo.find({
-      include: [{relation: 'image'}, {relation: 'todos'}],
+      include: ['image', 'todos'],
     });
 
     expect(toJSON(response)).to.deepEqual([

--- a/examples/todo-list/src/__tests__/integration/todo.repository.integration.ts
+++ b/examples/todo-list/src/__tests__/integration/todo.repository.integration.ts
@@ -37,7 +37,7 @@ describe('TodoRepository', () => {
     const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
 
     const response = await todoRepo.find({
-      include: [{relation: 'todoList'}],
+      include: ['todoList'],
     });
 
     expect(toJSON(response)).to.deepEqual([
@@ -53,7 +53,7 @@ describe('TodoRepository', () => {
     const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
 
     const response = await todoRepo.findById(todo.id, {
-      include: [{relation: 'todoList'}],
+      include: ['todoList'],
     });
 
     expect(toJSON(response)).to.deepEqual({
@@ -67,7 +67,7 @@ describe('TodoRepository', () => {
     const todo = await givenTodoInstance(todoRepo, {todoListId: list.id});
 
     const response = await todoRepo.findOne({
-      include: [{relation: 'todoList'}],
+      include: ['todoList'],
     });
 
     expect(toJSON(response)).to.deepEqual({

--- a/packages/filter/src/query.ts
+++ b/packages/filter/src/query.ts
@@ -220,8 +220,13 @@ export interface Filter<MT extends object = AnyObject> {
   /**
    * To include related objects
    */
-  include?: Inclusion[];
+  include?: InclusionFilter[];
 }
+
+/**
+ * Inclusion filter type e.g. 'property', {relation: 'property'}
+ */
+export type InclusionFilter = string | Inclusion;
 
 /**
  * Filter without `where` property

--- a/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
+++ b/packages/repository-json-schema/src/__tests__/unit/filter-json-schema.unit.ts
@@ -262,7 +262,7 @@ describe('getFilterJsonSchemaFor', () => {
 
   it('returns "include.items.title" when no options were provided', () => {
     expect(customerFilterSchema.properties)
-      .to.have.propertyByPath('include', 'items', 'title')
+      .to.have.propertyByPath('include', 'items', 'anyOf', '0', 'title')
       .to.equal('Customer.IncludeFilter.Items');
   });
 
@@ -271,6 +271,8 @@ describe('getFilterJsonSchemaFor', () => {
       .to.have.propertyByPath(
         'include',
         'items',
+        'anyOf',
+        '0',
         'properties',
         'scope',
         'title',
@@ -341,7 +343,7 @@ describe('getFilterJsonSchemaForOptionsSetTitle', () => {
 
   it('returns "include.items.title" when a single option "setTitle" is set', () => {
     expect(customerFilterSchema.properties)
-      .to.have.propertyByPath('include', 'items', 'title')
+      .to.have.propertyByPath('include', 'items', 'anyOf', '0', 'title')
       .to.equal('Customer.IncludeFilter.Items');
   });
 
@@ -350,6 +352,8 @@ describe('getFilterJsonSchemaForOptionsSetTitle', () => {
       .to.have.propertyByPath(
         'include',
         'items',
+        'anyOf',
+        '0',
         'properties',
         'scope',
         'title',
@@ -377,13 +381,13 @@ describe('getFilterJsonSchemaForOptionsUnsetTitle', () => {
 
   it('no title on include.items when single option "setTitle" is false', () => {
     expect(customerFilterSchema.properties)
-      .propertyByPath('include', 'items')
+      .propertyByPath('include', 'items', 'anyOf', '0')
       .to.not.have.property('title');
   });
 
   it('no title on scope when single option "setTitle" is false', () => {
     expect(customerFilterSchema.properties)
-      .propertyByPath('include', 'items', 'properties', 'scope')
+      .propertyByPath('include', 'items', 'anyOf', '0', 'properties', 'scope')
       .to.not.have.property('title');
   });
 });

--- a/packages/repository-json-schema/src/filter-json-schema.ts
+++ b/packages/repository-json-schema/src/filter-json-schema.ts
@@ -143,16 +143,23 @@ export function getFilterJsonSchemaFor(
       }),
       type: 'array',
       items: {
-        ...(options.setTitle !== false && {
-          title: `${modelCtor.modelName}.IncludeFilter.Items`,
-        }),
-        type: 'object',
-        properties: {
-          // TODO(bajtos) restrict values to relations defined by "model"
-          relation: {type: 'string'},
-          // TODO(bajtos) describe the filter for the relation target model
-          scope: getScopeFilterJsonSchemaFor(modelCtor, options),
-        },
+        anyOf: [
+          {
+            ...(options.setTitle !== false && {
+              title: `${modelCtor.modelName}.IncludeFilter.Items`,
+            }),
+            type: 'object',
+            properties: {
+              // TODO(bajtos) restrict values to relations defined by "model"
+              relation: {type: 'string'},
+              // TODO(bajtos) describe the filter for the relation target model
+              scope: getScopeFilterJsonSchemaFor(modelCtor, options),
+            },
+          },
+          {
+            type: 'string',
+          },
+        ],
       },
     };
   }

--- a/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/belongs-to.inclusion-resolver.relation.acceptance.ts
@@ -59,16 +59,14 @@ export function belongsToInclusionResolverAcceptance(
       await orderRepo.deleteAll();
     });
 
-    it('throws an error if it tries to query nonexists relation names', async () => {
+    it('throws an error if it tries to query nonexistent relation names', async () => {
       const customer = await customerRepo.create({name: 'customer'});
       await orderRepo.create({
         description: 'an order',
         customerId: customer.id,
       });
-      await expect(
-        orderRepo.find({include: [{relation: 'shipment'}]}),
-      ).to.be.rejectedWith(
-        `Invalid "filter.include" entries: {"relation":"shipment"}`,
+      await expect(orderRepo.find({include: ['shipment']})).to.be.rejectedWith(
+        `Invalid "filter.include" entries: "shipment"`,
       );
     });
 
@@ -79,7 +77,7 @@ export function belongsToInclusionResolverAcceptance(
         customerId: thor.id,
       });
       const result = await orderRepo.find({
-        include: [{relation: 'customer'}],
+        include: ['customer'],
       });
 
       const expected = {
@@ -107,7 +105,7 @@ export function belongsToInclusionResolverAcceptance(
       });
 
       const result = await orderRepo.find({
-        include: [{relation: 'customer'}],
+        include: ['customer'],
       });
 
       const expected = [
@@ -146,7 +144,7 @@ export function belongsToInclusionResolverAcceptance(
       });
 
       const result = await orderRepo.findById(odinOrder.id, {
-        include: [{relation: 'customer'}],
+        include: ['customer'],
       });
       const expected = {
         ...odinOrder,
@@ -194,7 +192,7 @@ export function belongsToInclusionResolverAcceptance(
         },
       ];
 
-      const result = await orderRepo.find({include: [{relation: 'customer'}]});
+      const result = await orderRepo.find({include: ['customer']});
       expect(toJSON(result)).to.deepEqual(toJSON(expected));
     });
 
@@ -207,10 +205,8 @@ export function belongsToInclusionResolverAcceptance(
       // unregister the resolver
       orderRepo.inclusionResolvers.delete('customer');
 
-      await expect(
-        orderRepo.find({include: [{relation: 'customer'}]}),
-      ).to.be.rejectedWith(
-        `Invalid "filter.include" entries: {"relation":"customer"}`,
+      await expect(orderRepo.find({include: ['customer']})).to.be.rejectedWith(
+        `Invalid "filter.include" entries: "customer"`,
       );
     });
   }

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-inclusion-resolver.relation.acceptance.ts
@@ -69,10 +69,8 @@ export function hasManyInclusionResolverAcceptance(
         customerId: customer.id,
       });
       await expect(
-        customerRepo.find({include: [{relation: 'managers'}]}),
-      ).to.be.rejectedWith(
-        `Invalid "filter.include" entries: {"relation":"managers"}`,
-      );
+        customerRepo.find({include: ['managers']}),
+      ).to.be.rejectedWith(`Invalid "filter.include" entries: "managers"`);
     });
 
     it('returns single model instance including single related instance', async () => {
@@ -82,7 +80,7 @@ export function hasManyInclusionResolverAcceptance(
         description: "Thor's Mjolnir",
       });
       const result = await customerRepo.find({
-        include: [{relation: 'orders'}],
+        include: ['orders'],
       });
 
       expect(toJSON(result)).to.deepEqual([
@@ -117,7 +115,7 @@ export function hasManyInclusionResolverAcceptance(
       });
 
       const result = await customerRepo.find({
-        include: [{relation: 'orders'}],
+        include: ['orders'],
       });
 
       const expected = [
@@ -169,7 +167,7 @@ export function hasManyInclusionResolverAcceptance(
       });
 
       const result = await customerRepo.findById(odin.id, {
-        include: [{relation: 'orders'}],
+        include: ['orders'],
       });
       const expected = {
         ...odin,
@@ -198,7 +196,7 @@ export function hasManyInclusionResolverAcceptance(
       });
 
       const found = await shipmentRepo.find({
-        include: [{relation: 'shipmentOrders'}],
+        include: ['shipmentOrders'],
       });
 
       expect(toJSON(found)).containDeep(
@@ -240,7 +238,7 @@ export function hasManyInclusionResolverAcceptance(
         const odinPizza = await orderRepo.findById(thorOrder.id);
 
         const result = await customerRepo.findById(odin.id, {
-          include: [{relation: 'orders'}],
+          include: ['orders'],
         });
         const expected = {
           ...odin,
@@ -283,7 +281,7 @@ export function hasManyInclusionResolverAcceptance(
         const odinPizza = await orderRepo.findById(thorOrder.id);
 
         const result = await customerRepo.find({
-          include: [{relation: 'orders'}],
+          include: ['orders'],
         });
         const expected = [
           {
@@ -323,7 +321,7 @@ export function hasManyInclusionResolverAcceptance(
       const odinPizza = await orderRepo.findById(thorOrder.id);
 
       const result = await customerRepo.find({
-        include: [{relation: 'orders'}],
+        include: ['orders'],
       });
       const expected = [
         {
@@ -357,7 +355,7 @@ export function hasManyInclusionResolverAcceptance(
       });
 
       const found = await customerRepo.findById(customerId, {
-        include: [{relation: 'orders'}],
+        include: ['orders'],
       });
       expect(found.orders).to.have.lengthOf(1);
 
@@ -383,10 +381,8 @@ export function hasManyInclusionResolverAcceptance(
       // unregister the resolver
       customerRepo.inclusionResolvers.delete('orders');
 
-      await expect(
-        customerRepo.find({include: [{relation: 'orders'}]}),
-      ).to.be.rejectedWith(
-        `Invalid "filter.include" entries: {"relation":"orders"}`,
+      await expect(customerRepo.find({include: ['orders']})).to.be.rejectedWith(
+        `Invalid "filter.include" entries: "orders"`,
       );
     });
   }

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many-through-inclusion-resolver.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many-through-inclusion-resolver.acceptance.ts
@@ -83,10 +83,8 @@ export function hasManyThroughInclusionResolverAcceptance(
           .create({description: 'crown'});
 
         await expect(
-          customerRepo.find({include: [{relation: 'crown'}]}),
-        ).to.be.rejectedWith(
-          `Invalid "filter.include" entries: {"relation":"crown"}`,
-        );
+          customerRepo.find({include: ['crown']}),
+        ).to.be.rejectedWith(`Invalid "filter.include" entries: "crown"`);
       });
 
       it('returns single model instance including single related instance', async () => {
@@ -96,7 +94,7 @@ export function hasManyThroughInclusionResolverAcceptance(
           .create({description: 'crown'});
 
         const result = await customerRepo.find({
-          include: [{relation: 'cartItems'}],
+          include: ['cartItems'],
         });
 
         expect(toJSON(result)).to.deepEqual([
@@ -121,7 +119,7 @@ export function hasManyThroughInclusionResolverAcceptance(
           .create({description: 'green hat'});
 
         const result = await customerRepo.find({
-          include: [{relation: 'cartItems'}],
+          include: ['cartItems'],
         });
 
         const expected = [
@@ -148,7 +146,7 @@ export function hasManyThroughInclusionResolverAcceptance(
           .create({description: 'green hat'});
 
         const result = await customerRepo.findById(zelda.id, {
-          include: [{relation: 'cartItems'}],
+          include: ['cartItems'],
         });
         const expected = {
           ...zelda,
@@ -228,7 +226,7 @@ export function hasManyThroughInclusionResolverAcceptance(
         const zelda = await userRepo.users(link.id).create({name: 'zelda'});
 
         const result = await userRepo.findById(link.id, {
-          include: [{relation: 'users'}],
+          include: ['users'],
         });
 
         expect(toJSON(result)).to.deepEqual(
@@ -246,7 +244,7 @@ export function hasManyThroughInclusionResolverAcceptance(
         const hilda = await userRepo.users(link.id).create({name: 'hilda'});
 
         const result = await userRepo.find({
-          include: [{relation: 'users'}],
+          include: ['users'],
         });
 
         const expected = [

--- a/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-many.relation.acceptance.ts
@@ -250,7 +250,7 @@ export function hasManyRelationAcceptance(
       });
 
       const found = await customerRepo.findById(created.id, {
-        include: [{relation: 'orders'}],
+        include: ['orders'],
       });
       expect(found.orders).to.have.lengthOf(1);
 
@@ -292,7 +292,7 @@ export function hasManyRelationAcceptance(
       });
 
       const found = await customerRepo.findById(customer.id, {
-        include: [{relation: 'orders'}],
+        include: ['orders'],
       });
 
       await expect(customerRepo.delete(found)).to.be.rejectedWith(

--- a/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/has-one.inclusion-resolver.acceptance.ts
@@ -68,10 +68,8 @@ export function hasOneInclusionResolverAcceptance(
         zipcode: '8200',
         customerId: customer.id,
       });
-      await expect(
-        customerRepo.find({include: [{relation: 'home'}]}),
-      ).to.be.rejectedWith(
-        `Invalid "filter.include" entries: {"relation":"home"}`,
+      await expect(customerRepo.find({include: ['home']})).to.be.rejectedWith(
+        `Invalid "filter.include" entries: "home"`,
       );
     });
 
@@ -85,7 +83,7 @@ export function hasOneInclusionResolverAcceptance(
         customerId: thor.id,
       });
       const result = await customerRepo.find({
-        include: [{relation: 'address'}],
+        include: ['address'],
       });
 
       const expected = {
@@ -115,7 +113,7 @@ export function hasOneInclusionResolverAcceptance(
       });
 
       const result = await customerRepo.find({
-        include: [{relation: 'address'}],
+        include: ['address'],
       });
 
       const expected = [
@@ -152,7 +150,7 @@ export function hasOneInclusionResolverAcceptance(
       });
 
       const result = await customerRepo.findById(odin.id, {
-        include: [{relation: 'address'}],
+        include: ['address'],
       });
       const expected = {
         ...odin,
@@ -175,10 +173,8 @@ export function hasOneInclusionResolverAcceptance(
       customerRepo.inclusionResolvers.delete('address');
 
       await expect(
-        customerRepo.find({include: [{relation: 'address'}]}),
-      ).to.be.rejectedWith(
-        `Invalid "filter.include" entries: {"relation":"address"}`,
-      );
+        customerRepo.find({include: ['address']}),
+      ).to.be.rejectedWith(`Invalid "filter.include" entries: "address"`);
     });
   }
 }

--- a/packages/repository-tests/src/crud/relations/acceptance/multi-relations-inclusion-resolver.relation.acceptance.ts
+++ b/packages/repository-tests/src/crud/relations/acceptance/multi-relations-inclusion-resolver.relation.acceptance.ts
@@ -66,7 +66,7 @@ export function hasManyInclusionResolverAcceptance(
       await orderRepo.deleteAll();
     });
 
-    it('include multiple relations', async () => {
+    it('includes multiple relations', async () => {
       const parent = await customerRepo.create({name: 'parent'});
       const customer = await customerRepo.create({
         name: 'customer',
@@ -86,6 +86,90 @@ export function hasManyInclusionResolverAcceptance(
 
       const result = await customerRepo.find({
         include: [{relation: 'orders'}, {relation: 'address'}],
+      });
+      const expected = [
+        {
+          ...parent,
+          parentId: features.emptyValue,
+          orders: [
+            {
+              ...order,
+              isShipped: features.emptyValue,
+              shipmentInfo: features.emptyValue,
+            },
+          ],
+          address: address,
+        },
+        {
+          ...customer,
+          parentId: features.emptyValue, //parent.id, // doesn't have any related models
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('includes multiple relations with simplified syntax', async () => {
+      const parent = await customerRepo.create({name: 'parent'});
+      const customer = await customerRepo.create({
+        name: 'customer',
+        //parentId: parent.id,
+      });
+      const address = await addressRepo.create({
+        street: '8200 Warden',
+        city: 'Markham',
+        province: 'On',
+        zipcode: '8200',
+        customerId: parent.id,
+      });
+      const order = await orderRepo.create({
+        description: 'an order',
+        customerId: parent.id,
+      });
+
+      const result = await customerRepo.find({
+        include: ['orders', 'address'],
+      });
+      const expected = [
+        {
+          ...parent,
+          parentId: features.emptyValue,
+          orders: [
+            {
+              ...order,
+              isShipped: features.emptyValue,
+              shipmentInfo: features.emptyValue,
+            },
+          ],
+          address: address,
+        },
+        {
+          ...customer,
+          parentId: features.emptyValue, //parent.id, // doesn't have any related models
+        },
+      ];
+      expect(toJSON(result)).to.deepEqual(toJSON(expected));
+    });
+
+    it('includes multiple relations with mixed syntax', async () => {
+      const parent = await customerRepo.create({name: 'parent'});
+      const customer = await customerRepo.create({
+        name: 'customer',
+        //parentId: parent.id,
+      });
+      const address = await addressRepo.create({
+        street: '8200 Warden',
+        city: 'Markham',
+        province: 'On',
+        zipcode: '8200',
+        customerId: parent.id,
+      });
+      const order = await orderRepo.create({
+        description: 'an order',
+        customerId: parent.id,
+      });
+
+      const result = await customerRepo.find({
+        include: ['orders', {relation: 'address'}],
       });
       const expected = [
         {
@@ -172,7 +256,7 @@ export function hasManyInclusionResolverAcceptance(
       expect(toJSON(result)).to.deepEqual(toJSON(expected));
     });
 
-    it('throws if the custom scope contains nonexists relation name', async () => {
+    it('throws if the custom scope contains nonexistent relation name', async () => {
       const customer = await customerRepo.create({name: 'customer'});
       await orderRepo.create({
         description: 'order',

--- a/packages/repository/src/__tests__/unit/repositories/legacy-juggler-bridge.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/legacy-juggler-bridge.unit.ts
@@ -425,7 +425,7 @@ describe('DefaultCrudRepository', () => {
 
         folderRepo.registerInclusionResolver('files', hasManyResolver);
 
-        const folders = await folderRepo.find({include: [{relation: 'files'}]});
+        const folders = await folderRepo.find({include: ['files']});
 
         expect(toJSON(folders)).to.deepEqual([
           {...createdFolders[0].toJSON(), files: [toJSON(files[0])]},
@@ -447,7 +447,7 @@ describe('DefaultCrudRepository', () => {
         fileRepo.registerInclusionResolver('folder', belongsToResolver);
 
         const file = await fileRepo.findById(1, {
-          include: [{relation: 'folder'}],
+          include: ['folder'],
         });
 
         expect(file.toJSON()).to.deepEqual({
@@ -470,7 +470,7 @@ describe('DefaultCrudRepository', () => {
         folderRepo.registerInclusionResolver('author', hasOneResolver);
 
         const folder = await folderRepo.findOne({
-          include: [{relation: 'author'}],
+          include: ['author'],
         });
 
         expect(folder!.toJSON()).to.deepEqual({

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/find-by-foreign-keys.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/find-by-foreign-keys.unit.ts
@@ -4,16 +4,16 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
-  expect,
   createStubInstance,
+  expect,
   sinon,
   StubbedInstanceWithSinonAccessor,
 } from '@loopback/testlab';
 import {findByForeignKeys} from '../../../..';
 import {
-  ProductRepository,
-  Product,
   createProduct,
+  Product,
+  ProductRepository,
 } from './relations-helpers-fixtures';
 
 describe('findByForeignKeys', () => {
@@ -142,7 +142,7 @@ describe('findByForeignKeys', () => {
     await productRepo.create({id: 2, name: 'product', categoryId: 1});
     await findByForeignKeys(productRepo, 'categoryId', 1, {
       where: {id: 2},
-      include: [{relation: 'nested inclusion'}],
+      include: ['nested inclusion'],
     });
 
     sinon.assert.calledWithMatch(find, {
@@ -150,7 +150,7 @@ describe('findByForeignKeys', () => {
         categoryId: 1,
         id: 2,
       },
-      include: [{relation: 'nested inclusion'}],
+      include: ['nested inclusion'],
     });
   });
 });

--- a/packages/repository/src/__tests__/unit/repositories/relations-helpers/include-related-models.unit.ts
+++ b/packages/repository/src/__tests__/unit/repositories/relations-helpers/include-related-models.unit.ts
@@ -42,7 +42,7 @@ describe('includeRelatedModels', () => {
   context(
     'throws error if the target repository does not have registered resolvers',
     () => {
-      it('the error message reports the invalid entry', async () => {
+      it('the error message reports the invalid entry with relation property', async () => {
         const category = await categoryRepo.create({name: 'category 1'});
         await expect(
           includeRelatedModels(
@@ -52,6 +52,14 @@ describe('includeRelatedModels', () => {
           ),
         ).to.be.rejectedWith(
           /Invalid "filter.include" entries: {"relation":"notRegistered"}/,
+        );
+      });
+      it('the error message reports the invalid entry', async () => {
+        const category = await categoryRepo.create({name: 'category 1'});
+        await expect(
+          includeRelatedModels(categoryRepo, [category], ['notRegistered']),
+        ).to.be.rejectedWith(
+          /Invalid "filter.include" entries: "notRegistered"/,
         );
       });
       it('the error statusCode should be 400', async () => {
@@ -80,7 +88,7 @@ describe('includeRelatedModels', () => {
     const categories = await includeRelatedModels(
       categoryRepo,
       [category],
-      [{relation: 'products'}],
+      ['products'],
     );
 
     expect(categories[0].products).to.be.empty();
@@ -98,7 +106,7 @@ describe('includeRelatedModels', () => {
     const productWithCategories = await includeRelatedModels(
       productRepo,
       [product],
-      [{relation: 'category'}],
+      ['category'],
     );
 
     expect(productWithCategories[0].toJSON()).to.deepEqual({
@@ -130,7 +138,7 @@ describe('includeRelatedModels', () => {
     const productWithCategories = await includeRelatedModels(
       productRepo,
       [productOne, productTwo, productThree],
-      [{relation: 'category'}],
+      ['category'],
     );
 
     expect(toJSON(productWithCategories)).to.deepEqual([
@@ -157,7 +165,7 @@ describe('includeRelatedModels', () => {
     const categoryWithProducts = await includeRelatedModels(
       categoryRepo,
       [category],
-      [{relation: 'products'}],
+      ['products'],
     );
 
     expect(toJSON(categoryWithProducts)).to.deepEqual([
@@ -192,7 +200,7 @@ describe('includeRelatedModels', () => {
     const categoryWithProducts = await includeRelatedModels(
       categoryRepo,
       [categoryOne, categoryTwo, categoryThree],
-      [{relation: 'products'}],
+      ['products'],
     );
 
     expect(toJSON(categoryWithProducts)).to.deepEqual([

--- a/packages/repository/src/relations/belongs-to/belongs-to.inclusion-resolver.ts
+++ b/packages/repository/src/relations/belongs-to/belongs-to.inclusion-resolver.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {Filter, InclusionFilter} from '@loopback/filter';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
-import {Filter, Inclusion} from '@loopback/filter';
 import {EntityCrudRepository} from '../../repositories/repository';
 import {
   deduplicate,
@@ -44,7 +44,7 @@ export function createBelongsToInclusionResolver<
 
   return async function fetchIncludedModels(
     entities: Entity[],
-    inclusion: Inclusion,
+    inclusion: InclusionFilter,
     options?: Options,
   ): Promise<((Target & TargetRelations) | undefined)[]> {
     if (!entities.length) return [];
@@ -54,12 +54,15 @@ export function createBelongsToInclusionResolver<
     const targetKey = relationMeta.keyTo as StringKeyOf<Target>;
     const dedupedSourceIds = deduplicate(sourceIds);
 
+    const scope =
+      typeof inclusion === 'string' ? {} : (inclusion.scope as Filter<Target>);
+
     const targetRepo = await getTargetRepo();
     const targetsFound = await findByForeignKeys(
       targetRepo,
       targetKey,
       dedupedSourceIds.filter(e => e),
-      inclusion.scope as Filter<Target>,
+      scope,
       options,
     );
 

--- a/packages/repository/src/relations/has-many/has-many-through.inclusion.resolver.ts
+++ b/packages/repository/src/relations/has-many/has-many-through.inclusion.resolver.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Filter, Inclusion} from '@loopback/filter';
+import {Filter, InclusionFilter} from '@loopback/filter';
 import debugFactory from 'debug';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
@@ -52,7 +52,7 @@ export function createHasManyThroughInclusionResolver<
 
   return async function fetchHasManyThroughModels(
     entities: Entity[],
-    inclusion: Inclusion,
+    inclusion: InclusionFilter,
     options?: Options,
   ): Promise<((Target & TargetRelations)[] | undefined)[]> {
     if (!entities.length) return [];
@@ -104,6 +104,9 @@ export function createHasManyThroughInclusionResolver<
 
     const result = [];
 
+    const scope =
+      typeof inclusion === 'string' ? {} : (inclusion.scope as Filter<Target>);
+
     // convert from through entities to the target entities
     for (const entityList of throughResult) {
       if (entityList) {
@@ -115,13 +118,7 @@ export function createHasManyThroughInclusionResolver<
           Target,
           TargetRelations,
           StringKeyOf<Target>
-        >(
-          targetRepo,
-          targetKey,
-          (targetIds as unknown) as [],
-          inclusion.scope as Filter<Target>,
-          options,
-        );
+        >(targetRepo, targetKey, (targetIds as unknown) as [], scope, options);
         result.push(targetEntityList);
       } else {
         // no entities found, add undefined to results

--- a/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-many/has-many.inclusion-resolver.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Filter, Inclusion} from '@loopback/filter';
+import {Filter, InclusionFilter} from '@loopback/filter';
 import debugFactory from 'debug';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
@@ -42,7 +42,7 @@ export function createHasManyInclusionResolver<
 
   return async function fetchHasManyModels(
     entities: Entity[],
-    inclusion: Inclusion,
+    inclusion: InclusionFilter,
     options?: Options,
   ): Promise<((Target & TargetRelations)[] | undefined)[]> {
     if (!entities.length) return [];
@@ -60,12 +60,15 @@ export function createHasManyInclusionResolver<
       sourceIds.map(i => typeof i),
     );
 
+    const scope =
+      typeof inclusion === 'string' ? {} : (inclusion.scope as Filter<Target>);
+
     const targetRepo = await getTargetRepo();
     const targetsFound = await findByForeignKeys(
       targetRepo,
       targetKey,
       sourceIds,
-      inclusion.scope as Filter<Target>,
+      scope,
       options,
     );
 

--- a/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
+++ b/packages/repository/src/relations/has-one/has-one.inclusion-resolver.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Filter, Inclusion} from '@loopback/filter';
+import {Filter, InclusionFilter} from '@loopback/filter';
 import {AnyObject, Options} from '../../common-types';
 import {Entity} from '../../model';
 import {EntityCrudRepository} from '../../repositories/repository';
@@ -39,7 +39,7 @@ export function createHasOneInclusionResolver<
 
   return async function fetchHasOneModel(
     entities: Entity[],
-    inclusion: Inclusion,
+    inclusion: InclusionFilter,
     options?: Options,
   ): Promise<((Target & TargetRelations) | undefined)[]> {
     if (!entities.length) return [];
@@ -48,12 +48,15 @@ export function createHasOneInclusionResolver<
     const sourceIds = entities.map(e => (e as AnyObject)[sourceKey]);
     const targetKey = relationMeta.keyTo as StringKeyOf<Target>;
 
+    const scope =
+      typeof inclusion === 'string' ? {} : (inclusion.scope as Filter<Target>);
+
     const targetRepo = await getTargetRepo();
     const targetsFound = await findByForeignKeys(
       targetRepo,
       targetKey,
       sourceIds,
-      inclusion.scope as Filter<Target>,
+      scope,
       options,
     );
 

--- a/packages/repository/src/relations/relation.helpers.ts
+++ b/packages/repository/src/relations/relation.helpers.ts
@@ -12,7 +12,7 @@ import {
   EntityCrudRepository,
   Filter,
   FilterBuilder,
-  Inclusion,
+  InclusionFilter,
   Options,
   Where,
 } from '..';
@@ -84,7 +84,7 @@ export async function includeRelatedModels<
 >(
   targetRepository: EntityCrudRepository<T, unknown, Relations>,
   entities: T[],
-  include?: Inclusion[],
+  include?: InclusionFilter[],
   options?: Options,
 ): Promise<(T & Relations)[]> {
   const result = entities as (T & Relations)[];
@@ -108,7 +108,10 @@ export async function includeRelatedModels<
   }
 
   const resolveTasks = include.map(async inclusionFilter => {
-    const relationName = inclusionFilter.relation;
+    const relationName =
+      typeof inclusionFilter === 'string'
+        ? inclusionFilter
+        : inclusionFilter.relation;
     const resolver = targetRepository.inclusionResolvers.get(relationName)!;
     const targets = await resolver(entities, inclusionFilter, options);
 
@@ -131,9 +134,9 @@ export async function includeRelatedModels<
  */
 function isInclusionAllowed<T extends Entity, Relations extends object = {}>(
   targetRepository: EntityCrudRepository<T, unknown, Relations>,
-  include: Inclusion,
+  include: InclusionFilter,
 ): boolean {
-  const relationName = include.relation;
+  const relationName = typeof include === 'string' ? include : include.relation;
   if (!relationName) {
     debug('isInclusionAllowed for %j? No: missing relation name', include);
     return false;

--- a/packages/repository/src/relations/relation.types.ts
+++ b/packages/repository/src/relations/relation.types.ts
@@ -3,7 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Inclusion} from '@loopback/filter';
+import {InclusionFilter} from '@loopback/filter';
 import {Options} from '../common-types';
 import {Entity} from '../model';
 import {TypeResolver} from '../type-resolver';
@@ -172,7 +172,7 @@ export type InclusionResolver<S extends Entity, T extends Entity> = (
   /**
    * Inclusion requested by the user (e.g. scope constraints to apply).
    */
-  inclusion: Inclusion,
+  inclusion: InclusionFilter,
   /**
    * Generic options object, e.g. carrying the Transaction object.
    */

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Getter} from '@loopback/core';
-import {Filter, FilterExcludingWhere, Inclusion, Where} from '@loopback/filter';
+import {
+  Filter,
+  FilterExcludingWhere,
+  InclusionFilter,
+  Where,
+} from '@loopback/filter';
 import assert from 'assert';
 import legacy from 'loopback-datasource-juggler';
 import {
@@ -695,7 +700,7 @@ export class DefaultCrudRepository<
    */
   protected async includeRelatedModels(
     entities: T[],
-    include?: Inclusion[],
+    include?: InclusionFilter[],
     options?: Options,
   ): Promise<(T & Relations)[]> {
     return includeRelatedModels<T, Relations>(this, entities, include, options);


### PR DESCRIPTION
Closes https://github.com/strongloop/loopback-next/issues/3205.

The following syntax will now also be supported:

```
include: ['relationName']

include: ['relationName', {relation: 'relationName2'}]
```


```
/modelName?filter[include][]=_relationName_
```

(Backwards compatible with older syntax).

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
