### PR TITLE
test(cli): use a more strict check license text

### DIFF
--- a/packages/cli/test/integration/generators/copyright.integration.js
+++ b/packages/cli/test/integration/generators/copyright.integration.js
@@ -7,14 +7,14 @@
 
 const path = require('path');
 const assert = require('yeoman-assert');
-const testlab = require('@loopback/testlab');
-const TestSandbox = testlab.TestSandbox;
+const {expect, TestSandbox} = require('@loopback/testlab');
 
 const generator = path.join(__dirname, '../../../generators/copyright');
 const {spdxLicenseList} = require('../../../generators/copyright/license');
 const SANDBOX_FILES = require('../../fixtures/copyright/single-package')
   .SANDBOX_FILES;
 const testUtils = require('../../test-utils');
+const fs = require('fs');
 
 // Test Sandbox
 const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
@@ -202,28 +202,36 @@ restricted by GSA ADP Schedule Contract with <%= owner %>.
       '"copyright.owner": "ACME Inc."',
     );
 
-    /*
-    Copyright (c) ACME Inc. 2020. All Rights Reserved.
-    Node module: myapp
-    This project is licensed under the ISC License, full text below.
-    */
-    assert.fileContent(
+    const licenseText = fs.readFileSync(
       path.join(sandbox.path, 'LICENSE'),
-      'This project is licensed under the ISC License, full text below.',
+      'utf-8',
     );
-    assert.fileContent(
-      path.join(sandbox.path, 'LICENSE'),
-      `Copyright (c) ACME Inc. ${year}.`,
-    );
-    assert.fileContent(
-      path.join(sandbox.path, 'LICENSE'),
-      'Node module: myapp',
-    );
-    assert.fileContent(
-      path.join(sandbox.path, 'LICENSE'),
-      `Permission to use, copy, modify, and /or distribute this software for any
+    expect(licenseText).to.equal(
+      `
+Copyright (c) ACME Inc. ${year}.
+Node module: myapp
+This project is licensed under the ISC License, full text below.
+
+--------
+
+ISC License
+
+ISC License Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and /or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above copyright
-notice and this permission notice appear in all copies.`,
+notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.
+IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA
+OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+`.trimLeft(), // remove leading newline character,
     );
   });
 
@@ -252,26 +260,21 @@ notice and this permission notice appear in all copies.`,
       '"copyright.owner": "IBM Corp."',
     );
 
-    /*
-    Copyright (c) ACME Inc. 2020. All Rights Reserved.
-    Node module: myapp
-    This project is licensed under the ISC License, full text below.
-    */
-    assert.fileContent(
+    const licenseText = fs.readFileSync(
       path.join(sandbox.path, 'LICENSE'),
-      'This project is licensed under the MIT License, full text below.',
+      'utf-8',
     );
-    assert.fileContent(
-      path.join(sandbox.path, 'LICENSE'),
-      `Copyright (c) IBM Corp. ${year}.`,
-    );
-    assert.fileContent(
-      path.join(sandbox.path, 'LICENSE'),
-      'Node module: myapp',
-    );
-    assert.fileContent(
-      path.join(sandbox.path, 'LICENSE'),
-      `MIT License Copyright (c) IBM Corp. ${year}
+    expect(licenseText).to.equal(
+      `
+Copyright (c) IBM Corp. ${year}.
+Node module: myapp
+This project is licensed under the MIT License, full text below.
+
+--------
+
+MIT License
+
+MIT License Copyright (c) IBM Corp. 2021
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -289,7 +292,8 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`,
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+`.trimLeft(), // remove leading newline character,
     );
   });
 });


### PR DESCRIPTION
Rework the assertions in `lb4 copyright` tests to verify the entire content of the `LICENSE` file generated, not just isolated substrings.

There is no change in CLI functionality, I am only updating the test to better describe the current behavior.

See also https://github.com/strongloop/loopback-next/pull/7107

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
