### PR TITLE
fix(authorization): allow `@authorize.skip` and other metadata for subclasses

### DIFF
--- a/packages/authorization/src/__tests__/unit/authorize-decorator.test.ts
+++ b/packages/authorization/src/__tests__/unit/authorize-decorator.test.ts
@@ -161,7 +161,42 @@ describe('Authentication', () => {
         getSecret() {}
       }
 
-      const metaData = getAuthorizationMetadata(TestClass, 'getSecret');
+      let metaData = getAuthorizationMetadata(TestClass, 'getSecret');
+      expect(metaData).to.eql({skip: true});
+
+      metaData = getAuthorizationMetadata(TestClass.prototype, 'getSecret');
+      expect(metaData).to.eql({skip: true});
+
+      metaData = getAuthorizationMetadata(new TestClass(), 'getSecret');
+      expect(metaData).to.eql({skip: true});
+    });
+
+    it('can skip authorization with a flag for sublclass', () => {
+      class TestClass {
+        @authorize({allowedRoles: ['admin']})
+        getSecret() {}
+
+        getNonSecret() {}
+      }
+
+      class SubTestClass extends TestClass {
+        @authorize({allowedRoles: [AUTHENTICATED]})
+        getProfile() {}
+
+        @authorize.skip()
+        getNonSecret() {}
+      }
+
+      let metaData = getAuthorizationMetadata(SubTestClass, 'getNonSecret');
+      expect(metaData).to.eql({skip: true});
+
+      metaData = getAuthorizationMetadata(
+        SubTestClass.prototype,
+        'getNonSecret',
+      );
+      expect(metaData).to.eql({skip: true});
+
+      metaData = getAuthorizationMetadata(new SubTestClass(), 'getNonSecret');
       expect(metaData).to.eql({skip: true});
     });
 

--- a/packages/authorization/src/decorators/authorize.ts
+++ b/packages/authorization/src/decorators/authorize.ts
@@ -43,7 +43,7 @@ export class AuthorizeMethodDecoratorFactory extends MethodDecoratorFactory<Auth
     ownMetadata = ownMetadata || {};
     let methodMeta = ownMetadata[methodName!];
     if (!methodMeta) {
-      methodMeta = {};
+      methodMeta = {...this.spec};
       ownMetadata[methodName!] = methodMeta;
     }
     if (this.spec.allowedRoles) {
@@ -65,15 +65,12 @@ export class AuthorizeMethodDecoratorFactory extends MethodDecoratorFactory<Auth
       methodMeta.voters = this.merge(methodMeta.voters, this.spec.voters);
     }
 
-    if (this.spec.resource) {
-      methodMeta.resource = this.spec.resource;
-    }
-
     return ownMetadata;
   }
 
   private merge<T>(src?: T[], target?: T[]): T[] {
     const list: T[] = [];
+    if (src === target) return src ?? list;
     const set = new Set<T>(src ?? []);
     if (target) {
       for (const i of target) {


### PR DESCRIPTION
The current implementation does not populete all attributes of the spec
from `@authorize` decorated for the subclass.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
