### PR TITLE
monorepo: fix eslint vscode formatter; enforce consistent eol vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     "source.organizeImports": true,
     "source.fixAll.eslint": true
   },
+  "files.eol": "\n",
   "files.exclude": {
     "**/.DS_Store": true,
     "**/.git": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,19 @@
 {
-  "editor.rulers": [80],
+  "editor.rulers": [
+    80
+  ],
   "editor.tabCompletion": "on",
   "editor.tabSize": 2,
   "editor.trimAutoWhitespace": true,
   "editor.formatOnSave": true,
   "[html]": {
     "editor.formatOnSave": false
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "editor.codeActionsOnSave": {
     "source.organizeImports": true,
@@ -35,5 +43,6 @@
   "eslint.validate": [
     "javascript",
     "typescript"
-  ]
+  ],
+  "eslint.format.enable": true
 }


### PR DESCRIPTION
This pull request is broken down into 2 commits:

1. Enable ESLint vscode extension as a formatter
    Previously, the ESLint vscode extension was using its own `onSave` hook to engage formatting. This led to a clash with vscode's built-in TypeScript formatter, which led to issues ranging minor formatting inconsistencies during save to a completely broken TypeScript file.
    This commit switches ESLint away from the custom `onSave` hook to vscode's built-in "default formatter" system for JavaScript/TypeScirpt files.

2. Enforce a consistent EOL character sequence
    Windows-based installations of vscode may inadvertently use `\r\n` when creating a new file. This commit enforces a consistent behavior across vscode installations. 

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
