### PR TITLE
ci: run GitHub Actions only for `master` and pull requests

### DIFF
--- a/.github/workflows/continous-integration.yaml
+++ b/.github/workflows/continous-integration.yaml
@@ -1,5 +1,10 @@
 name: Continous Integration
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
 
 env:
   CI: true


### PR DESCRIPTION
Improve GitHub Actions configuration to run CI only on pushes to master or pull requests to master.

Specifically, the new configuration does not run CI for pushes to feature branches, to avoid duplicate runs for the same commit: one run for the pull request, another for the feature branch the pull request is from.

See https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662

Note that our Travis CI configuration used to have the same setup.

This is a follow-up for https://github.com/strongloop/loopback-next/pull/5110

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
