### PR TITLE
fix(cli): add rebuild script to package.json of extensions

### DIFF
--- a/packages/cli/generators/project/templates/package.json.ejs
+++ b/packages/cli/generators/project/templates/package.json.ejs
@@ -102,15 +102,18 @@
 <% } -%>
     "openapi-spec": "node ./dist/openapi-spec",
 <% if (packageManager === 'yarn') { -%>
-    "rebuild": "yarn run clean && yarn run build",
     "prestart": "yarn run rebuild",
 <% } else { -%>
-    "rebuild": "npm run clean && npm run build",
     "prestart": "npm run rebuild",
 <% } -%>
     "start": "node -r source-map-support/register .",
 <% } -%>
-    "clean": "lb-clean dist *.tsbuildinfo .eslintcache"
+    "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
+<% if (packageManager === 'yarn') { -%>
+    "rebuild": "yarn run clean && yarn run build"
+<% } else { -%>
+    "rebuild": "npm run clean && npm run build"
+<% } -%>
   },
   "repository": {
     "type": "git",

--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -93,18 +93,21 @@
     "migrate": "node ./dist/migrate",
     "openapi-spec": "node ./dist/openapi-spec",
 <% if (packageManager === 'yarn') { -%>
-    "rebuild": "yarn run clean && yarn run build",
     "prestart": "yarn run rebuild",
 <% } else { -%>
-    "rebuild": "npm run clean && npm run build",
     "prestart": "npm run rebuild",
 <% } -%>
     "start": "node -r source-map-support/register .",
 <% } -%>
 <% if (packageManager === 'yarn') { -%>
-    "prepare": "yarn run build"
+    "prepare": "yarn run build",
 <% } else { -%>
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+<% } -%>
+<% if (packageManager === 'yarn') { -%>
+  "rebuild": "yarn run clean && yarn run build"
+<% } else { -%>
+  "rebuild": "npm run clean && npm run build"
 <% } -%>
   },
   "repository": {


### PR DESCRIPTION
Generating a lb4 extension does not include the `rebuild` script in the package.json file but it is called by the `pretest` script

`"pretest": "npm run rebuild"`

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
