### PR TITLE
feat(context): allow asProxyWithInterceptors to be used for non-class bindings

### DIFF
--- a/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
@@ -14,6 +14,7 @@ import {
   ResolutionSession,
   ValueOrPromise,
 } from '../..';
+import {Provider} from '../../provider';
 
 describe('Interception proxy', () => {
   let ctx: Context;
@@ -163,15 +164,70 @@ describe('Interception proxy', () => {
     ]);
   });
 
-  it('reports error when asProxyWithInterceptors is set for non-Class binding', async () => {
+  it('supports asProxyWithInterceptors resolution option for dynamic value', async () => {
+    // Apply `log` to all methods on the class
+    @intercept(log)
+    class MyController {
+      // Apply multiple interceptors. The order of `log` will be preserved as it
+      // explicitly listed at method level
+      @intercept(convertName, log)
+      async greet(name: string) {
+        return `Hello, ${name}`;
+      }
+    }
+
+    ctx.bind('my-controller').toDynamicValue(() => new MyController());
+    const proxy = await ctx.get<MyController>('my-controller', {
+      asProxyWithInterceptors: true,
+    });
+    const msg = await proxy!.greet('John');
+    expect(msg).to.equal('Hello, JOHN');
+    expect(events).to.eql([
+      'convertName: before-greet',
+      'log: [my-controller] before-greet',
+      'log: [my-controller] after-greet',
+      'convertName: after-greet',
+    ]);
+  });
+
+  it('supports asProxyWithInterceptors resolution option for provider', async () => {
+    // Apply `log` to all methods on the class
+    @intercept(log)
+    class MyController {
+      // Apply multiple interceptors. The order of `log` will be preserved as it
+      // explicitly listed at method level
+      @intercept(convertName, log)
+      async greet(name: string) {
+        return `Hello, ${name}`;
+      }
+    }
+
+    class MyControllerProvider implements Provider<MyController> {
+      value() {
+        return new MyController();
+      }
+    }
+
+    ctx.bind('my-controller').toProvider(MyControllerProvider);
+    const proxy = await ctx.get<MyController>('my-controller', {
+      asProxyWithInterceptors: true,
+    });
+    const msg = await proxy!.greet('John');
+    expect(msg).to.equal('Hello, JOHN');
+    expect(events).to.eql([
+      'convertName: before-greet',
+      'log: [my-controller] before-greet',
+      'log: [my-controller] after-greet',
+      'convertName: after-greet',
+    ]);
+  });
+
+  it('allows asProxyWithInterceptors for non-object value', async () => {
     ctx.bind('my-value').toDynamicValue(() => 'my-value');
-    await expect(
-      ctx.get<string>('my-value', {
-        asProxyWithInterceptors: true,
-      }),
-    ).to.be.rejectedWith(
-      `Binding 'my-value' (DynamicValue) does not support 'asProxyWithInterceptors'`,
-    );
+    const value = await ctx.get<string>('my-value', {
+      asProxyWithInterceptors: true,
+    });
+    expect(value).to.eql('my-value');
   });
 
   it('supports asProxyWithInterceptors resolution option for @inject', async () => {


### PR DESCRIPTION
The provider or dynamic value binding can also return an object that can
be proxied with interceptors.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
