### PR TITLE
feat(graphql): migrate to type-graphql 2.0.0-rc.2

### DIFF
--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -49,6 +49,7 @@
     "!*/__tests__"
   ],
   "dependencies": {
+    "@graphql-yoga/subscription": "^5.0.5",
     "@loopback/boot": "^8.0.9",
     "@loopback/core": "^7.0.8",
     "@loopback/graphql": "^0.12.9",

--- a/examples/graphql/src/__tests__/acceptance/graphql-context.acceptance.ts
+++ b/examples/graphql/src/__tests__/acceptance/graphql-context.acceptance.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {createPubSub} from '@graphql-yoga/subscription';
 import {createBindingFromClass} from '@loopback/core';
 import {GraphQLBindings, GraphQLServer} from '@loopback/graphql';
 import {expect, supertest} from '@loopback/testlab';
@@ -45,6 +46,7 @@ describe('GraphQL context', () => {
     });
 
     server.bind('recipes').to([...sampleRecipes]);
+    server.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
     const repoBinding = createBindingFromClass(RecipeRepository);
     server.add(repoBinding);
     server.add(createBindingFromClass(RecipesDataSource));

--- a/examples/graphql/src/__tests__/acceptance/graphql-middleware-options.acceptance.ts
+++ b/examples/graphql/src/__tests__/acceptance/graphql-middleware-options.acceptance.ts
@@ -3,8 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {createPubSub} from '@graphql-yoga/subscription';
 import {createBindingFromClass} from '@loopback/core';
-import {GraphQLServer} from '@loopback/graphql';
+import {GraphQLBindings, GraphQLServer} from '@loopback/graphql';
 import {supertest} from '@loopback/testlab';
 import {RecipesDataSource} from '../../datasources';
 import {RecipeResolver} from '../../graphql-resolvers/recipe-resolver';
@@ -38,6 +39,7 @@ describe('GraphQL middleware', () => {
     });
     server.resolver(RecipeResolver);
     server.bind('recipes').to([...sampleRecipes]);
+    server.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
     const repoBinding = createBindingFromClass(RecipeRepository);
     server.add(repoBinding);
     server.add(createBindingFromClass(RecipesDataSource));

--- a/examples/graphql/src/__tests__/acceptance/graphql-middleware.acceptance.ts
+++ b/examples/graphql/src/__tests__/acceptance/graphql-middleware.acceptance.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {createPubSub} from '@graphql-yoga/subscription';
 import {createBindingFromClass} from '@loopback/core';
 import {GraphQLBindings, GraphQLServer} from '@loopback/graphql';
 import {expect, supertest} from '@loopback/testlab';
@@ -76,6 +77,7 @@ describe('GraphQL middleware', () => {
     server = new GraphQLServer({host: '127.0.0.1', port: 0});
     server.resolver(RecipeResolver);
     server.bind('recipes').to([...sampleRecipes]);
+    server.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
     const repoBinding = createBindingFromClass(RecipeRepository);
     server.add(repoBinding);
     server.add(createBindingFromClass(RecipesDataSource));

--- a/examples/graphql/src/__tests__/acceptance/graphql-subscription.acceptance.ts
+++ b/examples/graphql/src/__tests__/acceptance/graphql-subscription.acceptance.ts
@@ -3,8 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {createPubSub} from '@graphql-yoga/subscription';
 import {Application, createBindingFromClass} from '@loopback/core';
-import {GraphQLServer} from '@loopback/graphql';
+import {GraphQLBindings, GraphQLServer} from '@loopback/graphql';
 import {
   createRestAppClient,
   expect,
@@ -51,6 +52,7 @@ describe('GraphQL server subscription', () => {
     server.bind('recipes').to([...sampleRecipes]);
     const repoBinding = createBindingFromClass(RecipeRepository);
     server.add(repoBinding);
+    server.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
     server.add(createBindingFromClass(RecipesDataSource));
     server.add(createBindingFromClass(RecipeService));
     await server.start();
@@ -99,6 +101,7 @@ describe('GraphQL application subscription', () => {
     app.bind('recipes').to([...sampleRecipes]);
     const repoBinding = createBindingFromClass(RecipeRepository);
     app.add(repoBinding);
+    server.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
     app.add(createBindingFromClass(RecipesDataSource));
     app.add(createBindingFromClass(RecipeService));
     await app.start();

--- a/examples/graphql/src/__tests__/acceptance/graphql.acceptance.ts
+++ b/examples/graphql/src/__tests__/acceptance/graphql.acceptance.ts
@@ -3,8 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {createPubSub} from '@graphql-yoga/subscription';
 import {Application, createBindingFromClass} from '@loopback/core';
-import {GraphQLServer} from '@loopback/graphql';
+import {GraphQLBindings, GraphQLServer} from '@loopback/graphql';
 import {
   createRestAppClient,
   givenHttpServerConfig,
@@ -35,6 +36,7 @@ describe('GraphQL server', () => {
     server.resolver(RecipeResolver);
 
     server.bind('recipes').to([...sampleRecipes]);
+    server.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
     const repoBinding = createBindingFromClass(RecipeRepository);
     server.add(repoBinding);
     server.add(createBindingFromClass(RecipesDataSource));
@@ -68,6 +70,7 @@ describe('GraphQL application', () => {
     server.resolver(RecipeResolver);
 
     app.bind('recipes').to([...sampleRecipes]);
+    server.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
     const repoBinding = createBindingFromClass(RecipeRepository);
     app.add(repoBinding);
     app.add(createBindingFromClass(RecipesDataSource));

--- a/examples/graphql/src/application.ts
+++ b/examples/graphql/src/application.ts
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {createPubSub} from '@graphql-yoga/subscription';
 import {BootMixin} from '@loopback/boot';
 import {ApplicationConfig} from '@loopback/core';
 import {GraphQLBindings, GraphQLComponent} from '@loopback/graphql';
@@ -29,6 +30,8 @@ export class GraphqlDemoApplication extends BootMixin(
     });
 
     this.expressMiddleware('middleware.express.GraphQL', server.expressApp);
+
+    this.bind(GraphQLBindings.PUB_SUB).to(createPubSub());
 
     // It's possible to register a graphql context resolver
     this.bind(GraphQLBindings.GRAPHQL_CONTEXT_RESOLVER).to(async context => {

--- a/examples/graphql/src/graphql-resolvers/recipe-resolver.ts
+++ b/examples/graphql/src/graphql-resolvers/recipe-resolver.ts
@@ -11,8 +11,7 @@ import {
   GraphQLBindings,
   Int,
   mutation,
-  Publisher,
-  pubSub,
+  PubSub,
   query,
   resolver,
   ResolverData,
@@ -33,6 +32,8 @@ export class RecipeResolver implements ResolverInterface<Recipe> {
     @repository('RecipeRepository')
     private readonly recipeRepo: RecipeRepository,
     @service(RecipeService) private readonly recipeService: RecipeService,
+    // inject pubSub for publishing a notification
+    @inject(GraphQLBindings.PUB_SUB) private pubSub: PubSub,
     // It's possible to inject the resolver data
     @inject(GraphQLBindings.RESOLVER_DATA) private resolverData: ResolverData,
   ) {}
@@ -49,12 +50,9 @@ export class RecipeResolver implements ResolverInterface<Recipe> {
   }
 
   @mutation(returns => Recipe)
-  async addRecipe(
-    @arg('recipe') recipe: RecipeInput,
-    @pubSub('recipeCreated') publish: Publisher<Recipe>,
-  ): Promise<Recipe> {
+  async addRecipe(@arg('recipe') recipe: RecipeInput): Promise<Recipe> {
     const result = await this.recipeRepo.add(recipe);
-    await publish(result);
+    this.pubSub.publish('recipeCreated', result);
     return result;
   }
 

--- a/extensions/graphql/package.json
+++ b/extensions/graphql/package.json
@@ -52,12 +52,12 @@
     "debug": "^4.4.3",
     "express": "^4.22.1",
     "graphql": "^16.12.0",
-    "graphql-subscriptions": "^2.0.0",
     "graphql-ws": "^5.16.2",
-    "type-graphql": "^2.0.0-beta.2",
+    "type-graphql": "^2.0.0-rc.2",
     "ws": "^8.19.0"
   },
   "devDependencies": {
+    "@graphql-yoga/subscription": "^5.0.5",
     "@loopback/boot": "^8.0.9",
     "@loopback/build": "^12.0.8",
     "@loopback/core": "^7.0.8",

--- a/extensions/graphql/src/__tests__/fixtures/graphql-resolvers/recipe/recipe.resolver.ts
+++ b/extensions/graphql/src/__tests__/fixtures/graphql-resolvers/recipe/recipe.resolver.ts
@@ -3,11 +3,12 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+import {inject} from '@loopback/core';
 import {
   arg,
   fieldResolver,
-  Publisher,
-  pubSub,
+  GraphQLBindings,
+  PubSub,
   query,
   resolver,
 } from '../../../../';
@@ -17,7 +18,7 @@ import {Recipe} from './recipe.model';
 
 @resolver(of => Recipe)
 export class RecipeResolver {
-  constructor() {}
+  constructor(@inject(GraphQLBindings.PUB_SUB) private pubSub: PubSub) {}
 
   @query(returns => [Recipe])
   async recipes(): Promise<Recipe[]> {
@@ -30,13 +31,10 @@ export class RecipeResolver {
   }
 
   @mutation(returns => Recipe)
-  async addRecipe(
-    @arg('recipe') recipe: RecipeInput,
-    @pubSub('recipeCreated') publish: Publisher<Recipe>,
-  ): Promise<Recipe> {
+  async addRecipe(@arg('recipe') recipe: RecipeInput): Promise<Recipe> {
     const result = new Recipe();
     result.title = recipe.title;
-    await publish(result);
+    this.pubSub.publish('recipeCreated', result);
     return result;
   }
 }

--- a/extensions/graphql/src/booters/resolver.booter.ts
+++ b/extensions/graphql/src/booters/resolver.booter.ts
@@ -18,7 +18,6 @@ import {
 } from '@loopback/core';
 import debugFactory from 'debug';
 import {getMetadataStorage} from 'type-graphql';
-import {ResolverClassMetadata} from 'type-graphql/dist/metadata/definitions';
 import {registerResolver} from '../graphql.server';
 
 const debug = debugFactory('loopback:graphql:resolver-booter');
@@ -59,9 +58,7 @@ export class GraphQLResolverBooter extends BaseArtifactBooter {
   async load() {
     await super.load();
 
-    const resolverClasses: ResolverClassMetadata[] =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (getMetadataStorage() as any).resolverClasses;
+    const resolverClasses = getMetadataStorage().resolverClasses;
     this.resolvers = this.classes.filter(cls => {
       return resolverClasses.some(r => /*!r.isAbstract && */ r.target === cls);
     });

--- a/extensions/graphql/src/decorators/index.ts
+++ b/extensions/graphql/src/decorators/index.ts
@@ -15,7 +15,6 @@ import {
   InputType,
   Mutation,
   ObjectType,
-  PubSub,
   Query,
   Resolver,
   Root,
@@ -41,4 +40,3 @@ export const inputType = InputType;
 export const objectType = ObjectType;
 export const authorized = Authorized;
 export const subscription = Subscription;
-export const pubSub = PubSub;

--- a/extensions/graphql/src/index.ts
+++ b/extensions/graphql/src/index.ts
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from 'type-graphql';
-export * from 'type-graphql/dist/interfaces';
 export * from './decorators';
 export * from './graphql.component';
 export * from './graphql.container';

--- a/extensions/graphql/src/keys.ts
+++ b/extensions/graphql/src/keys.ts
@@ -5,8 +5,7 @@
 
 import {ExpressMiddlewareOptions} from '@apollo/server/dist/esm/express4';
 import {BindingKey, Constructor, CoreBindings} from '@loopback/core';
-import {PubSubEngine} from 'graphql-subscriptions';
-import {AuthChecker, ResolverData} from 'type-graphql';
+import {AuthChecker, PubSub, ResolverData} from 'type-graphql';
 import {GraphQLComponent} from './graphql.component';
 import {GraphQLServer} from './graphql.server';
 import {GraphQLServerOptions, GraphQLWsContextResolver} from './types';
@@ -55,9 +54,7 @@ export namespace GraphQLBindings {
   /**
    * Binding key for the GraphQL pub/sub engine
    */
-  export const PUB_SUB_ENGINE = BindingKey.create<PubSubEngine>(
-    'graphql.pubSubEngine',
-  );
+  export const PUB_SUB = BindingKey.create<PubSub>('graphql.pubSub');
 
   /**
    * Binding key for the GraphQL resolver data - which is bound per request

--- a/extensions/graphql/src/types.ts
+++ b/extensions/graphql/src/types.ts
@@ -9,7 +9,7 @@ import {ExecutionArgs} from 'graphql';
 import {GraphQLExecutionContextValue, SubscribeMessage} from 'graphql-ws';
 
 export {Float, ID, Int, ResolverInterface} from 'type-graphql';
-export {Middleware as GraphQLMiddleware} from 'type-graphql/dist/interfaces/Middleware';
+export {Middleware as GraphQLMiddleware} from 'type-graphql/build/typings/typings/middleware';
 
 /**
  * Options for GraphQL component

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,6 +483,7 @@
       "version": "0.12.9",
       "license": "MIT",
       "dependencies": {
+        "@graphql-yoga/subscription": "^5.0.5",
         "@loopback/boot": "^8.0.9",
         "@loopback/core": "^7.0.8",
         "@loopback/graphql": "^0.12.9",
@@ -1427,12 +1428,12 @@
         "debug": "^4.4.3",
         "express": "^4.22.1",
         "graphql": "^16.12.0",
-        "graphql-subscriptions": "^2.0.0",
         "graphql-ws": "^5.16.2",
-        "type-graphql": "^2.0.0-beta.2",
+        "type-graphql": "^2.0.0-rc.2",
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@graphql-yoga/subscription": "^5.0.5",
         "@loopback/boot": "^8.0.9",
         "@loopback/build": "^12.0.8",
         "@loopback/core": "^7.0.8",
@@ -1458,42 +1459,8 @@
     "extensions/graphql/node_modules/@types/node": {
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw=="
-    },
-    "extensions/graphql/node_modules/type-graphql": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/type-graphql/-/type-graphql-2.0.0-beta.2.tgz",
-      "integrity": "sha512-MCGxRvNADu5Wp9QEudI/WQgiqHJfjanGcKRk/ErCow6IaG04NNI7o3bjjxQVWC+qDundSOhmaquNdjDiiTbcqQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/TypeGraphQL"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/typegraphql"
-        }
-      ],
-      "dependencies": {
-        "@types/node": "*",
-        "@types/semver": "^7.5.0",
-        "graphql-query-complexity": "^0.12.0",
-        "graphql-subscriptions": "^2.0.0",
-        "semver": "^7.5.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.5.0"
-      },
-      "peerDependencies": {
-        "class-validator": ">=0.14.0",
-        "graphql": "^16.6.0"
-      },
-      "peerDependenciesMeta": {
-        "class-validator": {
-          "optional": true
-        }
-      }
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "dev": true
     },
     "extensions/health": {
       "name": "@loopback/health",
@@ -3381,6 +3348,32 @@
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-yoga/subscription": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-5.0.5.tgz",
+      "integrity": "sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==",
+      "dependencies": {
+        "@graphql-yoga/typed-event-target": "^3.0.2",
+        "@repeaterjs/repeater": "^3.0.4",
+        "@whatwg-node/events": "^0.1.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@graphql-yoga/typed-event-target": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/typed-event-target/-/typed-event-target-3.0.2.tgz",
+      "integrity": "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==",
+      "dependencies": {
+        "@repeaterjs/repeater": "^3.0.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -6461,6 +6454,7 @@
       "integrity": "sha512-p7X/ytJDIdwUfFL/CLOhKgdfJe1Fa8uw9seJYvdOmnP9JBWGWHW69HkOixXS6Wy9yvGf1MbhcS6lVmrhy4jm2g==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -9393,6 +9387,11 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="
+    },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.19.1",
       "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.19.1.tgz",
@@ -11449,6 +11448,17 @@
         "webpack-dev-server": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.2.tgz",
+      "integrity": "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@whatwg-node/promise-helpers": {
@@ -19328,15 +19338,19 @@
         "graphql": "^14.6.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/graphql-subscriptions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-2.0.0.tgz",
-      "integrity": "sha512-s6k2b8mmt9gF9pEfkxsaO1lTxaySfKoEJzEfmwguBbQ//Oq23hIXCfR1hm4kdh5hnR20RdwB+s3BCb+0duHSZA==",
+    "node_modules/graphql-scalars": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.25.0.tgz",
+      "integrity": "sha512-b0xyXZeRFkne4Eq7NAnL400gStGqG/Sx9VqX0A05nHyEbv57UJnWKsjNnrpVqv5e/8N1MUxkt0wwcRXbiyKcFg==",
+      "peer": true,
       "dependencies": {
-        "iterall": "^1.3.0"
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^15.7.2 || ^16.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/graphql-ws": {
@@ -21013,11 +21027,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "node_modules/jackspeak": {
       "version": "3.1.2",
@@ -26840,7 +26849,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/meow": {
       "version": "12.1.1",
@@ -30892,7 +30902,8 @@
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.10.1",
@@ -33927,6 +33938,7 @@
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -34169,6 +34181,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
@@ -34179,6 +34192,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 6"
@@ -34188,6 +34202,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -34198,6 +34213,7 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
@@ -34227,6 +34243,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
@@ -34239,6 +34256,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -34259,6 +34277,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@tootallnate/once": "1",
@@ -34273,12 +34292,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "optional": true
     },
     "node_modules/sqlite3/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -34291,6 +34312,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
@@ -34318,6 +34340,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -34330,6 +34353,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -34342,6 +34366,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "minipass": "^3.1.0",
@@ -34359,6 +34384,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
       "optional": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -34371,6 +34397,7 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -34395,6 +34422,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "abbrev": "1"
@@ -34410,6 +34438,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -34425,6 +34454,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "agent-base": "^6.0.2",
@@ -34439,6 +34469,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
       "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "minipass": "^3.1.1"
@@ -34451,6 +34482,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
@@ -34460,6 +34492,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -34469,6 +34502,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -36853,6 +36887,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-graphql": {
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/type-graphql/-/type-graphql-2.0.0-rc.2.tgz",
+      "integrity": "sha512-DJ8erG1cmjteMrOhFIkBHOqRM+L+wCJxvNjbbj1Y+q2r4HZkB1qOSS4ZD4AaoAfRPAp1yU23gMtmzf0jen/FFA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/TypeGraphQL"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/typegraphql"
+        }
+      ],
+      "dependencies": {
+        "@graphql-yoga/subscription": "^5.0.0",
+        "@types/node": "*",
+        "@types/semver": "^7.5.6",
+        "graphql-query-complexity": "^0.12.0",
+        "semver": "^7.5.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "peerDependencies": {
+        "class-validator": ">=0.14.0",
+        "graphql": "^16.8.1",
+        "graphql-scalars": "^1.23.0"
+      },
+      "peerDependenciesMeta": {
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-is": {


### PR DESCRIPTION
# [graphql] Migrate GraphQL Extension to type-graphql v2.0.0-rc.2

The GraphQL extension currently uses `type-graphql` version `2.0.0-beta.2`.
This PR migrates the extension to the latest release candidate, `2.0.0-rc.2`.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Affected example projects in `examples/*` were updated

