### PR TITLE
feat: add connector interface enums

### DIFF
--- a/packages/repository/src/connectors/connector.ts
+++ b/packages/repository/src/connectors/connector.ts
@@ -13,12 +13,52 @@ import {
 import {Model} from '../model';
 
 /**
+ * Interfaces adopted by a {@link Connector}.
+ *
+ * @experimental
+ */
+export namespace ConnectorInterfaces {
+  /**
+   * Strong relation interfaces adopted by a {@link Connector}
+   *
+   * @experimental
+   */
+  export const enum StrongRelation {
+    BELONGS_TO = 'strongBelongsTo',
+    HAS_ONE = 'strongHasOne',
+    HAS_MANY = 'strongHasMany',
+    HAS_MANY_THROUGH = 'strongHasManyThrough',
+    HAS_AND_BELONGS_TO_MANY = 'strongHasAndBelongsToMany',
+    EMBEDS_ONE = 'strongEmbedsOne',
+    EMBEDS_MANY = 'strongEmbedsMany',
+    REFERNCES_MANY = 'strongReferencesMany',
+  }
+
+  /**
+   * Strong query join interfaces adopted by a {@link Connector}
+   *
+   * @experimental
+   */
+  export const enum StrongJoins {
+    INNER = 'strongInnerJoin',
+    LEFT = 'strongLeftJoin',
+    RIGHT = 'strongRightJoin',
+    FULL = 'strongFullJoin',
+    CARTESIAN = 'strongCartesianJoin',
+  }
+}
+
+/**
  * Common properties/operations for connectors
  */
 export interface Connector {
   name: string; // Name/type of the connector
   configModel?: Model; // The configuration model
-  interfaces?: string[]; // A list of interfaces implemented by the connector
+  interfaces?: (
+    | string
+    | ConnectorInterfaces.StrongRelation
+    | ConnectorInterfaces.StrongJoins
+  )[]; // A list of interfaces implemented by the connector
   connect(): Promise<void>; // Connect to the underlying system
   disconnect(): Promise<void>; // Disconnect from the underlying system
   ping(): Promise<void>; // Ping the underlying system


### PR DESCRIPTION
We would like to create new _repostories_ based off _CrudRepositoryImpl_, and would like to introduce the idea of native strong relations and query joins. This is the 1st pull request, which introduces well-defined values for the Connector.interfaces property.

Future pull requests will...
1. Introduce an optional `strong: boolean | 'try'` configuration for _@relation_ decorators, and new "guard code" for `CrudRepositoryImpl` to check and enforce this contract. `DefaultCrudRepository` should immediately reject any relations with `strong: true`.
2. Introduce relation repositories for `CrudRepositoryImpl` that can enforce the "strong relation" contract.
3. Introduce weak relation inclusion resolvers

---

Very Loosely Related: #7019, #4299

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
