### PR TITLE
docs: add note about current GeoPoint type support

### DIFF
--- a/docs/site/LoopBack-types.md
+++ b/docs/site/LoopBack-types.md
@@ -130,6 +130,9 @@ value is provided.
  The type name is case-insensitive; so for example you can use either \"Number\" or \"number\".
 " %}
 
+{% include note.html content="`GeoPoint` is not supported. See GitHub issue
+[#1981](https://github.com/strongloop/loopback-next/issues/1981)" %}
+
 ## Array types
 
 The following are examples of how you can define array type properties:


### PR DESCRIPTION
Signed-off-by: kursattokpinar <kursattokpinar@gmail.com>

GeoPoint implementation is not completed yet. It'd be better if we add a note to Loopback Types page.
See [Cannot start the application. Error: Unsupported type: geopoint](https://github.com/strongloop/loopback-next/issues/1981)"

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
