### PR TITLE
test(cli): increase timeout to avoid GitHub Actions failures

### DIFF
--- a/packages/cli/test/integration/generators/copyright-git.integration.js
+++ b/packages/cli/test/integration/generators/copyright-git.integration.js
@@ -22,7 +22,7 @@ let year = new Date().getFullYear();
 if (year !== 2020) year = `2020,${year}`;
 
 describe('lb4 copyright with git', /** @this {Mocha.Suite} */ function () {
-  this.timeout(30000);
+  this.timeout(60000);
 
   before('add files not tracked by git', async () => {
     await fs.outputFile(

--- a/packages/cli/test/integration/generators/copyright-monorepo.integration.js
+++ b/packages/cli/test/integration/generators/copyright-monorepo.integration.js
@@ -22,7 +22,7 @@ const sandbox = new TestSandbox(path.resolve(__dirname, '../.sandbox'));
 const year = new Date().getFullYear();
 
 describe('lb4 copyright for monorepo', /** @this {Mocha.Suite} */ function () {
-  this.timeout(30000);
+  this.timeout(60000);
 
   beforeEach('reset sandbox', async () => {
     await sandbox.reset();


### PR DESCRIPTION
The MacOS worker is often timing out, let's increase the value to avoid such test failures.

Example PRs that failed with a timeout: 
- #7284 (see https://github.com/strongloop/loopback-next/pull/7284/checks?check_run_id=2149908320)

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
