### PR TITLE
fix(cli): invalid package.plain.json.ejs template

### DIFF
--- a/packages/cli/generators/project/templates/package.plain.json.ejs
+++ b/packages/cli/generators/project/templates/package.plain.json.ejs
@@ -10,7 +10,7 @@
   "private": true,
 <% } -%>
   "main": "dist/index.js",
-  "main": "types/index.d.ts",
+  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=10.16"
   },
@@ -134,12 +134,17 @@
 <% if (project.projectType === 'application') { -%>
     "@loopback/boot": "<%= project.dependencies['@loopback/boot'] -%>",
     "@loopback/core": "<%= project.dependencies['@loopback/core'] -%>",
+<% if (project.repositories) { -%>
     "@loopback/repository": "<%= project.dependencies['@loopback/repository'] -%>",
+<% } -%>
 <% if (project.apiconnect) { -%>
     "@loopback/apiconnect": "<%= project.dependencies['@loopback/apiconnect'] -%>",
 <% } -%>
     "@loopback/rest": "<%= project.dependencies['@loopback/rest'] -%>",
     "@loopback/rest-explorer": "<%= project.dependencies['@loopback/rest-explorer'] -%>",
+<% } -%>
+<% if (project.services) { -%>
+    "@loopback/service-proxy": "<%= project.dependencies['@loopback/service-proxy'] -%>",
 <% } -%>
     "tslib": "<%= project.dependencies['tslib'] -%>"
   },
@@ -159,9 +164,6 @@
 <% } -%>
 <% if (project.prettier) { -%>
     "prettier": "<%= project.dependencies['prettier'] -%>",
-<% } -%>
-<% if (project.mocha) { -%>
-    "source-map-support": "<%= project.dependencies['source-map-support'] -%>",
 <% } -%>
 <% if (project.eslint) { -%>
     "@loopback/eslint-config": "<%= project.dependencies['@loopback/eslint-config'] -%>",


### PR DESCRIPTION
Generating a project (`lb4 app`) without enabling the `loopbackBuild` feature produces an invalid `package.json` with the following errors:

- duplicated `main` field (should be `types` for the second one) - introduced by #5440 ([diff](https://github.com/strongloop/loopback-next/commit/c3f048428f85eb1adcddc63b111db3286486339b#diff-4c3a2bc38d294c673194936e9f09b56f39a09b8db26eaa3313a57c1283088105R10))
- incorrect `types` path (should be `dist/index.d.ts`) - introduced by #5440 ([diff](https://github.com/strongloop/loopback-next/commit/c3f048428f85eb1adcddc63b111db3286486339b#diff-4c3a2bc38d294c673194936e9f09b56f39a09b8db26eaa3313a57c1283088105R10))
- `services` feature not handled (missing dependency) - missing in #1649
- `repositories` flag not handled (always enabled) - missing in #1649
- duplicated `source-map-support` dependency - introduced by #3228 ([diff](https://github.com/strongloop/loopback-next/commit/1882240c623c3e68b8b90630296e622b6193a1bd#diff-4c3a2bc38d294c673194936e9f09b56f39a09b8db26eaa3313a57c1283088105R89))

Fixes for these issues are consistent with `package.json.ejs`. 

Though, I'm wondering if I'm missing something because some of these bugs are 3 years old but I can't find any related bug report.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated