### PR TITLE
chore: symlink common docs files to root

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+./docs/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+./docs/CONTRIBUTING.md

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,1 @@
+./docs/MAINTAINING.md


### PR DESCRIPTION
Certain files such as `CONTRIBUTING.md` are expected at the root directory of the repository. Due to how the documentation's architecture is set-up, these files are hidden away under `docs/`, which may make it difficult to discover.

This pull request aims to reduce the discovery friction by creating a symbolic link of the original files into the root directory. This has the benefits of keeping future git history on those files consistent, and keeping the same maintenance overhead for changes to those files (as they're symlinks).

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
