### PR TITLE
fix: cli openapi generator op name inference

### DIFF
--- a/packages/cli/generators/openapi/spec-helper.js
+++ b/packages/cli/generators/openapi/spec-helper.js
@@ -140,11 +140,22 @@ function groupOperationsByController(apiSpec) {
  * as-is. Otherwise, derive the name from `operationId`.
  *
  * @param {object} opSpec OpenAPI operation spec
+ * @internal
  */
 function getMethodName(opSpec) {
-  return camelCase(
-    opSpec['x-operation-name'] || escapeIdentifier(opSpec.operationId),
-  );
+  let methodName;
+
+  if (opSpec['x-operation-name']) {
+    methodName = opSpec['x-operation-name'];
+  } else if (opSpec.operationId) {
+    methodName = escapeIdentifier(opSpec.operationId);
+  } else {
+    throw new Error(
+      'Could not infer method name from OpenAPI Operation Object. OpenAPI Operation Objects must have either `x-operation-name` or `operationId`.',
+    );
+  }
+
+  return camelCase(methodName);
 }
 
 function registerAnonymousSchema(names, schema, typeRegistry) {
@@ -467,6 +478,7 @@ function getServiceFileName(serviceName) {
 
 module.exports = {
   getControllerFileName,
+  getMethodName,
   getServiceFileName,
   generateControllerSpecs,
 };

--- a/packages/cli/test/unit/openapi/spec-helper.unit.js
+++ b/packages/cli/test/unit/openapi/spec-helper.unit.js
@@ -1,0 +1,48 @@
+const expect = require('@loopback/testlab').expect;
+const getMethodName = require('../../../generators/openapi/spec-helper')
+  .getMethodName;
+
+describe('Spec Helpers', () => {
+  describe('getMethodName', () => {
+    it('returns `x-operation-name` without `operationId` set.', () => {
+      const spec = {
+        'x-operation-name': 'foo',
+      };
+
+      const result = getMethodName(spec);
+
+      expect(result).to.equal('foo');
+    });
+
+    it('returns `x-operation-name` with `operationId` set.', () => {
+      const spec = {
+        'x-operation-name': 'foo',
+        operationId: 'bar',
+      };
+
+      const result = getMethodName(spec);
+
+      expect(result).to.equal('foo');
+    });
+
+    it('returns `operationId` without `x-operation-name` set.', () => {
+      const spec = {
+        operationId: 'baz',
+      };
+
+      const result = getMethodName(spec);
+
+      expect(result).to.equal('baz');
+    });
+
+    it('throws an error when neither `x-operation-name` nor `operationId` is set.', () => {
+      const spec = {};
+
+      const result = () => getMethodName(spec);
+
+      expect(result).to.throw(
+        'Could not infer method name from OpenAPI Operation Object. OpenAPI Operation Objects must have either `x-operation-name` or `operationId`.',
+      );
+    });
+  });
+});


### PR DESCRIPTION
fixes #3417

In the long-term, we should be providing a better experience by allowing the users to manually set the method name on the spot.

This is an interim solution to resolve a long-standing issue.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
