### PR TITLE
test: skip tests that use viz.js on z/OS

### DIFF
--- a/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
+++ b/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
@@ -67,7 +67,8 @@ describe('Context Explorer (acceptance)', function (this: Mocha.Suite) {
       );
     });
 
-    it('invokes GET /graph', async () => {
+    it('invokes GET /graph', async function (this: Mocha.Context) {
+      if ((process.platform as string) === 'os390') return this.skip();
       const res = await request.get('/context-explorer/graph').expect(200);
       expect(res.get('content-type')).to.match(/^image\/svg\+xml/);
     });

--- a/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
+++ b/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
@@ -14,7 +14,8 @@ describe('Visualizer', () => {
 
   beforeEach(givenContexts);
 
-  it('creates a dot graph with bindings', async () => {
+  it('creates a dot graph with bindings', async function (this: Mocha.Context) {
+    if ((process.platform as string) === 'os390') return this.skip();
     server.bind('port').to(3000);
     app.bind('now').toDynamicValue(() => new Date());
     const json = server.inspect();


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Skip tests that use viz.js to render graph on z/OS, which complain about
```
Runtime error: expected the system to be little-endian!
```
as z/OS is not in little-endian.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
