### PR TITLE
chore: remove types no longer needed

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -45,7 +45,6 @@
     "@loopback/eslint-config": "^16.0.0",
     "@loopback/testlab": "^8.0.2",
     "@types/node": "^16.18.126",
-    "@types/puppeteer": "^7.0.4",
     "assert": "^2.1.0",
     "buffer": "^6.0.3",
     "eslint": "^8.57.1",

--- a/extensions/cron/package.json
+++ b/extensions/cron/package.json
@@ -40,7 +40,6 @@
     "@loopback/core": "^7.0.0"
   },
   "dependencies": {
-    "@types/cron": "^2.4.3",
     "@types/debug": "^4.1.12",
     "cron": "^2.4.4",
     "debug": "^4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,7 +1292,6 @@
         "@loopback/eslint-config": "^16.0.0",
         "@loopback/testlab": "^8.0.2",
         "@types/node": "^16.18.126",
-        "@types/puppeteer": "^7.0.4",
         "assert": "^2.1.0",
         "buffer": "^6.0.3",
         "eslint": "^8.57.1",
@@ -1528,7 +1527,6 @@
       "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
-        "@types/cron": "^2.4.3",
         "@types/debug": "^4.1.12",
         "cron": "^2.4.4",
         "debug": "^4.4.1",
@@ -8861,16 +8859,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cron": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.4.3.tgz",
-      "integrity": "sha512-ViRBkoZD9Rk0hGeMdd2GHGaOaZuH9mDmwsE5/Zo53Ftwcvh7h9VJc8lIt2wdgEwS4EW5lbtTX6vlE0idCLPOyA==",
-      "deprecated": "This is a stub types definition. cron provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "cron": "*"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -8976,16 +8964,6 @@
       "dependencies": {
         "@types/jsonfile": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/glob": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-9.0.0.tgz",
-      "integrity": "sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==",
-      "deprecated": "This is a stub types definition. glob provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "*"
       }
     },
     "node_modules/@types/http-errors": {
@@ -9101,17 +9079,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
-    },
-    "node_modules/@types/minimatch": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-6.0.0.tgz",
-      "integrity": "sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==",
-      "deprecated": "This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -9375,16 +9342,6 @@
         "@types/passport": "*"
       }
     },
-    "node_modules/@types/puppeteer": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-7.0.4.tgz",
-      "integrity": "sha512-ja78vquZc8y+GM2al07GZqWDKQskQXygCDiu0e3uO0DMRKqE0MjrFBFmTulfPYzLB6WnL7Kl2tFPy0WXSpPomg==",
-      "deprecated": "This is a stub types definition. puppeteer provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "puppeteer": "*"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -9444,17 +9401,6 @@
       },
       "engines": {
         "node": ">= 0.12"
-      }
-    },
-    "node_modules/@types/rimraf": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-4.0.5.tgz",
-      "integrity": "sha512-DTCZoIQotB2SUJnYgrEx43cQIUYOlNZz0AZPbKU4PSLYTUdML5Gox0++z4F9kQocxStrCmRNhi4x5x/UlwtKUA==",
-      "deprecated": "This is a stub types definition. rimraf provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -37147,7 +37093,6 @@
         "@loopback/repository": "^8.0.2",
         "@loopback/service-proxy": "^8.0.2",
         "@types/debug": "^4.1.12",
-        "@types/glob": "^9.0.0",
         "debug": "^4.4.1",
         "glob": "^11.0.3",
         "tslib": "^2.8.1"
@@ -37511,7 +37456,6 @@
         "@loopback/testlab": "^8.0.2",
         "@types/ejs": "^3.1.5",
         "@types/fs-extra": "^11.0.4",
-        "@types/minimatch": "^6.0.0",
         "@types/node": "^16.18.126",
         "@types/yeoman-environment": "^2.10.11",
         "@types/yeoman-generator": "^5.2.14",
@@ -38626,7 +38570,6 @@
         "@loopback/testlab": "^8.0.2",
         "@types/debug": "^4.1.12",
         "@types/node": "^16.18.126",
-        "@types/rimraf": "^4.0.5",
         "@types/tunnel": "0.0.7",
         "delay": "^5.0.0",
         "tunnel": "0.0.6"

--- a/packages/boot/package.json
+++ b/packages/boot/package.json
@@ -42,7 +42,6 @@
     "@loopback/repository": "^8.0.2",
     "@loopback/service-proxy": "^8.0.2",
     "@types/debug": "^4.1.12",
-    "@types/glob": "^9.0.0",
     "debug": "^4.4.1",
     "glob": "^11.0.3",
     "tslib": "^2.8.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,6 @@
     "@loopback/testlab": "^8.0.2",
     "@types/ejs": "^3.1.5",
     "@types/fs-extra": "^11.0.4",
-    "@types/minimatch": "^6.0.0",
     "@types/node": "^16.18.126",
     "@types/yeoman-environment": "^2.10.11",
     "@types/yeoman-generator": "^5.2.14",

--- a/packages/http-caching-proxy/package.json
+++ b/packages/http-caching-proxy/package.json
@@ -51,7 +51,6 @@
     "@loopback/testlab": "^8.0.2",
     "@types/debug": "^4.1.12",
     "@types/node": "^16.18.126",
-    "@types/rimraf": "^4.0.5",
     "@types/tunnel": "0.0.7",
     "delay": "^5.0.0",
     "tunnel": "0.0.6"


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

When installing the dependencies in this repo, there are warnings that certain types are no longer needed because it's included in the corresponding package. This PR removes those unnecessary types. 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
