### PR TITLE
docs(site): fix link path to 'JWT Service'

### DIFF
--- a/docs/site/Inside-Loopback-Application.md
+++ b/docs/site/Inside-Loopback-Application.md
@@ -159,7 +159,7 @@ rapid testing.
 
 For example, a `TokenService` interface is injected into the `UserController` to
 `verify` and `generate` tokens. A
-[JWT Service](https://github.com/strongloop/loopback4-example-shopping/blob/master/packages/shopping/src/services/jwt-service.ts)
+[JWT Service](https://github.com/strongloop/loopback4-example-shopping/blob/master/packages/shopping/src/services/jwt.service.ts)
 provides a local implementation of this interface specifically for JWTs.
 
 Dependency injection is used to wire services and repositories with controllers


### PR DESCRIPTION
Signed-off-by: ddsultan <2477698+ddsultan@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
