### PR TITLE
fix(rest): fix the request body index handling

### DIFF
--- a/packages/openapi-v3/src/decorators/parameter.decorator.ts
+++ b/packages/openapi-v3/src/decorators/parameter.decorator.ts
@@ -16,6 +16,8 @@ import {
   SchemaObject,
 } from '../types';
 
+export const PARAMETER_INDEX = 'x-parameter-index';
+
 /**
  * Describe an input parameter of a Controller method.
  *
@@ -36,7 +38,7 @@ import {
  */
 export function param(paramSpec: ParameterObject) {
   return function (target: object, member: string, index: number) {
-    paramSpec = paramSpec || {};
+    paramSpec = {...paramSpec};
     // Get the design time method parameter metadata
     const methodSig = MetadataInspector.getDesignTypeForMethod(target, member);
     const paramTypes = methodSig?.parameterTypes || [];

--- a/packages/openapi-v3/src/decorators/request-body.decorator.ts
+++ b/packages/openapi-v3/src/decorators/request-body.decorator.ts
@@ -86,7 +86,7 @@ export function requestBody(requestBodySpec?: Partial<RequestBodyObject>) {
       debug('  options: %s', inspect(requestBodySpec, {depth: null}));
 
     // Use 'application/json' as default content if `requestBody` is undefined
-    requestBodySpec = requestBodySpec ?? {content: {}};
+    requestBodySpec = {content: {}, ...requestBodySpec};
 
     if (_.isEmpty(requestBodySpec.content))
       requestBodySpec.content = {'application/json': {}};
@@ -106,12 +106,6 @@ export function requestBody(requestBodySpec?: Partial<RequestBodyObject>) {
       }
       return c;
     });
-
-    // The default position for request body argument is 0
-    // if not, add extension 'x-parameter-index' to specify the position
-    if (index !== 0) {
-      requestBodySpec[REQUEST_BODY_INDEX] = index;
-    }
 
     /* istanbul ignore if */
     if (debug.enabled)

--- a/packages/rest/src/parser.ts
+++ b/packages/rest/src/parser.ts
@@ -71,7 +71,7 @@ async function buildOperationArguments(
       throw new Error('$ref requestBody is not supported yet.');
     }
     const i = operationSpec.requestBody[REQUEST_BODY_INDEX];
-    requestBodyIndex = i ? i : 0;
+    requestBodyIndex = i != null ? i : 0;
   }
 
   const paramArgs: OperationArgs = [];
@@ -96,7 +96,9 @@ async function buildOperationArguments(
     options,
   );
 
-  if (requestBodyIndex > -1) paramArgs.splice(requestBodyIndex, 0, body.value);
+  if (requestBodyIndex >= 0) {
+    paramArgs.splice(requestBodyIndex, 0, body.value);
+  }
   return paramArgs;
 }
 


### PR DESCRIPTION
See https://github.com/strongloop/loopback-next/discussions/7224. The
relative index should be used instead of the absolute index to insert
body to parameter list.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
