### PR TITLE
style(metrics): update variable names of openapi definitions

### DIFF
--- a/extensions/metrics/src/controllers/metrics.controller.ts
+++ b/extensions/metrics/src/controllers/metrics.controller.ts
@@ -17,7 +17,7 @@ import {DEFAULT_METRICS_OPTIONS, MetricsOptions} from '../types';
 /**
  * OpenAPI definition of metrics response
  */
-const metricsResponse: ResponseObject = {
+const METRICS_RESPONSE: ResponseObject = {
   description: 'Metrics Response',
   content: {
     'text/plain': {
@@ -31,16 +31,16 @@ const metricsResponse: ResponseObject = {
 /**
  * OpenAPI spec for metrics endpoint
  */
-const metricsSpec: OperationObject = {
+const METRICS_SPEC: OperationObject = {
   responses: {
-    '200': metricsResponse,
+    '200': METRICS_RESPONSE,
   },
 };
 
 /**
  * OpenAPI spec to hide endpoints
  */
-const hiddenSpec: OperationObject = {
+const HIDDEN_SPEC: OperationObject = {
   responses: {},
   'x-visibility': 'undocumented',
 };
@@ -49,7 +49,7 @@ export function metricsControllerFactory(
   options: MetricsOptions = DEFAULT_METRICS_OPTIONS,
 ): Constructor<unknown> {
   const basePath = options.endpoint?.basePath ?? '/metrics';
-  const spec = options.openApiSpec ? metricsSpec : hiddenSpec;
+  const spec = options.openApiSpec ? METRICS_SPEC : HIDDEN_SPEC;
 
   /**
    * Controller for metrics endpoint

--- a/extensions/metrics/src/types.ts
+++ b/extensions/metrics/src/types.ts
@@ -18,6 +18,10 @@ export interface MetricsOptions {
     disabled?: boolean;
   } & DefaultMetricsCollectorConfiguration;
 
+  defaultLabels?: {
+    [labelName: string]: string;
+  };
+
   pushGateway?: {
     disabled?: boolean;
     url: string;
@@ -30,10 +34,6 @@ export interface MetricsOptions {
   };
 
   openApiSpec?: boolean;
-
-  defaultLabels?: {
-    [labelName: string]: string;
-  };
 }
 
 /**


### PR DESCRIPTION
Update variable names of openapi definitions to follow naming convention (CONSTANT_CASE)

Signed-off-by: nflaig <nflaig@protonmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
