### PR TITLE
Additional method invocation labels and option to set default labels

### DIFF
--- a/extensions/metrics/README.md
+++ b/extensions/metrics/README.md
@@ -175,13 +175,37 @@ nodejs_heap_space_size_available_bytes{space="new_large_object"} 1047952 1564508
 nodejs_version_info{version="v12.4.0",major="12",minor="4",patch="0"} 1
 # HELP loopback_invocation_duration_seconds method invocation
 # TYPE loopback_invocation_duration_seconds gauge
+loopback_invocation_duration_seconds{targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002056
 # HELP loopback_invocation_duration_histogram method invocation histogram
 # TYPE loopback_invocation_duration_histogram histogram
-# HELP loopback_invocation_total method invocation counts
+loopback_invocation_duration_histogram_bucket{le="0.005",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="0.01",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="0.025",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="0.05",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="0.1",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="0.25",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="0.5",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="1",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="2.5",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="5",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="10",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_bucket{le="+Inf",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+loopback_invocation_duration_histogram_sum{targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002112
+loopback_invocation_duration_histogram_count{targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
+# HELP loopback_invocation_total method invocation count
 # TYPE loopback_invocation_total counter
-loopback_invocation_total 1
+loopback_invocation_total{targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
 # HELP loopback_invocation_duration_summary method invocation summary
 # TYPE loopback_invocation_duration_summary summary
+loopback_invocation_duration_summary{quantile="0.01",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary{quantile="0.05",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary{quantile="0.5",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary{quantile="0.9",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary{quantile="0.95",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary{quantile="0.99",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary{quantile="0.999",targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary_sum{targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 0.0002363
+loopback_invocation_duration_summary_count{targetName="MockController.prototype.success",method="GET",path="/success",statusCode="204"} 1
 </pre>
 
 </details>

--- a/extensions/metrics/README.md
+++ b/extensions/metrics/README.md
@@ -44,6 +44,10 @@ this.configure(MetricsBindings.COMPONENT).to({
   defaultMetrics: {
     timeout: 5000,
   },
+  defaultLabels: {
+    service: 'api',
+    version: '1.0.0',
+  },
 });
 ```
 

--- a/extensions/metrics/src/__tests__/acceptance/metrics.acceptance.ts
+++ b/extensions/metrics/src/__tests__/acceptance/metrics.acceptance.ts
@@ -254,6 +254,19 @@ describe('Metrics (acceptance)', () => {
         /loopback_invocation_duration_summary{quantile="0.01",targetName="MockController.prototype.success",method="GET",path="\/success",statusCode="204"}/,
       );
     });
+
+    it('uses the path pattern instead of the raw path in path labels', async () => {
+      await request.get('/path/1');
+      await request.get('/path/1/2');
+
+      const res = await request
+        .get('/metrics')
+        .expect(200)
+        .expect('content-type', /text/);
+
+      expect(res.text).to.match(/path="\/path\/{param}"/);
+      expect(res.text).to.match(/path="\/path\/{firstParam}\/{secondParam}"/);
+    });
   });
 
   context('with configured default labels', () => {

--- a/extensions/metrics/src/__tests__/acceptance/metrics.acceptance.ts
+++ b/extensions/metrics/src/__tests__/acceptance/metrics.acceptance.ts
@@ -4,7 +4,12 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {CoreBindings, GLOBAL_INTERCEPTOR_NAMESPACE} from '@loopback/core';
-import {RestApplication, RestServer, RestServerConfig} from '@loopback/rest';
+import {
+  RestApplication,
+  RestServer,
+  RestServerConfig,
+  SequenceActions,
+} from '@loopback/rest';
 import {
   Client,
   createRestAppClient,
@@ -16,6 +21,7 @@ import {MetricsBindings, MetricsComponent, MetricsOptions} from '../..';
 import {metricsControllerFactory} from '../../controllers';
 import {MetricsInterceptor} from '../../interceptors';
 import {MetricsObserver, MetricsPushObserver} from '../../observers';
+import {MockController} from './mock.controller';
 
 describe('Metrics (acceptance)', () => {
   let app: RestApplication;
@@ -169,10 +175,101 @@ describe('Metrics (acceptance)', () => {
     });
   });
 
+  context('with collected method invocation metrics', () => {
+    beforeEach(async () => {
+      await givenAppForMetricsCollection();
+    });
+
+    it('reports metrics with targetName label', async () => {
+      await request.get('/success');
+
+      const res = await request
+        .get('/metrics')
+        .expect(200)
+        .expect('content-type', /text/);
+
+      expect(res.text).to.match(
+        /targetName="MockController.prototype.success"/,
+      );
+    });
+
+    it('reports metrics with method and path label', async () => {
+      await request.get('/success');
+      await request.post('/success');
+      await request.put('/success');
+      await request.patch('/success');
+      await request.delete('/success');
+
+      const res = await request
+        .get('/metrics')
+        .expect(200)
+        .expect('content-type', /text/);
+
+      expect(res.text).to.match(/method="GET",path="\/success"/);
+      expect(res.text).to.match(/method="POST",path="\/success"/);
+      expect(res.text).to.match(/method="PUT",path="\/success"/);
+      expect(res.text).to.match(/method="PATCH",path="\/success"/);
+      expect(res.text).to.match(/method="DELETE",path="\/success"/);
+    });
+
+    it('reports metrics with status code label', async () => {
+      await request.get('/success-with-data').expect(200);
+      await request.get('/success').expect(204);
+      await request.get('/redirect').expect(302);
+      await request.get('/bad-request').expect(400);
+      await request.get('/entity-not-found').expect(404);
+      await request.get('/server-error').expect(500);
+
+      const res = await request
+        .get('/metrics')
+        .expect(200)
+        .expect('content-type', /text/);
+
+      expect(res.text).to.match(/path="\/success-with-data",statusCode="200"/);
+      expect(res.text).to.match(/path="\/success",statusCode="204"/);
+      expect(res.text).to.match(/path="\/redirect",statusCode="302"/);
+      expect(res.text).to.match(/path="\/bad-request",statusCode="400"/);
+      expect(res.text).to.match(/path="\/entity-not-found",statusCode="404"/);
+      expect(res.text).to.match(/path="\/server-error",statusCode="500"/);
+    });
+
+    it('adds the labels to all metric types', async () => {
+      await request.get('/success').expect(204);
+
+      const res = await request
+        .get('/metrics')
+        .expect(200)
+        .expect('content-type', /text/);
+
+      expect(res.text).to.match(
+        /loopback_invocation_duration_seconds{targetName="MockController.prototype.success",method="GET",path="\/success",statusCode="204"}/,
+      );
+      expect(res.text).to.match(
+        /loopback_invocation_duration_histogram_bucket{le="0.01",targetName="MockController.prototype.success",method="GET",path="\/success",statusCode="204"}/,
+      );
+      expect(res.text).to.match(
+        /loopback_invocation_total{targetName="MockController.prototype.success",method="GET",path="\/success",statusCode="204"}/,
+      );
+      expect(res.text).to.match(
+        /loopback_invocation_duration_summary{quantile="0.01",targetName="MockController.prototype.success",method="GET",path="\/success",statusCode="204"}/,
+      );
+    });
+  });
+
   async function givenAppWithCustomConfig(config: MetricsOptions) {
     app = givenRestApplication();
     app.configure(MetricsBindings.COMPONENT).to(config);
     app.component(MetricsComponent);
+    await app.start();
+    request = createRestAppClient(app);
+  }
+
+  async function givenAppForMetricsCollection(config?: MetricsOptions) {
+    app = givenRestApplication();
+    app.configure(MetricsBindings.COMPONENT).to(config);
+    app.component(MetricsComponent);
+    app.controller(MockController);
+    app.bind(SequenceActions.LOG_ERROR).to(() => {});
     await app.start();
     request = createRestAppClient(app);
   }

--- a/extensions/metrics/src/__tests__/acceptance/mock.controller.ts
+++ b/extensions/metrics/src/__tests__/acceptance/mock.controller.ts
@@ -8,6 +8,7 @@ import {
   del,
   get,
   HttpErrors,
+  param,
   patch,
   post,
   put,
@@ -63,4 +64,13 @@ export class MockController {
   serverError() {
     throw new Error();
   }
+
+  @get('/path/{param}')
+  pathWithParam(@param.path.string('param') _param: string) {}
+
+  @get('/path/{firstParam}/{secondParam}')
+  pathWithParams(
+    @param.path.string('firstParam') _firstParam: string,
+    @param.path.string('secondParam') _secondParam: string,
+  ) {}
 }

--- a/extensions/metrics/src/__tests__/acceptance/mock.controller.ts
+++ b/extensions/metrics/src/__tests__/acceptance/mock.controller.ts
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2021. All Rights Reserved.
+// Node module: @loopback/metrics
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {inject} from '@loopback/core';
+import {
+  del,
+  get,
+  HttpErrors,
+  patch,
+  post,
+  put,
+  Response,
+  RestBindings,
+} from '@loopback/rest';
+
+/**
+ * A mockup controller to collect different method invocation metrics
+ */
+export class MockController {
+  constructor() {}
+
+  @get('/success')
+  success() {}
+
+  @post('/success')
+  postSuccess() {}
+
+  @put('/success')
+  putSuccess() {}
+
+  @patch('/success')
+  patchSuccess() {}
+
+  @del('/success')
+  deleteSuccess() {}
+
+  @get('/success-with-data')
+  successWithData() {
+    return {key: 'value'};
+  }
+
+  @get('/redirect')
+  redirect(
+    @inject(RestBindings.Http.RESPONSE)
+    response: Response,
+  ) {
+    return response.redirect('/some-path');
+  }
+
+  @get('/bad-request')
+  badRequest() {
+    throw new HttpErrors.BadRequest();
+  }
+
+  @get('/entity-not-found')
+  entityNotFound() {
+    throw Object.assign(new Error(), {code: 'ENTITY_NOT_FOUND'});
+  }
+
+  @get('/server-error')
+  serverError() {
+    throw new Error();
+  }
+}

--- a/extensions/metrics/src/metrics.component.ts
+++ b/extensions/metrics/src/metrics.component.ts
@@ -13,6 +13,7 @@ import {
   inject,
   injectable,
 } from '@loopback/core';
+import {register} from 'prom-client';
 import {metricsControllerFactory} from './controllers';
 import {MetricsInterceptor} from './interceptors';
 import {MetricsBindings} from './keys';
@@ -43,6 +44,9 @@ export class MetricsComponent implements Component {
     this.application.add(createBindingFromClass(MetricsInterceptor));
     if (options.endpoint && !options.endpoint.disabled) {
       this.application.controller(metricsControllerFactory(options));
+    }
+    if (options.defaultLabels) {
+      register.setDefaultLabels(options.defaultLabels);
     }
   }
 }

--- a/extensions/metrics/src/types.ts
+++ b/extensions/metrics/src/types.ts
@@ -30,6 +30,10 @@ export interface MetricsOptions {
   };
 
   openApiSpec?: boolean;
+
+  defaultLabels?: {
+    [labelName: string]: string;
+  };
 }
 
 /**


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
## Description

This PR adds labels to all method invocation metrics to allow better filtering with PromQL and also improves visualization in Grafana. It is now possible to display the invocations based on method and path e.g. `GET /users` instead of only having the option to use an internal method name (`targetName`) which is still kept for backward compatibility. It is also now possible to create dashboards for error metrics since the status code of the response is now tracked. 

Another feature added by this PR is a new option to configure default labels, this could also be done in the prometheus scrape configuration but this might not always be the best solution, e.g. for setting the app version as a static label. 

## Further considerations

- create dashboard and publish to [Grafana Dashboards](https://grafana.com/grafana/dashboards)
- use middleware instead of interceptor, this would allow to collect metrics before the method invocation (e.g. failed authentication) and would allow to get the proper status code from the response directly if it is invoked after the result and error are written to the response

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
