### PR TITLE
fix(examples): typo in interface name

### DIFF
--- a/docs/site/tutorials/todo-list/todo-list-tutorial-relations.md
+++ b/docs/site/tutorials/todo-list/todo-list-tutorial-relations.md
@@ -179,7 +179,7 @@ import {Todo, TodoWithRelations} from './todo.model';
 ```
 
 ```ts
-export interface TodoRelations {
+export interface TodoListRelations {
   // add the following line
   todos?: TodoWithRelations[];
 }


### PR DESCRIPTION
fix interface name in tutorial from TodoRelations to TodoListRelations

Signed-off-by: gkraska <gkraska@poczta.onet.pl>

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
