### PR TITLE
Update links surrounding the authorization component documentation

### DIFF
--- a/docs/site/Authorization-component-decision-matrix.md
+++ b/docs/site/Authorization-component-decision-matrix.md
@@ -31,6 +31,6 @@ corresponding options.
   - if the `authorizer` function returns `ALLOW`, but voter 1 in authorize
     decorator returns `ABSTAIN` and voter 2 in decorator returns `DENY`.
   - In this case, if the options provided while
-    [registering the authorization component](#authorization-component),
+    [registering the authorization component](Authorization-component.md),
     provides precedence as `DENY`, then the access for the subject is denied to
     the endpoint.

--- a/docs/site/Authorization-component-interceptor.md
+++ b/docs/site/Authorization-component-interceptor.md
@@ -18,4 +18,4 @@ The `Authorization interceptor` enforces authorization with user-provided
   collects `voters` provided in the `@authorize` decorator of the endpoint.
 - It executes each of the above collected functions provided by the user.
 - Based on the result of all functions it enforces access/privilege control
-  using [a decision matrix](#authorization-by-decision-matrix).
+  using [a decision matrix](Authorization-component-decision-matrix.md).

--- a/docs/site/Authorization-component.md
+++ b/docs/site/Authorization-component.md
@@ -26,9 +26,9 @@ class.
   ```
 
 - The authorization `options` are provided specifically for enforcing the
-  [decision matrix](#authorization-by-decision-matrix), which is used to combine
-  voters from all `authorize` functions. The options are described per the
-  interface AuthorizationOptions.
+  [decision matrix](Authorization-component-decision-matrix.md), which is used
+  to combine voters from all `authorize` functions. The options are described
+  per the interface AuthorizationOptions.
 
   ```ts
   export interface AuthorizationOptions {

--- a/docs/site/Authorization-overview.md
+++ b/docs/site/Authorization-overview.md
@@ -30,9 +30,8 @@ by the users.
 A `Principal` could be a User, Application or Device. The `Principal` is
 identified from the credential provided by a client, by the configured
 `Authentication strategy` of the endpoint
-([see, LoopBack Authentication](https://loopback.io/doc/en/lb4/Loopback-component-authentication.html)).
-Access rights of the client is either associated with or included in the
-credential.
+([see, LoopBack Authentication](Loopback-component-authentication.md)). Access
+rights of the client is either associated with or included in the credential.
 
 The `Principal` is then used by LoopBack's authorization mechanism to enforce
 necessary privileges/access rights by using the permissions annotated by the


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

I noticed that there were a few links in the [Authorization Component](https://loopback.io/doc/en/lb4/Loopback-component-authorization.html) documentation section that were linking to an anchor tag in the same document; but those links were now broken since those sections were moved to separate pages.

Example is: https://loopback.io/doc/en/lb4/Loopback-component-authorization.html | contains a link to the decision matrix (https://loopback.io/doc/en/lb4/Loopback-component-authorization.html#authorization-by-decision-matrix) which doesn't go anywhere since the decision matrix has been updated to exist [here](https://loopback.io/doc/en/lb4/Authorization-component-decision-matrix.html) instead.

Several other links (including links to the decision matrix) were updated as well due to the same circumstances.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
