### PR TITLE
feat: improve TypeScript typing for AsyncProxy

### DIFF
--- a/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
+++ b/packages/context/src/__tests__/acceptance/interception-proxy.acceptance.ts
@@ -69,7 +69,7 @@ describe('Interception proxy', () => {
     expect(proxy.greet('Jane')).to.be.instanceOf(Promise);
   });
 
-  it('creates async methods for the proxy', () => {
+  it('creates async methods for the proxy', async () => {
     class MyController {
       name: string;
 
@@ -89,6 +89,8 @@ describe('Interception proxy', () => {
     }
 
     const proxy = createProxyWithInterceptors(new MyController(), ctx);
+    const greeting = await proxy.greet('John');
+    expect(greeting).to.eql('Hello, John');
 
     // Enforce compile time check to ensure the AsyncProxy typing works for TS
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/context/src/interception-proxy.ts
+++ b/packages/context/src/interception-proxy.ts
@@ -24,7 +24,7 @@ export type AsValueOrPromise<T> = T extends Promise<unknown>
 export type AsInterceptedFunction<T> = T extends (
   ...args: InvocationArgs
 ) => infer R
-  ? (...args: InvocationArgs) => AsValueOrPromise<R>
+  ? (...args: Parameters<T>) => AsValueOrPromise<R>
   : T;
 
 /**


### PR DESCRIPTION
Ensures the following method to keep its parameter types:

`greet(name: string): string` => greet(name: string): ValueOrPromise<string>`

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
