### PR TITLE
feat: adds support for disableMigration on repository mixin

### DIFF
--- a/docs/site/Database-migrations.md
+++ b/docs/site/Database-migrations.md
@@ -127,6 +127,34 @@ The migration process consists of two steps now:
    $ npm run migrate -- --rebuild
    ```
 
+### Skipping a dataSource for migration
+
+In some cases you do not want specific datasource(s) to be included in the
+migration process. For example, depending on the `process.env.NODE_ENV` you
+might be restricted to ALL or specific datasources from altering the table
+schemas.
+
+For such scenarios, you can include the property `disableMigration` in the
+datasource configuration. The Datasource will only be skipped from the migration
+process if you set it to`true`.
+
+If you do not include it or if you set it to `false` then your datasource will
+be migrated, this is to provide a non-breaking change with this new property.
+
+The example below shows how to do so in our Todo example application.
+
+{% include code-caption.html content="src/datasources/db.datasource.ts" %}
+
+```ts
+const config = {
+  name: 'db',
+  connector: 'memory',
+  localStorage: '',
+  file: './data/db.json',
+  disableMigration: true,
+};
+```
+
 ### Implement additional migration steps
 
 In some scenarios, the application may need to define additional schema

--- a/packages/repository/src/mixins/repository.mixin.ts
+++ b/packages/repository/src/mixins/repository.mixin.ts
@@ -4,16 +4,14 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {
+  Application,
   Binding,
   BindingFromClassOptions,
   BindingScope,
-  createBindingFromClass,
-} from '@loopback/core';
-import {
-  Application,
   Component,
   Constructor,
   CoreBindings,
+  createBindingFromClass,
   MixinTarget,
 } from '@loopback/core';
 import debugFactory from 'debug';
@@ -25,10 +23,6 @@ import {juggler, Repository} from '../repositories';
 
 const debug = debugFactory('loopback:repository:mixin');
 
-// FIXME(rfeng): Workaround for https://github.com/microsoft/rushstack/pull/1867
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import * as loopbackContext from '@loopback/core';
-import * as loopbackCore from '@loopback/core';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 /**
@@ -284,8 +278,13 @@ export function RepositoryMixin<T extends MixinTarget<Application>>(
       );
       for (const b of dsBindings) {
         const ds = await this.get<juggler.DataSource>(b.key);
+        const disableMigration = ds.settings.disableMigration ?? false;
 
-        if (operation in ds && typeof ds[operation] === 'function') {
+        if (
+          operation in ds &&
+          typeof ds[operation] === 'function' &&
+          !disableMigration
+        ) {
           debug('Migrating dataSource %s', b.key);
           await ds[operation](options.models);
         } else {


### PR DESCRIPTION
Signed-off-by: Mario Estrada <marioestradarosa@yahoo.com>

Developers have been asking a way to make a **DataSource** _readonly_ when migrating the database schema on certain environments. For a non-breaking change the property ```disableMigration``` is introduced that can be specified in the **DataSource** _configuration_, which behaves in the way it does currently if not specified or if set to false, so only when set to true it will skip that datasource when running the migrate script or when auto-migrate.

It can work together with the ```process.env.NODE_ENV``` in order to seamlessly achieve the readonly mode (not migrate flag).  The reason why I did not followed the pattern of models: property in the ```migrateSchemaoptions``` is because it is really easier to work along with the ```process.env.NODE_ENV``` for these use cases with the property flagged in the configuration.


<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [ ] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
