### PR TITLE
fix: fix ci with cert issue

### DIFF
--- a/packages/http-caching-proxy/src/http-caching-proxy.ts
+++ b/packages/http-caching-proxy/src/http-caching-proxy.ts
@@ -8,9 +8,9 @@ import debugFactory from 'debug';
 import {once} from 'node:events';
 import {
   createServer,
+  Server as HttpServer,
   IncomingMessage,
   OutgoingHttpHeaders,
-  Server as HttpServer,
   ServerResponse,
 } from 'node:http';
 import {AddressInfo} from 'node:net';
@@ -89,6 +89,11 @@ export class HttpCachingProxy {
       // http status code. Please note that Axios creates a new error in such
       // condition and the original low-level error is lost
       validateStatus: () => true,
+      // Disable SSL certificate validation for HTTPS requests
+      // This is acceptable for a testing/caching proxy
+      httpsAgent: new (require('node:https').Agent)({
+        rejectUnauthorized: false,
+      }),
     });
   }
 


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

CI suddenly fails with: 
```
 1) HttpCachingProxy
       proxies HTTPs requests (no tunneling):
     Error: 502 - "Error: unable to get local issuer certificate"
      at makeRequest (packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts:261:19)
      at processTicksAndRejections (node:internal/process/task_queues:103:5)
      at Context.<anonymous> (packages/http-caching-proxy/src/__tests__/integration/http-caching-proxy.integration.ts:88:20)

```

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [ ] API Documentation in code was updated
- [ ] Documentation in [/docs/site](../tree/master/docs/site) was updated
- [ ] Affected artifact templates in `packages/cli` were updated
- [ ] Affected example projects in `examples/*` were updated

👉 [Check out how to submit a PR](https://loopback.io/doc/en/lb4/submitting_a_pr.html) 👈
