### PR TITLE
ci: clean up before build and fix the tests for npm v7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,7 +38,9 @@ jobs:
           npm ci --ignore-scripts
           npm run postinstall
       - name: Build project
-        run: npm run build
+        run: |
+          npm run clean
+          npm run build
       - uses: Yuri6037/Action-FakeTTY@v1.1
       - name: Run tests
         run: faketty npm test --ignore-scripts

--- a/packages/cli/test/acceptance/app-run.acceptance.js
+++ b/packages/cli/test/acceptance/app-run.acceptance.js
@@ -69,44 +69,47 @@ skipIf(process.env.CI == null, describe, 'app-generator (SLOW)', () => {
     this.timeout(5 * 60 * 1000);
 
     // FixMe: NPM v7 does not run lifecycle scripts for some reason. To solve this problem, run `pretest`,`test` and `posttest` separately
-    return Promise.all([
-      new Promise(resolve => {
-        build
-          .runShell('npm', ['run', 'pretest'], {
-            // Disable stdout
-            stdio: [process.stdin, 'ignore', process.stderr],
-            cwd: appProps.outdir,
-          })
-          .on('close', code => {
-            assert.equal(code, 0);
-            resolve();
-          });
-      }),
-      new Promise(resolve => {
-        build
-          .runShell('npm', ['test', '--ignore-scripts'], {
-            // Disable stdout
-            stdio: [process.stdin, 'ignore', process.stderr],
-            cwd: appProps.outdir,
-          })
-          .on('close', code => {
-            assert.equal(code, 0);
-            resolve();
-          });
-      }),
-      new Promise(resolve => {
-        build
-          .runShell('npm', ['run', 'posttest'], {
-            // Disable stdout
-            stdio: [process.stdin, 'ignore', process.stderr],
-            cwd: appProps.outdir,
-          })
-          .on('close', code => {
-            assert.equal(code, 0);
-            resolve();
-          });
-      }),
-    ]);
+    // and should be run synchronous
+    return new Promise(resolve => {
+      build
+        .runShell('npm', ['run', 'pretest'], {
+          // Disable stdout
+          stdio: [process.stdin, 'ignore', process.stderr],
+          cwd: appProps.outdir,
+        })
+        .on('close', code => {
+          assert.equal(code, 0);
+          resolve();
+        });
+    })
+      .then(() => {
+        return new Promise(resolve => {
+          build
+            .runShell('npm', ['test', '--ignore-scripts'], {
+              // Disable stdout
+              stdio: [process.stdin, 'ignore', process.stderr],
+              cwd: appProps.outdir,
+            })
+            .on('close', code => {
+              assert.equal(code, 0);
+              resolve();
+            });
+        });
+      })
+      .then(() => {
+        return new Promise(resolve => {
+          build
+            .runShell('npm', ['run', 'posttest'], {
+              // Disable stdout
+              stdio: [process.stdin, 'ignore', process.stderr],
+              cwd: appProps.outdir,
+            })
+            .on('close', code => {
+              assert.equal(code, 0);
+              resolve();
+            });
+        });
+      });
   });
 
   after(


### PR DESCRIPTION
follow the [PR#7520](https://github.com/strongloop/loopback-next/pull/7520) I just want to make sure the lifecycle of the npm run synchronous, to make sure `npm run pretest`
run before `npm test`. I also add the script clean to ci, to reduce unknown bug.

Signed-off-by: Dat Pham <dat.pham@popsww.com>


## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- API Documentation in code was updated
- Documentation in [/docs/site](../tree/master/docs/site) was updated
- Affected artifact templates in `packages/cli` were updated
- Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
