### PR TITLE
build: use `npm@6` when testing Node.js v15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
 
 before_install:
   - npm i -g yarn
+  - yarn --version
   - |
     NPMVER=`npm --version`
     if [ ${NPMVER/\.*/} = 7 ]
@@ -31,6 +32,7 @@ before_install:
     else
       echo "Using bundled npm version $NPMVER"
     fi
+  - npm --version
 
 install: npm ci --ignore-scripts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,17 @@ env: TASK=test NODE_OPTIONS="--max-old-space-size=2048"
 cache:
   yarn: true
 
-before_install: npm i -g yarn
+before_install:
+  - npm i -g yarn
+  - |
+    NPMVER=`npm --version`
+    if [ ${NPMVER/\.*/} = 7 ]
+    then
+      echo "Downgrading bundled npm version $NPMVER to v6"
+      npm i -g npm@6
+    else
+      echo "Using bundled npm version $NPMVER"
+    fi
 
 install: npm ci --ignore-scripts
 


### PR DESCRIPTION
Add a new build step to Travis CI configuration to detect `npm@7` and downgrade it to `npm@6` to avoid CI builds getting stuck in `npm install` phase.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
