### PR TITLE
fix(context): ensure non-proxy value is cached for bindings

### DIFF
--- a/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
@@ -14,6 +14,7 @@ import {
   ResolutionSession,
   ValueOrPromise,
 } from '../..';
+import {BindingScope} from '../../binding';
 import {Provider} from '../../provider';
 
 describe('Interception proxy', () => {
@@ -162,6 +163,42 @@ describe('Interception proxy', () => {
       'log: [my-controller] after-greet',
       'convertName: after-greet',
     ]);
+  });
+
+  it('supports asProxyWithInterceptors resolution option for singletons', async () => {
+    // Apply `log` to all methods on the class
+    @intercept(log)
+    class MyController {
+      // Apply multiple interceptors. The order of `log` will be preserved as it
+      // explicitly listed at method level
+      @intercept(convertName, log)
+      async greet(name: string) {
+        return `Hello, ${name}`;
+      }
+    }
+    ctx
+      .bind('my-controller')
+      .toClass(MyController)
+      .inScope(BindingScope.SINGLETON);
+
+    // Proxy version
+    let proxy = await ctx.get<MyController>('my-controller', {
+      asProxyWithInterceptors: true,
+    });
+    let msg = await proxy!.greet('John');
+    expect(msg).to.equal('Hello, JOHN');
+
+    // Non proxy version
+    const inst = await ctx.get<MyController>('my-controller');
+    msg = await inst.greet('John');
+    expect(msg).to.equal('Hello, John');
+
+    // Try the proxy again
+    proxy = await ctx.get<MyController>('my-controller', {
+      asProxyWithInterceptors: true,
+    });
+    msg = await proxy!.greet('John');
+    expect(msg).to.equal('Hello, JOHN');
   });
 
   it('supports asProxyWithInterceptors resolution option for dynamic value', async () => {


### PR DESCRIPTION
A binding can be resolved with asProxyWithInterceptors. Before this fix,
if a singleton binding is first resolved with asProxyWithInterceptors = true,
sesquential resolutions will always get the proxy even with asProxyWithInterceptors
= false. This PR fixes the issue by caching the non-proxy value.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
