### PR TITLE
feat(cli): add models option in discover cli command to generate spec…

### DIFF
--- a/docs/site/Discovering-models.md
+++ b/docs/site/Discovering-models.md
@@ -49,6 +49,8 @@ placed. Default is `src/models`
 `--schema`: Specify the schema which the datasource will find the models to
 discover
 
+`--models`: generate the specific models
+
 `--optionalId`: Specify if the Id property of generated models will be marked as
 not required
 

--- a/packages/cli/.yo-rc.json
+++ b/packages/cli/.yo-rc.json
@@ -1278,6 +1278,12 @@
           "name": "outDir",
           "hide": false
         },
+        "models": {
+          "type": "String",
+          "description": "Discover specific models without prompting users to select ex:--models=tale1,table2",
+          "name": "models",
+          "hide": false
+        },
         "optionalId": {
           "type": "Boolean",
           "description": "Boolean to mark id property as optional field",

--- a/packages/cli/generators/discover/index.js
+++ b/packages/cli/generators/discover/index.js
@@ -57,6 +57,14 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
       default: undefined,
     });
 
+    this.option('models', {
+      type: String,
+      description: g.f(
+        'Discover specific models without prompting users to select ex:--models=tale1,table2',
+      ),
+      default: undefined,
+    });
+
     this.option('optionalId', {
       type: Boolean,
       description: g.f('Boolean to mark id property as optional field'),
@@ -196,6 +204,16 @@ module.exports = class DiscoveryGenerator extends ArtifactGenerator {
     /* istanbul ignore next */
     if (this.options.all) {
       this.discoveringModels = this.modelChoices;
+    }
+
+    if (this.options.models) {
+      const answers = {discoveringModels: this.options.models.split(',')};
+      debug(`Models chosen: ${JSON.stringify(answers)}`);
+      this.discoveringModels = [];
+      answers.discoveringModels.forEach(m => {
+        this.discoveringModels.push(this.modelChoices.find(c => c.name === m));
+      });
+      return;
     }
 
     const prompts = [

--- a/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/cli/cli.integration.snapshots.js
@@ -1336,6 +1336,12 @@ exports[`cli saves command metadata to .yo-rc.json 1`] = `
           "name": "outDir",
           "hide": false
         },
+        "models": {
+          "type": "String",
+          "description": "Discover specific models without prompting users to select ex:--models=tale1,table2",
+          "name": "models",
+          "hide": false
+        },
         "optionalId": {
           "type": "Boolean",
           "description": "Boolean to mark id property as optional field",

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -50,6 +50,12 @@ const disableCamelCaseOptions = {
 const missingDataSourceOptions = {
   dataSource: 'foo',
 };
+const specificmodelsOptions = {
+  models: 'Test',
+  dataSource: 'mem',
+  views: false,
+  disableCamelCase: true,
+};
 const optionalIdOptions = {
   ...baseOptions,
   optionalId: true,
@@ -173,5 +179,19 @@ describe('lb4 discover integration', () => {
       assert.file(defaultExpectedTestModel);
       expectFileToMatchSnapshot(defaultExpectedTestModel);
     });
+  });
+
+  it('generates specific models without prompts using --models', async () => {
+    await testUtils
+      .executeGenerator(generator)
+      .inDir(sandbox.path, () =>
+        testUtils.givenLBProject(sandbox.path, {
+          additionalFiles: SANDBOX_FILES,
+        }),
+      )
+      .withOptions(specificmodelsOptions);
+
+    basicModelFileChecks(defaultExpectedTestModel, defaultExpectedIndexFile);
+    assert.file(defaultExpectedTestModel);
   });
 });


### PR DESCRIPTION
added --models option inside lb4 discover the command to generate specific models

Fixes #7104 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] API Documentation in code was updated
- [x] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [x] Affected artifact templates in `packages/cli` were updated
- [x] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
