### PR TITLE
fix(metrics): fix error thrown by interceptor if invoked by proxy

### DIFF
--- a/extensions/metrics/src/__tests__/acceptance/metrics.acceptance.ts
+++ b/extensions/metrics/src/__tests__/acceptance/metrics.acceptance.ts
@@ -3,7 +3,11 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {CoreBindings, GLOBAL_INTERCEPTOR_NAMESPACE} from '@loopback/core';
+import {
+  CoreBindings,
+  createProxyWithInterceptors,
+  GLOBAL_INTERCEPTOR_NAMESPACE,
+} from '@loopback/core';
 import {
   RestApplication,
   RestServer,
@@ -266,6 +270,23 @@ describe('Metrics (acceptance)', () => {
 
       expect(res.text).to.match(/path="\/path\/{param}"/);
       expect(res.text).to.match(/path="\/path\/{firstParam}\/{secondParam}"/);
+    });
+
+    it('only adds targetName label if the invocation source is an interception proxy', async () => {
+      const proxy = createProxyWithInterceptors(new MockController(), app);
+      await proxy.success();
+
+      const res = await request
+        .get('/metrics')
+        .expect(200)
+        .expect('content-type', /text/);
+
+      expect(res.text).to.match(
+        /targetName="MockController.prototype.success"/,
+      );
+      expect(res.text).to.not.match(/method=/);
+      expect(res.text).to.not.match(/path=/);
+      expect(res.text).to.not.match(/statusCode=/);
     });
   });
 


### PR DESCRIPTION
Fix error thrown by metrics interceptor if invocation source is an
interception proxy and only add targetName label.

Signed-off-by: nflaig <nflaig@protonmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
