### PR TITLE
fix: support options in passport auth strategies

### DIFF
--- a/extensions/authentication-passport/src/__tests__/unit/passport-strategy-adapter.unit.ts
+++ b/extensions/authentication-passport/src/__tests__/unit/passport-strategy-adapter.unit.ts
@@ -14,21 +14,25 @@ describe('Strategy Adapter', () => {
   const mockUser: UserProfile = {name: 'user-name', [securityId]: 'mock-id'};
 
   describe('authenticate()', () => {
-    it('calls the authenticate method of the strategy', async () => {
+    it('calls the authenticate method of the strategy with provided options', async () => {
       let calledFlag = false;
+      let calledOptions = null;
       // TODO: (as suggested by @bajtos) use sinon spy
       class MyStrategy extends MockPassportStrategy {
         // override authenticate method to set calledFlag
         async authenticate(req: Request, options?: AuthenticateOptions) {
           calledFlag = true;
+          calledOptions = options;
           await super.authenticate(req, options);
         }
       }
       const strategy = new MyStrategy();
       const adapter = new StrategyAdapter(strategy, 'mock-strategy');
       const request = <Request>{};
-      await adapter.authenticate(request);
+      const providedOptions = {passReqToCallback: true};
+      await adapter.authenticate(request, providedOptions);
       expect(calledFlag).to.be.true();
+      expect(calledOptions).to.be.eql(providedOptions);
     });
 
     it('returns a promise which resolves to an object', async () => {

--- a/extensions/authentication-passport/src/strategy-adapter.ts
+++ b/extensions/authentication-passport/src/strategy-adapter.ts
@@ -9,7 +9,7 @@ import {
 } from '@loopback/authentication';
 import {HttpErrors, RedirectRoute, Request} from '@loopback/rest';
 import {UserProfile} from '@loopback/security';
-import {Strategy} from 'passport';
+import {Strategy, AuthenticateOptions} from 'passport';
 
 const passportRequestMixin = require('passport/lib/http/request');
 
@@ -41,8 +41,12 @@ export class StrategyAdapter<U> implements AuthenticationStrategy {
    *     2. add success and failure state handlers
    *     3. authenticate using the strategy
    * @param request The incoming request.
+   * @param options Options passed through to strategy.authenticate.
    */
-  authenticate(request: Request): Promise<UserProfile | RedirectRoute> {
+  authenticate(
+    request: Request,
+    options?: AuthenticateOptions,
+  ): Promise<UserProfile | RedirectRoute> {
     const userProfileFactory = this.userProfileFactory;
     return new Promise<UserProfile | RedirectRoute>((resolve, reject) => {
       // mix-in passport additions like req.logIn and req.logOut
@@ -82,7 +86,7 @@ export class StrategyAdapter<U> implements AuthenticationStrategy {
       };
 
       // authenticate
-      strategy.authenticate(request);
+      strategy.authenticate(request, options);
     });
   }
 }


### PR DESCRIPTION
The `authenticate` method of a `passport` strategy supports options to configure the authentication attempt. This PR adds support for these optional `authenticate` options. Some passport strategies currently require an options object, even if empty, due to missing defaults (e.g. [`passport-saml`](https://github.com/node-saml/passport-saml/blob/master/src/passport-saml/strategy.ts#L42)). While that can be addressed separately for each strategy, the changes in this PR allow the consumer to handle that case for all similarly affected strategies.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated