### PR TITLE
Error handling in case of empty request body for patch request

### DIFF
--- a/packages/repository/src/__tests__/unit/errors/invalid-body-error.test.ts
+++ b/packages/repository/src/__tests__/unit/errors/invalid-body-error.test.ts
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. and LoopBack contributors 2019,2020. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {expect} from '@loopback/testlab';
+import {InvalidBodyError, isInvalidBodyError} from '../../..';
+
+describe('InvalidBodyDefinitionError', () => {
+  it('inherits from Error correctly', () => {
+    const err = givenAnErrorInstance();
+    expect(err).to.be.instanceof(InvalidBodyError);
+    expect(err).to.be.instanceof(Error);
+    expect(err.stack)
+      .to.be.String()
+      // NOTE(bajtos) We cannot assert using __filename because stack traces
+      // are typically converted from JS paths to TS paths using source maps.
+      .and.match(/invalid-body-error\.test\.(ts|js)/);
+  });
+
+  it('sets code to "INVALID_BODY_DEFINITION"', () => {
+    const err = givenAnErrorInstance();
+    expect(err.code).to.equal('INVALID_BODY_DEFINITION');
+  });
+});
+
+describe('isInvalidBodyError', () => {
+  it('returns true for an instance of InvalidBodyError', () => {
+    const error = givenAnErrorInstance();
+    expect(isInvalidBodyError(error)).to.be.true();
+  });
+
+  it('returns false for an instance of Error', () => {
+    const error = new Error('A generic error');
+    expect(isInvalidBodyError(error)).to.be.false();
+  });
+});
+
+function givenAnErrorInstance() {
+  return new InvalidBodyError('a reason', {
+    entityOrName: 'products',
+    entityId: 1,
+  });
+}

--- a/packages/repository/src/errors/index.ts
+++ b/packages/repository/src/errors/index.ts
@@ -6,3 +6,4 @@
 export * from './entity-not-found.error';
 export * from './invalid-polymorphism.error';
 export * from './invalid-relation.error';
+export * from './invalid-body.error';

--- a/packages/repository/src/errors/invalid-body.error.ts
+++ b/packages/repository/src/errors/invalid-body.error.ts
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. and LoopBack contributors 2018,2019. All Rights Reserved.
+// Node module: @loopback/repository
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity} from '../model';
+
+export class InvalidBodyError<ID, Props extends object = {}> extends Error {
+  code: string;
+  entityName: string;
+  entityId: ID;
+  statusCode: number;
+
+  constructor(
+    entityOrName: typeof Entity | string,
+    entityId: ID,
+    extraProperties?: Props,
+  ) {
+    const entityName =
+      typeof entityOrName === 'string'
+        ? entityOrName
+        : entityOrName.modelName || entityOrName.name;
+
+    super('Data is required for the patch request');
+
+    Error.captureStackTrace(this, this.constructor);
+
+    this.code = 'INVALID_BODY_DEFINITION';
+    this.statusCode = 400;
+    this.entityName = entityName;
+    this.entityId = entityId;
+
+    Object.assign(this, extraProperties);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isInvalidBodyError(e: any): e is InvalidBodyError<any> {
+  return e instanceof InvalidBodyError;
+}

--- a/packages/repository/src/repositories/legacy-juggler-bridge.ts
+++ b/packages/repository/src/repositories/legacy-juggler-bridge.ts
@@ -22,7 +22,7 @@ import {
   Options,
   PositionalParameters,
 } from '../common-types';
-import {EntityNotFoundError} from '../errors';
+import {EntityNotFoundError, InvalidBodyError} from '../errors';
 import {
   Entity,
   Model,
@@ -593,6 +593,9 @@ export class DefaultCrudRepository<
     data: DataObject<T>,
     options?: Options,
   ): Promise<void> {
+    if (!Object.keys(data).length) {
+      throw new InvalidBodyError(this.entityClass, id);
+    }
     if (id === undefined) {
       throw new Error('Invalid Argument: id cannot be undefined');
     }


### PR DESCRIPTION
In case of an empty request body for a patch request, the lb4 app returns 500 error while it should throw an error with 400 (Bad data). 

This PR fixes that.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
