### PR TITLE
feat: create controller and repo while discovering when `relations: true`

### DIFF
--- a/packages/cli/generators/repository/index.js
+++ b/packages/cli/generators/repository/index.js
@@ -571,5 +571,37 @@ module.exports = class RepositoryGenerator extends ArtifactGenerator {
     );
     this.artifactInfo.name = `${this.artifactInfo.className}Repository`;
     await super.end();
+    await this._generateRelations();
+  }
+
+  async _generateRelations() {
+    if (!this.artifactInfo.relations) {
+      debug('No relation configurations found, skipping relation generation');
+      return;
+    }
+    this.artifactInfo.relations = JSON.parse(this.artifactInfo.relations);
+    if (!this.artifactInfo.relations.length) {
+      debug('No relation configurations found, skipping relation generation');
+      return;
+    }
+    this.artifactInfo.relations.forEach(relation => {
+      const repoGen = require('../relation');
+      this.composeWith(
+        {
+          Generator: repoGen,
+          path: require.resolve('../relation'),
+        },
+        {
+          sourceModel: relation.sourceModel,
+          destinationModel: relation.destinationModel,
+          foreignKeyName: relation.foreignKeyName,
+          relationType: relation.relationType,
+          registerInclusionResolver: relation.registerInclusionResolver,
+          yes: true,
+          skipInstall: true,
+          skipCache: true,
+        },
+      );
+    });
   }
 };

--- a/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
+++ b/packages/cli/snapshots/integration/generators/discover.integration.snapshots.js
@@ -58,15 +58,137 @@ export type ViewWithRelations = View & ViewRelations;
 
 
 exports[`lb4 discover integration model discovery discovers models with --relations 1`] = `
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Appointment,
+  Doctor,
+} from '../models';
+import {AppointmentRepository} from '../repositories';
+
+export class AppointmentDoctorController {
+  constructor(
+    @repository(AppointmentRepository)
+    public appointmentRepository: AppointmentRepository,
+  ) { }
+
+  @get('/appointments/{id}/doctor', {
+    responses: {
+      '200': {
+        description: 'Doctor belonging to Appointment',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Doctor),
+          },
+        },
+      },
+    },
+  })
+  async getDoctor(
+    @param.path.number('id') id: typeof Appointment.prototype.id,
+  ): Promise<Doctor> {
+    return this.appointmentRepository.doctor(id);
+  }
+}
+
+`;
+
+
+exports[`lb4 discover integration model discovery discovers models with --relations 2`] = `
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Appointment,
+  Patient,
+} from '../models';
+import {AppointmentRepository} from '../repositories';
+
+export class AppointmentPatientController {
+  constructor(
+    @repository(AppointmentRepository)
+    public appointmentRepository: AppointmentRepository,
+  ) { }
+
+  @get('/appointments/{id}/patient', {
+    responses: {
+      '200': {
+        description: 'Patient belonging to Appointment',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Patient),
+          },
+        },
+      },
+    },
+  })
+  async getPatient(
+    @param.path.number('id') id: typeof Appointment.prototype.id,
+  ): Promise<Patient> {
+    return this.appointmentRepository.patient(id);
+  }
+}
+
+`;
+
+
+exports[`lb4 discover integration model discovery discovers models with --relations 3`] = `
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Doctor,
+} from '../models';
+import {DoctorRepository} from '../repositories';
+
+export class DoctorDoctorController {
+  constructor(
+    @repository(DoctorRepository)
+    public doctorRepository: DoctorRepository,
+  ) { }
+
+  @get('/doctors/{id}/doctor', {
+    responses: {
+      '200': {
+        description: 'Doctor belonging to Doctor',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Doctor),
+          },
+        },
+      },
+    },
+  })
+  async getDoctor(
+    @param.path.number('id') id: typeof Doctor.prototype.id,
+  ): Promise<Doctor> {
+    return this.doctorRepository.reportsTo(id);
+  }
+}
+
+`;
+
+
+exports[`lb4 discover integration model discovery discovers models with --relations 4`] = `
 import {Entity, model, property, belongsTo} from '@loopback/repository';
 
-@model({
-  settings: {
-    foreignKeys: {
-      doctorRel: {name: 'doctorRel', entity: 'Doctor', entityKey: 'id', foreignKey: 'reportsTo'}
-    }
-  }
-})
+@model()
 export class Doctor extends Entity {
   @property({
     type: 'number',
@@ -82,8 +204,7 @@ export class Doctor extends Entity {
   name?: string;
 
   @belongsTo(() => Doctor)
-  reportsTo?: number;
-
+  reportsTo: number;
   // Define well-known properties here
 
   // Indexer property to allow additional data
@@ -162,22 +283,139 @@ export type TestWithRelations = Test & TestRelations;
 
 
 exports[`lb4 discover integration model discovery generate relations with --relations 1`] = `
-import {Entity, model, property, belongsTo} from '@loopback/repository';
-import {Doctor,Patient} from '.';
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Appointment,
+  Doctor,
+} from '../models';
+import {AppointmentRepository} from '../repositories';
 
-@model({
-  settings: {
-    foreignKeys: {
-      doctorIdRel: {name: 'doctorIdRel', entity: 'Doctor', entityKey: 'id', foreignKey: 'doctorId'},
-      patientIdRel: {
-        name: 'patientIdRel',
-        entity: 'Patient',
-        entityKey: 'pid',
-        foreignKey: 'patientId'
-      }
-    }
+export class AppointmentDoctorController {
+  constructor(
+    @repository(AppointmentRepository)
+    public appointmentRepository: AppointmentRepository,
+  ) { }
+
+  @get('/appointments/{id}/doctor', {
+    responses: {
+      '200': {
+        description: 'Doctor belonging to Appointment',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Doctor),
+          },
+        },
+      },
+    },
+  })
+  async getDoctor(
+    @param.path.number('id') id: typeof Appointment.prototype.id,
+  ): Promise<Doctor> {
+    return this.appointmentRepository.doctor(id);
   }
-})
+}
+
+`;
+
+
+exports[`lb4 discover integration model discovery generate relations with --relations 2`] = `
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Appointment,
+  Patient,
+} from '../models';
+import {AppointmentRepository} from '../repositories';
+
+export class AppointmentPatientController {
+  constructor(
+    @repository(AppointmentRepository)
+    public appointmentRepository: AppointmentRepository,
+  ) { }
+
+  @get('/appointments/{id}/patient', {
+    responses: {
+      '200': {
+        description: 'Patient belonging to Appointment',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Patient),
+          },
+        },
+      },
+    },
+  })
+  async getPatient(
+    @param.path.number('id') id: typeof Appointment.prototype.id,
+  ): Promise<Patient> {
+    return this.appointmentRepository.patient(id);
+  }
+}
+
+`;
+
+
+exports[`lb4 discover integration model discovery generate relations with --relations 3`] = `
+import {
+  repository,
+} from '@loopback/repository';
+import {
+  param,
+  get,
+  getModelSchemaRef,
+} from '@loopback/rest';
+import {
+  Doctor,
+} from '../models';
+import {DoctorRepository} from '../repositories';
+
+export class DoctorDoctorController {
+  constructor(
+    @repository(DoctorRepository)
+    public doctorRepository: DoctorRepository,
+  ) { }
+
+  @get('/doctors/{id}/doctor', {
+    responses: {
+      '200': {
+        description: 'Doctor belonging to Doctor',
+        content: {
+          'application/json': {
+            schema: getModelSchemaRef(Doctor),
+          },
+        },
+      },
+    },
+  })
+  async getDoctor(
+    @param.path.number('id') id: typeof Doctor.prototype.id,
+  ): Promise<Doctor> {
+    return this.doctorRepository.reportsTo(id);
+  }
+}
+
+`;
+
+
+exports[`lb4 discover integration model discovery generate relations with --relations 4`] = `
+import {Entity, model, property, belongsTo} from '@loopback/repository';
+import {Doctor} from './doctor.model';
+import {Patient} from './patient.model';
+
+@model()
 export class Appointment extends Entity {
   @property({
     type: 'number',
@@ -188,13 +426,11 @@ export class Appointment extends Entity {
     mysql: {columnName: 'id', dataType: 'int', dataLength: null, dataPrecision: 10, dataScale: 0, nullable: 'N', generated: 1},
   })
   id?: number;
+  @belongsTo(() => Doctor)
+  doctorId: number;
 
   @belongsTo(() => Patient)
-  patientId?: number;
-
-  @belongsTo(() => Doctor)
-  doctorId?: number;
-
+  patientId: number;
   // Define well-known properties here
 
   // Indexer property to allow additional data

--- a/packages/cli/test/fixtures/discover/index.js
+++ b/packages/cli/test/fixtures/discover/index.js
@@ -6,4 +6,14 @@ exports.SANDBOX_FILES = [
     file: 'mem.datasource.js',
     content: fs.readFileSync(require.resolve('./mem.datasource.js.txt')),
   },
+  {
+    path: 'src/datasources',
+    file: 'mem.datasource.ts',
+    content: fs.readFileSync(require.resolve('./mem.datasource.ts.txt')),
+  },
+  {
+    path: 'src/datasources',
+    file: 'index.ts',
+    content: `export * from './mem.datasource';\n`,
+  },
 ];

--- a/packages/cli/test/fixtures/discover/mem.datasource.ts.txt
+++ b/packages/cli/test/fixtures/discover/mem.datasource.ts.txt
@@ -1,0 +1,22 @@
+import {lifeCycleObserver, LifeCycleObserver} from '@loopback/core';
+import {juggler} from '@loopback/repository';
+
+const config = {
+  name: 'mem',
+  connector: 'memory',
+};
+
+@lifeCycleObserver('datasource')
+export class MemDataSource extends juggler.DataSource
+  implements LifeCycleObserver {
+  static dataSourceName = 'mem';
+  static readonly defaultConfig = config;
+
+  constructor(
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+}
+
+export default MemDataSource;

--- a/packages/cli/test/integration/generators/discover.integration.js
+++ b/packages/cli/test/integration/generators/discover.integration.js
@@ -97,6 +97,31 @@ const appointmentModel = path.join(
   'src/models/appointment.model.ts',
 );
 const doctorModel = path.join(sandbox.path, 'src/models/doctor.model.ts');
+const doctorRepository = path.join(
+  sandbox.path,
+  'src/repositories/doctor.repository.ts',
+);
+const appointmentRepository = path.join(
+  sandbox.path,
+  'src/repositories/appointment.repository.ts',
+);
+const patientRepository = path.join(
+  sandbox.path,
+  'src/repositories/patient.repository.ts',
+);
+
+const doctorDoctorController = path.join(
+  sandbox.path,
+  'src/controllers/doctor-doctor.controller.ts',
+);
+const appointmentDoctorController = path.join(
+  sandbox.path,
+  'src/controllers/appointment-doctor.controller.ts',
+);
+const appointmentPatientController = path.join(
+  sandbox.path,
+  'src/controllers/appointment-patient.controller.ts',
+);
 
 const defaultExpectedIndexFile = path.join(sandbox.path, 'src/models/index.ts');
 const movedExpectedTestModel = path.join(sandbox.path, 'src/test.model.ts');
@@ -111,6 +136,7 @@ describe('lb4 discover integration', () => {
     beforeEach('reset sandbox', async () => {
       await sandbox.reset();
       await sandbox.mkdir('dist/datasources');
+      await sandbox.mkdir('src/datasources');
     });
 
     it('generates all models without prompts using --all --dataSource', /** @this {Mocha.Context} */ async function () {
@@ -212,7 +238,8 @@ describe('lb4 discover integration', () => {
       assert.file(defaultExpectedTestModel);
       expectFileToMatchSnapshot(defaultExpectedTestModel);
     });
-    it('generate relations with --relations', async () => {
+    it('generate relations with --relations', /** @this {Mocha.Context} */ async function () {
+      this.timeout(20000);
       await testUtils
         .executeGenerator(generator)
         .inDir(sandbox.path, () =>
@@ -221,10 +248,20 @@ describe('lb4 discover integration', () => {
           }),
         )
         .withOptions(relationsSetTrue);
+      assert.file(appointmentRepository);
+      assert.file(patientRepository);
+      assert.file(doctorRepository);
+      assert.file(appointmentDoctorController);
+      assert.file(appointmentPatientController);
+      assert.file(doctorDoctorController);
+      expectFileToMatchSnapshot(appointmentDoctorController);
+      expectFileToMatchSnapshot(appointmentPatientController);
+      expectFileToMatchSnapshot(doctorDoctorController);
       assert.file(appointmentModel);
       expectFileToMatchSnapshot(appointmentModel);
     });
-    it('discovers models with --relations', async () => {
+    it('discovers models with --relations', /** @this {Mocha.Context} */ async function () {
+      this.timeout(20000);
       await testUtils
         .executeGenerator(generator)
         .inDir(sandbox.path, () =>
@@ -233,6 +270,15 @@ describe('lb4 discover integration', () => {
           }),
         )
         .withOptions(relationsSetTrue);
+      assert.file(appointmentRepository);
+      assert.file(patientRepository);
+      assert.file(doctorRepository);
+      assert.file(appointmentDoctorController);
+      assert.file(appointmentPatientController);
+      assert.file(doctorDoctorController);
+      expectFileToMatchSnapshot(appointmentDoctorController);
+      expectFileToMatchSnapshot(appointmentPatientController);
+      expectFileToMatchSnapshot(doctorDoctorController);
       assert.file(doctorModel);
       expectFileToMatchSnapshot(doctorModel);
     });


### PR DESCRIPTION
[This PR](https://github.com/loopbackio/loopback-next/pull/8461) enabled creating relations while discovering models by setting `relations` to true in the configs. Only models are being updated with relation; No repository or controllers are created for the relations.

This PR creates repositories and relations through respective generators using `withCompose` from yeoman.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
