### PR TITLE
fix: use Symbol.for() for MIDDLEWARE_CONTEXT 

### DIFF
--- a/extensions/graphql/src/graphql.container.ts
+++ b/extensions/graphql/src/graphql.container.ts
@@ -12,13 +12,12 @@ import {
   filterByKey,
   filterByServiceInterface,
 } from '@loopback/core';
+import {MIDDLEWARE_CONTEXT} from '@loopback/rest';
 import {ExpressContext} from 'apollo-server-express/dist/ApolloServer';
 import debugFactory from 'debug';
 import {ContainerType, ResolverData} from 'type-graphql';
 import {GraphQLBindings, GraphQLTags} from './keys';
-
 const debug = debugFactory('loopback:graphql:container');
-const MIDDLEWARE_CONTEXT = Symbol.for('loopback.middleware.context');
 
 /**
  * Context for graphql resolver resolution

--- a/extensions/graphql/src/graphql.container.ts
+++ b/extensions/graphql/src/graphql.container.ts
@@ -12,12 +12,13 @@ import {
   filterByKey,
   filterByServiceInterface,
 } from '@loopback/core';
-import {MIDDLEWARE_CONTEXT} from '@loopback/rest';
 import {ExpressContext} from 'apollo-server-express/dist/ApolloServer';
 import debugFactory from 'debug';
 import {ContainerType, ResolverData} from 'type-graphql';
 import {GraphQLBindings, GraphQLTags} from './keys';
+
 const debug = debugFactory('loopback:graphql:container');
+const MIDDLEWARE_CONTEXT = Symbol.for('loopback.middleware.context');
 
 /**
  * Context for graphql resolver resolution

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -325,7 +325,8 @@ export interface ExpressMiddlewareFactory<C> {
 }
 
 /**
- * A symbol to store `MiddlewareContext` on the request object
+ * A symbol to store `MiddlewareContext` on the request object.  This symbol
+ * can be referenced by name, before it is created.
  */
 export const MIDDLEWARE_CONTEXT = Symbol.for('loopback.middleware.context');
 

--- a/packages/express/src/types.ts
+++ b/packages/express/src/types.ts
@@ -327,7 +327,7 @@ export interface ExpressMiddlewareFactory<C> {
 /**
  * A symbol to store `MiddlewareContext` on the request object
  */
-export const MIDDLEWARE_CONTEXT = Symbol('loopback.middleware.context');
+export const MIDDLEWARE_CONTEXT = Symbol.for('loopback.middleware.context');
 
 /**
  * Constants for middleware groups


### PR DESCRIPTION
Signed-off-by: Matthew Schnee <i.am@matthew.engineer>

The middleware chain is bound in context by using the Symbol `import { MIDDLEWARE_CONTEXT } from '@loopback/rest`;
However, `@loopback/graphql` was creating a different `MIDDLEWARE_CONTEXT`, and `LoopBackCountainer` was using a default context instead, because `Symbol.for('name') !== Symbol('name')`.  This could be caused due to order of imports.

## Use Case
Given a system that already has a lot of services expecting `@inject(SecurityBindings.CURRENT_USER)`, and a desire to use inject these services and providers into a `GraphQLResolver`, we need to verify and bind the CurrentUser ourselves:
```ts
// in Application.ts
this.bind(GraphQLBindings.GRAPHQL_CONTEXT_RESOLVER).to(async (graphQLCtx) => {
  // we need to get the request Context from the given express request first,
  // so that we can set the CURRENT_USER for services to inject
  const reqCtx = (graphQLCtx?.req as any)?.[MIDDLEWARE_CONTEXT];

  const tokenService = await this.get<MySpecificTokenService>('services.MySpecificTokenService');
  if (graphQLCtx.req.headers?.authorization?.startsWith('Bearer ')) {
    const token = graphQLCtx.req.headers.authorization.replace('Bearer ', '');
    const currentUser = await tokenService.verifyToken(token, graphQLCtx.req);
    reqCtx?.bind(AuthenticationBindings.CURRENT_USER).to(currentUser);
  }
  return graphQLCtx;
});
```

The effect of this code is that we use `MySpecificTokenService` as the one-and-only token resolver.  This is a brute-force method to ensure that CurrentUser is available when LoopBackContainer gets the resolver in `LoopbackContainer.get()`


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
