### PR TITLE
docs: correct ServiceBooter Options in README

### DIFF
--- a/packages/boot/README.md
+++ b/packages/boot/README.md
@@ -180,12 +180,12 @@ The options for this are passed in a `services` object on `BootOptions`.
 
 Available options on the `services` object on `BootOptions` are as follows:
 
-| Options      | Type                 | Default              | Description                                                                                                  |
-| ------------ | -------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `dirs`       | `string \| string[]` | `['repositories']`   | Paths relative to projectRoot to look in for Service artifacts                                               |
-| `extensions` | `string \| string[]` | `['.repository.js']` | File extensions to match for Service artifacts                                                               |
-| `nested`     | `boolean`            | `true`               | Look in nested directories in `dirs` for Service artifacts                                                   |
-| `glob`       | `string`             |                      | A `glob` pattern string. This takes precedence over above 3 options (which are used to make a glob pattern). |
+| Options      | Type                 | Default           | Description                                                                                                  |
+| ------------ | -------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `dirs`       | `string \| string[]` | `['services']`    | Paths relative to projectRoot to look in for Service artifacts                                               |
+| `extensions` | `string \| string[]` | `['.service.js']` | File extensions to match for Service artifacts                                                               |
+| `nested`     | `boolean`            | `true`            | Look in nested directories in `dirs` for Service artifacts                                                   |
+| `glob`       | `string`             |                   | A `glob` pattern string. This takes precedence over above 3 options (which are used to make a glob pattern). |
 
 ## Contributions
 


### PR DESCRIPTION
Signed-off-by: Fengyuhe heyufeng8080@gmail.com

Updating ServiceBooter options(dirs and extensions) default value.

## Checklist
* [x]  DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
* [ ]  `npm test` passes on your machine
* [ ]  New tests added or existing tests modified to cover all changes
* [x]  Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
* [x]  API Documentation in code was updated
* [ ]  Documentation in [/docs/site](../tree/master/docs/site) was updated
* [ ]  Affected artifact templates in `packages/cli` were updated
* [ ]  Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
