### PR TITLE
[CI] do only commit-lint job for PR

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -84,6 +84,7 @@ jobs:
   commit-lint:
     name: Commit Lint
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Signed-off-by: Francisco Buceta <frbuceta@gmail.com>

I have seen that the command for the `commit-lint` job compares it from the `master` branch therefore it makes no sense to compare `master` with `master`

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
