### PR TITLE
docs: how to nominate a new maintainer

### DIFF
--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -28,6 +28,11 @@ http://loopback.io/doc/en/contrib/Governance.html. This means mostly:
   take a look at issues and pull requests related to code you contributed
   yourself.
 
+Please look for community members that are actively involved with the project
+and consider nominating them to become maintainers too. See
+[Nominating new maintainers](https://github.com/strongloop/loopback-governance/blob/master/docs/maintainer-nomination.md)
+for more information.
+
 ## More questions?
 
 **Q: Now that I have rights to merge pull requests, how many approvals from


### PR DESCRIPTION
As part of our effort to make LoopBack an _open_ open source project, we would like to open up the process of nominating new maintainers. 🎉 

In the past, it was up to the core team at IBM to watch for non-trivial contributions and nominate their authors. Let's open this process to all maintainers, both from IBM and the community.

@strongloop/loopback-maintainers Please review the propsal in the markdown file I am editing and let me know if you agree/disagree with the proposed process, where to add more details or which parts to clarify.

**UPDATE 2021-03-26:** I moved the description of the nomination process to https://github.com/strongloop/loopback-governance/pull/8.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
