### PR TITLE
fix(docs): Filter "include" can't accept simply string

### DIFF
--- a/docs/site/HasMany-relation.md
+++ b/docs/site/HasMany-relation.md
@@ -513,13 +513,13 @@ allows users to retrieve all customers along with their related orders through
 the following code at the repository level:
 
 ```ts
-customerRepo.find({include: ['orders']});
+customerRepo.find({include: [{ relation: 'orders' }]});
 ```
 
 or use APIs with controllers:
 
 ```
-GET http://localhost:3000/customers?filter[include][]=orders
+GET http://localhost:3000/customers?filter[include][0][relation]=orders
 ```
 
 ### Enable/disable the inclusion resolvers
@@ -565,13 +565,13 @@ export class CustomerRepository extends DefaultCrudRepository {
   if you process data at the repository level:
 
   ```ts
-  customerRepository.find({include: ['orders']});
+  customerRepository.find({include: [{ relation: 'orders' }]});
   ```
 
   this is the same as the url:
 
   ```
-  GET http://localhost:3000/customers?filter[include][]=orders
+  GET http://localhost:3000/customers?filter[include][0][relation]=orders
   ```
 
   which returns:
@@ -618,7 +618,7 @@ To query **multiple relations**, for example, return all customers including
 their orders and address, in Node API:
 
 ```ts
-customerRepo.find({include: ['orders', 'address']});
+customerRepo.find({include: [{ relation: 'orders' }, { relation: 'address' }]});
 ```
 
 Equivalently, with url, you can do:
@@ -663,7 +663,7 @@ customerRepo.find({
     {
       relation: 'orders',
       scope: {
-        include: ['manufacturers'],
+        include: [{ relation: 'manufacturers' }],
       },
     },
   ],
@@ -722,7 +722,7 @@ customerRepo.find({
       relation: 'orders',
       scope: {
         where: {name: 'ToysRUs'},
-        include: ['manufacturers'],
+        include: [{ relation: 'manufacturers' }],
       },
     },
   ],


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Filter "include" can't accept simply string.
If you pass into "include" - array of strings you got this error:
![error](https://i.ibb.co/vhVGFqN/bug7.png)

I change string to "Inclusion" object in docs.

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈

