### PR TITLE
feat(cli): add cli options for controller generator

### DIFF
--- a/packages/cli/generators/controller/index.js
+++ b/packages/cli/generators/controller/index.js
@@ -61,6 +61,12 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
   }
 
   setOptions() {
+    this.artifactInfo.modelName = this.options.modelName;
+    this.artifactInfo.repositoryName = this.options.repositoryName;
+    this.artifactInfo.id = this.options.id;
+    this.artifactInfo.idType = this.options.idType;
+    this.artifactInfo.idOmitted = this.options.idOmitted;
+    this.artifactInfo.httpPathName = this.options.httpPathName;
     return super.setOptions();
   }
 
@@ -196,6 +202,7 @@ module.exports = class ControllerGenerator extends ArtifactGenerator {
         type: 'confirm',
         name: 'idOmitted',
         message: g.f('Is the id omitted when creating a new instance?'),
+        when: this.artifactInfo.idOmitted === undefined,
         default: true,
       },
       {


### PR DESCRIPTION
Almost none of the questions can be answered in advance with the controller generator via cli options. This pull request adds the following options to the generator:

`lb4 controller --modelName=<String> --repositoryName=<String> --id=<String> --idType=<String> --idOmitted=<Boolean> --httpPathName=<String>`

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
