### PR TITLE
docs: fix breaking change from js-yaml

### DIFF
--- a/docs/bin/build-jekyll-preview-config.js
+++ b/docs/bin/build-jekyll-preview-config.js
@@ -25,7 +25,7 @@ Usage:
 }
 
 console.log('Reading Jekyll config from %s', src);
-const config = yaml.safeLoad(fs.readFileSync(src, 'utf8'));
+const config = yaml.load(fs.readFileSync(src, 'utf8'));
 
 config.sidebars = ['lb4_sidebar'];
 config.defaults[0].values.sidebar = 'lb4_sidebar';


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

Reported by @mrmodise. 
When running `npm run docs:prepare`, there's an error:
```
Reading Jekyll config from _loopback.io/_config.yml
...../loopback-next/docs/node_modules/js-yaml/index.js:10
    throw new Error('Function yaml.' + from + ' is removed in js-yaml 4. ' +
    ^
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```

Switching to use `yaml.load` in the `bin/build-jekyll-preview-config.js` as suggested by the error seems to fix the problem.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
