### PR TITLE
fix(docs): fix mutation name in openapi-to-graphql how-to guide

### DIFF
--- a/docs/site/Using-openapi-to-graphql.md
+++ b/docs/site/Using-openapi-to-graphql.md
@@ -116,7 +116,7 @@ Here are some examples of the `query` and `mutation` calls:
 
    ```
    mutation {
-     todoControllerCreateTodo(newTodoInput: {
+     todoControllerCreate(newTodoInput: {
        title: "Take over the universe"
      }) {
        id
@@ -130,7 +130,7 @@ Here are some examples of the `query` and `mutation` calls:
    ```json
    {
      "data": {
-       "todoControllerCreateTodo": {
+       "todoControllerCreate": {
          "id": 5,
          "title": "Take over the universe"
        }


### PR DESCRIPTION
Signed-off-by: Javier Zapata <javierzapata82@gmail.com>

The mutation name provided by the guide was wrong. I updated it.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
