### PR TITLE
chore: use correct refresh token binding namespace

### DIFF
--- a/extensions/authentication-jwt/README.md
+++ b/extensions/authentication-jwt/README.md
@@ -125,7 +125,7 @@ export class TestApplication extends BootMixin(
     // Bind datasource for user
     this.dataSource(DbDataSource, UserServiceBindings.DATASOURCE_NAME);
     // Bind datasource for refresh token
-    this.dataSource(DbDataSource, RefreshTokenBindings.DATASOURCE_NAME);
+    this.dataSource(DbDataSource, RefreshTokenServiceBindings.DATASOURCE_NAME);
 
     this.component(RestExplorerComponent);
     this.projectRoot = __dirname;


### PR DESCRIPTION
Replaced RefreshTokenBindings (incorrect/non-existing namespace) with the correct RefreshTokenServiceBindings

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈

