### PR TITLE
feat: allow one strategy to fail the authentication process

### DIFF
--- a/docs/site/Authentication-component-options.md
+++ b/docs/site/Authentication-component-options.md
@@ -34,6 +34,16 @@ app
   .to({defaultMetadata: {strategy: 'xyz'}});
 ```
 
+If multiple strategies are used for a given method, we can configure the
+`failOnError` option so that a strategy can abort the authentication process by
+throwing an error. Otherwise, other strategies will be invoked and it only fails
+when none of the strategies succeeds by returning a `UserProfile` or
+`RedirectRoute`.
+
+```ts
+app.configure(AuthenticationBindings.COMPONENT).to({failOnError: true});
+```
+
 ### Define the Options Interface and Binding Key
 
 Define an options interface and a binding key for the default options of that

--- a/packages/authentication/src/types.ts
+++ b/packages/authentication/src/types.ts
@@ -60,6 +60,15 @@ export interface AuthenticationOptions {
    * those methods without authentication metadata.
    */
   defaultMetadata?: AuthenticationMetadata[];
+
+  /**
+   * This flag allows an authentication strategy to abort the authentication by
+   * throwing an error if `failOnError` is set to `true`. By default, the
+   * authentication process continues to the next one even when a strategy
+   * throws an error. If one of other strategies succeed, the error will be
+   * discarded.
+   */
+  failOnError?: boolean;
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: The current code allows a strategy to throw an error but
it only fails the authentication process if other ones either skip or fail.
This behavior does not allow a strategy to abort the process. With this PR,
a strategy can decide how to proceed as follows:

1. Return normal user profile or redirect to finish the authentication
2. Return undefined/null to continue with next one
3. Throw an error to abort the process

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
