### PR TITLE
Fixes broken links and naming for UserController

### DIFF
--- a/docs/site/Inside-Loopback-Application.md
+++ b/docs/site/Inside-Loopback-Application.md
@@ -138,10 +138,10 @@ endpoints with API `decorators`.
 For example,
 
 - `login()` method in the
-  [UserController](https://github.com/strongloop/loopback4-example-shopping/blob/master/packages/shopping/src/controllers/user.controller.ts)
+  [UserManagementController](https://github.com/strongloop/loopback4-example-shopping/blob/master/packages/shopping/src/controllers/user-management.controller.ts)
   class is defined as `/users/login` API endpoint.
 - argument of method `findById` in the
-  [UserController](https://github.com/strongloop/loopback4-example-shopping/blob/master/packages/shopping/src/controllers/user.controller.ts)
+  [UserManagementController](https://github.com/strongloop/loopback4-example-shopping/blob/master/packages/shopping/src/controllers/user-management.controller.ts)
   is decorated with `@param.path.string('userId')` which means that the `userId`
   parameter in the URL path is passed into the method at runtime.
 


### PR DESCRIPTION
I noticed that the UserController has been moved/renamed to UserManagementController in the shopping application but the docs is outdated. This commit fixes the broken links and name references to the UserManagementController.